### PR TITLE
Game scripts: strict TypeScript types + relative import support

### DIFF
--- a/gallery/game_engine/scripting/GAME_SCRIPTING.md
+++ b/gallery/game_engine/scripting/GAME_SCRIPTING.md
@@ -90,12 +90,58 @@ function calls, and JSX. Known constraints:
 
 `game.d.ts` gives editor autocomplete/type-checking while authoring. The runtime
 ignores annotations (the parser records them but the evaluator does not use
-them), exactly like the existing `evg_types.tsx` intellisense file. Reference it
-from a script with:
+them), exactly like the existing `evg_types.tsx` intellisense file.
+
+### Local `tsconfig.json`
+
+[`tsconfig.json`](./tsconfig.json) enables **strict** checking (`noImplicitAny`,
+etc.) for annotated scripts. Add your `*.game.tsx` to `"include"` as you add
+type annotations — start with [`breakout.game.tsx`](./breakout.game.tsx) as the
+reference example.
+
+```bash
+cd gallery/game_engine/scripting && npx tsc --noEmit
+```
+
+### Referencing types
+
+Reference globals (`game`, `screen`, `Buttons`, `View`, `Label`) via:
 
 ```tsx
 /// <reference path="./game.d.ts" />
 ```
+
+When a script uses runtime `import`, add a triple-slash reference at the top of
+each file (the runtime parser does not evaluate `import type` yet):
+
+```tsx
+/// <reference path="./game.d.ts" />
+import { brickId } from "./breakout_bricks";
+```
+
+Per-game screen state (e.g. `BreakoutState`, `BreakoutPlayScreen`) lives in
+`game.d.ts` or a sibling `*.d.ts` / shared module.
+
+### Relative `import` between scripts
+
+`ComponentEngine.processImports()` resolves **relative** paths from the script
+directory on disk:
+
+```tsx
+import { brickId, BRICK_COUNT } from "./breakout_bricks";
+```
+
+Requirements:
+
+1. Host calls `runner.setScriptDir("gallery/game_engine/scripting")` **before**
+   `loadScript()` (SDL runner and all `*_runner_demo.rgr` files do this).
+2. Paths must start with `./` (or `../`).
+3. `import type { ... } from "./game.d.ts"` is stripped at runtime (type-only).
+4. Exported `function` / `const` bindings from the imported file are registered
+   into the script module scope.
+
+Example split: [`breakout_bricks.tsx`](./breakout_bricks.tsx) (shared brick
+helpers) imported by [`breakout.game.tsx`](./breakout.game.tsx).
 
 ## Retained-mode runner (GameRunner)
 

--- a/gallery/game_engine/scripting/breakout.game.tsx
+++ b/gallery/game_engine/scripting/breakout.game.tsx
@@ -13,70 +13,24 @@
 // Run:
 //   npm run engine:game-sdl:run -- gallery/game_engine/scripting/breakout.game.tsx
 
-const COLS = 10;
-const ROWS = 5;
-const BRICK_COUNT = COLS * ROWS;
-const BRICK_W = 40;
-const BRICK_H = 12;
-const BRICK_GAP = 4;
-const BRICK_TOP = 52;
-const BRICK_LEFT = 40;
+import {
+  BRICK_COUNT,
+  BRICK_W,
+  brickId,
+  brickX,
+  brickY,
+  buildBrickSprites,
+  countAlive,
+  hitBrick,
+  makeAlive,
+  placeBricks
+} from "./breakout_bricks";
 
