### PR TITLE
fix(cpp): silence r_utf8_substr and trigraph compile warnings

### DIFF
--- a/bin/Lang.rgr
+++ b/bin/Lang.rgr
@@ -3028,10 +3028,10 @@ std::vector<std::string> r_get_keys_of_map(  std::map<std::string, T> orig_map )
 (create_polyfill '
 std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
 {
-    unsigned int start ((unsigned int)start_i);
-    unsigned int leng ((unsigned int)leng_i);
+    size_t start = (size_t)start_i;
+    size_t leng = (size_t)leng_i;
     if (leng==0) { return ""; }
-    unsigned int c, i, ix, q, min= (unsigned int) std::string::npos, max=(unsigned int)std::string::npos;
+    size_t c, i, ix, q, min= std::string::npos, max= std::string::npos;
     for (q=0, i=0, ix=str.length(); i < ix; i++, q++)
     {
         if (q==start){ min=i; }

--- a/bin/output.js
+++ b/bin/output.js
@@ -18678,7 +18678,16 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           wr.out("" + node.double_value, false);
           break;
         case 4 : 
-          const s = this.EncodeString(node, ctx, wr);
+          let s = this.EncodeString(node, ctx, wr);
+          s = s.replace("??=", "\\?\\?=");
+          s = s.replace("??(", "\\?\\?(");
+          s = s.replace("??/", "\\?\\?/");
+          s = s.replace("??)", "\\?\\?)");
+          s = s.replace("??'", "\\?\\?'");
+          s = s.replace("??<", "\\?\\?<");
+          s = s.replace("??!", "\\?\\?!");
+          s = s.replace("??>", "\\?\\?>");
+          s = s.replace("??-", "\\?\\?-");
           wr.out(("std::string(" + (("\"" + s) + "\"")) + ")", false);
           break;
         case 3 : 

--- a/compiler/Lang.rgr
+++ b/compiler/Lang.rgr
@@ -3028,10 +3028,10 @@ std::vector<std::string> r_get_keys_of_map(  std::map<std::string, T> orig_map )
 (create_polyfill '
 std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
 {
-    unsigned int start ((unsigned int)start_i);
-    unsigned int leng ((unsigned int)leng_i);
+    size_t start = (size_t)start_i;
+    size_t leng = (size_t)leng_i;
     if (leng==0) { return ""; }
-    unsigned int c, i, ix, q, min= (unsigned int) std::string::npos, max=(unsigned int)std::string::npos;
+    size_t c, i, ix, q, min= std::string::npos, max= std::string::npos;
     for (q=0, i=0, ix=str.length(); i < ix; i++, q++)
     {
         if (q==start){ min=i; }

--- a/compiler/ng_RangerCppClassWriter.rgr
+++ b/compiler/ng_RangerCppClassWriter.rgr
@@ -14,8 +14,6 @@ class RangerCppClassWriter {
     return tn
   }
 
-  ; std::string
-
   fn WriteScalarValue:void (node:CodeNode ctx:RangerAppWriterContext wr:CodeWriter) {
     switch node.value_type {
       case RangerNodeType.Double {
@@ -23,6 +21,15 @@ class RangerCppClassWriter {
       }
       case RangerNodeType.String {
         def s:string (this.EncodeString(node ctx wr))
+        s = (replace s "??=" "\\?\\?=")
+        s = (replace s "??(" "\\?\\?(")
+        s = (replace s "??/" "\\?\\?/")
+        s = (replace s "??)" "\\?\\?)")
+        s = (replace s "??'" "\\?\\?'")
+        s = (replace s "??<" "\\?\\?<")
+        s = (replace s "??!" "\\?\\?!")
+        s = (replace s "??>" "\\?\\?>")
+        s = (replace s "??-" "\\?\\?-")
         wr.out( "std::string(" + (("\"" + s) + "\"") + ")" , false)
       }
       case RangerNodeType.Integer {

--- a/tests/compiler-cpp.test.ts
+++ b/tests/compiler-cpp.test.ts
@@ -101,6 +101,30 @@ describe("Ranger Compiler - C++ Target", () => {
       expect(charAtDefs).toBeLessThanOrEqual(1);
       expect(substrDefs).toBeLessThanOrEqual(1);
     });
+
+    it("should use size_t in r_utf8_substr polyfill (no npos tautology warnings)", () => {
+      const result = getGeneratedCppCode(
+        `${FIXTURES_DIR}/string_substring.rgr`
+      );
+
+      expect(result.success, `Compile failed: ${result.error}`).toBe(true);
+      expect(result.code).toContain("size_t start = (size_t)start_i");
+      expect(result.code).not.toContain(
+        "unsigned int c, i, ix, q, min= (unsigned int) std::string::npos"
+      );
+    });
+  });
+
+  describe("C++ string literal safety", () => {
+    it("should escape trigraph sequences in string literals", () => {
+      const result = getGeneratedCppCode(
+        `${FIXTURES_DIR}/cpp_trigraph_string.rgr`
+      );
+
+      expect(result.success, `Compile failed: ${result.error}`).toBe(true);
+      expect(result.code).toContain('std::string("\\?\\?=")');
+      expect(result.code).not.toMatch(/std::string\("[^"]*\?\?=/)
+    });
   });
 
   describe("C++ Specific Code Generation", () => {

--- a/tests/fixtures/cpp_trigraph_string.rgr
+++ b/tests/fixtures/cpp_trigraph_string.rgr
@@ -1,0 +1,11 @@
+class TrigraphTest {
+  fn run:string () {
+    def op:string "??="
+    return op
+  }
+}
+
+fn main:void () {
+  def t:TrigraphTest (new TrigraphTest)
+  print (t.run())
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the clang++ warnings reported when building `game_sdl` (and other C++ targets):

1. **`-Wtautological-constant-out-of-range-compare`** in `r_utf8_substr` — the polyfill used `unsigned int` with `std::string::npos`, which is always false on 64-bit platforms.
2. **`-Wtrigraphs`** for `??=` — TypeScript lexer/parser code generates string literals like `"??="`, which clang treats as a trigraph sequence.

## Changes

- **`compiler/Lang.rgr`**: switch `r_utf8_substr` internals to `size_t` so `npos` comparisons are well-typed.
- **`compiler/ng_RangerCppClassWriter.rgr`**: escape C++ trigraph sequences in generated string literals (`??=` → `\?\?=`, etc.).
- **Tests**: add coverage for both fixes in `tests/compiler-cpp.test.ts`.

## Verification

- `npm test -- tests/compiler-cpp.test.ts` — 14/14 passed
- Regenerated `game_sdl.cpp` no longer contains raw `??=` literals or `unsigned int`/`npos` mismatches in `r_utf8_substr`

After merging, rebuild with `npm run compile` (or use the updated `bin/output.js`) and re-run your `game-sdl` build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afae43ad-782d-4c0c-b90b-c93f6d0fb221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afae43ad-782d-4c0c-b90b-c93f6d0fb221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

