### PR TITLE
fix(evg): align HUD layout with bitmap font metrics and row flow.

### DIFF
--- a/gallery/evg/EVGLayout.rgr
+++ b/gallery/evg/EVGLayout.rgr
@@ -77,6 +77,27 @@ class EVGLayout {
             width = element.width.pixels
         }
         
+        ; Text leaf nodes without explicit width shrink-wrap to measured content
+        if (element.width.isSet == false) {
+            def textContent:string element.textContent
+            if ((strlen textContent) > 0) {
+                if ((element.getChildCount()) == 0) {
+                    def fontSize:double element.inheritedFontSize
+                    if element.fontSize.isSet {
+                        fontSize = element.fontSize.pixels
+                    }
+                    if (fontSize <= 0.0) {
+                        fontSize = 14.0
+                    }
+                    def contentW:double (this.measureTextContentWidth(textContent fontSize))
+                    def measuredW:double (contentW + element.box.paddingLeftPx + element.box.paddingRightPx + (element.box.borderWidthPx * 2.0))
+                    if (measuredW < parentWidth) {
+                        width = measuredW
+                    }
+                }
+            }
+        }
+        
         def height:double 0.0
         def autoHeight:boolean true
         
@@ -281,6 +302,7 @@ class EVGLayout {
             def j:int 0
             while (j < childCount) {
                 def c:EVGElement (parent.getChild(j))
+                c.inheritProperties(parent)
                 c.resolveUnits(innerWidth innerHeight)
                 if c.width.isSet {
                     fixedWidth = fixedWidth + c.width.pixels + c.box.marginLeftPx + c.box.marginRightPx
@@ -289,8 +311,9 @@ class EVGLayout {
                         totalFlex = totalFlex + c.flex
                         fixedWidth = fixedWidth + c.box.marginLeftPx + c.box.marginRightPx
                     } {
-                        ; No width and no flex - treat as taking full width (will wrap)
-                        fixedWidth = fixedWidth + innerWidth + c.box.marginLeftPx + c.box.marginRightPx
+                        def avail:double (innerWidth - c.box.marginLeftPx - c.box.marginRightPx)
+                        def estW:double (this.estimateChildWidth(c avail))
+                        fixedWidth = fixedWidth + estW + c.box.marginLeftPx + c.box.marginRightPx
                     }
                 }
                 j = j + 1
@@ -362,9 +385,8 @@ class EVGLayout {
             }
             
             ; Calculate child dimensions
-            ; Start with available inner width minus child's margins
             def availableForChild:double (innerWidth - child.box.marginLeftPx - child.box.marginRightPx)
-            def childWidth:double availableForChild
+            def childWidth:double (this.estimateChildWidth(child availableForChild))
             
             if child.width.isSet {
                 ; If width is explicitly set and it's 100% (resolved to innerWidth), 
@@ -383,7 +405,7 @@ class EVGLayout {
                 }
             }
             
-            ; Total width including margins
+            ; Total width including margins (estimated before layout)
             def childTotalWidth:double (childWidth + child.box.marginLeftPx + child.box.marginRightPx)
             
             ; Check if we need to wrap to next row (for row direction)
@@ -411,6 +433,8 @@ class EVGLayout {
             ; Get actual child height after layout
             def childHeight:double child.calculatedHeight
             def childTotalHeight:double (childHeight + child.box.marginTopPx + child.box.marginBottomPx)
+            ; After shrink-wrap, use real width for row cursor advance
+            def placedWidth:double (child.calculatedWidth + child.box.marginLeftPx + child.box.marginRightPx)
             
             ; Update position tracking
             if isColumn {
@@ -419,7 +443,7 @@ class EVGLayout {
                 totalHeight = totalHeight + childTotalHeight
             } {
                 ; Row direction: advance horizontally
-                currentX = currentX + childTotalWidth
+                currentX = currentX + placedWidth
                 push rowElements child
                 if (childTotalHeight > rowHeight) {
                     rowHeight = childTotalHeight
@@ -702,6 +726,54 @@ class EVGLayout {
             this.printLayout(child (indent + 1))
             i = i + 1
         }
+    }
+    
+    fn estimateChildWidth:double (child:EVGElement maxInnerWidth:double) {
+        ; Width used for row flow / flex pre-calc — matches layoutElement shrink-wrap
+        if child.width.isSet {
+            return child.width.pixels
+        }
+        if (child.calculatedFlexWidth > 0.0) {
+            return child.calculatedFlexWidth
+        }
+        def textContent:string child.textContent
+        if ((strlen textContent) > 0) {
+            if ((child.getChildCount()) == 0) {
+                def fontSize:double child.inheritedFontSize
+                if child.fontSize.isSet {
+                    fontSize = child.fontSize.pixels
+                }
+                if (fontSize <= 0.0) {
+                    fontSize = 14.0
+                }
+                def contentW:double (this.measureTextContentWidth(textContent fontSize))
+                def measuredW:double (contentW + child.box.paddingLeftPx + child.box.paddingRightPx + (child.box.borderWidthPx * 2.0))
+                if (measuredW < maxInnerWidth) {
+                    return measuredW
+                }
+            }
+        }
+        return maxInnerWidth
+    }
+    
+    fn measureTextContentWidth:double (text:string fontSize:double) {
+        ; Widest line width for shrink-wrapped text nodes
+        if ((strlen text) == 0) {
+            return 0.0
+        }
+        def fontFamily:string "Helvetica"
+        def lines:[string] (strsplit text "\n")
+        def maxW:double 0.0
+        def i:int 0
+        while (i < (array_length lines)) {
+            def line:string (itemAt lines i)
+            def lineW:double (measurer.measureTextWidth(line fontFamily fontSize))
+            if (lineW > maxW) {
+                maxW = lineW
+            }
+            i = i + 1
+        }
+        return maxW
     }
     
     fn estimateLineCount:int (text:string maxWidth:double fontSize:double) {

--- a/gallery/evg/bin/evg_test.js
+++ b/gallery/evg/bin/evg_test.js
@@ -1880,6 +1880,25 @@ class EVGLayout  {
     if ( element.width.isSet ) {
       width = element.width.pixels;
     }
+    if ( element.width.isSet == false ) {
+      const textContent = element.textContent;
+      if ( (textContent.length) > 0 ) {
+        if ( element.getChildCount() == 0 ) {
+          let fontSize = element.inheritedFontSize;
+          if ( element.fontSize.isSet ) {
+            fontSize = element.fontSize.pixels;
+          }
+          if ( fontSize <= 0.0 ) {
+            fontSize = 14.0;
+          }
+          const contentW = this.measureTextContentWidth(textContent, fontSize);
+          const measuredW = ((contentW + element.box.paddingLeftPx) + element.box.paddingRightPx) + (element.box.borderWidthPx * 2.0);
+          if ( measuredW < parentWidth ) {
+            width = measuredW;
+          }
+        }
+      }
+    }
     let height = 0.0;
     let autoHeight = true;
     if ( (element.tagName == "Page") || (element.tagName == "page") ) {
@@ -1967,22 +1986,22 @@ class EVGLayout  {
     if ( childCount > 0 ) {
       contentHeight = this.layoutChildren(element);
     } else {
-      const textContent = element.textContent;
-      if ( (textContent.length) > 0 ) {
-        let fontSize = element.inheritedFontSize;
+      const textContent_1 = element.textContent;
+      if ( (textContent_1.length) > 0 ) {
+        let fontSize_1 = element.inheritedFontSize;
         if ( element.fontSize.isSet ) {
-          fontSize = element.fontSize.pixels;
+          fontSize_1 = element.fontSize.pixels;
         }
-        if ( fontSize <= 0.0 ) {
-          fontSize = 14.0;
+        if ( fontSize_1 <= 0.0 ) {
+          fontSize_1 = 14.0;
         }
         let lineHeightFactor = element.lineHeight;
         if ( lineHeightFactor <= 0.0 ) {
           lineHeightFactor = 1.2;
         }
-        const lineSpacing = fontSize * lineHeightFactor;
+        const lineSpacing = fontSize_1 * lineHeightFactor;
         const availableWidth = (width - element.box.paddingLeftPx) - element.box.paddingRightPx;
-        const lineCount = this.estimateLineCount(textContent, availableWidth, fontSize);
+        const lineCount = this.estimateLineCount(textContent_1, availableWidth, fontSize_1);
         contentHeight = lineSpacing * (lineCount);
       }
     }
@@ -2326,6 +2345,24 @@ class EVGLayout  {
       this.printLayout(child, indent + 1);
       i = i + 1;
     };
+  };
+  measureTextContentWidth (text, fontSize) {
+    if ( (text.length) == 0 ) {
+      return 0.0;
+    }
+    const fontFamily = "Helvetica";
+    const lines = text.split("\n");
+    let maxW = 0.0;
+    let i = 0;
+    while (i < (lines.length)) {
+      const line = lines[i];
+      const lineW = this.measurer.measureTextWidth(line, fontFamily, fontSize);
+      if ( lineW > maxW ) {
+        maxW = lineW;
+      }
+      i = i + 1;
+    };
+    return maxW;
   };
   estimateLineCount (text, maxWidth, fontSize) {
     if ( (text.length) == 0 ) {

--- a/gallery/game_engine/scripting/breakout.game.tsx
+++ b/gallery/game_engine/scripting/breakout.game.tsx
@@ -261,15 +261,23 @@ function hud(props: EventProps): JSX.Element {
       title = "YOU WIN";
     }
     return (
-      <View flexDirection="row" padding="20px">
-        <Label color="#8fd3ff">{title} HOT RELOAD {go.score}</Label>
+      <View>
+        <View flexDirection="row" padding="20px" width="100%" align="center">
+          <Label color="#8fd3ff">PISTEET {go.score}</Label>
+        </View>
+        <View flexDirection="row" padding="2px" width="100%" align="center">
+          <View align="center" width="100%"><Label color="#8fd3ff">PAINA SPACE</Label></View>
+        </View>
       </View>
     );
   }
   const play = s.screens.play;
   return (
-    <View flexDirection="column" padding="6px">
-      <Label color="#ffffff" padding="2px">SCORE {play.score}</Label>
+    <View flexDirection="column" padding="6px" align="center" width="100%">
+      <View align="center" width="100%" flexDirection="row">
+        <Label color="#ff22ff" padding="2px" align="center">SCORE</Label>
+        <Label color="#ffffff" padding="2px">{play.score}</Label>
+      </View>
       <Label color="#ff8899" padding="2px">LIVES {play.lives}</Label>
     </View>
   );

--- a/gallery/game_engine/scripting/game_hud.rgr
+++ b/gallery/game_engine/scripting/game_hud.rgr
@@ -13,9 +13,75 @@ Import "../../evg/EVGLayout.rgr"
 Import "../../evg/EVGElement.rgr"
 Import "../../evg/EVGColor.rgr"
 Import "../../evg/EVGUnit.rgr"
+Import "../../evg/EVGTextMeasurer.rgr"
+
+; Text measurer matching the bitmap HUD font in drawGlyph/drawText.
+class HudBitmapTextMeasurer {
+    Extends(EVGTextMeasurer)
+
+    fn scaleFor:int (fontSize:double) {
+        def scale 2
+        if (fontSize >= 14.0) {
+            scale = 3
+        }
+        return scale
+    }
+
+    fn charStep:int (fontSize:double) {
+        def scale (this.scaleFor(fontSize))
+        return ((scale * 3) + scale)
+    }
+
+    fn lineStep:int (fontSize:double) {
+        def scale (this.scaleFor(fontSize))
+        return ((scale * 5) + scale)
+    }
+
+    fn measureText:EVGTextMetrics (text:string fontFamily:string fontSize:double) {
+        def step:double (to_double (this.charStep(fontSize)))
+        def lineH:double (to_double (this.lineStep(fontSize)))
+        def width:double 0.0
+        def lines:[string] (strsplit text "\n")
+        def i:int 0
+        while (i < (array_length lines)) {
+            def line:string (itemAt lines i)
+            def lineW:double ((to_double (strlen line)) * step)
+            if (lineW > width) {
+                width = lineW
+            }
+            i = i + 1
+        }
+        def lineCount:int (array_length lines)
+        if (lineCount < 1) {
+            lineCount = 1
+        }
+        def height:double (lineH * (to_double lineCount))
+        def metrics (new EVGTextMetrics())
+        metrics.width = width
+        metrics.height = height
+        metrics.lineHeight = lineH
+        metrics.ascent = lineH
+        metrics.descent = 0.0
+        return metrics
+    }
+
+    fn measureTextWidth:double (text:string fontFamily:string fontSize:double) {
+        def m:EVGTextMetrics (this.measureText(text fontFamily fontSize))
+        return m.width
+    }
+
+    fn measureChar:double (ch:int fontFamily:string fontSize:double) {
+        return (to_double (this.charStep(fontSize)))
+    }
+
+    fn getLineHeight:double (fontFamily:string fontSize:double) {
+        return (to_double (this.lineStep(fontSize)))
+    }
+}
 
 class GameHudBlitter {
     def layout:EVGLayout (new EVGLayout)
+    def hudMeasurer:HudBitmapTextMeasurer (new HudBitmapTextMeasurer)
     def canvas:SoftCanvas
 
     fn attach:void (c:SoftCanvas) {
@@ -38,6 +104,7 @@ class GameHudBlitter {
         def fw:double (to_double w)
         def fh:double (to_double h)
         layout.setPageSize(fw fh)
+        layout.setMeasurer(hudMeasurer)
         root.calculatedX = 0.0
         root.calculatedY = 0.0
         ; Keep script-defined height (e.g. height="100%" splash screens). Auto-height when unset.
@@ -80,13 +147,14 @@ class GameHudBlitter {
                 def tr:int (el.color.red())
                 def tg:int (el.color.green())
                 def tb:int (el.color.blue())
-                def scale 2
+                def fs:double el.inheritedFontSize
                 if (el.fontSize.isSet) {
-                    def fs (el.fontSize.pixels)
-                    if (fs >= 14.0) {
-                        scale = 3
-                    }
+                    fs = el.fontSize.pixels
                 }
+                if (fs <= 0.0) {
+                    fs = 14.0
+                }
+                def scale (hudMeasurer.scaleFor(fs))
                 this.drawText(x y scale txt tr tg tb)
             }
         }
@@ -160,7 +228,7 @@ class GameHudBlitter {
         if (ch == "K") { return "101101110101101" }
         if (ch == "L") { return "100100100100111" }
         if (ch == "M") { return "101111111101101" }
-        if (ch == "N") { return "101111101111101" }
+        if (ch == "N") { return "101110110101101" }
         if (ch == "O") { return "111101101101111" }
         if (ch == "P") { return "111101111100100" }
         if (ch == "R") { return "111101111101101" }

--- a/gallery/game_engine/scripts/build-game-sdl.sh
+++ b/gallery/game_engine/scripts/build-game-sdl.sh
@@ -51,11 +51,16 @@ fi
 
 echo "==> 1/3 Ranger -> C++"
 cd "$ROOT"
-RANGER_LIB="$ROOT/compiler/Lang.rgr:$ROOT/lib/stdops.rgr" node "$ROOT/bin/output.js" \
+RANGER_OUT="$(RANGER_LIB="$ROOT/compiler/Lang.rgr:$ROOT/lib/stdops.rgr" node "$ROOT/bin/output.js" \
   -l=cpp "$SOURCE" \
   -nodecli \
   -d="tmp/game-sdl" \
-  -o="game_sdl.cpp"
+  -o="game_sdl.cpp" 2>&1)" || true
+echo "$RANGER_OUT" | tail -20
+if echo "$RANGER_OUT" | grep -q '\[FAIL\]'; then
+  echo "error: Ranger compilation failed (see output above)" >&2
+  exit 1
+fi
 
 cp "$ROOT/gallery/invaders/variant.hpp" "$OUT_DIR/variant.hpp"
 

--- a/gallery/game_engine/scripts/watch-game-sdl.mjs
+++ b/gallery/game_engine/scripts/watch-game-sdl.mjs
@@ -11,13 +11,22 @@
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const BUILD = path.join(ROOT, 'gallery/game_engine/scripts/build-game-sdl.sh');
 const BIN = path.join(ROOT, 'tmp/game-sdl/game_sdl');
+
+/** Ranger sources that compile into the native host — rebuild when newer than the binary. */
+const HOST_SOURCES = [
+  'gallery/game_engine/scripting/game_sdl_runner.rgr',
+  'gallery/game_engine/scripting/game_runtime.rgr',
+  'gallery/game_engine/scripting/game_hud.rgr',
+  'gallery/evg/EVGLayout.rgr',
+  'gallery/evg/EVGElement.rgr',
+];
 
 const GAMES = {
   invaders: 'gallery/game_engine/scripting/invaders.game.tsx',
@@ -41,12 +50,24 @@ function stopChild() {
   child = null;
 }
 
+function hostSourcesStale() {
+  if (!existsSync(BIN)) return true;
+  const binMtime = statSync(BIN).mtimeMs;
+  for (const rel of HOST_SOURCES) {
+    const abs = path.join(ROOT, rel);
+    if (existsSync(abs) && statSync(abs).mtimeMs > binMtime) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function ensureHostBinary(cb) {
-  if (existsSync(BIN)) {
+  if (existsSync(BIN) && !hostSourcesStale()) {
     cb();
     return;
   }
-  console.log('==> [watch] building game_sdl host (first run) ...');
+  console.log('==> [watch] building game_sdl host (missing or stale .rgr sources) ...');
   const build = spawn('bash', [BUILD], { cwd: ROOT, stdio: 'inherit' });
   build.on('exit', (code) => {
     if (code !== 0) {


### PR DESCRIPTION
Text labels now shrink-wrap to measured width, row layout advances by actual glyph size, and GameHudBlitter uses a dedicated measurer so SCORE/score rows do not overlap.