### PR TITLE
Kotlin reserved-word codegen and process dispatch-turn notify.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Source map VLQ line breaks** — `buildMappingsString` no longer resets source/original relative state on `;` (fixes DevTools breakpoints on `.rgr` sources)
 - **Source map original line** — `addMappingFromNode` uses `node.getLine()` from `sp` instead of stale `node.row`
+- **Kotlin `floor` / `int2double`** — `int2double` emits `.toDouble()`; reserved parameter names escaped (`val`, `object`, …)
+- **`proc_send` dispatch wrapping** — turn boundaries around handler calls; `ProcessRuntime.beginDispatchTurn` / `endDispatchTurn`
 
 ## [3.1.0] - 2026-06-02
 

--- a/PROCESS_RUNTIME_INVARIANTS.md
+++ b/PROCESS_RUNTIME_INVARIANTS.md
@@ -1,0 +1,87 @@
+# Process runtime invariants
+
+Normative contract for `@process` UI turns. Implementation: [`lib/RangerProcess.rgr`](lib/RangerProcess.rgr).  
+Related: [PROCESS_UI_NOTIFY.md](PROCESS_UI_NOTIFY.md), [PROCESS_MVP.md](PROCESS_MVP.md), [PROCESS_STATUS.md](PROCESS_STATUS.md).
+
+---
+
+## Separation
+
+| Layer | Responsibility |
+|-------|----------------|
+| **Process runtime** | State, `proc_send`, child tree, lifecycle, sync hooks, coalesced UI notify |
+| **Host** | Timers, storage, network, UI framework, `ProcessUiHost` listeners, DTO snapshot build |
+
+The runtime is a **portable state machine**, not a React/Zustand replacement.
+
+---
+
+## Turn model (target pipeline)
+
+One **dispatch turn** on a **root** process:
+
+```text
+beginDispatchTurn(root)
+  → handler / proc_send body (mutate)
+  → root.__rangerSyncChildren()   ; optional override
+endDispatchTurn(root)
+  → at most one host UI delivery (path + id) when not suppressed
+```
+
+Hosts should build view DTOs **after** notify (in the listener), not inside Ranger handlers.
+
+---
+
+## Invariants
+
+1. **One UI delivery per root turn** — While `ProcessRuntime` dispatch depth &gt; 0, `markStateDirty` / `flushUiNotify` bump generation but do **not** call host `notifyPath` / `notifyId`. `endDispatchTurn` ends suppress and calls `root.flushUiNotify()` once.
+
+2. **No notify during suppress** — `ProcessUiHost.isUiNotifySuppressed()` is true inside `beginDispatchTurn` … `endDispatchTurn` (nested turns increase depth).
+
+3. **Child sync in runtime hook** — Override `fn __rangerSyncChildren:void ()` on the root (or parent) instead of calling host APIs from `ProcessUiHost.notifyPath`. Parent merges child `pending*` fields here.
+
+4. **Handlers stay pure-ish** — Handlers mutate process fields and may `proc_send`; they must not call host timer/storage/network APIs directly.
+
+5. **`proc_send` is turn-wrapped** — Compiler lowers `proc_send` to `beginDispatchTurn(root)` … handler … `endDispatchTurn(root)` where `root` is `target.__rangerFindRoot()`.
+
+---
+
+## APIs
+
+| API | Use |
+|-----|-----|
+| `ProcessRuntime.beginDispatchTurn(root)` / `endDispatchTurn(root)` | Host or manual batching; Ranger source may use `begin_dispatch_turn root` / `end_dispatch_turn root` |
+| `proc_send` | Compiler-wrapped in dispatch turn (find root via `__rangerFindRoot`) |
+| `target.__rangerFindRoot()` | Outermost ancestor for turn root |
+| `root.__rangerSyncChildren()` | Merge child → parent state (override on app root) |
+| `markStateDirty()` | Bump generation; notify immediately **only** outside dispatch turn |
+| `bumpStateGeneration()` | Bump without notify (legacy sync blocks; prefer turn) |
+| `flushUiNotify()` | Deliver after manual suppress block |
+
+---
+
+## Host TypeScript pattern
+
+```typescript
+// dispatch → snapshot → subscribe (see gallery/active-workout processRoot.ts)
+handle.dispatch(() => { proc_send ... });
+const dto = handle.snapshot();
+handle.subscribe(() => setRevision((n) => n + 1));
+```
+
+Install `notifyDepth` guard when overriding `ProcessUiHost.notifyPath` — see [PROCESS_UI_NOTIFY.md](PROCESS_UI_NOTIFY.md).
+
+---
+
+## Regression tests
+
+- [`tests/fixtures/process_dispatch_turn_notify.rgr`](tests/fixtures/process_dispatch_turn_notify.rgr) — `proc_send` inside turn → `notifyPathDeliveredCount <= 1`
+- [`tests/compiler-process-dispatch-turn.test.ts`](tests/compiler-process-dispatch-turn.test.ts)
+
+---
+
+## Not in scope (yet)
+
+- Async message queue / `tick` in compiler
+- Automatic DTO codegen
+- Non-replaceable `notifyPath` wrapper (see PROCESS_UI_NOTIFY.md future work)

--- a/PROCESS_STATUS.md
+++ b/PROCESS_STATUS.md
@@ -1,6 +1,7 @@
 # Ranger `@process` — implementation status
 
 Factual status of the **compiler and runtime** slice. For whether the MVP is **enough to build product orchestration** (messages, UI, timers, navigation), see **[PROCESS_MVP.md](PROCESS_MVP.md)**.  
+**Turn / notify invariants:** [PROCESS_RUNTIME_INVARIANTS.md](PROCESS_RUNTIME_INVARIANTS.md).  
 For how `@process` relates to Smalltalk, React hooks, Erlang, and other models, see **[PROCESS_COMPARISON.md](PROCESS_COMPARISON.md)**.
 
 Last updated after **`proc_send`**, **`findProcess` on `ProcessNameRegistry`**, singleton `new` for TS, and the **Vite counter-board gallery**.
@@ -44,6 +45,7 @@ Last updated after **`proc_send`**, **`findProcess` on `ProcessNameRegistry`**, 
 | **`findProcess(path)` (registry)** | Done — generated `extension ProcessNameRegistry`; live-only (`hasLive`); TS: `interface` overloads for literal paths |
 | **Singleton `new` in TS/JS emit** | Done — `new ProcessNameRegistry()` returns `__singleton_instance` (constructor guard) |
 | **`markStateDirty` / `ProcessUiHost`** | Done — bump + notify; `flushUiNotify`, `bumpStateGeneration`, `beginSuppressUiNotify` — see [PROCESS_UI_NOTIFY.md](PROCESS_UI_NOTIFY.md) |
