### PR TITLE
Fix Swift/Kotlin codegen for cross-target parser parity.

### DIFF
--- a/bin/Lang.rgr
+++ b/bin/Lang.rgr
@@ -493,6 +493,7 @@ func r_io_get_env( name string) *GoNullable {
                 swift6 ("CommandLine.arguments[" (e 1) " + 1]")
                 es6 ( "process.argv[ 2 + " (e 1) "]")
                 rust ( "std::env::args().nth((" (e 1) " + 1) as usize).unwrap_or_default()")
+                kotlin ( "args[" (e 1) "]")
                 ranger ("( shell_arg " (e 1) " )")
             }
         }
@@ -508,6 +509,7 @@ func r_io_get_env( name string) *GoNullable {
                 go ( "int64( len( os.Args) - 1 )"  (imp "os"))
                 es6 ( "(process.argv.length - 2)" )
                 rust ( "(std::env::args().len() as i64 - 1)")
+                kotlin ( "(args.size - 1)")
                 ranger ("( shell_arg_cnt )")
             }
         }        
@@ -930,6 +932,7 @@ fn r_read_file(path: &str, filename: &str) -> Option<String> {
 }
 "))
                 es6 ( "(require('fs').readFileSync( " (e 1) " + '/' + " (e 2) " , 'utf8'))" )
+                kotlin ( "try { java.io.File(if (" (e 1) ".isEmpty()) " (e 2) " else " (e 1) " + \"/\" + " (e 2) ").readText() } catch (_: Exception) { null }" (imp "java.io.File") )
             }
         }
 
