### PR TITLE
Add @process CLI demos and tests for modal timer and external spawn.

### DIFF
--- a/PROCESS_MVP.md
+++ b/PROCESS_MVP.md
@@ -270,6 +270,29 @@ node tests/.output/process_page_lifecycle.js
 node tests/.output/process_page_lifecycle.js interactive
 ```
 
+### `process_modal_dialog_timer.rgr` — page → modal → timer → close → repeat
+
+Home `UIPage` opens a `ModalDialog` child; the modal owns a `DialogTimer` (4 ticks). When the timer hits zero the modal and timer are `proc_stop`ped, then the page opens the next modal (3 cycles, then exit). CLI shows the process tree and lifecycle log each frame.
+
+```bash
+node bin/output.js -es6 tests/fixtures/process_modal_dialog_timer.rgr -nodecli -d=tests/.output -o=process_modal_dialog_timer.js
+node tests/.output/process_modal_dialog_timer.js
+node tests/.output/process_modal_dialog_timer.js interactive
+```
+
+Vitest: `tests/compiler-process-modal-dialog.test.ts` (auto mode).
+
+### `process_external_spawn.rgr` — `new` parent when caller is outside the process
+
+A normal class calls `host.spawnWorkerFromOutside()`; `new WorkerProcess` inside that method must register under the host (`parentIdOf` / `__rangerParentId`). Controls: direct `new` from the orchestrator (root) and `sfn` static spawn on the process class (root).
+
+```bash
+node bin/output.js -es6 tests/fixtures/process_external_spawn.rgr -nodecli -d=tests/.output -o=process_external_spawn.js
+node tests/.output/process_external_spawn.js
+```
+
+Vitest: `tests/compiler-process-external-spawn.test.ts`.
+
 These are **mechanism demos**. A follow-up fixture could add `inboundMessages` + `drainInbound` on the same classes to show orchestration **without** compiler changes — optional next step.
 
 ---

--- a/tests/compiler-process-external-spawn.test.ts
+++ b/tests/compiler-process-external-spawn.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileAndRun,
+  compileAndRunKotlin,
+  getGeneratedKotlinCode,
+  isKotlinAvailable,
+} from "./helpers/compiler";
+
+const FIXTURE = "tests/fixtures/process_external_spawn.rgr";
+
+const kotlinAvailable = isKotlinAvailable();
+
+describe("Ranger @process — spawn from external caller", () => {
+  it("should parent new Worker to host when created inside host method (JS)", () => {
+    const { compile, run } = compileAndRun(FIXTURE);
+
+    expect(compile.success, `Compile failed: ${compile.error || compile.output}`).toBe(
+      true
+    );
+    expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+    const out = run?.output ?? "";
+    expect(out).toContain("OK process external spawn");
+    expect(out).toContain("OK   worker parents to host (parentIdOf)");
+    expect(out).toContain("OK   worker parents to host (__rangerParentId)");
+    expect(out).toContain("OK   orphan NOT under host (parentIdOf)");
+    expect(out).toContain("OK   static spawn NOT under instance host (parentIdOf)");
+    expect(out).not.toContain("FAIL ");
+  });
+
+  it("should emit __rangerRegisterChild(this) in host instance spawn method (Kotlin)", () => {
+    const result = getGeneratedKotlinCode(FIXTURE);
+    expect(result.success, `Failed: ${result.error}`).toBe(true);
+    expect(result.code).toContain("spawnWorkerFromOutside");
+    expect(result.code).toMatch(
+      /spawnWorkerFromOutside[\s\S]*__rangerRegisterChild/
+    );
+    expect(result.code).toContain("spawnWorkerFromStatic");
+  });
+
+  describe.skipIf(!kotlinAvailable)("Kotlin runtime", () => {
+    it("should parent new Worker to host when created inside host method", () => {
+      const { compile, run } = compileAndRunKotlin(FIXTURE);
+      expect(compile.success, `Compile failed: ${compile.error}`).toBe(true);
+      expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+      expect(run?.output).toContain("OK process external spawn");
+    });
+  });
+});

--- a/tests/compiler-process-modal-dialog.test.ts
+++ b/tests/compiler-process-modal-dialog.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { compileAndRun, compileAndRunKotlin, isKotlinAvailable } from "./helpers/compiler";
+
+const FIXTURE = "tests/fixtures/process_modal_dialog_timer.rgr";
+
+const kotlinAvailable = isKotlinAvailable();
+
+function expectModalTimerOutput(out: string) {
+  expect(out).toContain("OK process modal dialog timer");
+  expect(out).toContain("START UIPage");
+  expect(out).toContain("START ModalDialog");
+  expect(out).toContain("START DialogTimer");
+  expect(out).toContain("modal: timer done, closing");
+  expect(out).toContain("page: all modal cycles complete");
+  expect(out).toContain("STOP DialogTimer");
+  expect(out).toContain("STOP ModalDialog");
+  expect(out).toContain("STOP UIPage");
+  const timerStop = out.indexOf("STOP DialogTimer");
+  const modalStop = out.indexOf("STOP ModalDialog");
+  expect(timerStop).toBeGreaterThan(-1);
+  expect(modalStop).toBeGreaterThan(timerStop);
+}
+
+describe("Ranger @process — modal dialog timer", () => {
+  it("should run modal timer cycles and stop children in order (JS)", () => {
+    const { compile, run } = compileAndRun(FIXTURE);
+
+    expect(compile.success, `Compile failed: ${compile.error || compile.output}`).toBe(
+      true
+    );
+    expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+    const out = run?.output ?? "";
+    expectModalTimerOutput(out);
+    expect(out).toContain("page: opened modal cycle=0");
+    expect(out).toContain("page: opened modal cycle=1");
+    expect(out).toContain("page: opened modal cycle=2");
+    expect(out).toContain("live now  modal=0 timer=0");
+  });
+
+  describe.skipIf(!kotlinAvailable)("Kotlin", () => {
+    it("compiles and runs modal dialog timer fixture", () => {
+      const { compile, run } = compileAndRunKotlin(FIXTURE);
+      expect(compile.success, `Compile failed: ${compile.error}`).toBe(true);
+      expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+      expectModalTimerOutput(run?.output ?? "");
+    });
+  });
+});

--- a/tests/fixtures/process_external_spawn.rgr
+++ b/tests/fixtures/process_external_spawn.rgr
@@ -1,0 +1,113 @@
+; When a normal (non-@process) class calls an instance method on a live process,
+; a `new` of another @process class inside that method must register the child
+; under *this* (the host process), not under the external caller.
+;
+; Controls:
+;   - `new WorkerProcess` from ExternalOrchestrator → root (no host parent)
+;   - HostProcess.spawnFromStatic → root (static method host)
+
+Import "RangerProcess.rgr"
+
+class HostProcess @process(true) extends RangerProcessBase {
+  def spawnCount:int 0
+
+  fn spawnWorkerFromOutside:WorkerProcess () {
+    def w:WorkerProcess (new WorkerProcess)
+    w.label = "via-host-method"
+    spawnCount = spawnCount + 1
+    return w
+  }
+
+  sfn spawnWorkerFromStatic:WorkerProcess () {
+    def w:WorkerProcess (new WorkerProcess)
+    w.label = "via-host-static"
+    return w
+  }
+}
+
+class WorkerProcess @process(true) extends RangerProcessBase {
+  def label:string ""
+}
+
+class ExternalOrchestrator {
+  def passed:boolean true
+
+  fn expectEqual:void (label:string got:int expected:int) {
+    if (got != expected) {
+      print ("FAIL " + label + " got=" + (to_string got) + " expected=" + (to_string expected))
+      passed = false
+    } {
+      print ("OK   " + label)
+    }
+  }
+
+  fn expectNonZero:void (label:string got:int) {
+    if (got == 0) {
+      print ("FAIL " + label + " got=0")
+      passed = false
+    } {
+      print ("OK   " + label)
+    }
+  }
+
+  fn run:void () {
+    print "  external spawn hierarchy test"
+    print ""
+
+    def host:HostProcess (new HostProcess)
+    proc_start host
+    this.expectNonZero("host __rangerId" host.__rangerId)
+
+    ; --- case A: normal class calls process instance method ---
+    def viaMethod:WorkerProcess (host.spawnWorkerFromOutside())
+    def hostId:int host.__rangerId
+    def parentViaLookup:int (HostProcess.parentIdOf(viaMethod))
+    def parentViaField:int viaMethod.__rangerParentId
+
+    print ""
+    print "  case A: orchestrator -> host.spawnWorkerFromOutside() -> new Worker"
+    print ("    host id=" + (to_string hostId))
+    print ("    worker id=" + (to_string viaMethod.__rangerId) + " label=" + viaMethod.label)
+    print ("    parentIdOf(worker)->Host=" + (to_string parentViaLookup))
+    print ("    worker.__rangerParentId=" + (to_string parentViaField))
+    this.expectEqual("worker parents to host (parentIdOf)" parentViaLookup hostId)
+    this.expectEqual("worker parents to host (__rangerParentId)" parentViaField hostId)
+
+    ; --- case B: same orchestrator does new directly (not under host) ---
+    def orphan:WorkerProcess (new WorkerProcess)
+    orphan.label = "via-orchestrator-new"
+    def orphanUnderHost:int (HostProcess.parentIdOf(orphan))
+
+    print ""
+    print "  case B: orchestrator -> new Worker (no host method)"
+    print ("    worker id=" + (to_string orphan.__rangerId) + " label=" + orphan.label)
+    print ("    parentIdOf(worker)->Host=" + (to_string orphanUnderHost))
+    this.expectEqual("orphan NOT under host (parentIdOf)" orphanUnderHost 0)
+
+    ; --- case C: static method on process class (no instance this) ---
+    def viaStatic:WorkerProcess (HostProcess.spawnWorkerFromStatic())
+    def staticUnderHost:int (HostProcess.parentIdOf(viaStatic))
+
+    print ""
+    print "  case C: orchestrator -> HostProcess.spawnFromStatic() -> new Worker"
+    print ("    worker id=" + (to_string viaStatic.__rangerId) + " label=" + viaStatic.label)
+    print ("    parentIdOf(worker)->Host=" + (to_string staticUnderHost))
+    this.expectEqual("static spawn NOT under instance host (parentIdOf)" staticUnderHost 0)
+
+    proc_stop host
+
+    print ""
+    if (passed) {
+      print "OK process external spawn"
+    } {
+      print "FAILED process external spawn"
+    }
+  }
+}
+
+class Test_ExternalProcessSpawn {
+  sfn m@(main):void () {
+    def app (new ExternalOrchestrator)
+    app.run()
+  }
+}

--- a/tests/fixtures/process_modal_dialog_timer.rgr
+++ b/tests/fixtures/process_modal_dialog_timer.rgr
@@ -1,0 +1,383 @@
+; CLI demo: UIPage with a ModalDialog child; ModalDialog owns a countdown timer.
+; When the timer hits zero the modal stops (and its timer), then the page opens
+; the next modal. Run auto (vitest) or interactive:
+;   node bin/output.js -es6 tests/fixtures/process_modal_dialog_timer.rgr interactive
+
+Import "RangerProcess.rgr"
+
+class LifecycleLog @singleton(true) {
+  def lines:[string]
+
+  fn add:void (msg:string) {
+    push lines msg
+  }
+
+  fn dump:void () {
+    print "  lifecycle:"
+    for lines ln:string i {
+      print ("    | " + ln)
+    }
+  }
+
+  fn clear:void () {
+    def empty:[string]
+    lines = empty
+  }
+
+  sfn log:void (msg:string) {
+    def inst (LifecycleLog.__singleton())
+    inst.add(msg)
+  }
+
+  sfn dumpAll:void () {
+    def inst (LifecycleLog.__singleton())
+    inst.dump()
+  }
+}
+
+class ScreenProcess @process(true) extends RangerProcessBase {
+  def width:int 0
+  def height:int 0
+
+  fn openHomePage:UIPage () {
+    def page (new UIPage)
+    page.screen = this
+    page.title = "Home"
+    return page
+  }
+
+  fn stop:void () {
+    LifecycleLog.log("STOP ScreenProcess")
+  }
+}
+
+class UIPage @process(true) extends RangerProcessBase {
+  def screen@(optional):ScreenProcess
+  def title:string ""
+  def activeModal@(optional):ModalDialog
+  def hasModal:boolean false
+  def cycle:int 0
+  def maxCycles:int 3
+  def allCyclesDone:boolean false
+
+  fn start:void () {
+    LifecycleLog.log(("START UIPage \"" + this.title + "\""))
+    this.openModal()
+  }
+
+  fn openModal:void () {
+    if (hasModal) {
+      def old:ModalDialog (unwrap activeModal)
+      proc_stop old
+      hasModal = false
+    }
+    def m:ModalDialog (new ModalDialog)
+    m.page = this
+    m.cycleNumber = cycle
+    activeModal = m
+    hasModal = true
+    proc_start m
+    LifecycleLog.log(("page: opened modal cycle=" + (to_string cycle)))
+  }
+
+  fn onModalClosed:void (m:ModalDialog) {
+    if (hasModal) {
+      proc_stop m
+      hasModal = false
+    }
+    cycle = cycle + 1
+    LifecycleLog.log(("page: modal finished, next cycle=" + (to_string cycle)))
+    if (cycle < maxCycles) {
+      this.openModal()
+    } {
+      allCyclesDone = true
+      LifecycleLog.log("page: all modal cycles complete")
+    }
+  }
+
+  fn stop:void () {
+    if (hasModal) {
+      def old:ModalDialog (unwrap activeModal)
+      proc_stop old
+      hasModal = false
+    }
+    LifecycleLog.log(("STOP UIPage \"" + this.title + "\""))
+  }
+}
+
+class ModalDialog @process(true) extends RangerProcessBase {
+  def page@(optional):UIPage
+  def cycleNumber:int 0
+  def timer@(optional):DialogTimer
+  def hasTimer:boolean false
+
+  fn start:void () {
+    LifecycleLog.log(("START ModalDialog cycle=" + (to_string cycleNumber)))
+    def t:DialogTimer (new DialogTimer)
+    t.modal = this
+    t.remaining = 4
+    timer = t
+    hasTimer = true
+    proc_start t
+  }
+
+  fn pulse:void () {
+    if (hasTimer == false) {
+      return
+    }
+    def t:DialogTimer (unwrap timer)
+    if (t.remaining <= 0) {
+      return
+    }
+    t.remaining = t.remaining - 1
+    LifecycleLog.log(("  timer tick remaining=" + (to_string t.remaining)))
+    if (t.remaining <= 0) {
+      this.closeAndNotifyPage()
+    }
+  }
+
+  fn closeAndNotifyPage:void () {
+    if (hasTimer) {
+      def t:DialogTimer (unwrap timer)
+      proc_stop t
+      hasTimer = false
+    }
+    LifecycleLog.log("  modal: timer done, closing")
+    def pg:UIPage (unwrap page)
+    pg.onModalClosed(this)
+  }
+
+  fn stop:void () {
+    if (hasTimer) {
+      def t:DialogTimer (unwrap timer)
+      proc_stop t
+      hasTimer = false
+    }
+    LifecycleLog.log(("STOP ModalDialog cycle=" + (to_string cycleNumber)))
+  }
+}
+
+class DialogTimer @process(true) extends RangerProcessBase {
+  def modal@(optional):ModalDialog
+  def remaining:int 0
+
+  fn start:void () {
+    LifecycleLog.log(("START DialogTimer remaining=" + (to_string remaining)))
+  }
+
+  fn stop:void () {
+    LifecycleLog.log(("STOP DialogTimer remaining=" + (to_string remaining)))
+  }
+}
+
+class ModalDialogTimerDemo {
+  def screen@(optional):ScreenProcess
+  def hasScreen:boolean false
+  def page@(optional):UIPage
+  def hasPage:boolean false
+  def running:boolean true
+  def interactive:boolean false
+  def frame:int 0
+  def pulseEvery:int 4
+
+  fn bootstrap:void () {
+    screen = (new ScreenProcess)
+    hasScreen = true
+    def sc:ScreenProcess (unwrap screen)
+    sc.width = 480
+    sc.height = 800
+    def pg:UIPage (sc.openHomePage())
+    page = pg
+    hasPage = true
+    pg.maxCycles = 3
+    proc_start pg
+    LifecycleLog.log("demo: bootstrap done")
+  }
+
+  fn countLive:int (className:string) {
+    if (className == "ModalDialog") {
+      def list (ModalDialog.allInstances())
+      def n 0
+      for list m:ModalDialog i {
+        if (m.__rangerId != 0) {
+          n = n + 1
+        }
+      }
+      return n
+    }
+    if (className == "DialogTimer") {
+      def list (DialogTimer.allInstances())
+      def n 0
+      for list t:DialogTimer i {
+        if (t.__rangerId != 0) {
+          n = n + 1
+        }
+      }
+      return n
+    }
+    return 0
+  }
+
+  fn printCounts:void (label:string) {
+    print ("  live " + label + "  modal=" + (to_string (this.countLive("ModalDialog"))) + " timer=" + (to_string (this.countLive("DialogTimer"))))
+  }
+
+  fn visualStack:void () {
+    print ""
+    print "  Process tree"
+    def sc:ScreenProcess (unwrap screen)
+    print ("    Screen #" + (to_string sc.__rangerId))
+    def pg:UIPage (unwrap page)
+    print ("      Page \"" + pg.title + "\" #" + (to_string pg.__rangerId) + "  cycle=" + (to_string pg.cycle) + "/" + (to_string pg.maxCycles))
+    if (pg.hasModal) {
+      def m:ModalDialog (unwrap pg.activeModal)
+      print ("        Modal #" + (to_string m.__rangerId) + "  dialogCycle=" + (to_string m.cycleNumber))
+      if (m.hasTimer) {
+        def t:DialogTimer (unwrap m.timer)
+        def bar:string ""
+        def i 0
+        while (i < 4) {
+          if (i < t.remaining) {
+            bar = bar + "#"
+          } {
+            bar = bar + "."
+          }
+          i = i + 1
+        }
+        print ("          Timer #" + (to_string t.__rangerId) + "  [" + bar + "] " + (to_string t.remaining))
+      } {
+        print "          Timer (none)"
+      }
+    } {
+      print "        Modal (closed)"
+    }
+  }
+
+  fn drawFrame:void () {
+    if (interactive) {
+      clear_screen
+      move_cursor 1 1
+    }
+    print "  +-- ModalDialog + Timer (q=quit) ---------------------+"
+    def pg:UIPage (unwrap page)
+    if (pg.allCyclesDone) {
+      print "  |  FINISHED — all modal cycles done                 |"
+    } {
+      print "  |  RUNNING — timer ticks on modal child             |"
+    }
+    print "  +------------------------------------------------------+"
+    this.visualStack()
+    this.printCounts("now")
+    LifecycleLog.dumpAll()
+  }
+
+  fn tickModal:void () {
+    if (hasPage == false) {
+      return
+    }
+    frame = frame + 1
+    def phase (frame % pulseEvery)
+    if (phase != 0) {
+      return
+    }
+    def pg:UIPage (unwrap page)
+    if (pg.allCyclesDone) {
+      return
+    }
+    if (pg.hasModal) {
+      def m:ModalDialog (unwrap pg.activeModal)
+      m.pulse()
+    }
+  }
+
+  fn checkDone:void () {
+    if (hasPage == false) {
+      return
+    }
+    def pg:UIPage (unwrap page)
+    if (pg.allCyclesDone) {
+      running = false
+    }
+  }
+
+  fn drainKeys:void () {
+    while (true) {
+      def key (poll_keypress)
+      if (key == "") {
+        return
+      }
+      if (key == "q") {
+        running = false
+        LifecycleLog.log("demo: quit key")
+        return
+      }
+    }
+  }
+
+  fn shutdown:void () {
+    if (hasPage) {
+      def pg:UIPage (unwrap page)
+      proc_stop pg
+      hasPage = false
+    }
+    if (hasScreen) {
+      def sc:ScreenProcess (unwrap screen)
+      proc_stop sc
+      hasScreen = false
+    }
+  }
+
+  fn runAuto:void () {
+    while (running) {
+      this.tickModal()
+      this.drawFrame()
+      this.checkDone()
+      sleep_ms 120
+    }
+  }
+
+  fn runInteractive:void () {
+    hide_cursor
+    while (running) {
+      this.tickModal()
+      this.drawFrame()
+      this.checkDone()
+      this.drainKeys()
+      sleep_ms 80
+    }
+    show_cursor
+    clear_screen
+  }
+
+  fn run:void () {
+    this.bootstrap()
+    if (interactive) {
+      this.runInteractive()
+    } {
+      this.runAuto()
+    }
+    this.shutdown()
+    LifecycleLog.dumpAll()
+    print ""
+    print "OK process modal dialog timer"
+  }
+}
+
+class Test_ModalDialogTimer {
+  sfn m@(main):void () {
+    def app (new ModalDialogTimerDemo)
+    def argc (shell_arg_cnt)
+    if (argc > 0) {
+      def mode (shell_arg 0)
+      if (mode == "interactive") {
+        app.interactive = true
+      }
+    }
+    if (app.interactive) {
+      def key:string ""
+      on_keypress key {
+      }
+    }
+    app.run()
+  }
+}


### PR DESCRIPTION
- process_modal_dialog_timer: page → modal → timer → close → repeat (CLI + vitest)
- process_external_spawn: verify new inside host method parents to host when called from a normal orchestrator class; controls for direct new and static spawn
- Document fixture run commands in PROCESS_MVP.md