+| **`ProcessRuntime.beginDispatchTurn` / `endDispatchTurn`** | Done — `__rangerFindRoot`, `__rangerSyncChildren`; `proc_send` wrapped — [PROCESS_RUNTIME_INVARIANTS.md](PROCESS_RUNTIME_INVARIANTS.md) |
 | **`ProcessRuntime.collectAllLiveRoots`** | Done — static extension (`sfn`); used by gallery process tree panel |
 
 **Wiring:** `ng_RangerFlowParser`, `ng_RangerProcessClass`, `ng_RangerProcessLifecycle`, `ng_RangerJavaScriptClassWriter` (singleton ctor), `VirtualCompiler` (`file_end` TS helpers).

--- a/PROCESS_UI_NOTIFY.md
+++ b/PROCESS_UI_NOTIFY.md
@@ -6,6 +6,8 @@ This is not unique to Active Workout; any `@process` parent that merges child `p
 
 ---
 
+**Normative turn contract:** [PROCESS_RUNTIME_INVARIANTS.md](PROCESS_RUNTIME_INVARIANTS.md) (`ProcessRuntime.beginDispatchTurn` / `endDispatchTurn`, `proc_send` wrapping).
+
 ## Language/runtime primitives (`lib/RangerProcess.rgr`)
 
 | API | Role |

--- a/bin/Lang.rgr
+++ b/bin/Lang.rgr
@@ -92,6 +92,40 @@ language {
         }
         kotlin {
             object _object
+            val _val
+            var _var
+            fun _fun
+            class _class
+            when _when
+            is _is
+            in _in
+            as _as
+            null _null
+            interface _interface
+            package _package
+            typealias _typealias
+            companion _companion
+            init _init
+            override _override
+            open _open
+            abstract _abstract
+            sealed _sealed
+            data _data
+            internal _internal
+            private _private
+            protected _protected
+            public _public
+            operator _operator
+            inline _inline
+            lateinit _lateinit
+            vararg _vararg
+            reified _reified
+            suspend _suspend
+            tailrec _tailrec
+            where _where
+            get _get
+            set _set
+            field _field
         }
         rust {
             type r#type
@@ -1462,6 +1496,8 @@ fn r_read_file(path: &str, filename: &str) -> Option<String> {
         int2double      cmdIntToDouble:double            ( value:int ) { 
                 templates {
                     ranger ( "(int2double " (e 1) ")" ) 
+                    kotlin ( (e 1) ".toDouble()" )
+                    swift6 ( "Double(" (e 1) ")" )
                     * ( "parseFloat(" (e 1) ")" ) 
                 } 
         }
@@ -1504,6 +1540,7 @@ fn r_read_file(path: &str, filename: &str) -> Option<String> {
                 rust ( "" (e 1) ".floor() as i64" )                
                 scala ( "math.floor(" (e 1) ").toInt" (imp "scala.math"))                
                 java7 ( "(int)Math.floor(" (e 1) ")" (imp "java.lang.Math"))
+                kotlin ( "(Math.floor(" (e 1) ")).toInt()" (imp "java.lang.Math"))
                 * ( "Math.floor(" (e 1) ")")
             }
         }
@@ -2972,7 +3009,9 @@ std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
                 ranger ( "(strfromcode " (e 1) ")")
                 csharp ( "((char)" (e 1) ").toString()") 
                 java7 ( "(new String( new char[] {" (e 1) " }))") 
+                kotlin ( (e 1) ".toChar().toString()")
                 swift3 ( "(String( Character( UnicodeScalar(" (e 1) " ) )))") 
+                swift6 ( "String(UnicodeScalar(" (e 1) ")!)")
                 php ( "chr(" (e 1) ")") 
                 scala ( "(" (e 1) ".toChar)")      
                 go ("string([]rune{rune(" (e 1) ")})")      
@@ -2988,7 +3027,9 @@ std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
                 ranger ( "(strfromcode " (e 1) ")")
                 csharp ( "((char)" (e 1) ").toString()") 
                 java7 ( "(new String( Character.toChars(" (e 1) ")))") 
+                kotlin ( (e 1) ".toChar().toString()")
                 swift3 ( "(String( Character( UnicodeScalar(" (e 1) " )! )))") 
+                swift6 ( "String(UnicodeScalar(" (e 1) ")!)")
                 php ( "chr(" (e 1) ")") 
                 scala ( "(" (e 1) ".toChar)")      
                 go ("string([]rune{rune(" (e 1) ")})")        
@@ -3565,6 +3606,7 @@ int r_string_index_of_from( std::string str, std::string key, int start )  {
 " )                   
                 )
                 rust ( "(" (e 1) "[" (e 3) " as usize..].find(&*" (e 2) ").map(|i| (i + " (e 3) " as usize) as i64).unwrap_or(-1))" )
+                kotlin ( (e 1) ".indexOf(" (e 2 ) ", " (e 3) ")" )
                 ranger ( "(indexOfFrom " (e 1) " " (e 2) " " (e 3) ")")
             }        
         }
@@ -4875,10 +4917,12 @@ fun r_read_key(): String {
             templates {
                 es6 ((e 1) '.toLowerCase()')
                 java7 ((e 1) '.toLowerCase()')
+                kotlin ((e 1) '.lowercase()')
                 go ( "strings.ToLower(" (e 1) ")" (imp "strings"))
                 php ("strtolower(" (e 1) ")")
                 csharp ((e 1) ".ToLower()")
                 swift3 ((e 1) ".lowercased()")
+                swift6 ((e 1) ".lowercased()")
                 scala ((e 1) ".toLowerCase()")
                 python ((e 1) ".lower()")
             }
@@ -4886,6 +4930,8 @@ fun r_read_key(): String {
         to_uppercase _:string (s:string) {
             templates {
                 swift3 ( (e 1) ".uppercased()")
+                swift6 ( (e 1) ".uppercased()")
+                kotlin ( (e 1) ".uppercase()" )
                 scala ( (e 1 ) ".toUpperCase()" )
                 ranger ("(to_uppercase " (e 1) ")")
                 es6 ( (e 1) ".toUpperCase()")
@@ -5352,6 +5398,26 @@ std::string r_cpp_str_to_uppercase(std::string original)
         }
 
         ; proc_send is lowered in ng_RangerProcessProcSend.rgr (typed handler methods, overload match).
+
+        begin_dispatch_turn@(moves@( 1 )) cmdBeginDispatchTurn:void (root:RangerProcessBase) {
+            templates {
+                es6 ( "ProcessRuntime.beginDispatchTurn(" (e 1) ")" )
+                kotlin ( "ProcessRuntime.beginDispatchTurn(" (e 1) ")" )
+                swift6 ( "ProcessRuntime.beginDispatchTurn(root: " (e 1) ")" )
+                swift3 ( "ProcessRuntime.beginDispatchTurn(root: " (e 1) ")" )
+                * ( "/* begin_dispatch_turn not implemented */" )
+            }
+        }
+
+        end_dispatch_turn@(moves@( 1 )) cmdEndDispatchTurn:void (root:RangerProcessBase) {
+            templates {
+                es6 ( "ProcessRuntime.endDispatchTurn(" (e 1) ")" )
+                kotlin ( "ProcessRuntime.endDispatchTurn(" (e 1) ")" )
+                swift6 ( "ProcessRuntime.endDispatchTurn(root: " (e 1) ")" )
+                swift3 ( "ProcessRuntime.endDispatchTurn(root: " (e 1) ")" )
+                * ( "/* end_dispatch_turn not implemented */" )
+            }
+        }
 
         proc_start@(moves@( 1 )) cmdProcStart:void (proc:RangerProcessBase) {
             templates {

--- a/compiler/Lang.rgr
+++ b/compiler/Lang.rgr
@@ -92,6 +92,40 @@ language {
         }
         kotlin {
             object _object
+            val _val
+            var _var
+            fun _fun
+            class _class
+            when _when
+            is _is
+            in _in
+            as _as
+            null _null
+            interface _interface
+            package _package
+            typealias _typealias
+            companion _companion
+            init _init
+            override _override
+            open _open
+            abstract _abstract
+            sealed _sealed
+            data _data
+            internal _internal
+            private _private
+            protected _protected
+            public _public
+            operator _operator
+            inline _inline
+            lateinit _lateinit
+            vararg _vararg
+            reified _reified
+            suspend _suspend
+            tailrec _tailrec
+            where _where
+            get _get
+            set _set
+            field _field
         }
         rust {
             type r#type
@@ -1462,6 +1496,8 @@ fn r_read_file(path: &str, filename: &str) -> Option<String> {
         int2double      cmdIntToDouble:double            ( value:int ) { 
                 templates {
                     ranger ( "(int2double " (e 1) ")" ) 
+                    kotlin ( (e 1) ".toDouble()" )
+                    swift6 ( "Double(" (e 1) ")" )
                     * ( "parseFloat(" (e 1) ")" ) 
                 } 
         }
@@ -1504,6 +1540,7 @@ fn r_read_file(path: &str, filename: &str) -> Option<String> {
                 rust ( "" (e 1) ".floor() as i64" )                
                 scala ( "math.floor(" (e 1) ").toInt" (imp "scala.math"))                
                 java7 ( "(int)Math.floor(" (e 1) ")" (imp "java.lang.Math"))
+                kotlin ( "(Math.floor(" (e 1) ")).toInt()" (imp "java.lang.Math"))
                 * ( "Math.floor(" (e 1) ")")
             }
         }
@@ -2972,7 +3009,9 @@ std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
                 ranger ( "(strfromcode " (e 1) ")")
                 csharp ( "((char)" (e 1) ").toString()") 
                 java7 ( "(new String( new char[] {" (e 1) " }))") 
+                kotlin ( (e 1) ".toChar().toString()")
                 swift3 ( "(String( Character( UnicodeScalar(" (e 1) " ) )))") 
+                swift6 ( "String(UnicodeScalar(" (e 1) ")!)")
                 php ( "chr(" (e 1) ")") 
                 scala ( "(" (e 1) ".toChar)")      
                 go ("string([]rune{rune(" (e 1) ")})")      
@@ -2988,7 +3027,9 @@ std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
                 ranger ( "(strfromcode " (e 1) ")")
                 csharp ( "((char)" (e 1) ").toString()") 
                 java7 ( "(new String( Character.toChars(" (e 1) ")))") 
+                kotlin ( (e 1) ".toChar().toString()")
                 swift3 ( "(String( Character( UnicodeScalar(" (e 1) " )! )))") 
+                swift6 ( "String(UnicodeScalar(" (e 1) ")!)")
                 php ( "chr(" (e 1) ")") 
                 scala ( "(" (e 1) ".toChar)")      
                 go ("string([]rune{rune(" (e 1) ")})")        
@@ -3565,6 +3606,7 @@ int r_string_index_of_from( std::string str, std::string key, int start )  {
 " )                   
                 )
                 rust ( "(" (e 1) "[" (e 3) " as usize..].find(&*" (e 2) ").map(|i| (i + " (e 3) " as usize) as i64).unwrap_or(-1))" )
+                kotlin ( (e 1) ".indexOf(" (e 2 ) ", " (e 3) ")" )
                 ranger ( "(indexOfFrom " (e 1) " " (e 2) " " (e 3) ")")
             }        
         }
@@ -4875,10 +4917,12 @@ fun r_read_key(): String {
             templates {
                 es6 ((e 1) '.toLowerCase()')
                 java7 ((e 1) '.toLowerCase()')
+                kotlin ((e 1) '.lowercase()')
                 go ( "strings.ToLower(" (e 1) ")" (imp "strings"))
                 php ("strtolower(" (e 1) ")")
                 csharp ((e 1) ".ToLower()")
                 swift3 ((e 1) ".lowercased()")
+                swift6 ((e 1) ".lowercased()")
                 scala ((e 1) ".toLowerCase()")
                 python ((e 1) ".lower()")
             }
@@ -4886,6 +4930,8 @@ fun r_read_key(): String {
         to_uppercase _:string (s:string) {
             templates {
                 swift3 ( (e 1) ".uppercased()")
+                swift6 ( (e 1) ".uppercased()")
+                kotlin ( (e 1) ".uppercase()" )
                 scala ( (e 1 ) ".toUpperCase()" )
                 ranger ("(to_uppercase " (e 1) ")")
                 es6 ( (e 1) ".toUpperCase()")
@@ -5352,6 +5398,26 @@ std::string r_cpp_str_to_uppercase(std::string original)
         }
 
         ; proc_send is lowered in ng_RangerProcessProcSend.rgr (typed handler methods, overload match).
+
+        begin_dispatch_turn@(moves@( 1 )) cmdBeginDispatchTurn:void (root:RangerProcessBase) {
+            templates {
+                es6 ( "ProcessRuntime.beginDispatchTurn(" (e 1) ")" )
+                kotlin ( "ProcessRuntime.beginDispatchTurn(" (e 1) ")" )
+                swift6 ( "ProcessRuntime.beginDispatchTurn(root: " (e 1) ")" )
+                swift3 ( "ProcessRuntime.beginDispatchTurn(root: " (e 1) ")" )
+                * ( "/* begin_dispatch_turn not implemented */" )
+            }
+        }
+
+        end_dispatch_turn@(moves@( 1 )) cmdEndDispatchTurn:void (root:RangerProcessBase) {
+            templates {
+                es6 ( "ProcessRuntime.endDispatchTurn(" (e 1) ")" )
+                kotlin ( "ProcessRuntime.endDispatchTurn(" (e 1) ")" )
+                swift6 ( "ProcessRuntime.endDispatchTurn(root: " (e 1) ")" )
+                swift3 ( "ProcessRuntime.endDispatchTurn(root: " (e 1) ")" )
+                * ( "/* end_dispatch_turn not implemented */" )
+            }
+        }
 
         proc_start@(moves@( 1 )) cmdProcStart:void (proc:RangerProcessBase) {
             templates {

--- a/compiler/ng_RangerAppWriterContext.rgr
+++ b/compiler/ng_RangerAppWriterContext.rgr
@@ -1138,9 +1138,7 @@ class RangerAppWriterContext {
 
       def p@(lives temp):RangerAppParamDesc (new RangerAppParamDesc ())
       p.name = arg.vref
-      if(p.name == "self") {
-        p.compiledName = "__self"
-      }
+      rCtx.assignParamCompiledName(p)
       p.value_type = arg.value_type
       p.node = arg
       p.init_cnt = 1
@@ -1652,6 +1650,22 @@ class RangerAppWriterContext {
       }
     }
     return false
+  }
+  fn assignParamCompiledName:void (p:RangerAppParamDesc) {
+    switch p.name {
+      case "self" {
+        p.compiledName = "__self"
+      }
+      case "process" {
+        p.compiledName = "_process"
+      }
+      case "len" {
+        p.compiledName = "__len"
+      }
+      default {
+        p.compiledName = (this.transformWord(p.name))
+      }
+    }
   }
   fn defineVariable:void (name:string desc@(strong):RangerAppParamDesc) {
     def cnt:int 0

--- a/compiler/ng_RangerFlowParser.rgr
+++ b/compiler/ng_RangerFlowParser.rgr
@@ -3913,6 +3913,7 @@ class RangerFlowParser {
       this.CheckTypeAnnotationOf( arg ctx wr )
       def p@(lives):RangerAppParamDesc (new RangerAppParamDesc ())
       p.name = arg.vref
+      ctx.assignParamCompiledName(p)
       p.value_type = arg.value_type
       p.node = arg
       p.init_cnt = 1

--- a/compiler/ng_RangerKotlinClassWriter.rgr
+++ b/compiler/ng_RangerKotlinClassWriter.rgr
@@ -290,13 +290,19 @@ class RangerKotlinClassWriter {
       }
     }
   }
+  fn paramEmitName:string (arg:RangerAppParamDesc ctx:RangerAppWriterContext) {
+    if ((strlen arg.compiledName) > 0) {
+      return arg.compiledName
+    }
+    return (ctx.transformWord(arg.name))
+  }
   fn writeArgsDef:void (fnDesc:RangerAppFunctionDesc ctx:RangerAppWriterContext wr:CodeWriter) {
     for fnDesc.params arg:RangerAppParamDesc i {
       if (i > 0) {
         wr.out("," false)
       }
       wr.out(" " false)
-      wr.out((arg.name + " : ") false)
+      wr.out(( (this.paramEmitName(arg ctx)) + " : ") false)
       this.writeTypeDef( (unwrap arg.nameNode) ctx wr)
     }
   }

--- a/compiler/ng_RangerProcessProcSend.rgr
+++ b/compiler/ng_RangerProcessProcSend.rgr
@@ -176,6 +176,15 @@ class RangerProcessProcSend {
     return (r.expression (r.vref 'call') (r.vref targetVref) (r.vref handlerName) callArgs)
   }
 
+  sfn buildFindRootExpr:CodeNode (targetVref:string) {
+    def emptyArgs:CodeNode (CodeNode.expressionNode())
+    return (r.expression (r.vref 'call') (r.vref targetVref) (r.vref '__rangerFindRoot') emptyArgs)
+  }
+
+  sfn buildDispatchTurnBoundary:CodeNode (opName:string rootExpr:CodeNode) {
+    return (r.expression (r.vref opName) rootExpr)
+  }
+
   sfn transform:boolean (parser:RangerFlowParser node:CodeNode ctx:RangerAppWriterContext wr:CodeWriter) {
     def childCnt:int (size node.children)
     if (childCnt < 3) {
@@ -237,6 +246,11 @@ class RangerProcessProcSend {
     }
 
     def stmts:[CodeNode]
+    def turnRoot:CodeNode (RangerProcessProcSend.buildFindRootExpr(target.vref))
+    def beginTurn:CodeNode (RangerProcessProcSend.buildDispatchTurnBoundary('begin_dispatch_turn' turnRoot))
+    def endTurn:CodeNode (RangerProcessProcSend.buildDispatchTurnBoundary('end_dispatch_turn' turnRoot))
+    push stmts beginTurn
+
     def refGuard:CodeNode (RangerProcessProcSend.buildLiveGuard(target.vref))
     def refCall:CodeNode (RangerProcessProcSend.buildHandlerCall(target.vref emitName argNodes))
     def refList:[CodeNode]
@@ -244,6 +258,8 @@ class RangerProcessProcSend {
     def refInner:CodeNode (CodeNode.blockFromList(refList))
     def refIf (r.expression (r.vref 'if') refGuard refInner)
     push stmts refIf
+
+    push stmts endTurn
 
     def newBlock:CodeNode (CodeNode.blockFromList(stmts))
     newBlock.flow_done = false

--- a/dist/Lang.rgr
+++ b/dist/Lang.rgr
@@ -92,6 +92,40 @@ language {
         }
         kotlin {
             object _object
+            val _val
+            var _var
+            fun _fun
+            class _class
+            when _when
+            is _is
+            in _in
+            as _as
+            null _null
+            interface _interface
+            package _package
+            typealias _typealias
+            companion _companion
+            init _init
+            override _override
+            open _open
+            abstract _abstract
+            sealed _sealed
+            data _data
+            internal _internal
+            private _private
+            protected _protected
+            public _public
+            operator _operator
+            inline _inline
+            lateinit _lateinit
+            vararg _vararg
+            reified _reified
+            suspend _suspend
+            tailrec _tailrec
+            where _where
+            get _get
+            set _set
+            field _field
         }
         rust {
             type r#type
@@ -193,9 +227,11 @@ language {
             templates {
                 ranger ("(cast " (e 1) " " (e 2) ":" (typeof 2) " )")
                 ts ( (e 1) " as " (typeof 2) )
+                kotlin ( (e 1) " as " (typeof 2) )
                 es6 ( (e 1) )
                 java7 ( "((" (typeof 2) ")" (e 1) ")" )
                 swift3 ( (e 1) " as " (typeof 2) "" )
+                swift6 ( (e 1) " as " (typeof 2) "" )
                 cpp ( "mpark::get<" (typeof 2) ">(" (e 1) ")" 
                 
                     (plugin 'makefile' ((dep 'variant.hpp' 'https://github.com/mpark/variant/releases/download/v1.2.2/variant.hpp')))            
@@ -1460,6 +1496,8 @@ fn r_read_file(path: &str, filename: &str) -> Option<String> {
         int2double      cmdIntToDouble:double            ( value:int ) { 
                 templates {
                     ranger ( "(int2double " (e 1) ")" ) 
+                    kotlin ( (e 1) ".toDouble()" )
+                    swift6 ( "Double(" (e 1) ")" )
                     * ( "parseFloat(" (e 1) ")" ) 
                 } 
         }
@@ -1502,6 +1540,7 @@ fn r_read_file(path: &str, filename: &str) -> Option<String> {
                 rust ( "" (e 1) ".floor() as i64" )                
                 scala ( "math.floor(" (e 1) ").toInt" (imp "scala.math"))                
                 java7 ( "(int)Math.floor(" (e 1) ")" (imp "java.lang.Math"))
+                kotlin ( "(Math.floor(" (e 1) ")).toInt()" (imp "java.lang.Math"))
                 * ( "Math.floor(" (e 1) ")")
             }
         }
@@ -2970,7 +3009,9 @@ std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
                 ranger ( "(strfromcode " (e 1) ")")
                 csharp ( "((char)" (e 1) ").toString()") 
                 java7 ( "(new String( new char[] {" (e 1) " }))") 
+                kotlin ( (e 1) ".toChar().toString()")
                 swift3 ( "(String( Character( UnicodeScalar(" (e 1) " ) )))") 
+                swift6 ( "String(UnicodeScalar(" (e 1) ")!)")
                 php ( "chr(" (e 1) ")") 
                 scala ( "(" (e 1) ".toChar)")      
                 go ("string([]rune{rune(" (e 1) ")})")      
@@ -2986,7 +3027,9 @@ std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
                 ranger ( "(strfromcode " (e 1) ")")
                 csharp ( "((char)" (e 1) ").toString()") 
                 java7 ( "(new String( Character.toChars(" (e 1) ")))") 
+                kotlin ( (e 1) ".toChar().toString()")
                 swift3 ( "(String( Character( UnicodeScalar(" (e 1) " )! )))") 
+                swift6 ( "String(UnicodeScalar(" (e 1) ")!)")
                 php ( "chr(" (e 1) ")") 
                 scala ( "(" (e 1) ".toChar)")      
                 go ("string([]rune{rune(" (e 1) ")})")        
@@ -3563,6 +3606,7 @@ int r_string_index_of_from( std::string str, std::string key, int start )  {
 " )                   
                 )
                 rust ( "(" (e 1) "[" (e 3) " as usize..].find(&*" (e 2) ").map(|i| (i + " (e 3) " as usize) as i64).unwrap_or(-1))" )
+                kotlin ( (e 1) ".indexOf(" (e 2 ) ", " (e 3) ")" )
                 ranger ( "(indexOfFrom " (e 1) " " (e 2) " " (e 3) ")")
             }        
         }
@@ -4873,10 +4917,12 @@ fun r_read_key(): String {
             templates {
                 es6 ((e 1) '.toLowerCase()')
                 java7 ((e 1) '.toLowerCase()')
+                kotlin ((e 1) '.lowercase()')
                 go ( "strings.ToLower(" (e 1) ")" (imp "strings"))
                 php ("strtolower(" (e 1) ")")
                 csharp ((e 1) ".ToLower()")
                 swift3 ((e 1) ".lowercased()")
+                swift6 ((e 1) ".lowercased()")
                 scala ((e 1) ".toLowerCase()")
                 python ((e 1) ".lower()")
             }
@@ -4884,6 +4930,8 @@ fun r_read_key(): String {
         to_uppercase _:string (s:string) {
             templates {
                 swift3 ( (e 1) ".uppercased()")
+                swift6 ( (e 1) ".uppercased()")
+                kotlin ( (e 1) ".uppercase()" )
                 scala ( (e 1 ) ".toUpperCase()" )
                 ranger ("(to_uppercase " (e 1) ")")
                 es6 ( (e 1) ".toUpperCase()")
@@ -5349,23 +5397,25 @@ std::string r_cpp_str_to_uppercase(std::string original)
             }
         }
 
-        proc_send@(moves@( 2 )) cmdProcSendPath:void (path:string msg:Any) {
+        ; proc_send is lowered in ng_RangerProcessProcSend.rgr (typed handler methods, overload match).
+
+        begin_dispatch_turn@(moves@( 1 )) cmdBeginDispatchTurn:void (root:RangerProcessBase) {
             templates {
-                es6 ( "(() => { const __rgrP = ProcessNameRegistry.__singleton().findByPath(" (e 1) "); if (!__rgrP || __rgrP.__rangerId === 0) return; __rgrP.receiveMessage(" (e 2) "); })()" )
-                kotlin ( "run { val __rgrP = ProcessNameRegistry.__singleton().findByPath(" (e 1) "); if (__rgrP == null || __rgrP.__rangerId == 0) return@run; __rgrP.receiveMessage(" (e 2) ") }" )
-                swift6 ( "{ let __rgrP = ProcessNameRegistry.__singleton().findByPath(" (e 1) "); guard let p = __rgrP, p.__rangerId != 0 else { return }; p.receiveMessage(" (e 2) ") }" )
-                swift3 ( "{ let __rgrP = ProcessNameRegistry.__singleton().findByPath(" (e 1) "); guard let p = __rgrP, p.__rangerId != 0 else { return }; p.receiveMessage(" (e 2) ") }" )
-                * ( "/* proc_send path not implemented */" )
+                es6 ( "ProcessRuntime.beginDispatchTurn(" (e 1) ")" )
+                kotlin ( "ProcessRuntime.beginDispatchTurn(" (e 1) ")" )
+                swift6 ( "ProcessRuntime.beginDispatchTurn(root: " (e 1) ")" )
+                swift3 ( "ProcessRuntime.beginDispatchTurn(root: " (e 1) ")" )
+                * ( "/* begin_dispatch_turn not implemented */" )
             }
         }
 
-        proc_send@(moves@( 2 )) cmdProcSendProc:void (proc:RangerProcessBase msg:Any) {
+        end_dispatch_turn@(moves@( 1 )) cmdEndDispatchTurn:void (root:RangerProcessBase) {
             templates {
-                es6 ( "(() => { const __rgrP = " (e 1) "; if (!__rgrP || __rgrP.__rangerId === 0) return; __rgrP.receiveMessage(" (e 2) "); })()" )
-                kotlin ( "run { val __rgrP = " (e 1) "; if (__rgrP.__rangerId == 0) return@run; __rgrP.receiveMessage(" (e 2) ") }" )
-                swift6 ( "{ let __rgrP = " (e 1) "; guard __rgrP.__rangerId != 0 else { return }; __rgrP.receiveMessage(" (e 2) ") }" )
-                swift3 ( "{ let __rgrP = " (e 1) "; guard __rgrP.__rangerId != 0 else { return }; __rgrP.receiveMessage(" (e 2) ") }" )
-                * ( "/* proc_send proc not implemented */" )
+                es6 ( "ProcessRuntime.endDispatchTurn(" (e 1) ")" )
+                kotlin ( "ProcessRuntime.endDispatchTurn(" (e 1) ")" )
+                swift6 ( "ProcessRuntime.endDispatchTurn(root: " (e 1) ")" )
+                swift3 ( "ProcessRuntime.endDispatchTurn(root: " (e 1) ")" )
+                * ( "/* end_dispatch_turn not implemented */" )
             }
         }
 

--- a/gallery/process_counter_board/src/generated/counter_board.ts
+++ b/gallery/process_counter_board/src/generated/counter_board.ts
@@ -17,13 +17,24 @@ export class RangerProcessBase  {
     this.__rangerStateGeneration = 0;
     this.__rangerChildren = [];
   }
+  bumpStateGeneration () : void  {
+    this.__rangerStateGeneration = this.__rangerStateGeneration + 1;
+  };
   markStateDirty () : void  {
     this.__rangerStateGeneration = this.__rangerStateGeneration + 1;
+    this.flushUiNotify();
+  };
+  flushUiNotify () : void  {
+    const uiHost : ProcessUiHost  = ProcessUiHost.__singleton();
+    if ( uiHost.isUiNotifySuppressed() ) {
+      return;
+    }
+    uiHost.notifyPathDeliveredCount = uiHost.notifyPathDeliveredCount + 1;
     if ( (this.__rangerPath.length) > 0 ) {
-      (ProcessUiHost.__singleton()).notifyPath(this.__rangerPath);
+      uiHost.notifyPath(this.__rangerPath);
     }
     if ( this.__rangerId != 0 ) {
-      (ProcessUiHost.__singleton()).notifyId(this.__rangerId);
+      uiHost.notifyId(this.__rangerId);
     }
   };
   __rangerOnDescendantUiChanged (child : RangerProcessBase, hint : string) : void  {
@@ -43,6 +54,17 @@ export class RangerProcessBase  {
     let empty : Array<RangerProcessBase> | undefined  = [];
     this.__rangerChildren = empty;
   };
+  __rangerFindRoot () : RangerProcessBase  {
+    let cur : RangerProcessBase  = this;
+    let parent : RangerProcessBase | undefined  = cur.__rangerParent;
+    while ((typeof(parent) === "undefined") == false) {
+      cur = parent;
+      parent = cur.__rangerParent;
+    };
+    return cur;
+  };
+  __rangerSyncChildren () : void  {
+  };
   __rangerInvokeStart () : void  {
   };
   __rangerInvokeStop () : void  {
@@ -54,7 +76,7 @@ export class RangerProcessBase  {
   };
   __rangerStopSubtree () : void  {
   };
-  receiveMessage (msg : union_Any) : void  {
+  receiveMessage (name : string, value : string) : void  {
   };
 }
 export class ProcessIdRegistry  {
@@ -152,12 +174,30 @@ export class ProcessNameRegistry  {
   };
 }
 export class ProcessUiHost  {
+  __uiNotifySuppressDepth!: number;
+  notifyPathDeliveredCount!: number;
   constructor() {
     if (ProcessUiHost.__singleton_instance != null) {
       return ProcessUiHost.__singleton_instance;
     }
+    this.__uiNotifySuppressDepth = 0;
+    this.notifyPathDeliveredCount = 0;
     ProcessUiHost.__singleton_instance = this;
   }
+  isUiNotifySuppressed () : boolean  {
+    return this.__uiNotifySuppressDepth > 0;
+  };
+  resetNotifyDeliveryCount () : void  {
+    this.notifyPathDeliveredCount = 0;
+  };
+  beginSuppressUiNotify () : void  {
+    this.__uiNotifySuppressDepth = this.__uiNotifySuppressDepth + 1;
+  };
+  endSuppressUiNotify () : void  {
+    if ( this.__uiNotifySuppressDepth > 0 ) {
+      this.__uiNotifySuppressDepth = this.__uiNotifySuppressDepth - 1;
+    }
+  };
   notifyPath (path : string) : void  {
   };
   notifyId (processId : number) : void  {
@@ -171,12 +211,36 @@ export class ProcessUiHost  {
   };
 }
 export class ProcessRuntime  {
+  __dispatchTurnDepth!: number;
   constructor() {
     if (ProcessRuntime.__singleton_instance != null) {
       return ProcessRuntime.__singleton_instance;
     }
+    this.__dispatchTurnDepth = 0;
     ProcessRuntime.__singleton_instance = this;
   }
+  static beginDispatchTurn (root : RangerProcessBase) : void  {
+    const rt : ProcessRuntime  = ProcessRuntime.__singleton();
+    if ( rt.__dispatchTurnDepth == 0 ) {
+      const uiHost : ProcessUiHost  = ProcessUiHost.__singleton();
+      uiHost.beginSuppressUiNotify();
+    }
+    rt.__dispatchTurnDepth = rt.__dispatchTurnDepth + 1;
+  };
+  static endDispatchTurn (root : RangerProcessBase) : void  {
+    const rt : ProcessRuntime  = ProcessRuntime.__singleton();
+    if ( rt.__dispatchTurnDepth == 0 ) {
+      return;
+    }
+    rt.__dispatchTurnDepth = rt.__dispatchTurnDepth - 1;
+    if ( rt.__dispatchTurnDepth > 0 ) {
+      return;
+    }
+    root.__rangerSyncChildren();
+    const uiHost : ProcessUiHost  = ProcessUiHost.__singleton();
+    uiHost.endSuppressUiNotify();
+    root.flushUiNotify();
+  };
   static stopInstance (proc : RangerProcessBase) : void  {
     (ProcessNameRegistry.__singleton()).unbindIfConfigured(proc);
     proc.__rangerStopSubtree();
@@ -383,6 +447,8 @@ export class CounterRowProcess  extends RangerProcessBase {
     this.running = false;
     this.tickCount = 0;
   }
+  start () : void  {
+  };
   addRep () : void  {
     this.value = this.value + 1;
     if ( (typeof(this.board) === "undefined") == false ) {
@@ -432,6 +498,9 @@ export class CounterRowProcess  extends RangerProcessBase {
   __rangerUnregister () : void  {
     this.__rangerId = 0;
     this.__rangerParentId = 0;
+  };
+  __rangerInvokeStart () : void  {
+    (this).start();
   };
   __rangerInvokeStop () : void  {
     (this).stop();

--- a/gallery/process_counter_board/src/hooks/useProcess.ts
+++ b/gallery/process_counter_board/src/hooks/useProcess.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { getCounterBoard, ensureCounterBoardStarted } from "../host/counterBoardHost";
+import { counterBoardRoot } from "../host/counterBoardRoot";
 import { subscribePath } from "../host/processUiBridge";
 import { BOARD_PROCESS_PATH, findProcessByPath, type ProcessPath } from "../processPaths";
 
@@ -12,9 +13,13 @@ export function useProcess<P extends ProcessPath>(path: P): ReturnType<typeof re
   // Start before first paint so toolbar is not stuck on "Starting…" (effect alone never re-renders).
   if (path === BOARD_PROCESS_PATH) {
     ensureCounterBoardStarted();
+    counterBoardRoot.refreshSnapshot();
   }
 
   useEffect(() => {
+    if (path === BOARD_PROCESS_PATH) {
+      return counterBoardRoot.subscribe(() => setTick((n) => n + 1));
+    }
     return subscribePath(path, () => setTick((n) => n + 1));
   }, [path]);
 

--- a/gallery/process_counter_board/src/host/counterBoardRoot.ts
+++ b/gallery/process_counter_board/src/host/counterBoardRoot.ts
@@ -1,0 +1,25 @@
+import { ProcessRuntime, type CounterBoardPage } from "../generated/counter_board";
+import { BOARD_PROCESS_PATH } from "../processPaths";
+import { ensureCounterBoardStarted, getCounterBoard } from "./counterBoardHost";
+import { createProcessRootHandle } from "./processRoot";
+import { installProcessUiBridge, subscribePath } from "./processUiBridge";
+
+export type CounterBoardSnapshot = CounterBoardPage;
+
+export const counterBoardRoot = createProcessRootHandle<CounterBoardSnapshot>({
+  rootPath: BOARD_PROCESS_PATH,
+  getRoot: () => getCounterBoard(),
+  buildSnapshot: (root) => root as CounterBoardPage,
+  revisionOf: (root) => root.__rangerStateGeneration,
+  installBridge: () => {
+    installProcessUiBridge(counterBoardRoot.refreshSnapshot);
+  },
+  subscribePath,
+  ProcessRuntime,
+});
+
+export function ensureCounterBoardRoot(): CounterBoardPage {
+  const board = ensureCounterBoardStarted();
+  counterBoardRoot.refreshSnapshot();
+  return board;
+}

--- a/gallery/process_counter_board/src/host/processRoot.ts
+++ b/gallery/process_counter_board/src/host/processRoot.ts
@@ -1,0 +1,71 @@
+import type { ProcessRuntime, RangerProcessBase } from "../generated/counter_board";
+
+export interface ProcessRootHandle<TSnapshot> {
+  dispatch(work: () => void): void;
+  snapshot(): TSnapshot | null;
+  subscribe(listener: () => void): () => void;
+  getRevision(): number;
+  refreshSnapshot(): void;
+}
+
+export function createProcessRootHandle<TSnapshot>(config: {
+  rootPath: string;
+  getRoot: () => RangerProcessBase | null;
+  buildSnapshot: (root: RangerProcessBase) => TSnapshot;
+  revisionOf: (root: RangerProcessBase) => number;
+  installBridge: () => void;
+  subscribePath: (path: string, listener: () => void) => () => void;
+  ProcessRuntime: typeof ProcessRuntime;
+}): ProcessRootHandle<TSnapshot> {
+  let cachedRevision = -1;
+  let cachedSnapshot: TSnapshot | null = null;
+
+  function refreshSnapshot(): void {
+    const root = config.getRoot();
+    if (!root || root.__rangerId === 0) {
+      cachedRevision = -1;
+      cachedSnapshot = null;
+      return;
+    }
+    const nextRev = config.revisionOf(root);
+    if (nextRev === cachedRevision && cachedSnapshot !== null) {
+      return;
+    }
+    cachedRevision = nextRev;
+    cachedSnapshot = config.buildSnapshot(root);
+  }
+
+  return {
+    dispatch(work) {
+      config.installBridge();
+      const root = config.getRoot();
+      if (!root || root.__rangerId === 0) {
+        work();
+        refreshSnapshot();
+        return;
+      }
+      config.ProcessRuntime.beginDispatchTurn(root);
+      try {
+        work();
+      } finally {
+        config.ProcessRuntime.endDispatchTurn(root);
+      }
+      refreshSnapshot();
+    },
+    snapshot() {
+      refreshSnapshot();
+      return cachedSnapshot;
+    },
+    subscribe(listener) {
+      config.installBridge();
+      return config.subscribePath(config.rootPath, () => {
+        refreshSnapshot();
+        listener();
+      });
+    },
+    getRevision() {
+      return cachedRevision;
+    },
+    refreshSnapshot,
+  };
+}

--- a/gallery/process_counter_board/src/host/processUiBridge.ts
+++ b/gallery/process_counter_board/src/host/processUiBridge.ts
@@ -5,23 +5,44 @@ type Unsubscribe = () => void;
 const pathSubs = new Map<string, Set<() => void>>();
 const idSubs = new Map<number, Set<() => void>>();
 let installed = false;
+let notifyDepth = 0;
+let onNotifyRefresh: (() => void) | null = null;
 
-export function installProcessUiBridge(): void {
+function notifyListeners(): void {
+  if (notifyDepth > 0) {
+    return;
+  }
+  notifyDepth += 1;
+  try {
+    onNotifyRefresh?.();
+    for (const [, set] of pathSubs) {
+      for (const fn of set) {
+        fn();
+      }
+    }
+    for (const [, set] of idSubs) {
+      for (const fn of set) {
+        fn();
+      }
+    }
+  } finally {
+    notifyDepth -= 1;
+  }
+}
+
+export function installProcessUiBridge(onRefresh?: () => void): void {
+  if (onRefresh) {
+    onNotifyRefresh = onRefresh;
+  }
   if (installed) return;
   installed = true;
 
   const host = ProcessUiHost.__singleton();
-  host.notifyPath = (path: string) => {
-    const set = pathSubs.get(path);
-    if (set) {
-      for (const fn of set) fn();
-    }
+  host.notifyPath = () => {
+    notifyListeners();
   };
-  host.notifyId = (processId: number) => {
-    const set = idSubs.get(processId);
-    if (set) {
-      for (const fn of set) fn();
-    }
+  host.notifyId = () => {
+    notifyListeners();
   };
 }
 

--- a/lib/RangerProcess.rgr
+++ b/lib/RangerProcess.rgr
@@ -27,6 +27,7 @@ class RangerProcessBase {
     if (uiHost.isUiNotifySuppressed()) {
       return
     }
+    uiHost.notifyPathDeliveredCount = uiHost.notifyPathDeliveredCount + 1
     if ((strlen __rangerPath) > 0) {
       uiHost.notifyPath(__rangerPath)
     }
@@ -53,6 +54,21 @@ class RangerProcessBase {
   fn __rangerClearChildren:void () {
     def empty:[RangerProcessBase]
     __rangerChildren = empty
+  }
+
+  ; Outermost live ancestor (self if no parent). Used as dispatch-turn root.
+  fn __rangerFindRoot:RangerProcessBase () {
+    def cur:RangerProcessBase this
+    def parent@(optional):RangerProcessBase (cur.__rangerParent)
+    while ((null? parent) == false) {
+      cur = (unwrap parent)
+      parent = cur.__rangerParent
+    }
+    return cur
+  }
+
+  ; Override on app root to merge child pending* into parent before UI notify.
+  fn __rangerSyncChildren:void () {
   }
 
   fn __rangerInvokeStart:void () {
@@ -140,9 +156,15 @@ class ProcessNameRegistry @singleton(true) {
 ; Hosts may replace notifyPath/notifyId on the singleton instance; markStateDirty respects suppressUiNotify.
 class ProcessUiHost @singleton(true) {
   def __uiNotifySuppressDepth:int 0
+  ; Test/diagnostic: host notifyPath/notifyId deliveries (not suppressed).
+  def notifyPathDeliveredCount:int 0
 
   fn isUiNotifySuppressed:boolean () {
     return __uiNotifySuppressDepth > 0
+  }
+
+  fn resetNotifyDeliveryCount:void () {
+    notifyPathDeliveredCount = 0
   }
 
   fn beginSuppressUiNotify:void () {
@@ -163,6 +185,31 @@ class ProcessUiHost @singleton(true) {
 }
 
 class ProcessRuntime @singleton(true) {
+  def __dispatchTurnDepth:int 0
+
+  sfn beginDispatchTurn:void (root:RangerProcessBase) {
+    def rt:ProcessRuntime (ProcessRuntime.__singleton())
+    if (rt.__dispatchTurnDepth == 0) {
+      def uiHost:ProcessUiHost (ProcessUiHost.__singleton())
+      uiHost.beginSuppressUiNotify()
+    }
+    rt.__dispatchTurnDepth = rt.__dispatchTurnDepth + 1
+  }
+
+  sfn endDispatchTurn:void (root:RangerProcessBase) {
+    def rt:ProcessRuntime (ProcessRuntime.__singleton())
+    if (rt.__dispatchTurnDepth == 0) {
+      return
+    }
+    rt.__dispatchTurnDepth = rt.__dispatchTurnDepth - 1
+    if (rt.__dispatchTurnDepth > 0) {
+      return
+    }
+    root.__rangerSyncChildren()
+    def uiHost:ProcessUiHost (ProcessUiHost.__singleton())
+    uiHost.endSuppressUiNotify()
+    root.flushUiNotify()
+  }
 
   sfn stopInstance:void (proc:RangerProcessBase) {
     ProcessNameRegistry.__singleton().unbindIfConfigured(proc)

--- a/tests/codegen-kotlin.test.ts
+++ b/tests/codegen-kotlin.test.ts
@@ -170,4 +170,24 @@ describe("Kotlin Code Generation", () => {
       expect(result.code).toContain("fun main(");
     });
   });
+
+  describe("Reserved Words", () => {
+    it("should escape val parameter name for Kotlin", () => {
+      const result = getGeneratedKotlinCode(
+        `${FIXTURES_DIR}/kotlin_reserved_val.rgr`
+      );
+      expect(result.success, `Failed: ${result.error}`).toBe(true);
+      expect(result.code).toMatch(/fun\s+setNumber\(\s*key\s*:\s*String,\s*_val\s*:\s*Double/);
+      expect(result.code).not.toMatch(/,\s*val\s*:\s*Double/);
+    });
+
+    it("should escape object parameter name for Kotlin", () => {
+      const result = getGeneratedKotlinCode(
+        `${FIXTURES_DIR}/kotlin_reserved_object.rgr`
+      );
+      expect(result.success, `Failed: ${result.error}`).toBe(true);
+      expect(result.code).toMatch(/fun\s+take\(\s*_object\s*:\s*String/);
+      expect(result.code).not.toMatch(/fun\s+take\(\s*object\s*:/);
+    });
+  });
 });

--- a/tests/compiler-process-dispatch-turn.test.ts
+++ b/tests/compiler-process-dispatch-turn.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { compileAndRun, compileRanger } from "./helpers/compiler";
+
+const FIXTURE = "tests/fixtures/process_dispatch_turn_notify.rgr";
+const OUTPUT_JS = path.join(__dirname, ".output", "process_dispatch_turn_notify.js");
+
+describe("Ranger process dispatch turn", () => {
+  it("should wrap proc_send with beginDispatchTurn/endDispatchTurn", () => {
+    const result = compileRanger(FIXTURE);
+    expect(result.success, `Compile failed: ${result.error || result.output}`).toBe(true);
+    const code = fs.readFileSync(OUTPUT_JS, "utf-8");
+    expect(code).toContain("ProcessRuntime.beginDispatchTurn");
+    expect(code).toContain("ProcessRuntime.endDispatchTurn");
+    expect(code).toContain("__rangerFindRoot");
+  });
+
+  it("should deliver at most one UI notify per proc_send turn", () => {
+    const { compile, run } = compileAndRun(FIXTURE);
+    expect(compile.success, `Compile failed: ${compile.error}`).toBe(true);
+    expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+    expect(run?.output).toContain("OK process dispatch turn notify");
+    expect(run?.output).not.toContain("FAIL dispatch turn");
+  });
+});

--- a/tests/fixtures/kotlin_reserved_object.rgr
+++ b/tests/fixtures/kotlin_reserved_object.rgr
@@ -1,0 +1,13 @@
+; Kotlin codegen: object is a Kotlin keyword — emit _object in signatures
+
+class ReservedObjectTest {
+  fn take (object:string) {
+    return
+  }
+}
+
+class Test_KotlinReservedObject {
+  sfn m@(main):void () {
+    print "Done"
+  }
+}

--- a/tests/fixtures/kotlin_reserved_val.rgr
+++ b/tests/fixtures/kotlin_reserved_val.rgr
@@ -1,0 +1,13 @@
+; Kotlin codegen: reserved parameter names must be escaped in signatures
+
+class ReservedValTest {
+  fn setNumber (key:string val:double) {
+    return
+  }
+}
+
+class Test_KotlinReservedVal {
+  sfn m@(main):void () {
+    print "Done"
+  }
+}

--- a/tests/fixtures/process_dispatch_turn_notify.rgr
+++ b/tests/fixtures/process_dispatch_turn_notify.rgr
@@ -1,0 +1,70 @@
+Import "RangerProcess.rgr"
+
+; Regression: proc_send is wrapped in dispatch turn → at most one UI delivery per send.
+class NotifyRoot @process(true) @name("app.notifyRoot") extends RangerProcessBase {
+  def child@(optional):NotifyChild
+  def mergedCount:int 0
+
+  fn __rangerSyncChildren:void () {
+    if ((null? child) == false) {
+      def c:NotifyChild (unwrap child)
+      if (c.__rangerId != 0) {
+        if (c.pendingBump) {
+          mergedCount = mergedCount + 1
+          c.pendingBump = false
+          this.bumpStateGeneration()
+        }
+      }
+    }
+  }
+
+  fn start:void () {
+    def c:NotifyChild (new NotifyChild)
+    c.parent = this
+    child = c
+    proc_start c
+  }
+}
+
+class NotifyChild @process(true) extends RangerProcessBase {
+  def parent@(optional):NotifyRoot
+  def pendingBump:boolean false
+
+  fn start:void () {
+  }
+
+  fn onBump:void () {
+    pendingBump = true
+    this.markStateDirty()
+    if ((null? parent) == false) {
+      def p:NotifyRoot (unwrap parent)
+      p.markStateDirty()
+    }
+  }
+}
+
+class DispatchTurnNotifyMain {
+  sfn main@(main):void () {
+    def root:NotifyRoot (new NotifyRoot)
+    proc_start root
+    def uiHost:ProcessUiHost (ProcessUiHost.__singleton())
+    uiHost.resetNotifyDeliveryCount()
+    if ((null? root.child) == false) {
+      def c:NotifyChild (unwrap root.child)
+      proc_send c onBump
+    } {
+      print "FAIL dispatch turn: no child"
+      return
+    }
+    def count:int (uiHost.notifyPathDeliveredCount)
+    if (count != 1) {
+      print ("FAIL dispatch turn notify count=" + (to_string count))
+      return
+    }
+    if (root.mergedCount != 1) {
+      print ("FAIL dispatch turn sync mergedCount=" + (to_string root.mergedCount))
+      return
+    }
+    print "OK process dispatch turn notify"
+  }
+}


### PR DESCRIPTION
Expand kotlin reserved_words and int2double template; escape parameter names in Kotlin writer. Wrap proc_send handlers with dispatch turn boundaries and add ProcessRuntime turn coalescing. Regenerate bootstrap compiler output.