-const BRICK_COLORS = [
-  { r: 220, g: 80, b: 90 },
-  { r: 255, g: 150, b: 60 },
-  { r: 255, g: 220, b: 80 },
-  { r: 120, g: 220, b: 140 },
-  { r: 90, g: 170, b: 255 }
-];
-
-function screens() {
+function screens(): string[] {
   return ["play", "gameOver"];
 }
 
-function brickId(i) {
-  return ("b" + i);
-}
-
-function brickCol(i) {
-  return i % COLS;
-}
-
-function brickRow(i) {
-  return (i - brickCol(i)) / COLS;
-}
-
-function brickX(i) {
-  const c = brickCol(i);
-  return BRICK_LEFT + c * (BRICK_W + BRICK_GAP);
-}
-
-function brickY(i) {
-  const r = brickRow(i);
-  return BRICK_TOP + r * (BRICK_H + BRICK_GAP);
-}
-
-function buildBrickSprites() {
-  const list = [];
-  let i = 0;
-  while (i < BRICK_COUNT) {
-    const row = brickRow(i);
-    const pal = BRICK_COLORS[row % BRICK_COLORS.length];
-    list.push({
-      id: brickId(i),
-      kind: "rect",
-      w: BRICK_W,
-      h: BRICK_H,
-      r: pal.r,
-      g: pal.g,
-      b: pal.b
-    });
-    i = i + 1;
-  }
-  return list;
-}
-
-function sprites(props) {
+function sprites(props: { screen: string }): SpriteDef[] {
   if (props.screen == "play") {
     const list = buildBrickSprites();
     list.push({ id: "paddle", kind: "rect", w: 64, h: 10, r: 120, g: 220, b: 255 });
@@ -86,18 +40,8 @@ function sprites(props) {
   return [];
 }
 
-function makeAlive() {
-  const alive = [];
-  let i = 0;
-  while (i < BRICK_COUNT) {
-    alive.push(1);
-    i = i + 1;
-  }
-  return alive;
-}
-
-function initEntities() {
-  const entities = {};
+function initEntities(): Record<string, EntityPose> {
+  const entities: Record<string, EntityPose> = {};
   entities.paddle = { x: 240, y: 248 };
   entities.ball = { x: 240, y: 220 };
   let i = 0;
@@ -108,7 +52,7 @@ function initEntities() {
   return entities;
 }
 
-function initPlayState() {
+function initPlayState(): BreakoutPlayScreen {
   return {
     layout: "breakout",
     showNet: 0,
@@ -127,7 +71,7 @@ function initPlayState() {
   };
 }
 
-function initState() {
+function initState(): BreakoutState {
   return {
     screen: "play",
     screens: {
@@ -136,44 +80,15 @@ function initState() {
   };
 }
 
-function countAlive(alive) {
-  let n = 0;
-  let i = 0;
-  while (i < alive.length) {
-    if (alive[i] == 1) { n = n + 1; }
-    i = i + 1;
-  }
-  return n;
-}
-
-function resetBall(px, py) {
+function resetBall(px: number, py: number): { bx: number; by: number; vx: number; vy: number } {
   return { bx: px, by: py - 24, vx: 0.18, vy: 0.14 };
 }
 
-function placeBricks(entities, alive) {
-  let i = 0;
-  while (i < BRICK_COUNT) {
-    const id = brickId(i);
-    if (alive[i] == 0) {
-      entities[id] = { x: -40, y: -40, visible: 0 };
-    } else {
-      entities[id] = { x: brickX(i), y: brickY(i) };
-    }
-    i = i + 1;
-  }
-}
-
-function hitBrick(bx, by, i) {
-  const x = brickX(i);
-  const y = brickY(i);
-  if (bx < x - 4) { return 0; }
-  if (bx > x + BRICK_W + 4) { return 0; }
-  if (by < y - 4) { return 0; }
-  if (by > y + BRICK_H + 4) { return 0; }
-  return 1;
-}
-
-function goToGameOver(s, play, won) {
+function goToGameOver(
+  s: BreakoutState,
+  play: BreakoutPlayScreen,
+  won: number
+): BreakoutState {
   return {
     screen: "gameOver",
     screens: {
@@ -188,9 +103,9 @@ function goToGameOver(s, play, won) {
   };
 }
 
-function updatePlay(s, props) {
+function updatePlay(s: BreakoutState, props: EventProps): BreakoutState {
   const play = s.screens.play;
-  const dt = props.dt;
+  const dt = props.dt as number;
   let px = play.px;
   let py = play.py;
   let bx = play.bx;
@@ -232,7 +147,7 @@ function updatePlay(s, props) {
     vx = reset.vx;
     vy = reset.vy;
     if (lives <= 0) {
-      const frozen = {
+      const frozen: BreakoutPlayScreen = {
         layout: "breakout",
         entities: play.entities,
         px: px,
@@ -264,7 +179,7 @@ function updatePlay(s, props) {
   }
 
   if (countAlive(alive) == 0) {
-    const frozen = {
+    const frozen: BreakoutPlayScreen = {
       layout: "breakout",
       entities: play.entities,
       px: px,
@@ -282,12 +197,12 @@ function updatePlay(s, props) {
     return goToGameOver(s, frozen, 1);
   }
 
-  const entities = {};
+  const entities: Record<string, EntityPose> = {};
   entities.paddle = { x: px, y: py };
   entities.ball = { x: bx, y: by };
   placeBricks(entities, alive);
 
-  const nextPlay = {
+  const nextPlay: BreakoutPlayScreen = {
     layout: "breakout",
     entities: entities,
     px: px,
@@ -311,7 +226,7 @@ function updatePlay(s, props) {
   };
 }
 
-function updateGameOver(s, props) {
+function updateGameOver(s: BreakoutState, props: EventProps): BreakoutState {
   if (props.action) {
     return {
       screen: "play",
@@ -324,8 +239,8 @@ function updateGameOver(s, props) {
   return s;
 }
 
-function update(props) {
-  const s = props.state;
+function update(props: EventProps): BreakoutState {
+  const s = props.state as BreakoutState;
   const sc = s.screen;
   if (sc == "play") {
     return updatePlay(s, props);
@@ -336,11 +251,11 @@ function update(props) {
   return s;
 }
 
-function hud(props) {
-  const s = props.state;
+function hud(props: EventProps): JSX.Element {
+  const s = props.state as BreakoutState;
   const sc = s.screen;
   if (sc == "gameOver") {
-    const go = s.screens.gameOver;
+    const go = s.screens.gameOver!;
     let title = "PELI OHI!!";
     if (go.won == 1) {
       title = "YOU WIN";

--- a/gallery/game_engine/scripting/breakout_bricks.tsx
+++ b/gallery/game_engine/scripting/breakout_bricks.tsx
@@ -1,0 +1,119 @@
+/// <reference path="./game.d.ts" />
+//
+// Shared Breakout brick layout + sprite helpers.
+// Imported by breakout.game.tsx to demonstrate relative `import` support.
+
+export const COLS = 10;
+export const ROWS = 5;
+export const BRICK_COUNT = COLS * ROWS;
+export const BRICK_W = 40;
+export const BRICK_H = 12;
+export const BRICK_GAP = 4;
+export const BRICK_TOP = 52;
+export const BRICK_LEFT = 40;
+
+export const BRICK_COLORS: RgbColor[] = [
+  { r: 220, g: 80, b: 90 },
+  { r: 255, g: 150, b: 60 },
+  { r: 255, g: 220, b: 80 },
+  { r: 120, g: 220, b: 140 },
+  { r: 90, g: 170, b: 255 }
+];
+
+export function brickId(i: number): string {
+  return "b" + i;
+}
+
+export function brickCol(i: number): number {
+  return i % COLS;
+}
+
+export function brickRow(i: number): number {
+  return (i - brickCol(i)) / COLS;
+}
+
+export function brickX(i: number): number {
+  const c = brickCol(i);
+  return BRICK_LEFT + c * (BRICK_W + BRICK_GAP);
+}
+
+export function brickY(i: number): number {
+  const r = brickRow(i);
+  return BRICK_TOP + r * (BRICK_H + BRICK_GAP);
+}
+
+export function buildBrickSprites(): SpriteDef[] {
+  const list: SpriteDef[] = [];
+  let i = 0;
+  while (i < BRICK_COUNT) {
+    const row = brickRow(i);
+    const pal = BRICK_COLORS[row % BRICK_COLORS.length];
+    list.push({
+      id: brickId(i),
+      kind: "rect",
+      w: BRICK_W,
+      h: BRICK_H,
+      r: pal.r,
+      g: pal.g,
+      b: pal.b
+    });
+    i = i + 1;
+  }
+  return list;
+}
+
+export function makeAlive(): number[] {
+  const alive: number[] = [];
+  let i = 0;
+  while (i < BRICK_COUNT) {
+    alive.push(1);
+    i = i + 1;
+  }
+  return alive;
+}
+
+export function countAlive(alive: number[]): number {
+  let n = 0;
+  let i = 0;
+  while (i < alive.length) {
+    if (alive[i] == 1) {
+      n = n + 1;
+    }
+    i = i + 1;
+  }
+  return n;
+}
+
+export function hitBrick(bx: number, by: number, i: number): number {
+  const x = brickX(i);
+  const y = brickY(i);
+  if (bx < x - 4) {
+    return 0;
+  }
+  if (bx > x + BRICK_W + 4) {
+    return 0;
+  }
+  if (by < y - 4) {
+    return 0;
+  }
+  if (by > y + BRICK_H + 4) {
+    return 0;
+  }
+  return 1;
+}
+
+export function placeBricks(
+  entities: Record<string, EntityPose>,
+  alive: number[]
+): void {
+  let i = 0;
+  while (i < BRICK_COUNT) {
+    const id = brickId(i);
+    if (alive[i] == 0) {
+      entities[id] = { x: -40, y: -40, visible: 0 };
+    } else {
+      entities[id] = { x: brickX(i), y: brickY(i) };
+    }
+    i = i + 1;
+  }
+}

--- a/gallery/game_engine/scripting/breakout_runner_demo.rgr
+++ b/gallery/game_engine/scripting/breakout_runner_demo.rgr
@@ -11,6 +11,7 @@ class BreakoutRunnerDemo {
 
         def buf:buffer (buffer_read_file "gallery/game_engine/scripting" "breakout.game.tsx")
         def src:string (buffer_to_string buf)
+        runner.setScriptDir("gallery/game_engine/scripting")
         runner.loadScript(src)
         runner.setupScene()
 

--- a/gallery/game_engine/scripting/counter_runner_demo.rgr
+++ b/gallery/game_engine/scripting/counter_runner_demo.rgr
@@ -10,6 +10,7 @@ class CounterRunnerDemo {
         runner.init(64 64)
         def buf:buffer (buffer_read_file "gallery/game_engine/scripting" "counter.game.tsx")
         def src:string (buffer_to_string buf)
+        runner.setScriptDir("gallery/game_engine/scripting")
         runner.loadScript(src)
         runner.setupScene()
         runner.frame(16 false false false false false)

--- a/gallery/game_engine/scripting/game.d.ts
+++ b/gallery/game_engine/scripting/game.d.ts
@@ -15,10 +15,10 @@
 // ============================================================================
 
 /** Abstract controller buttons delivered to the script (device-independent). */
-export type GameButton = "up" | "down" | "action" | "quit";
+type GameButton = "up" | "down" | "action" | "quit";
 
 /** Read-only game configuration / host info, injected as the `game` global. */
-export interface Game {
+interface Game {
   /** Window / screen title. */
   readonly title: string;
   /** Score at which the match ends (0 = unbounded). */
@@ -30,7 +30,7 @@ export interface Game {
 }
 
 /** Read-only render-surface info, injected as the `screen` global. */
-export interface Screen {
+interface Screen {
   /** Pixel width of the frame buffer. */
   readonly width: number;
   /** Pixel height of the frame buffer. */
@@ -38,10 +38,10 @@ export interface Screen {
 }
 
 /** Retained sprite kinds understood by game_sprite.rgr / GameRunner. */
-export type SpriteKind = "rect" | "circle" | "wedge" | "ghost" | "bitmap";
+type SpriteKind = "rect" | "circle" | "wedge" | "ghost" | "bitmap";
 
 /** Static sprite definition returned from sprites(). */
-export interface SpriteDef {
+interface SpriteDef {
   id: string;
   kind: SpriteKind;
   w?: number;
@@ -67,7 +67,7 @@ export interface SpriteDef {
 }
 
 /** Per-frame entity pose written by update() into state.entities[id]. */
-export interface EntityPose {
+interface EntityPose {
   x: number;
   y: number;
   visible?: number;
@@ -86,7 +86,7 @@ export interface EntityPose {
  * booleans, arrays, plain objects) so it stays portable and deterministic
  * across every Ranger target. `screen` selects which screen is active.
  */
-export interface GameState {
+interface GameState {
   screen?: string;
   score?: number;
   /** 0 hides Pong-style centre net (GameRunner). */
@@ -95,11 +95,72 @@ export interface GameState {
   entities?: Record<string, EntityPose>;
   /** Per-screen sub-state when using the multi-screen model. */
   screens?: Record<string, unknown>;
-  [key: string]: unknown;
 }
 
+/**
+ * Multi-screen root state: `screen` selects the active page and each page
+ * keeps its own frozen sub-state under `screens[name]`.
+ */
+interface MultiScreenState<
+  TScreen extends string,
+  TScreens extends Record<TScreen, unknown>
+> {
+  screen: TScreen;
+  screens: TScreens;
+}
+
+/** RGB colour triple used by retained sprites and HUD. */
+interface RgbColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/** Breakout play-screen sub-state (paddle, ball, bricks). */
+interface BreakoutPlayScreen {
+  layout: "breakout";
+  showNet?: number;
+  entities: Record<string, EntityPose>;
+  px: number;
+  py: number;
+  bx: number;
+  by: number;
+  vx: number;
+  vy: number;
+  alive: number[];
+  score: number;
+  lives: number;
+  score1: number;
+  score2: number;
+}
+
+/** Breakout game-over screen sub-state. */
+interface BreakoutGameOverScreen {
+  layout: "breakout";
+  score: number;
+  won: number;
+  lives: number;
+}
+
+/** Full Breakout multi-screen state. */
+type BreakoutScreens = {
+  play: BreakoutPlayScreen;
+  gameOver?: BreakoutGameOverScreen;
+};
+
+type BreakoutState = {
+  screen: "play" | "gameOver";
+  screens: BreakoutScreens;
+};
+
+/** Screen update helper: receives full state + per-frame props, returns next state. */
+type ScreenUpdateFn<TState extends GameState = GameState> = (
+  s: TState,
+  props: EventProps
+) => TState;
+
 /** Props object passed to every event handler (React-style single argument). */
-export interface EventProps {
+interface EventProps {
   /** Current game state. */
   state: GameState;
   /** Active screen name (multi-screen games). */
@@ -124,7 +185,7 @@ export interface EventProps {
  * optional; the host calls the ones that exist. State transitions are pure:
  * return the NEW state (reducer style) rather than mutating in place.
  */
-export interface GameScript {
+interface GameScript {
   /** Return the initial state (called once at start). */
   initState?(): GameState;
   /** Handle a button event; return the next state. */
@@ -151,3 +212,18 @@ declare const Buttons: {
   readonly ACTION: "action";
   readonly QUIT: "quit";
 };
+
+// Minimal JSX surface for HUD overlays (View / Label used by game_hud.rgr).
+declare namespace JSX {
+  interface Element {}
+  interface IntrinsicElements {
+    View: Record<string, unknown>;
+    Label: Record<string, unknown>;
+    [elemName: string]: Record<string, unknown>;
+  }
+}
+
+/** EVG layout primitive (injected by ComponentEngine JSX expansion). */
+declare function View(props: Record<string, unknown>): JSX.Element;
+/** EVG text primitive. */
+declare function Label(props: Record<string, unknown>): JSX.Element;

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -77,6 +77,12 @@ class GameRunner {
         hudEnabled = (this.scriptHasFunction("hud"))
     }
 
+    ; Directory of the loaded .game.tsx on disk — required for relative imports.
+    fn setScriptDir:void (dir:string) {
+        options.scriptDir = dir
+        engine.setBasePath(dir)
+    }
+
     fn setHotReload:void (enabled:boolean) {
         options.hotReload = enabled
     }
@@ -93,6 +99,9 @@ class GameRunner {
         }
         options.scriptDir = dir
         options.scriptFile = file
+        if ((strlen dir) > 0) {
+            engine.setBasePath(dir)
+        }
         if ((strlen file) > 0) {
             options.scriptMtime = (file_mtime dir file)
         }

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -72,6 +72,7 @@ class GameSdlRunner {
         def buf:buffer (buffer_read_file dir file)
         def src:string (buffer_to_string buf)
         runner.init(pw ph)
+        runner.setScriptDir(dir)
         runner.loadScript(src)
         runner.setupScene()
         runner.trackScriptFile(tsxPath)

--- a/gallery/game_engine/scripting/invaders_runner_demo.rgr
+++ b/gallery/game_engine/scripting/invaders_runner_demo.rgr
@@ -15,6 +15,7 @@ class InvadersRunnerDemo {
 
         def buf:buffer (buffer_read_file "gallery/game_engine/scripting" "invaders.game.tsx")
         def src:string (buffer_to_string buf)
+        runner.setScriptDir("gallery/game_engine/scripting")
         runner.loadScript(src)
         runner.setupScene()
 

--- a/gallery/game_engine/scripting/pacman_runner_demo.rgr
+++ b/gallery/game_engine/scripting/pacman_runner_demo.rgr
@@ -11,6 +11,7 @@ class PacmanRunnerDemo {
 
         def buf:buffer (buffer_read_file "gallery/game_engine/scripting" "pacman.game.tsx")
         def src:string (buffer_to_string buf)
+        runner.setScriptDir("gallery/game_engine/scripting")
         runner.loadScript(src)
         runner.setupScene()
 

--- a/gallery/game_engine/scripting/pong_runner_demo.rgr
+++ b/gallery/game_engine/scripting/pong_runner_demo.rgr
@@ -22,6 +22,7 @@ class PongRunnerDemo {
         ; load the game script from disk
         def buf:buffer (buffer_read_file "gallery/game_engine/scripting" "pong.game.tsx")
         def src:string (buffer_to_string buf)
+        runner.setScriptDir("gallery/game_engine/scripting")
         runner.loadScript(src)
         runner.setupScene()
 

--- a/gallery/game_engine/scripting/spawner_runner_demo.rgr
+++ b/gallery/game_engine/scripting/spawner_runner_demo.rgr
@@ -17,6 +17,7 @@ class SpawnerRunnerDemo {
 
         def buf:buffer (buffer_read_file "gallery/game_engine/scripting" "spawner.game.tsx")
         def src:string (buffer_to_string buf)
+        runner.setScriptDir("gallery/game_engine/scripting")
         runner.loadScript(src)
         runner.setupScene()
 

--- a/gallery/game_engine/scripting/tsconfig.json
+++ b/gallery/game_engine/scripting/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "jsx": "preserve",
+    "lib": ["ES2015"],
+    "skipLibCheck": true
+  },
+  "include": [
+    "game.d.ts",
+    "breakout.game.tsx",
+    "breakout_bricks.tsx"
+  ]
+}

--- a/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
+++ b/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
@@ -278,6 +278,19 @@ class ComponentEngine {
         def src:string (buffer_to_string fileContent)
         return (this.parse(src))
     }
+
+    ; Set the directory used to resolve relative `import "./module"` paths.
+    ; GameRunner calls this before loadScript() when loading from disk.
+    fn setBasePath:void (dirPath:string) {
+        basePath = dirPath
+        if ((strlen dirPath) > 0) {
+            def last:int (strlen dirPath)
+            def lastCh:string (substring dirPath (last - 1) last)
+            if (lastCh != "/") {
+                basePath = (dirPath + "/")
+            }
+        }
+    }
     
     fn parse:EVGElement (src:string) {
         source = src
@@ -484,6 +497,11 @@ class ComponentEngine {
     }
     
     fn processImportDeclaration:void (node:TSNode) {
+        ; Skip type-only imports (import type { ... } from "...")
+        if (node.kind == "type") {
+            return
+        }
+
         ; Get the module path from node.left (StringLiteral - 'from' clause)
         def modulePath:string ""
         if node.left {
@@ -501,6 +519,9 @@ class ComponentEngine {
         if ((indexOf modulePath "evg_") >= 0) {
             return
         }
+        if ((indexOf modulePath ".d.ts") >= 0) {
+            return
+        }
         
         ; Get imported symbols from node.children (import specifiers)
         def importedNames:[string]
@@ -508,7 +529,9 @@ class ComponentEngine {
         while (j < (array_length node.children)) {
             def spec:TSNode (itemAt node.children j)
             if (spec.nodeType == "ImportSpecifier") {
-                push importedNames spec.name
+                if (spec.kind != "type") {
+                    push importedNames spec.name
+                }
             }
             if (spec.nodeType == "ImportDefaultSpecifier") {
                 push importedNames spec.name
@@ -558,6 +581,10 @@ class ComponentEngine {
         importParser.tsxMode = true
         def importAst:TSNode (importParser.parseProgram())
         
+        ; Register all top-level bindings from the imported module so script
+        ; code can call imported functions and read imported constants.
+        this.materializeImportedModule(importAst)
+        
         ; Collect all non-exported helper functions from the file
         def helperFns:[TSNode]
         def hk:int 0
@@ -596,6 +623,7 @@ class ComponentEngine {
                             sym.functionNode = declNode
                             sym.helperFunctions = helperFns
                             push localComponents sym
+                            this.defineModuleBinding(fnName (EvalValue.function(declNode)))
                             print ("Imported component: " + fnName + " from " + fullPath)
                         }
                     }
@@ -614,11 +642,49 @@ class ComponentEngine {
                     sym.functionNode = stmt
                     sym.helperFunctions = helperFns
                     push localComponents sym
+                    this.defineModuleBinding(fnName (EvalValue.function(stmt)))
                     print ("Imported component: " + fnName + " from " + fullPath)
                 }
             }
             
             k = k + 1
+        }
+    }
+
+    ; Bind every top-level function/const from an imported module into moduleScope.
+    fn materializeImportedModule:void (ast:TSNode) {
+        def saved:EvalContext context
+        context = moduleScope
+        def i:int 0
+        while (i < (array_length ast.children)) {
+            def node:TSNode (itemAt ast.children i)
+            this.materializeImportedNode(node)
+            i = i + 1
+        }
+        context = saved
+    }
+
+    fn materializeImportedNode:void (node:TSNode) {
+        if (node.nodeType == "FunctionDeclaration") {
+            if (node.name != "render") {
+                this.defineModuleBinding(node.name (EvalValue.function(node)))
+            }
+            return
+        }
+        if (node.nodeType == "VariableDeclaration") {
+            this.processModuleVariableDeclaration(node)
+            return
+        }
+        if (node.nodeType == "ExportNamedDeclaration") {
+            if node.left {
+                this.materializeImportedNode((unwrap node.left))
+            }
+            return
+        }
+        if (node.nodeType == "ExportDefaultDeclaration") {
+            if node.left {
+                this.materializeImportedNode((unwrap node.left))
+            }
         }
     }
     
@@ -2336,6 +2402,20 @@ class ComponentEngine {
                 return (this.evaluateExpr(inner))
             }
         }
+
+        ; Type assertion (expr as Type) — runtime ignores the type
+        if (node.nodeType == "TSAsExpression") {
+            if node.left {
+                return (this.evaluateExpr((unwrap node.left)))
+            }
+        }
+
+        ; Non-null assertion (expr!) — runtime evaluates the operand
+        if (node.nodeType == "TSNonNullExpression") {
+            if node.left {
+                return (this.evaluateExpr((unwrap node.left)))
+            }
+        }
         
         ; JSX Element as expression (for props like children={<View/>})
         if (node.nodeType == "JSXElement") {
@@ -2709,6 +2789,20 @@ class ComponentEngine {
                 def leftExpr:TSNode (unwrap node.left)
                 def left:EvalValue (this.evaluateExpr(leftExpr))
                 if (left.toBool()) {
+                    return left
+                }
+                if node.right {
+                    def rightExpr:TSNode (unwrap node.right)
+                    return (this.evaluateExpr(rightExpr))
+                }
+            }
+        }
+
+        if (op == "??") {
+            if node.left {
+                def leftExpr:TSNode (unwrap node.left)
+                def left:EvalValue (this.evaluateExpr(leftExpr))
+                if (false == (left.isNull())) {
                     return left
                 }
                 if node.right {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the game scripting developer experience so `*.game.tsx` files can use real TypeScript types in the editor and split code across modules with runtime `import`.

## TypeScript tooling

- Adds [`gallery/game_engine/scripting/tsconfig.json`](gallery/game_engine/scripting/tsconfig.json) with `strict` + `noImplicitAny` for annotated scripts
- Expands [`game.d.ts`](gallery/game_engine/scripting/game.d.ts) with per-screen types (`BreakoutState`, `BreakoutPlayScreen`, `EntityPose`, JSX primitives)
- Fully types [`breakout.game.tsx`](gallery/game_engine/scripting/breakout.game.tsx) as the reference example

```bash
cd gallery/game_engine/scripting && npx tsc --noEmit
```

Add more `*.game.tsx` files to `tsconfig.json` `"include"` as they are annotated.

## Runtime `import` support

`ComponentEngine` already had import parsing; this wires it up for game scripts:

- `GameRunner.setScriptDir(dir)` + `ComponentEngine.setBasePath(dir)` resolve `./relative` paths from the script directory
- Imported modules materialize exported `function` / `const` bindings into the script scope
- Skips `import type` and `.d.ts` paths (types are editor-only via `/// <reference path="./game.d.ts" />`)
- Adds evaluator support for `as` assertions, non-null `!`, and `??`

Example split: [`breakout_bricks.tsx`](gallery/game_engine/scripting/breakout_bricks.tsx) imported by `breakout.game.tsx`.

## Docs

Updates [`GAME_SCRIPTING.md`](gallery/game_engine/scripting/GAME_SCRIPTING.md) with tsconfig, typing, and import instructions.

## Tests

- `tests/game-runner.test.ts` (including breakout with imports)
- `tests/game-scripting.test.ts`
- `tests/tsx-engine.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd688bde-0553-4cc0-a7aa-8c6cb718e140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd688bde-0553-4cc0-a7aa-8c6cb718e140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