@@ -2716,6 +2719,7 @@ std::vector<uint8_t> r_buffer_read_file(const std::string& path, const std::stri
                 ranger ( "(to_int " (e 1) ")") 
                 csharp ( "(int)" (e 1 ) "" )
                 swift3 ( "Int(" (e 1 ) ")" )
+                swift6 ( "Int(" (e 1 ) ")" )
                 kotlin ( (e 1 ) ".toInt()" )
                 scala ( (e 1 ) ".toInt" )
                 rust ( (e 1 ) " as i64 " )
@@ -3165,9 +3169,50 @@ func r_str_2_i64(s string) *GoNullable {
                 )
                 php ( "is_numeric(" (e 1) ") ? intval(" (e 1) ") : NULL ")
                 scala ( "Try(" (e 1) ".toInt).toOption" (imp "scala.util.Try"))
-                kotlin (  (e 1) ".toIntOrNull()")
-                swift3 ("Int(" (e 1) ")")
-                swift6 ("Int(" (e 1) ")")
+                kotlin ( "rangerStr2IntPrefix(" (e 1) ")"
+(create_polyfill "
+fun rangerStr2IntPrefix(s: String): Int? {
+  val m = Regex(\"^-?\\\\d+\").find(s) ?: return null
+  return m.value.toIntOrNull()
+}
+")
+                )
+                swift3 ("rangerStr2IntPrefix(" (e 1) ")"
+(create_polyfill "
+func rangerStr2IntPrefix(_ s: String) -> Int? {
+  var i = s.startIndex
+  if i < s.endIndex && s[i] == \"-\" {
+    i = s.index(after: i)
+  }
+  var end = i
+  while end < s.endIndex && s[end].isNumber {
+    end = s.index(after: end)
+  }
+  if end == i {
+    return nil
+  }
+  return Int(s[i..<end])
+}
+")
+                )
+                swift6 ("rangerStr2IntPrefix(" (e 1) ")"
+(create_polyfill "
+func rangerStr2IntPrefix(_ s: String) -> Int? {
+  var i = s.startIndex
+  if i < s.endIndex && s[i] == \"-\" {
+    i = s.index(after: i)
+  }
+  var end = i
+  while end < s.endIndex && s[end].isNumber {
+    end = s.index(after: end)
+  }
+  if end == i {
+    return nil
+  }
+  return Int(s[i..<end])
+}
+")
+                )
                 csharp( "Int32.Parse(" (e 1) ")" )
                 rust ( (e 1) ".parse::<i64>().ok()" )
                 * ( "isNaN( parseInt(" (e 1) ") ) ? undefined : parseInt(" (e 1) ")")
@@ -3247,7 +3292,7 @@ Double _getDoubleOrNull ( String str ) {
                 scala ( "Try(" (e 1) ".toDouble).toOption" (imp "scala.util.Try"))
                 kotlin (  (e 1) ".toDoubleOrNull()")
                 swift3 ("Double(" (e 1) ")")
-                rust ( (e 1) ".parse::<f64>().ok()" )
+                swift6 ("Double(" (e 1) ")")
                 * ( "isNaN( parseFloat(" (e 1) ") ) ? undefined : parseFloat(" (e 1) ")")
             }
         }
@@ -4863,8 +4908,10 @@ std::string r_cpp_str_to_uppercase(std::string original)
                 go ("float64( " (e 1) " )")
                 es6 ( (e 1) )
                 swift3 ("Double(" (e 1) ")")
+                swift6 ("Double(" (e 1) ")")
                 scala ( (e 1) '.toDouble')
                 java7 ("Double.valueOf(" (e 1) ")")
+                kotlin ( (e 1) ".toDouble()" )
                 cpp ("(double)(" (e 1) ")")
                 php ( (e 1) )
                 rust ("(" (e 1) " as f64)")

--- a/bin/output.js
+++ b/bin/output.js
@@ -8871,7 +8871,10 @@ class RangerFlowParser  {
     await this.WalkNode(obj_2, ctx, wr);
     if ( ctx.isDefinedClass(obj_2.eval_type_name) ) {
       const cl = ctx.findClass(obj_2.eval_type_name);
-      const m = cl.findMethod(method_2.vref);
+      let m = cl.findMethod(method_2.vref);
+      if ( typeof(m) === "undefined" ) {
+        m = cl.findStaticMethod(method_2.vref);
+      }
       if ( (typeof(m) !== "undefined" && m != null )  ) {
         node.has_call = true;
         const currM = ctx.getCurrentMethod();
@@ -9025,6 +9028,9 @@ class RangerFlowParser  {
   };
   async cmdLocalCall (node, ctx, wr) {
     const fnNode = node.getFirst();
+    if ( await this.tryRepairDotMethodInfix(node, fnNode, ctx, wr) ) {
+      return true;
+    }
     const udesc = ctx.getCurrentClass();
     const desc = udesc;
     let expects_error = false;
@@ -10232,6 +10238,84 @@ class RangerFlowParser  {
     }
     return false;
   };
+  resolveStaticMethodRef (fc) {
+    let result = [];
+    if ( (fc.ns.length) > 1 ) {
+      const nn = fc.copy();
+      nn.ns.pop();
+      result.push(nn.ns.join("."));
+      result.push(fc.ns[((fc.ns.length) - 1)]);
+      return result;
+    }
+    if ( (fc.ns.length) == 1 ) {
+      result.push(fc.ns[0]);
+      result.push(fc.vref);
+      return result;
+    }
+    const dotPos = fc.vref.indexOf(".");
+    if ( dotPos > 0 ) {
+      result.push(fc.vref.substring(0, dotPos ));
+      const afterDot = dotPos + 1;
+      result.push(fc.vref.substring(afterDot, (fc.vref.length) ));
+      return result;
+    }
+    return result;
+  };
+  async buildDotMethodInfixRepair (node, fc, op_vref, methodArg, rhs, ctx, wr) {
+    const refParts = this.resolveStaticMethodRef(fc);
+    if ( (refParts.length) != 2 ) {
+      return false;
+    }
+    const objName = refParts[0];
+    const possible_cmd = refParts[1];
+    const vFnDef = this.findFunctionDesc(fc, ctx, wr);
+    if ( typeof(vFnDef) === "undefined" ) {
+      return false;
+    }
+    const callNode = node.newExpressionNode();
+    callNode.children.push(node.newVRefNode("call"));
+    callNode.children.push(node.newVRefNode(objName));
+    callNode.children.push(node.newVRefNode(possible_cmd));
+    callNode.children.push(methodArg.copy());
+    const repaired = node.newExpressionNode();
+    repaired.children.push(node.newVRefNode(op_vref));
+    repaired.children.push(callNode);
+    repaired.children.push(rhs.copy());
+    node.getChildrenFrom(repaired);
+    node.flow_done = false;
+    await this.stdParamMatch(node, ctx, wr, true);
+    return true;
+  };
+  async tryRepairDotMethodInfix (node, fc, ctx, wr) {
+    if ( (node.children.length) != 2 ) {
+      return false;
+    }
+    if ( (this.resolveStaticMethodRef(fc).length) != 2 ) {
+      return false;
+    }
+    const second = node.getSecond();
+    if ( (second.children.length) >= 3 ) {
+      const opNode = second.getFirst();
+      if ( (opNode.vref.length) > 0 ) {
+        const op_check = await ctx.getOperators(opNode.vref);
+        if ( (op_check.length) > 0 ) {
+          return await this.buildDotMethodInfixRepair(node, fc, opNode.vref, second.getSecond(), second.getThird(), ctx, wr);
+        }
+      }
+    }
+    if ( second.infix_operator && ((typeof(second.infix_node) !== "undefined" && second.infix_node != null ) ) ) {
+      const ifNode = second.infix_node;
+      if ( (ifNode.vref.length) > 0 ) {
+        const op_check2 = await ctx.getOperators(ifNode.vref);
+        if ( (op_check2.length) > 0 ) {
+          if ( (ifNode.children.length) >= 2 ) {
+            return await this.buildDotMethodInfixRepair(node, fc, ifNode.vref, ifNode.getFirst(), ifNode.getSecond(), ctx, wr);
+          }
+        }
+      }
+    }
+    return false;
+  };
   async matchNode (node, ctx, wr) {
     if ( 0 == (node.children.length) ) {
       return false;
@@ -10249,26 +10333,33 @@ class RangerFlowParser  {
         return true;
       }
     };
-    if ( ((fc.ns.length) > 1) && ((node.children.length) > 1) ) {
-      const possible_cmd = fc.ns[((fc.ns.length) - 1)];
-      const op_list_2 = await ctx.getOperators(possible_cmd);
-      if ( (op_list_2.length) > 0 ) {
-        const args = node.getSecond();
-        const nn = fc.copy();
-        nn.ns.pop();
-        const objName = nn.ns.join(".");
-        const newNode = node.newExpressionNode();
-        newNode.add(node.newVRefNode("call"));
-        newNode.add(node.newVRefNode(objName));
-        newNode.add(node.newVRefNode(possible_cmd));
-        newNode.add(args.copy());
-        node.getChildrenFrom(newNode);
-        if ( ctx.expressionLevel() == 0 ) {
-          ctx.lastBlockOp = node;
+    if ( (node.children.length) > 1 ) {
+      const refParts = this.resolveStaticMethodRef(fc);
+      const isStaticRef = (refParts.length) == 2;
+      if ( isStaticRef && (false == node.infix_operator) ) {
+        if ( await this.tryRepairDotMethodInfix(node, fc, ctx, wr) ) {
+          return true;
         }
-        node.flow_done = false;
-        await this.WalkNode(node, ctx, wr);
-        return true;
+      }
+      if ( isStaticRef ) {
+        const possible_cmd = refParts[1];
+        const op_list_2 = await ctx.getOperators(possible_cmd);
+        if ( (op_list_2.length) > 0 ) {
+          const args = node.getSecond();
+          const objName = refParts[0];
+          const newNode = node.newExpressionNode();
+          newNode.add(node.newVRefNode("call"));
+          newNode.add(node.newVRefNode(objName));
+          newNode.add(node.newVRefNode(possible_cmd));
+          newNode.add(args.copy());
+          node.getChildrenFrom(newNode);
+          if ( ctx.expressionLevel() == 0 ) {
+            ctx.lastBlockOp = node;
+          }
+          node.flow_done = false;
+          await this.WalkNode(node, ctx, wr);
+          return true;
+        }
       }
     }
     return false;
@@ -12902,6 +12993,27 @@ class RangerGenericClassWriter  {
   adjustType (tn) {
     return tn;
   };
+  defValueHasSideEffects (value) {
+    if ( value.has_call ) {
+      return true;
+    }
+    if ( value.hasFnCall ) {
+      return true;
+    }
+    if ( value.is_direct_method_call ) {
+      return true;
+    }
+    return false;
+  };
+  async writeSideEffectOnlyStmt (value, ctx, wr) {
+    ctx.setInExpr();
+    await this.WalkNode(value, ctx, wr);
+    ctx.unsetInExpr();
+    if ( ctx.expressionLevel() == 0 ) {
+      wr.out(";", true);
+    }
+    wr.newline();
+  };
   async WriteVRef (node, ctx, wr) {
     if ( node.eval_type == 13 ) {
       if ( (node.ns.length) > 1 ) {
@@ -15357,6 +15469,13 @@ class RangerSwift6ClassWriter  extends RangerGenericClassWriter {
         }
       }
       if ( (p.ref_cnt == 0) && (p.is_class_variable == false) ) {
+        if ( (node.children.length) > 2 ) {
+          const value = node.getThird();
+          if ( this.defValueHasSideEffects(value) ) {
+            await this.writeSideEffectOnlyStmt(value, ctx, wr);
+            return;
+          }
+        }
         wr.out("/** unused:  ", false);
       }
       if ( p.is_static ) {
@@ -15371,8 +15490,8 @@ class RangerSwift6ClassWriter  extends RangerGenericClassWriter {
       if ( (node.children.length) > 2 ) {
         wr.out(" = ", false);
         ctx.setInExpr();
-        const value = node.getThird();
-        await this.WalkNode(value, ctx, wr);
+        const value_1 = node.getThird();
+        await this.WalkNode(value_1, ctx, wr);
         ctx.unsetInExpr();
       } else {
         if ( nn.value_type == 6 ) {
@@ -15440,29 +15559,78 @@ class RangerSwift6ClassWriter  extends RangerGenericClassWriter {
       await this.writeTypeDef(arg.nameNode, ctx, wr);
     };
   };
+  resolveCallReceiverClassName (obj, ctx) {
+    if ( (obj.vref.length) > 0 ) {
+      if ( ctx.isDefinedClass(obj.vref) ) {
+        return obj.vref;
+      }
+    }
+    if ( (obj.eval_type_name.length) > 0 ) {
+      if ( ctx.isDefinedClass(obj.eval_type_name) ) {
+        return obj.eval_type_name;
+      }
+    }
+    if ( (obj.ns.length) >= 1 ) {
+      const head = obj.ns[0];
+      if ( ctx.isDefinedClass(head) ) {
+        return head;
+      }
+    }
+    if ( (obj.children.length) == 1 ) {
+      const inner = obj.children[0];
+      const innerName = this.resolveCallReceiverClassName(inner, ctx);
+      if ( (innerName.length) > 0 ) {
+        return innerName;
+      }
+    }
+    return "";
+  };
+  isSimpleClassCallReceiver (obj, ctx) {
+    const className = this.resolveCallReceiverClassName(obj, ctx);
+    if ( (className.length) == 0 ) {
+      return false;
+    }
+    if ( obj.vref == className ) {
+      return true;
+    }
+    if ( (obj.children.length) == 1 ) {
+      const inner = obj.children[0];
+      if ( inner.vref == className ) {
+        return true;
+      }
+    }
+    return false;
+  };
   async CreateCallExpression (node, ctx, wr) {
     if ( node.has_call ) {
       const obj = node.getSecond();
       const method = node.getThird();
       const args = node.children[3];
-      wr.out("(", false);
+      const simpleReceiver = this.isSimpleClassCallReceiver(obj, ctx);
+      if ( simpleReceiver == false ) {
+        wr.out("(", false);
+      }
       ctx.setInExpr();
       await this.WalkNode(obj, ctx, wr);
       ctx.unsetInExpr();
-      wr.out(").", false);
+      if ( simpleReceiver == false ) {
+        wr.out(").", false);
+      } else {
+        wr.out(".", false);
+      }
       wr.out(method.vref, false);
       wr.out("(", false);
       ctx.setInExpr();
+      const fnDesc = this.resolveMethodFnDesc(node, ctx);
+      const hasFnDesc = (typeof(fnDesc) !== "undefined" && fnDesc != null ) ;
       for ( let i = 0; i < args.children.length; i++) {
         var arg = args.children[i];
         if ( i > 0 ) {
           wr.out(", ", false);
         }
-        if ( ctx.isDefinedClass(obj.eval_type_name) ) {
-          const clDef = ctx.findClass(obj.eval_type_name);
-          const clMethod = clDef.findMethod(method.vref);
-          if ( (typeof(clMethod) !== "undefined" && clMethod != null )  ) {
-            const mm = clMethod;
+        if ( hasFnDesc ) {
+          const mm = fnDesc;
+          if ( i < (mm.params.length) ) {
             const pDesc = mm.params[i];
             wr.out(pDesc.compiledName + " : ", false);
             if ( ((pDesc.nameNode)).hasFlag("mutates") ) {
@@ -15471,8 +15639,6 @@ class RangerSwift6ClassWriter  extends RangerGenericClassWriter {
             await this.WalkNode(arg, ctx, wr);
             continue;
           }
-        } else {
-          ctx.addError(arg, "Could not find evaluated class for the call");
         }
         await this.WalkNode(arg, ctx, wr);
       };
@@ -15932,6 +16098,85 @@ class RangerSwift6ClassWriter  extends RangerGenericClassWriter {
         theEnd.out("}", true);
       }
     };
+  };
+  resolveMethodFnDesc (methodNode, ctx) {
+    let res;
+    if ( methodNode.hasParamDesc ) {
+      const raw = (methodNode.paramDesc);
+      if ( (raw.params.length) > 0 ) {
+        res = raw;
+        return res;
+      }
+    }
+    if ( (methodNode.ns.length) >= 2 ) {
+      const className = methodNode.ns[0];
+      if ( ctx.isDefinedClass(className) ) {
+        const clDef = ctx.findClass(className);
+        const methodName = methodNode.ns[1];
+        let found = clDef.findStaticMethod(methodName);
+        if ( typeof(found) === "undefined" ) {
+          found = clDef.findMethod(methodName);
+        }
+        if ( (typeof(found) !== "undefined" && found != null )  ) {
+          res = found;
+          return res;
+        }
+      }
+    }
+    if ( methodNode.has_call ) {
+      const obj = methodNode.getSecond();
+      const method = methodNode.getThird();
+      const className_1 = this.resolveCallReceiverClassName(obj, ctx);
+      if ( (className_1.length) > 0 ) {
+        const clDef_1 = ctx.findClass(className_1);
+        let found_1 = clDef_1.findStaticMethod(method.vref);
+        if ( typeof(found_1) === "undefined" ) {
+          found_1 = clDef_1.findMethod(method.vref);
+        }
+        if ( (typeof(found_1) !== "undefined" && found_1 != null )  ) {
+          res = found_1;
+          return res;
+        }
+      }
+    }
+    return res;
+  };
+  async CreateMethodCall (node, ctx, wr) {
+    const methodNode = node.getFirst();
+    const args = node.getSecond();
+    ctx.setInExpr();
+    await this.WalkNode(methodNode, ctx, wr);
+    ctx.unsetInExpr();
+    wr.out("(", false);
+    ctx.setInExpr();
+    let hasFnDesc = false;
+    let fnDesc;
+    const resolved = this.resolveMethodFnDesc(methodNode, ctx);
+    if ( (typeof(resolved) !== "undefined" && resolved != null )  ) {
+      fnDesc = resolved;
+      hasFnDesc = true;
+    }
+    const pms = operatorsOf.filter_36(args.children, ((item, index) => { 
+      if ( item.hasFlag("keyword") ) {
+        return false;
+      }
+      return true;
+    }));
+    for ( let i = 0; i < pms.length; i++) {
+      var arg = pms[i];
+      if ( i > 0 ) {
+        wr.out(", ", false);
+      }
+      if ( hasFnDesc ) {
+        if ( i < (fnDesc.params.length) ) {
+          const pArg = fnDesc.params[i];
+          wr.out(pArg.compiledName + " : ", false);
+        }
+      }
+      await this.WalkNode(arg, ctx, wr);
+    };
+    ctx.unsetInExpr();
+    wr.out(")", false);
   };
 }
 class RangerCppClassWriter  extends RangerGenericClassWriter {
@@ -20141,6 +20386,13 @@ class RangerKotlinClassWriter  extends RangerGenericClassWriter {
       const nn = node.children[1];
       const p = nn.paramDesc;
       if ( (p.ref_cnt == 0) && (p.is_class_variable == false) ) {
+        if ( (node.children.length) > 2 ) {
+          const value = node.getThird();
+          if ( this.defValueHasSideEffects(value) ) {
+            await this.writeSideEffectOnlyStmt(value, ctx, wr);
+            return;
+          }
+        }
         wr.out("/** unused:  ", false);
       }
       if ( p.is_class_variable ) {
@@ -20158,8 +20410,8 @@ class RangerKotlinClassWriter  extends RangerGenericClassWriter {
       if ( (node.children.length) > 2 ) {
         wr.out(" = ", false);
         ctx.setInExpr();
-        const value = node.getThird();
-        await this.WalkNode(value, ctx, wr);
+        const value_1 = node.getThird();
+        await this.WalkNode(value_1, ctx, wr);
         ctx.unsetInExpr();
       } else {
         if ( nn.hasFlag("optional") ) {
@@ -20197,6 +20449,7 @@ class RangerKotlinClassWriter  extends RangerGenericClassWriter {
   };
   async writeFnCall (node, ctx, wr) {
     if ( node.hasFnCall ) {
+      ctx.setInExpr();
       const fc = node.getFirst();
       await this.WriteVRef(fc, ctx, wr);
       wr.out("(", false);
@@ -20220,6 +20473,7 @@ class RangerKotlinClassWriter  extends RangerGenericClassWriter {
         await this.WalkNode(n, ctx, wr);
       };
       wr.out(")", false);
+      ctx.unsetInExpr();
       if ( ctx.expressionLevel() == 0 ) {
         wr.out(";", true);
       }
@@ -20328,6 +20582,8 @@ class RangerKotlinClassWriter  extends RangerGenericClassWriter {
             };
           }
           wr.out(")", false);
+        } else {
+          wr.out("()", false);
         }
       };
     }

--- a/compiler/Lang.rgr
+++ b/compiler/Lang.rgr
@@ -493,6 +493,7 @@ func r_io_get_env( name string) *GoNullable {
                 swift6 ("CommandLine.arguments[" (e 1) " + 1]")
                 es6 ( "process.argv[ 2 + " (e 1) "]")
                 rust ( "std::env::args().nth((" (e 1) " + 1) as usize).unwrap_or_default()")
+                kotlin ( "args[" (e 1) "]")
                 ranger ("( shell_arg " (e 1) " )")
             }
         }
@@ -508,6 +509,7 @@ func r_io_get_env( name string) *GoNullable {
                 go ( "int64( len( os.Args) - 1 )"  (imp "os"))
                 es6 ( "(process.argv.length - 2)" )
                 rust ( "(std::env::args().len() as i64 - 1)")
+                kotlin ( "(args.size - 1)")
                 ranger ("( shell_arg_cnt )")
             }
         }        
@@ -930,6 +932,7 @@ fn r_read_file(path: &str, filename: &str) -> Option<String> {
 }
 "))
                 es6 ( "(require('fs').readFileSync( " (e 1) " + '/' + " (e 2) " , 'utf8'))" )
+                kotlin ( "try { java.io.File(if (" (e 1) ".isEmpty()) " (e 2) " else " (e 1) " + \"/\" + " (e 2) ").readText() } catch (_: Exception) { null }" (imp "java.io.File") )
             }
         }
 
@@ -2716,6 +2719,7 @@ std::vector<uint8_t> r_buffer_read_file(const std::string& path, const std::stri
                 ranger ( "(to_int " (e 1) ")") 
                 csharp ( "(int)" (e 1 ) "" )
                 swift3 ( "Int(" (e 1 ) ")" )
+                swift6 ( "Int(" (e 1 ) ")" )
                 kotlin ( (e 1 ) ".toInt()" )
                 scala ( (e 1 ) ".toInt" )
                 rust ( (e 1 ) " as i64 " )
@@ -3165,9 +3169,50 @@ func r_str_2_i64(s string) *GoNullable {
                 )
                 php ( "is_numeric(" (e 1) ") ? intval(" (e 1) ") : NULL ")
                 scala ( "Try(" (e 1) ".toInt).toOption" (imp "scala.util.Try"))
-                kotlin (  (e 1) ".toIntOrNull()")
-                swift3 ("Int(" (e 1) ")")
-                swift6 ("Int(" (e 1) ")")
+                kotlin ( "rangerStr2IntPrefix(" (e 1) ")"
+(create_polyfill "
+fun rangerStr2IntPrefix(s: String): Int? {
+  val m = Regex(\"^-?\\\\d+\").find(s) ?: return null
+  return m.value.toIntOrNull()
+}
+")
+                )
+                swift3 ("rangerStr2IntPrefix(" (e 1) ")"
+(create_polyfill "
+func rangerStr2IntPrefix(_ s: String) -> Int? {
+  var i = s.startIndex
+  if i < s.endIndex && s[i] == \"-\" {
+    i = s.index(after: i)
+  }
+  var end = i
+  while end < s.endIndex && s[end].isNumber {
+    end = s.index(after: end)
+  }
+  if end == i {
+    return nil
+  }
+  return Int(s[i..<end])
+}
+")
+                )
+                swift6 ("rangerStr2IntPrefix(" (e 1) ")"
+(create_polyfill "
+func rangerStr2IntPrefix(_ s: String) -> Int? {
+  var i = s.startIndex
+  if i < s.endIndex && s[i] == \"-\" {
+    i = s.index(after: i)
+  }
+  var end = i
+  while end < s.endIndex && s[end].isNumber {
+    end = s.index(after: end)
+  }
+  if end == i {
+    return nil
+  }
+  return Int(s[i..<end])
+}
+")
+                )
                 csharp( "Int32.Parse(" (e 1) ")" )
                 rust ( (e 1) ".parse::<i64>().ok()" )
                 * ( "isNaN( parseInt(" (e 1) ") ) ? undefined : parseInt(" (e 1) ")")
@@ -3247,7 +3292,7 @@ Double _getDoubleOrNull ( String str ) {
                 scala ( "Try(" (e 1) ".toDouble).toOption" (imp "scala.util.Try"))
                 kotlin (  (e 1) ".toDoubleOrNull()")
                 swift3 ("Double(" (e 1) ")")
-                rust ( (e 1) ".parse::<f64>().ok()" )
+                swift6 ("Double(" (e 1) ")")
                 * ( "isNaN( parseFloat(" (e 1) ") ) ? undefined : parseFloat(" (e 1) ")")
             }
         }
@@ -4863,8 +4908,10 @@ std::string r_cpp_str_to_uppercase(std::string original)
                 go ("float64( " (e 1) " )")
                 es6 ( (e 1) )
                 swift3 ("Double(" (e 1) ")")
+                swift6 ("Double(" (e 1) ")")
                 scala ( (e 1) '.toDouble')
                 java7 ("Double.valueOf(" (e 1) ")")
+                kotlin ( (e 1) ".toDouble()" )
                 cpp ("(double)(" (e 1) ")")
                 php ( (e 1) )
                 rust ("(" (e 1) " as f64)")

--- a/compiler/ng_RangerGenericClassWriter.rgr
+++ b/compiler/ng_RangerGenericClassWriter.rgr
@@ -226,6 +226,29 @@ class RangerGenericClassWriter {
     return tn
   }
 
+  fn defValueHasSideEffects:boolean (value:CodeNode) {
+    if (value.has_call) {
+      return true
+    }
+    if (value.hasFnCall) {
+      return true
+    }
+    if (value.is_direct_method_call) {
+      return true
+    }
+    return false
+  }
+
+  fn writeSideEffectOnlyStmt:void (value:CodeNode ctx:RangerAppWriterContext wr:CodeWriter) {
+    ctx.setInExpr()
+    this.WalkNode(value ctx wr)
+    ctx.unsetInExpr()
+    if ((ctx.expressionLevel()) == 0) {
+      wr.out(";" true)
+    }
+    wr.newline()
+  }
+
   fn WriteVRef:void (node:CodeNode ctx:RangerAppWriterContext wr:CodeWriter) {
     if (node.eval_type == RangerNodeType.Enum) {
       if( (array_length node.ns) > 1) {

--- a/compiler/ng_RangerKotlinClassWriter.rgr
+++ b/compiler/ng_RangerKotlinClassWriter.rgr
@@ -240,6 +240,13 @@ class RangerKotlinClassWriter {
       def nn:CodeNode (itemAt node.children 1)
       def p:RangerAppParamDesc nn.paramDesc
       if ((p.ref_cnt == 0) && (p.is_class_variable == false)) {
+        if ((array_length node.children) > 2) {
+          def value:CodeNode (node.getThird())
+          if (this.defValueHasSideEffects(value)) {
+            this.writeSideEffectOnlyStmt(value ctx wr)
+            return
+          }
+        }
         wr.out("/** unused:  " false)
       }
       if p.is_class_variable {
@@ -295,6 +302,7 @@ class RangerKotlinClassWriter {
   }
   fn writeFnCall:void (node:CodeNode ctx:RangerAppWriterContext wr:CodeWriter) {
     if node.hasFnCall {
+      ctx.setInExpr()
       def fc:CodeNode (node.getFirst())
       this.WriteVRef(fc ctx wr)
       wr.out("(" false)
@@ -317,6 +325,7 @@ class RangerKotlinClassWriter {
         this.WalkNode(n ctx wr)
       }
       wr.out(")" false)
+      ctx.unsetInExpr()
       if ((ctx.expressionLevel()) == 0) {
         wr.out(";" true)
       }
@@ -419,6 +428,9 @@ class RangerKotlinClassWriter {
             }
           }
           wr.out(")" false)
+        } {
+          ; Kotlin requires explicit super constructor invocation: class Child : Parent()
+          wr.out("()" false)
         }
       }
     }

--- a/compiler/ng_RangerSwift6ClassWriter.rgr
+++ b/compiler/ng_RangerSwift6ClassWriter.rgr
@@ -350,6 +350,13 @@ class RangerSwift6ClassWriter {
       }
 
       if ((p.ref_cnt == 0) && (p.is_class_variable == false)) {
+        if ((array_length node.children) > 2) {
+          def value:CodeNode (node.getThird())
+          if (this.defValueHasSideEffects(value)) {
+            this.writeSideEffectOnlyStmt(value ctx wr)
+            return
+          }
+        }
         wr.out("/** unused:  " false)
       }
       if p.is_static {
@@ -435,40 +442,90 @@ class RangerSwift6ClassWriter {
     }
   }
 
+  fn resolveCallReceiverClassName:string (obj:CodeNode ctx:RangerAppWriterContext) {
+    if ((strlen obj.vref) > 0) {
+      if (ctx.isDefinedClass(obj.vref)) {
+        return obj.vref
+      }
+    }
+    if ((strlen obj.eval_type_name) > 0) {
+      if (ctx.isDefinedClass(obj.eval_type_name)) {
+        return obj.eval_type_name
+      }
+    }
+    if ((array_length obj.ns) >= 1) {
+      def head:string (itemAt obj.ns 0)
+      if (ctx.isDefinedClass(head)) {
+        return head
+      }
+    }
+    if ((array_length obj.children) == 1) {
+      def inner:CodeNode (itemAt obj.children 0)
+      def innerName:string (this.resolveCallReceiverClassName(inner ctx))
+      if ((strlen innerName) > 0) {
+        return innerName
+      }
+    }
+    return ""
+  }
+
+  fn isSimpleClassCallReceiver:boolean (obj:CodeNode ctx:RangerAppWriterContext) {
+    def className:string (this.resolveCallReceiverClassName(obj ctx))
+    if ((strlen className) == 0) {
+      return false
+    }
+    if (obj.vref == className) {
+      return true
+    }
+    if ((array_length obj.children) == 1) {
+      def inner:CodeNode (itemAt obj.children 0)
+      if (inner.vref == className) {
+        return true
+      }
+    }
+    return false
+  }
+
   fn CreateCallExpression(node:CodeNode ctx:RangerAppWriterContext wr:CodeWriter) {
     if node.has_call {
       def obj:CodeNode (node.getSecond())
       def method:CodeNode (node.getThird())
       def args:CodeNode (itemAt node.children 3)
 
-      wr.out("(" false)
+      def simpleReceiver:boolean (this.isSimpleClassCallReceiver(obj ctx))
+      if (simpleReceiver == false) {
+        wr.out("(" false)
+      }
       ctx.setInExpr()
       this.WalkNode( obj ctx wr)
       ctx.unsetInExpr()
-      wr.out(")." false)
+      if (simpleReceiver == false) {
+        wr.out(")." false)
+      } {
+        wr.out("." false)
+      }
       wr.out(method.vref false)
       wr.out("(" false)
       ctx.setInExpr()
+
+      def fnDesc@(optional) (this.resolveMethodFnDesc(node ctx))
+      def hasFnDesc:boolean (!null? fnDesc)
+
       for args.children arg:CodeNode i {
         if (i > 0) {
           wr.out(", " false)
         }
-
-        if( ctx.isDefinedClass(obj.eval_type_name)) {
-          def clDef (ctx.findClass(obj.eval_type_name))
-          def clMethod (clDef.findMethod(method.vref))
-          if(!null? clMethod) {
-            def mm (unwrap clMethod)
-            def pDesc (itemAt mm.params i)
+        if (hasFnDesc) {
+          def mm:RangerAppFunctionDesc (unwrap fnDesc)
+          if (i < (size mm.params)) {
+            def pDesc:RangerAppParamDesc (itemAt mm.params i)
             wr.out((pDesc.compiledName + " : ") false)
             if ((unwrap pDesc.nameNode).hasFlag("mutates")) {
               wr.out("&" false)
             }
             this.WalkNode(arg ctx wr)
             continue
-          } 
-        } {
-          ctx.addError(arg "Could not find evaluated class for the call")          
+          }
         }
         this.WalkNode(arg ctx wr)          
 
@@ -951,4 +1008,88 @@ class RangerSwift6ClassWriter {
       }
     }
   }
+
+  fn resolveMethodFnDesc@(weak optional):RangerAppFunctionDesc (methodNode:CodeNode ctx:RangerAppWriterContext) {
+    def res@(weak lives):RangerAppFunctionDesc
+    if (methodNode.hasParamDesc) {
+      def raw (cast (unwrap methodNode.paramDesc) to:RangerAppFunctionDesc)
+      if ((size raw.params) > 0) {
+        res = raw
+        return res
+      }
+    }
+    if ((size methodNode.ns) >= 2) {
+      def className (itemAt methodNode.ns 0)
+      if (ctx.isDefinedClass(className)) {
+        def clDef (ctx.findClass(className))
+        def methodName (itemAt methodNode.ns 1)
+        def found@(optional) (clDef.findStaticMethod(methodName))
+        if (null? found) {
+          found = (clDef.findMethod(methodName))
+        }
+        if (!null? found) {
+          res = (unwrap found)
+          return res
+        }
+      }
+    }
+    if (methodNode.has_call) {
+      def obj:CodeNode (methodNode.getSecond())
+      def method:CodeNode (methodNode.getThird())
+      def className:string (this.resolveCallReceiverClassName(obj ctx))
+      if ((strlen className) > 0) {
+        def clDef (ctx.findClass(className))
+        def found@(optional) (clDef.findStaticMethod(method.vref))
+        if (null? found) {
+          found = (clDef.findMethod(method.vref))
+        }
+        if (!null? found) {
+          res = (unwrap found)
+          return res
+        }
+      }
+    }
+    return res
+  }
+
+  fn CreateMethodCall(node:CodeNode ctx:RangerAppWriterContext wr:CodeWriter) {
+    def methodNode:CodeNode (node.getFirst())
+    def args:CodeNode (node.getSecond())
+    ctx.setInExpr()
+    this.WalkNode(methodNode ctx wr)
+    ctx.unsetInExpr()
+    wr.out("(" false)
+    ctx.setInExpr()
+
+    def hasFnDesc@(mutable):boolean false
+    def fnDesc:RangerAppFunctionDesc
+    def resolved@(optional) (this.resolveMethodFnDesc(methodNode ctx))
+    if (!null? resolved) {
+      fnDesc = (unwrap resolved)
+      hasFnDesc = true
+    }
+
+    def pms (filter (args.children) {
+      if (item.hasFlag("keyword")) {
+        return false
+      }
+      return true
+    })
+
+    for pms arg:CodeNode i {
+      if (i > 0) {
+        wr.out(", " false)
+      }
+      if (hasFnDesc) {
+        if (i < (size fnDesc.params)) {
+          def pArg (itemAt fnDesc.params i)
+          wr.out((pArg.compiledName + " : ") false)
+        }
+      }
+      this.WalkNode(arg ctx wr)
+    }
+    ctx.unsetInExpr()
+    wr.out(")" false)
+  }
+
 }

--- a/dist/Lang.rgr
+++ b/dist/Lang.rgr
@@ -493,6 +493,7 @@ func r_io_get_env( name string) *GoNullable {
                 swift6 ("CommandLine.arguments[" (e 1) " + 1]")
                 es6 ( "process.argv[ 2 + " (e 1) "]")
                 rust ( "std::env::args().nth((" (e 1) " + 1) as usize).unwrap_or_default()")
+                kotlin ( "args[" (e 1) "]")
                 ranger ("( shell_arg " (e 1) " )")
             }
         }
@@ -508,6 +509,7 @@ func r_io_get_env( name string) *GoNullable {
                 go ( "int64( len( os.Args) - 1 )"  (imp "os"))
                 es6 ( "(process.argv.length - 2)" )
                 rust ( "(std::env::args().len() as i64 - 1)")
+                kotlin ( "(args.size - 1)")
                 ranger ("( shell_arg_cnt )")
             }
         }        
@@ -930,6 +932,7 @@ fn r_read_file(path: &str, filename: &str) -> Option<String> {
 }
 "))
                 es6 ( "(require('fs').readFileSync( " (e 1) " + '/' + " (e 2) " , 'utf8'))" )
+                kotlin ( "try { java.io.File(if (" (e 1) ".isEmpty()) " (e 2) " else " (e 1) " + \"/\" + " (e 2) ").readText() } catch (_: Exception) { null }" (imp "java.io.File") )
             }
         }
 
@@ -2716,6 +2719,7 @@ std::vector<uint8_t> r_buffer_read_file(const std::string& path, const std::stri
                 ranger ( "(to_int " (e 1) ")") 
                 csharp ( "(int)" (e 1 ) "" )
                 swift3 ( "Int(" (e 1 ) ")" )
+                swift6 ( "Int(" (e 1 ) ")" )
                 kotlin ( (e 1 ) ".toInt()" )
                 scala ( (e 1 ) ".toInt" )
                 rust ( (e 1 ) " as i64 " )
@@ -3165,9 +3169,50 @@ func r_str_2_i64(s string) *GoNullable {
                 )
                 php ( "is_numeric(" (e 1) ") ? intval(" (e 1) ") : NULL ")
                 scala ( "Try(" (e 1) ".toInt).toOption" (imp "scala.util.Try"))
-                kotlin (  (e 1) ".toIntOrNull()")
-                swift3 ("Int(" (e 1) ")")
-                swift6 ("Int(" (e 1) ")")
+                kotlin ( "rangerStr2IntPrefix(" (e 1) ")"
+(create_polyfill "
+fun rangerStr2IntPrefix(s: String): Int? {
+  val m = Regex(\"^-?\\\\d+\").find(s) ?: return null
+  return m.value.toIntOrNull()
+}
+")
+                )
+                swift3 ("rangerStr2IntPrefix(" (e 1) ")"
+(create_polyfill "
+func rangerStr2IntPrefix(_ s: String) -> Int? {
+  var i = s.startIndex
+  if i < s.endIndex && s[i] == \"-\" {
+    i = s.index(after: i)
+  }
+  var end = i
+  while end < s.endIndex && s[end].isNumber {
+    end = s.index(after: end)
+  }
+  if end == i {
+    return nil
+  }
+  return Int(s[i..<end])
+}
+")
+                )
+                swift6 ("rangerStr2IntPrefix(" (e 1) ")"
+(create_polyfill "
+func rangerStr2IntPrefix(_ s: String) -> Int? {
+  var i = s.startIndex
+  if i < s.endIndex && s[i] == \"-\" {
+    i = s.index(after: i)
+  }
+  var end = i
+  while end < s.endIndex && s[end].isNumber {
+    end = s.index(after: end)
+  }
+  if end == i {
+    return nil
+  }
+  return Int(s[i..<end])
+}
+")
+                )
                 csharp( "Int32.Parse(" (e 1) ")" )
                 rust ( (e 1) ".parse::<i64>().ok()" )
                 * ( "isNaN( parseInt(" (e 1) ") ) ? undefined : parseInt(" (e 1) ")")
@@ -3247,7 +3292,7 @@ Double _getDoubleOrNull ( String str ) {
                 scala ( "Try(" (e 1) ".toDouble).toOption" (imp "scala.util.Try"))
                 kotlin (  (e 1) ".toDoubleOrNull()")
                 swift3 ("Double(" (e 1) ")")
-                rust ( (e 1) ".parse::<f64>().ok()" )
+                swift6 ("Double(" (e 1) ")")
                 * ( "isNaN( parseFloat(" (e 1) ") ) ? undefined : parseFloat(" (e 1) ")")
             }
         }
@@ -4863,8 +4908,10 @@ std::string r_cpp_str_to_uppercase(std::string original)
                 go ("float64( " (e 1) " )")
                 es6 ( (e 1) )
                 swift3 ("Double(" (e 1) ")")
+                swift6 ("Double(" (e 1) ")")
                 scala ( (e 1) '.toDouble')
                 java7 ("Double.valueOf(" (e 1) ")")
+                kotlin ( (e 1) ".toDouble()" )
                 cpp ("(double)(" (e 1) ")")
                 php ( (e 1) )
                 rust ("(" (e 1) " as f64)")

--- a/dist/rgrc.js
+++ b/dist/rgrc.js
@@ -8871,7 +8871,10 @@ class RangerFlowParser  {
     await this.WalkNode(obj_2, ctx, wr);
     if ( ctx.isDefinedClass(obj_2.eval_type_name) ) {
       const cl = ctx.findClass(obj_2.eval_type_name);
-      const m = cl.findMethod(method_2.vref);
+      let m = cl.findMethod(method_2.vref);
+      if ( typeof(m) === "undefined" ) {
+        m = cl.findStaticMethod(method_2.vref);
+      }
       if ( (typeof(m) !== "undefined" && m != null )  ) {
         node.has_call = true;
         const currM = ctx.getCurrentMethod();
@@ -9025,6 +9028,9 @@ class RangerFlowParser  {
   };
   async cmdLocalCall (node, ctx, wr) {
     const fnNode = node.getFirst();
+    if ( await this.tryRepairDotMethodInfix(node, fnNode, ctx, wr) ) {
+      return true;
+    }
     const udesc = ctx.getCurrentClass();
     const desc = udesc;
     let expects_error = false;
@@ -10232,6 +10238,84 @@ class RangerFlowParser  {
     }
     return false;
   };
+  resolveStaticMethodRef (fc) {
+    let result = [];
+    if ( (fc.ns.length) > 1 ) {
+      const nn = fc.copy();
+      nn.ns.pop();
+      result.push(nn.ns.join("."));
+      result.push(fc.ns[((fc.ns.length) - 1)]);
+      return result;
+    }
+    if ( (fc.ns.length) == 1 ) {
+      result.push(fc.ns[0]);
+      result.push(fc.vref);
+      return result;
+    }
+    const dotPos = fc.vref.indexOf(".");
+    if ( dotPos > 0 ) {
+      result.push(fc.vref.substring(0, dotPos ));
+      const afterDot = dotPos + 1;
+      result.push(fc.vref.substring(afterDot, (fc.vref.length) ));
+      return result;
+    }
+    return result;
+  };
+  async buildDotMethodInfixRepair (node, fc, op_vref, methodArg, rhs, ctx, wr) {
+    const refParts = this.resolveStaticMethodRef(fc);
+    if ( (refParts.length) != 2 ) {
+      return false;
+    }
+    const objName = refParts[0];
+    const possible_cmd = refParts[1];
+    const vFnDef = this.findFunctionDesc(fc, ctx, wr);
+    if ( typeof(vFnDef) === "undefined" ) {
+      return false;
+    }
+    const callNode = node.newExpressionNode();
+    callNode.children.push(node.newVRefNode("call"));
+    callNode.children.push(node.newVRefNode(objName));
+    callNode.children.push(node.newVRefNode(possible_cmd));
+    callNode.children.push(methodArg.copy());
+    const repaired = node.newExpressionNode();
+    repaired.children.push(node.newVRefNode(op_vref));
+    repaired.children.push(callNode);
+    repaired.children.push(rhs.copy());
+    node.getChildrenFrom(repaired);
+    node.flow_done = false;
+    await this.stdParamMatch(node, ctx, wr, true);
+    return true;
+  };
+  async tryRepairDotMethodInfix (node, fc, ctx, wr) {
+    if ( (node.children.length) != 2 ) {
+      return false;
+    }
+    if ( (this.resolveStaticMethodRef(fc).length) != 2 ) {
+      return false;
+    }
+    const second = node.getSecond();
+    if ( (second.children.length) >= 3 ) {
+      const opNode = second.getFirst();
+      if ( (opNode.vref.length) > 0 ) {
+        const op_check = await ctx.getOperators(opNode.vref);
+        if ( (op_check.length) > 0 ) {
+          return await this.buildDotMethodInfixRepair(node, fc, opNode.vref, second.getSecond(), second.getThird(), ctx, wr);
+        }
+      }
+    }
+    if ( second.infix_operator && ((typeof(second.infix_node) !== "undefined" && second.infix_node != null ) ) ) {
+      const ifNode = second.infix_node;
+      if ( (ifNode.vref.length) > 0 ) {
+        const op_check2 = await ctx.getOperators(ifNode.vref);
+        if ( (op_check2.length) > 0 ) {
+          if ( (ifNode.children.length) >= 2 ) {
+            return await this.buildDotMethodInfixRepair(node, fc, ifNode.vref, ifNode.getFirst(), ifNode.getSecond(), ctx, wr);
+          }
+        }
+      }
+    }
+    return false;
+  };
   async matchNode (node, ctx, wr) {
     if ( 0 == (node.children.length) ) {
       return false;
@@ -10249,26 +10333,33 @@ class RangerFlowParser  {
         return true;
       }
     };
-    if ( ((fc.ns.length) > 1) && ((node.children.length) > 1) ) {
-      const possible_cmd = fc.ns[((fc.ns.length) - 1)];
-      const op_list_2 = await ctx.getOperators(possible_cmd);
-      if ( (op_list_2.length) > 0 ) {
-        const args = node.getSecond();
-        const nn = fc.copy();
-        nn.ns.pop();
-        const objName = nn.ns.join(".");
-        const newNode = node.newExpressionNode();
-        newNode.add(node.newVRefNode("call"));
-        newNode.add(node.newVRefNode(objName));
-        newNode.add(node.newVRefNode(possible_cmd));
-        newNode.add(args.copy());
-        node.getChildrenFrom(newNode);
-        if ( ctx.expressionLevel() == 0 ) {
-          ctx.lastBlockOp = node;
+    if ( (node.children.length) > 1 ) {
+      const refParts = this.resolveStaticMethodRef(fc);
+      const isStaticRef = (refParts.length) == 2;
+      if ( isStaticRef && (false == node.infix_operator) ) {
+        if ( await this.tryRepairDotMethodInfix(node, fc, ctx, wr) ) {
+          return true;
         }
-        node.flow_done = false;
-        await this.WalkNode(node, ctx, wr);
-        return true;
+      }
+      if ( isStaticRef ) {
+        const possible_cmd = refParts[1];
+        const op_list_2 = await ctx.getOperators(possible_cmd);
+        if ( (op_list_2.length) > 0 ) {
+          const args = node.getSecond();
+          const objName = refParts[0];
+          const newNode = node.newExpressionNode();
+          newNode.add(node.newVRefNode("call"));
+          newNode.add(node.newVRefNode(objName));
+          newNode.add(node.newVRefNode(possible_cmd));
+          newNode.add(args.copy());
+          node.getChildrenFrom(newNode);
+          if ( ctx.expressionLevel() == 0 ) {
+            ctx.lastBlockOp = node;
+          }
+          node.flow_done = false;
+          await this.WalkNode(node, ctx, wr);
+          return true;
+        }
       }
     }
     return false;
@@ -12902,6 +12993,27 @@ class RangerGenericClassWriter  {
   adjustType (tn) {
     return tn;
   };
+  defValueHasSideEffects (value) {
+    if ( value.has_call ) {
+      return true;
+    }
+    if ( value.hasFnCall ) {
+      return true;
+    }
+    if ( value.is_direct_method_call ) {
+      return true;
+    }
+    return false;
+  };
+  async writeSideEffectOnlyStmt (value, ctx, wr) {
+    ctx.setInExpr();
+    await this.WalkNode(value, ctx, wr);
+    ctx.unsetInExpr();
+    if ( ctx.expressionLevel() == 0 ) {
+      wr.out(";", true);
+    }
+    wr.newline();
+  };
   async WriteVRef (node, ctx, wr) {
     if ( node.eval_type == 13 ) {
       if ( (node.ns.length) > 1 ) {
@@ -15357,6 +15469,13 @@ class RangerSwift6ClassWriter  extends RangerGenericClassWriter {
         }
       }
       if ( (p.ref_cnt == 0) && (p.is_class_variable == false) ) {
+        if ( (node.children.length) > 2 ) {
+          const value = node.getThird();
+          if ( this.defValueHasSideEffects(value) ) {
+            await this.writeSideEffectOnlyStmt(value, ctx, wr);
+            return;
+          }
+        }
         wr.out("/** unused:  ", false);
       }
       if ( p.is_static ) {
@@ -15371,8 +15490,8 @@ class RangerSwift6ClassWriter  extends RangerGenericClassWriter {
       if ( (node.children.length) > 2 ) {
         wr.out(" = ", false);
         ctx.setInExpr();
-        const value = node.getThird();
-        await this.WalkNode(value, ctx, wr);
+        const value_1 = node.getThird();
+        await this.WalkNode(value_1, ctx, wr);
         ctx.unsetInExpr();
       } else {
         if ( nn.value_type == 6 ) {
@@ -15440,29 +15559,78 @@ class RangerSwift6ClassWriter  extends RangerGenericClassWriter {
       await this.writeTypeDef(arg.nameNode, ctx, wr);
     };
   };
+  resolveCallReceiverClassName (obj, ctx) {
+    if ( (obj.vref.length) > 0 ) {
+      if ( ctx.isDefinedClass(obj.vref) ) {
+        return obj.vref;
+      }
+    }
+    if ( (obj.eval_type_name.length) > 0 ) {
+      if ( ctx.isDefinedClass(obj.eval_type_name) ) {
+        return obj.eval_type_name;
+      }
+    }
+    if ( (obj.ns.length) >= 1 ) {
+      const head = obj.ns[0];
+      if ( ctx.isDefinedClass(head) ) {
+        return head;
+      }
+    }
+    if ( (obj.children.length) == 1 ) {
+      const inner = obj.children[0];
+      const innerName = this.resolveCallReceiverClassName(inner, ctx);
+      if ( (innerName.length) > 0 ) {
+        return innerName;
+      }
+    }
+    return "";
+  };
+  isSimpleClassCallReceiver (obj, ctx) {
+    const className = this.resolveCallReceiverClassName(obj, ctx);
+    if ( (className.length) == 0 ) {
+      return false;
+    }
+    if ( obj.vref == className ) {
+      return true;
+    }
+    if ( (obj.children.length) == 1 ) {
+      const inner = obj.children[0];
+      if ( inner.vref == className ) {
+        return true;
+      }
+    }
+    return false;
+  };
   async CreateCallExpression (node, ctx, wr) {
     if ( node.has_call ) {
       const obj = node.getSecond();
       const method = node.getThird();
       const args = node.children[3];
-      wr.out("(", false);
+      const simpleReceiver = this.isSimpleClassCallReceiver(obj, ctx);
+      if ( simpleReceiver == false ) {
+        wr.out("(", false);
+      }
       ctx.setInExpr();
       await this.WalkNode(obj, ctx, wr);
       ctx.unsetInExpr();
-      wr.out(").", false);
+      if ( simpleReceiver == false ) {
+        wr.out(").", false);
+      } else {
+        wr.out(".", false);
+      }
       wr.out(method.vref, false);
       wr.out("(", false);
       ctx.setInExpr();
+      const fnDesc = this.resolveMethodFnDesc(node, ctx);
+      const hasFnDesc = (typeof(fnDesc) !== "undefined" && fnDesc != null ) ;
       for ( let i = 0; i < args.children.length; i++) {
         var arg = args.children[i];
         if ( i > 0 ) {
           wr.out(", ", false);
         }
-        if ( ctx.isDefinedClass(obj.eval_type_name) ) {
-          const clDef = ctx.findClass(obj.eval_type_name);
-          const clMethod = clDef.findMethod(method.vref);
-          if ( (typeof(clMethod) !== "undefined" && clMethod != null )  ) {
-            const mm = clMethod;
+        if ( hasFnDesc ) {
+          const mm = fnDesc;
+          if ( i < (mm.params.length) ) {
             const pDesc = mm.params[i];
             wr.out(pDesc.compiledName + " : ", false);
             if ( ((pDesc.nameNode)).hasFlag("mutates") ) {
@@ -15471,8 +15639,6 @@ class RangerSwift6ClassWriter  extends RangerGenericClassWriter {
             await this.WalkNode(arg, ctx, wr);
             continue;
           }
-        } else {
-          ctx.addError(arg, "Could not find evaluated class for the call");
         }
         await this.WalkNode(arg, ctx, wr);
       };
@@ -15932,6 +16098,85 @@ class RangerSwift6ClassWriter  extends RangerGenericClassWriter {
         theEnd.out("}", true);
       }
     };
+  };
+  resolveMethodFnDesc (methodNode, ctx) {
+    let res;
+    if ( methodNode.hasParamDesc ) {
+      const raw = (methodNode.paramDesc);
+      if ( (raw.params.length) > 0 ) {
+        res = raw;
+        return res;
+      }
+    }
+    if ( (methodNode.ns.length) >= 2 ) {
+      const className = methodNode.ns[0];
+      if ( ctx.isDefinedClass(className) ) {
+        const clDef = ctx.findClass(className);
+        const methodName = methodNode.ns[1];
+        let found = clDef.findStaticMethod(methodName);
+        if ( typeof(found) === "undefined" ) {
+          found = clDef.findMethod(methodName);
+        }
+        if ( (typeof(found) !== "undefined" && found != null )  ) {
+          res = found;
+          return res;
+        }
+      }
+    }
+    if ( methodNode.has_call ) {
+      const obj = methodNode.getSecond();
+      const method = methodNode.getThird();
+      const className_1 = this.resolveCallReceiverClassName(obj, ctx);
+      if ( (className_1.length) > 0 ) {
+        const clDef_1 = ctx.findClass(className_1);
+        let found_1 = clDef_1.findStaticMethod(method.vref);
+        if ( typeof(found_1) === "undefined" ) {
+          found_1 = clDef_1.findMethod(method.vref);
+        }
+        if ( (typeof(found_1) !== "undefined" && found_1 != null )  ) {
+          res = found_1;
+          return res;
+        }
+      }
+    }
+    return res;
+  };
+  async CreateMethodCall (node, ctx, wr) {
+    const methodNode = node.getFirst();
+    const args = node.getSecond();
+    ctx.setInExpr();
+    await this.WalkNode(methodNode, ctx, wr);
+    ctx.unsetInExpr();
+    wr.out("(", false);
+    ctx.setInExpr();
+    let hasFnDesc = false;
+    let fnDesc;
+    const resolved = this.resolveMethodFnDesc(methodNode, ctx);
+    if ( (typeof(resolved) !== "undefined" && resolved != null )  ) {
+      fnDesc = resolved;
+      hasFnDesc = true;
+    }
+    const pms = operatorsOf.filter_36(args.children, ((item, index) => { 
+      if ( item.hasFlag("keyword") ) {
+        return false;
+      }
+      return true;
+    }));
+    for ( let i = 0; i < pms.length; i++) {
+      var arg = pms[i];
+      if ( i > 0 ) {
+        wr.out(", ", false);
+      }
+      if ( hasFnDesc ) {
+        if ( i < (fnDesc.params.length) ) {
+          const pArg = fnDesc.params[i];
+          wr.out(pArg.compiledName + " : ", false);
+        }
+      }
+      await this.WalkNode(arg, ctx, wr);
+    };
+    ctx.unsetInExpr();
+    wr.out(")", false);
   };
 }
 class RangerCppClassWriter  extends RangerGenericClassWriter {
@@ -20141,6 +20386,13 @@ class RangerKotlinClassWriter  extends RangerGenericClassWriter {
       const nn = node.children[1];
       const p = nn.paramDesc;
       if ( (p.ref_cnt == 0) && (p.is_class_variable == false) ) {
+        if ( (node.children.length) > 2 ) {
+          const value = node.getThird();
+          if ( this.defValueHasSideEffects(value) ) {
+            await this.writeSideEffectOnlyStmt(value, ctx, wr);
+            return;
+          }
+        }
         wr.out("/** unused:  ", false);
       }
       if ( p.is_class_variable ) {
@@ -20158,8 +20410,8 @@ class RangerKotlinClassWriter  extends RangerGenericClassWriter {
       if ( (node.children.length) > 2 ) {
         wr.out(" = ", false);
         ctx.setInExpr();
-        const value = node.getThird();
-        await this.WalkNode(value, ctx, wr);
+        const value_1 = node.getThird();
+        await this.WalkNode(value_1, ctx, wr);
         ctx.unsetInExpr();
       } else {
         if ( nn.hasFlag("optional") ) {
@@ -20197,6 +20449,7 @@ class RangerKotlinClassWriter  extends RangerGenericClassWriter {
   };
   async writeFnCall (node, ctx, wr) {
     if ( node.hasFnCall ) {
+      ctx.setInExpr();
       const fc = node.getFirst();
       await this.WriteVRef(fc, ctx, wr);
       wr.out("(", false);
@@ -20220,6 +20473,7 @@ class RangerKotlinClassWriter  extends RangerGenericClassWriter {
         await this.WalkNode(n, ctx, wr);
       };
       wr.out(")", false);
+      ctx.unsetInExpr();
       if ( ctx.expressionLevel() == 0 ) {
         wr.out(";", true);
       }
@@ -20328,6 +20582,8 @@ class RangerKotlinClassWriter  extends RangerGenericClassWriter {
             };
           }
           wr.out(")", false);
+        } else {
+          wr.out("()", false);
         }
       };
     }

--- a/tests/codegen-swift.test.ts
+++ b/tests/codegen-swift.test.ts
@@ -70,6 +70,17 @@ describe("Swift6 Code Generation", () => {
       // Swift uses "class func" for type methods (equivalent to static)
       expect(result.code).toContain("class func");
     });
+
+    it("should emit argument labels for static calls in expressions", () => {
+      const result = getGeneratedSwiftCode(
+        `${FIXTURES_DIR}/swift_static_call_labels.rgr`
+      );
+      expect(result.success, `Failed: ${result.error}`).toBe(true);
+      expect(result.code).toMatch(/NumUtil\.parseStrict\(s\s*:/);
+      expect(result.code).not.toMatch(
+        /\(NumUtil\)\.parseStrict\([^s]/
+      );
+    });
   });
 
   describe("Control Flow", () => {

--- a/tests/compiler-kotlin.test.ts
+++ b/tests/compiler-kotlin.test.ts
@@ -3,6 +3,7 @@ import {
   compileAndRunKotlin,
   isKotlinAvailable,
   compileRangerToKotlin,
+  getGeneratedKotlinCode,
 } from "./helpers/compiler";
 import * as path from "path";
 import * as fs from "fs";
@@ -237,5 +238,11 @@ describe("Ranger to Kotlin Compilation", () => {
   it("should compile static_factory.rgr to valid Kotlin syntax", () => {
     const result = compileRangerToKotlin(`${FIXTURES_DIR}/static_factory.rgr`);
     expect(result.success, `Compile failed: ${result.error}`).toBe(true);
+  });
+
+  it("should compile to_double_int.rgr with int to_double templates", () => {
+    const result = getGeneratedKotlinCode(`${FIXTURES_DIR}/to_double_int.rgr`);
+    expect(result.success, `Compile failed: ${result.error}`).toBe(true);
+    expect(result.code).toMatch(/\.toDouble\(\)/);
   });
 });

--- a/tests/fixtures/swift_static_call_labels.rgr
+++ b/tests/fixtures/swift_static_call_labels.rgr
@@ -1,0 +1,16 @@
+; Static class call used inside a comparison (CreateCallExpression path)
+
+class NumUtil {
+  sfn parseStrict:int (s:string) {
+    return 0
+  }
+}
+
+class Test_StaticCallLabels {
+  sfn m@(main):void () {
+    def part:string "12"
+    if (NumUtil.parseStrict(part) >= 0) {
+      print "ok"
+    }
+  }
+}

--- a/tests/fixtures/to_double_int.rgr
+++ b/tests/fixtures/to_double_int.rgr
@@ -1,0 +1,5 @@
+class ToDoubleIntFixture {
+    sfn totalMinutes:double (minV:int secV:int) {
+        return ( (to_double minV) + ( (to_double secV) / 60.0) )
+    }
+}


### PR DESCRIPTION
Emit side-effect calls for unused locals, add Swift6 static call labels, and use prefix str2int polyfills on kotlin/swift6.