### PR TITLE
feat(game-engine): synthetic audio with callback sink + Breakout sounds

### DIFF
--- a/gallery/game_engine/gfx_sdl.rgr
+++ b/gallery/game_engine/gfx_sdl.rgr
@@ -32,10 +32,32 @@ operators {
 static SDL_Window*   g_rgfx_win = nullptr;
 static SDL_Renderer* g_rgfx_ren = nullptr;
 static SDL_Texture*  g_rgfx_tex = nullptr;
+static SDL_AudioDeviceID g_rgfx_audio = 0;
 static int g_rgfx_should_close = 0;
 
+static int rgfx_audio_open(int sampleRate) {
+    if (g_rgfx_audio != 0) { return 1; }
+    SDL_AudioSpec want, have;
+    SDL_zero(want);
+    want.freq = sampleRate > 0 ? sampleRate : 22050;
+    want.format = AUDIO_S16SYS;
+    want.channels = 1;
+    want.samples = 512;
+    want.callback = nullptr;
+    want.userdata = nullptr;
+    g_rgfx_audio = SDL_OpenAudioDevice(nullptr, 0, &want, &have, 0);
+    if (g_rgfx_audio == 0) { return 0; }
+    SDL_PauseAudioDevice(g_rgfx_audio, 0);
+    return 1;
+}
+static void rgfx_audio_queue(const uint8_t* pcm, int byteCount) {
+    if (g_rgfx_audio == 0) { return; }
+    if (pcm == nullptr || byteCount <= 0) { return; }
+    SDL_QueueAudio(g_rgfx_audio, pcm, (Uint32) byteCount);
+}
+
 static int rgfx_open(const std::string& title, int w, int h) {
-    if (SDL_Init(SDL_INIT_VIDEO) != 0) { return 0; }
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) != 0) { return 0; }
     g_rgfx_win = SDL_CreateWindow(title.c_str(),
         SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, w, h, SDL_WINDOW_SHOWN);
     if (g_rgfx_win == nullptr) { return 0; }
@@ -81,6 +103,7 @@ static void rgfx_set_title(const std::string& title) {
     if (g_rgfx_win != nullptr) { SDL_SetWindowTitle(g_rgfx_win, title.c_str()); }
 }
 static void rgfx_close() {
+    if (g_rgfx_audio) { SDL_CloseAudioDevice(g_rgfx_audio); g_rgfx_audio = 0; }
     if (g_rgfx_tex) { SDL_DestroyTexture(g_rgfx_tex); g_rgfx_tex = nullptr; }
     if (g_rgfx_ren) { SDL_DestroyRenderer(g_rgfx_ren); g_rgfx_ren = nullptr; }
     if (g_rgfx_win) { SDL_DestroyWindow(g_rgfx_win); g_rgfx_win = nullptr; }
@@ -145,6 +168,22 @@ static void rgfx_close() {
     gfx_close _:void () {
         templates {
             cpp ( "rgfx_close()" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Open a mono S16 audio output device (call once after gfx_open).
+    gfx_audio_open _:int (sampleRate:int) {
+        templates {
+            cpp ( "rgfx_audio_open(" (e 1) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+
+    ; Queue raw PCM bytes (mono int16 little-endian) for playback.
+    gfx_audio_queue _:void (pcm:buffer byteCount:int) {
+        templates {
+            cpp ( "rgfx_audio_queue(" (e 1) ".data(), " (e 2) ")" (imp "<SDL2/SDL.h>") (imp "<cstdint>") )
             es6 ( "undefined" )
         }
     }

--- a/gallery/game_engine/scripting/audio_runner_demo.rgr
+++ b/gallery/game_engine/scripting/audio_runner_demo.rgr
@@ -1,0 +1,41 @@
+; ==============================================================================
+; audio_runner_demo - exercises built-in synth sounds via playSound events.
+; ==============================================================================
+
+Import "./game_runtime.rgr"
+
+class AudioRunnerDemo {
+    sfn m@(main):void () {
+        def runner:GameRunner (new GameRunner)
+        runner.init(320 240)
+
+        def src:string ""
+        src = (src + "function initState() { return { entities: { dot: { x: 10, y: 10 } } }; }\n")
+        src = (src + "function sprites() { return [{ id: \"dot\", kind: \"circle\", rad: 4, r: 255, g: 200, b: 80 }]; }\n")
+        src = (src + "function update(props) {\n")
+        src = (src + "  const t = props.state.t || 0;\n")
+        src = (src + "  const next = t + 1;\n")
+        src = (src + "  let ev = [];\n")
+        src = (src + "  if (next == 1) { ev = [{ kind: \"playSound\", id: \"brick\" }]; }\n")
+        src = (src + "  if (next == 2) { ev = [{ kind: \"playSound\", id: \"bounce\" }]; }\n")
+        src = (src + "  if (next == 3) { ev = [{ kind: \"playSound\", id: \"win\" }]; }\n")
+        src = (src + "  return { entities: { dot: { x: 10 + next, y: 10 } }, t: next, events: ev };\n")
+        src = (src + "}\n")
+
+        runner.loadScript(src)
+        runner.setupScene()
+
+        def i 0
+        while (i < 5) {
+            runner.frame(16 false false false false false)
+            i = (i + 1)
+        }
+
+        def host:GameHost (runner.hostRef())
+        def audio:GameAudio (runner.audioRef())
+        print (("soundPlays=" + (host.soundPlayCount())))
+        print (("audioPlays=" + audio.playCount))
+        print (("lastSound=" + audio.lastId))
+        print "audio-runner done"
+    }
+}

--- a/gallery/game_engine/scripting/breakout.game.tsx
+++ b/gallery/game_engine/scripting/breakout.game.tsx
@@ -26,7 +26,7 @@ import {
   makeAlive,
   placeBricks
 } from "./breakout_bricks";
-import { getScreen, isActiveScreen } from "./game_helpers";
+import { getScreen, isActiveScreen, soundEvent } from "./game_helpers";
 
 function screens(): string[] {
   return ["play", "gameOver"];
@@ -107,6 +107,7 @@ function goToGameOver(
 
 function updatePlay(s: BreakoutState, props: EventProps): BreakoutState {
   const play = getScreen(s, "play");
+  const events: GameEvent[] = [];
   const dt = props.dt as number;
   let px = play.px;
   let py = play.py;
@@ -126,9 +127,9 @@ function updatePlay(s: BreakoutState, props: EventProps): BreakoutState {
   bx = bx + vx * dt;
   by = by + vy * dt;
 
-  if (by < 8) { by = 8; vy = 0 - vy; }
-  if (bx < 6) { bx = 6; vx = 0 - vx; }
-  if (bx > 474) { bx = 474; vx = 0 - vx; }
+  if (by < 8) { by = 8; vy = 0 - vy; events.push(soundEvent("wall")); }
+  if (bx < 6) { bx = 6; vx = 0 - vx; events.push(soundEvent("wall")); }
+  if (bx > 474) { bx = 474; vx = 0 - vx; events.push(soundEvent("wall")); }
 
   if (by > py - 14) {
     if (bx > px - 36) {
@@ -137,12 +138,14 @@ function updatePlay(s: BreakoutState, props: EventProps): BreakoutState {
         vy = 0 - vy;
         const hit = (bx - px) / 36.0;
         vx = vx + hit * 0.06;
+        events.push(soundEvent("bounce"));
       }
     }
   }
 
   if (by > 270) {
     lives = lives - 1;
+    events.push(soundEvent("lose"));
     const reset = resetBall(px, py);
     bx = reset.bx;
     by = reset.by;
@@ -164,7 +167,12 @@ function updatePlay(s: BreakoutState, props: EventProps): BreakoutState {
         score1: score,
         score2: 0
       };
-      return goToGameOver(s, frozen, 0);
+      const over = goToGameOver(s, frozen, 0);
+      return {
+        screen: over.screen,
+        screens: over.screens,
+        events: events
+      };
     }
   }
 
@@ -175,6 +183,7 @@ function updatePlay(s: BreakoutState, props: EventProps): BreakoutState {
         alive[i] = 0;
         vy = 0 - vy;
         score = score + 10;
+        events.push(soundEvent("brick"));
       }
     }
     i = i + 1;
@@ -196,7 +205,13 @@ function updatePlay(s: BreakoutState, props: EventProps): BreakoutState {
       score1: score,
       score2: lives
     };
-    return goToGameOver(s, frozen, 1);
+    const over = goToGameOver(s, frozen, 1);
+    events.push(soundEvent("win"));
+    return {
+      screen: over.screen,
+      screens: over.screens,
+      events: events
+    };
   }
 
   const entities: Record<string, EntityPose> = {};
@@ -224,7 +239,8 @@ function updatePlay(s: BreakoutState, props: EventProps): BreakoutState {
     screen: "play",
     screens: {
       play: nextPlay
-    }
+    },
+    events: events
   };
 }
 

--- a/gallery/game_engine/scripting/breakout_runner_demo.rgr
+++ b/gallery/game_engine/scripting/breakout_runner_demo.rgr
@@ -41,6 +41,9 @@ class BreakoutRunnerDemo {
         print (("score=" + runner.score1) + ("," + runner.score2))
         def ec:int (runner.entityCount())
         print (("entities=" + ec))
+        def audio:GameAudio (runner.audioRef())
+        def audioPlays:int audio.playCount
+        print (("audioPlays=" + audioPlays))
         print "breakout-runner done"
     }
 }

--- a/gallery/game_engine/scripting/engine.d.ts
+++ b/gallery/game_engine/scripting/engine.d.ts
@@ -115,6 +115,32 @@ interface GameState {
   screen?: string;
   /** Per-screen frozen sub-state (multi-screen model). */
   screens?: object;
+  /** Transient per-frame events drained by the host (sounds, spawn, …). */
+  events?: GameEvent[];
+}
+
+/** Built-in synthetic sound ids (no file resources required). */
+type BuiltinSoundId =
+  | "blip"
+  | "brick"
+  | "bounce"
+  | "wall"
+  | "lose"
+  | "win";
+
+/** Transient event emitted from update() and drained by GameHost each frame. */
+interface GameEvent {
+  kind: string;
+  id: string;
+  x?: number;
+  y?: number;
+  amount?: number;
+}
+
+/** Convenience type for playSound events using built-in synth ids. */
+interface PlaySoundEvent extends GameEvent {
+  kind: "playSound";
+  id: BuiltinSoundId | string;
 }
 
 /**

--- a/gallery/game_engine/scripting/game_audio.rgr
+++ b/gallery/game_engine/scripting/game_audio.rgr
@@ -1,0 +1,241 @@
+; ==============================================================================
+; game_audio - built-in synthetic sounds + host callback sink.
+; ==============================================================================
+;
+; No file-based resource management yet. Games emit { kind: "playSound", id }
+; events (or call GameAudio.play directly from the host). Built-in ids are
+; synthesised on demand as mono PCM and delivered to an optional sink callback
+; (SDL runner queues them; headless tests count plays).
+;
+; Built-in sound ids:
+;   blip, brick, bounce, wall, lose, win
+; ==============================================================================
+
+; Waveform selector for the tone generator.
+class SynthWave {
+    sfn sine:int () { return 0 }
+    sfn square:int () { return 1 }
+    sfn triangle:int () { return 2 }
+    sfn noise:int () { return 3 }
+}
+
+; Parameters for a single synthetic tone burst.
+class SynthToneSpec {
+    def freqHz:double 440.0
+    def durationMs:int 80
+    def volume:double 0.35
+    def wave:int 0
+    def slideHz:double 0.0        ; linear freq slide to this value over duration
+}
+
+; Host callback interface. Override onSynthPlay in a subclass (e.g. SDL sink).
+class GameAudioSink {
+    fn onSynthPlay:void (soundId:string sampleRate:int sampleCount:int pcm:buffer) {
+    }
+}
+
+class GameAudio {
+    def sampleRate:int 22050
+    def sink:GameAudioSink (new GameAudioSink)
+    def playCount:int 0
+    def lastId:string ""
+    def verbose:boolean false
+    def sineTable:[double]
+
+    fn init:void () {
+        sineTable = (this.buildSineTable())
+    }
+
+    fn buildSineTable:[double] () {
+        def table:[double]
+        def i 0
+        while (i < 64) {
+            def angle:double ((to_double i) / 64.0)
+            angle = (angle * 6.283185307)
+            ; Taylor-ish sine approximation (good enough for blips).
+            def x:double angle
+            def x3:double (x * x * x)
+            def x5:double (x3 * x * x)
+            def s:double (x - (x3 / 6.0) + (x5 / 120.0))
+            push table s
+            i = (i + 1)
+        }
+        return table
+    }
+
+    fn setSink:void (s:GameAudioSink) {
+        sink = s
+    }
+
+    fn hasBuiltin:boolean (id:string) {
+        if (id == "blip") { return true }
+        if (id == "brick") { return true }
+        if (id == "bounce") { return true }
+        if (id == "wall") { return true }
+        if (id == "lose") { return true }
+        if (id == "win") { return true }
+        return false
+    }
+
+    fn lookupSpec:SynthToneSpec (id:string) {
+        def spec:SynthToneSpec (new SynthToneSpec)
+        if (id == "blip") {
+            spec.freqHz = 660.0
+            spec.durationMs = 40
+            spec.volume = 0.30
+            spec.wave = (SynthWave.square())
+            return spec
+        }
+        if (id == "brick") {
+            spec.freqHz = 880.0
+            spec.durationMs = 55
+            spec.volume = 0.32
+            spec.wave = (SynthWave.square())
+            return spec
+        }
+        if (id == "bounce") {
+            spec.freqHz = 330.0
+            spec.durationMs = 45
+            spec.volume = 0.28
+            spec.wave = (SynthWave.triangle())
+            return spec
+        }
+        if (id == "wall") {
+            spec.freqHz = 220.0
+            spec.durationMs = 25
+            spec.volume = 0.18
+            spec.wave = (SynthWave.triangle())
+            return spec
+        }
+        if (id == "lose") {
+            spec.freqHz = 420.0
+            spec.durationMs = 280
+            spec.volume = 0.30
+            spec.wave = (SynthWave.sine())
+            spec.slideHz = 160.0
+            return spec
+        }
+        if (id == "win") {
+            spec.freqHz = 523.0
+            spec.durationMs = 120
+            spec.volume = 0.30
+            spec.wave = (SynthWave.sine())
+            return spec
+        }
+        spec.freqHz = 440.0
+        spec.durationMs = 60
+        spec.volume = 0.25
+        spec.wave = (SynthWave.sine())
+        return spec
+    }
+
+    fn writeInt16LE:void (buf:buffer offset:int value:int) {
+        def v value
+        if (v < 0) {
+            v = (65536 + v)
+        }
+        def lo:int (bit_and v 255)
+        def hi:int (bit_and (to_int (v / 256)) 255)
+        buffer_set buf offset lo
+        buffer_set buf (offset + 1) hi
+    }
+
+    fn sampleWave:double (wave:int phase:double noiseSeed:int) {
+        if (wave == (SynthWave.square())) {
+            if (phase < 0.5) {
+                return 1.0
+            }
+            return -1.0
+        }
+        if (wave == (SynthWave.triangle())) {
+            if (phase < 0.25) {
+                return (phase * 4.0)
+            }
+            if (phase < 0.75) {
+                return (1.0 - ((phase - 0.25) * 4.0))
+            }
+            return (-1.0 + ((phase - 0.75) * 4.0))
+        }
+        if (wave == (SynthWave.noise())) {
+            def n:int (bit_and ((noiseSeed * 1103515245) + 12345) 255)
+            return ((to_double n) / 127.5) - 1.0
+        }
+        def idx:int (bit_and (to_int (phase * 64.0)) 63)
+        return (itemAt sineTable idx)
+    }
+
+    fn synthTone:buffer (spec:SynthToneSpec) {
+        def frames:int (to_int (((to_double spec.durationMs) * (to_double sampleRate)) / 1000.0))
+        if (frames < 1) {
+            frames = 1
+        }
+        def pcm:buffer (buffer_alloc (frames * 2))
+        def phase:double 0.0
+        def freq:double spec.freqHz
+        def slidePerFrame:double 0.0
+        if (spec.slideHz != 0.0) {
+            slidePerFrame = ((spec.slideHz - spec.freqHz) / (to_double frames))
+        }
+        def i 0
+        while (i < frames) {
+            def t:double ((to_double i) / (to_double frames))
+            def env:double (1.0 - t)
+            env = (env * env)
+            def sample:double (this.sampleWave(spec.wave phase i))
+            def amp:double (sample * spec.volume * env * 32767.0)
+            def iv:int (to_int amp)
+            if (iv > 32767) { iv = 32767 }
+            if (iv < -32768) { iv = -32768 }
+            this.writeInt16LE(pcm (i * 2) iv)
+            freq = (freq + slidePerFrame)
+            if (freq < 40.0) { freq = 40.0 }
+            phase = (phase + (freq / (to_double sampleRate)))
+            while (phase >= 1.0) {
+                phase = (phase - 1.0)
+            }
+            i = (i + 1)
+        }
+        return pcm
+    }
+
+    fn queueSpec:void (id:string spec:SynthToneSpec) {
+        def pcm:buffer (this.synthTone(spec))
+        def frames:int (to_int (((to_double spec.durationMs) * (to_double sampleRate)) / 1000.0))
+        if (frames < 1) {
+            frames = 1
+        }
+        sink.onSynthPlay(id sampleRate frames pcm)
+    }
+
+    fn play:void (id:string) {
+        playCount = (playCount + 1)
+        lastId = id
+        if verbose {
+            print ("[audio] play " + id)
+        }
+        if (id == "win") {
+            this.playWinArpeggio()
+            return
+        }
+        def spec:SynthToneSpec (this.lookupSpec(id))
+        this.queueSpec(id spec)
+    }
+
+    fn playWinArpeggio:void () {
+        def notes:[double]
+        push notes 523.0
+        push notes 659.0
+        push notes 784.0
+        push notes 1046.0
+        def i 0
+        while (i < (array_length notes)) {
+            def spec:SynthToneSpec (new SynthToneSpec)
+            spec.freqHz = (itemAt notes i)
+            spec.durationMs = 90
+            spec.volume = 0.28
+            spec.wave = (SynthWave.sine())
+            this.queueSpec("win" spec)
+            i = (i + 1)
+        }
+    }
+}

--- a/gallery/game_engine/scripting/game_audio_sdl.rgr
+++ b/gallery/game_engine/scripting/game_audio_sdl.rgr
@@ -1,0 +1,12 @@
+; ==============================================================================
+; game_audio_sdl - SDL audio sink for GameAudio synth playback.
+; ==============================================================================
+
+Import "./game_audio.rgr"
+Import "../gfx_sdl.rgr"
+
+class SdlGameAudioSink extends GameAudioSink {
+    fn onSynthPlay:void (soundId:string sampleRate:int sampleCount:int pcm:buffer) {
+        gfx_audio_queue(pcm (sampleCount * 2))
+    }
+}

--- a/gallery/game_engine/scripting/game_helpers.tsx
+++ b/gallery/game_engine/scripting/game_helpers.tsx
@@ -26,3 +26,8 @@ export function isActiveScreen<TActive extends string>(
 ): state is { screen: TActive } {
   return state.screen === name;
 }
+
+/** Build a playSound event for a built-in synthetic sound id. */
+export function soundEvent(id: BuiltinSoundId): PlaySoundEvent {
+  return { kind: "playSound", id: id };
+}

--- a/gallery/game_engine/scripting/game_native_runtime.rgr
+++ b/gallery/game_engine/scripting/game_native_runtime.rgr
@@ -10,11 +10,13 @@ Import "../framebuffer.rgr"
 Import "../../ts_to_ranger/game_script_types.rgr"
 Import "../../pdf_writer/src/jsx/EvalValue.rgr"
 Import "./game_sprite.rgr"
+Import "./game_audio.rgr"
 
 class NativeGameRunner {
     def canvas:SoftCanvas (new SoftCanvas)
     def stateOps:NativeGameStateOps (new NativeGameStateOps)
     def host:GameHost (new GameHost)
+    def audio:GameAudio (new GameAudio)
     def spriteRenderer:GameSpriteRenderer (new GameSpriteRenderer)
     def entities:[GameEntity]
     def state:NativeGameState (new NativeGameState)
@@ -28,9 +30,11 @@ class NativeGameRunner {
     def currentScreen:string ""
 
     fn init:void (w:int h:int) {
+        audio.init()
         pw = w
         ph = h
         canvas.init(w h)
+        host.audio = audio
     }
 
     fn half:int (n:int) {
@@ -201,6 +205,7 @@ class NativeGameRunner {
     }
 
     fn setupScene:void (initState:NativeGameState sprites:[SpriteDefNative]) {
+        host.audio = audio
         state = initState
         this.setupSprites(sprites)
         this.syncFromState()

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -21,6 +21,7 @@ Import "../../evg/EVGElement.rgr"
 Import "./game_sprite.rgr"
 Import "./game_hud.rgr"
 Import "../../ts_to_ranger/game_host.rgr"
+Import "./game_audio.rgr"
 
 ; Runtime options for script-driven games (SDL host, tests, custom hosts).
 class GameRuntimeOptions {
@@ -39,6 +40,7 @@ class GameRunner {
     def hudBlitter:GameHudBlitter (new GameHudBlitter)
     def spriteRenderer:GameSpriteRenderer (new GameSpriteRenderer)
     def host:GameHost (new GameHost)
+    def audio:GameAudio (new GameAudio)
     def entities:[GameEntity]
     def screenSpritesLoaded:[string]
     def state:EvalValue (EvalValue.null())
@@ -53,6 +55,7 @@ class GameRunner {
 
     fn init:void (w:int h:int) {
         engine.quiet = true
+        audio.init()
         pw = w
         ph = h
         canvas.init(w h)
@@ -135,6 +138,7 @@ class GameRunner {
         def emptyScreens:[string]
         screenSpritesLoaded = emptyScreens
         host = (new GameHost)
+        host.audio = audio
         currentScreen = ""
         state = (EvalValue.null())
     }
@@ -280,6 +284,14 @@ class GameRunner {
         return host
     }
 
+    fn audioRef:GameAudio () {
+        return audio
+    }
+
+    fn wireHostAudio:void () {
+        host.audio = audio
+    }
+
     fn memDouble:double (obj:EvalValue key:string dflt:double) {
         def v:EvalValue (obj.getMember(key))
         if (v.isNull()) {
@@ -342,6 +354,7 @@ class GameRunner {
 
     ; Build retained entities from sprites() and init state.
     fn setupScene:void () {
+        this.wireHostAudio()
         this.setupResources()
         state = (engine.callFunction("initState" (EvalValue.null())))
         if (this.multiScreenMode()) {

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -23,6 +23,7 @@
 
 Import "./game_runtime.rgr"
 Import "../gfx_sdl.rgr"
+Import "./game_audio_sdl.rgr"
 
 class GameSdlRunner {
     def runner:GameRunner (new GameRunner)
@@ -72,6 +73,7 @@ class GameSdlRunner {
         def buf:buffer (buffer_read_file dir file)
         def src:string (buffer_to_string buf)
         runner.init(pw ph)
+        runner.audio.setSink((new SdlGameAudioSink))
         runner.setScriptDir(dir)
         runner.loadScript(src)
         runner.setupScene()
@@ -99,6 +101,7 @@ class GameSdlRunner {
         if (ok == 0) {
             print "gfx_open failed (no display?) - still rendering into the RGBA buffer"
         }
+        gfx_audio_open(22050)
         while (running) {
             runner.maybeHotReload()
             def now:int (gfx_ticks_ms)

--- a/gallery/ts_to_ranger/game_host.rgr
+++ b/gallery/ts_to_ranger/game_host.rgr
@@ -14,7 +14,12 @@
 ; This file is native Ranger. The interpreter path fills these structs from
 ; EvalValue; the static path fills them from generated code. Nothing here is
 ; game-specific.
+;
+; playSound events route to GameAudio (built-in synth ids) when audio is wired.
+; File-based sound resources are still registered for future loaders.
 ; ==============================================================================
+
+Import "../game_engine/scripting/game_audio.rgr"
 
 ; A declared engine resource. `kind` selects the registry.
 class ResourceDefNative {
@@ -47,6 +52,7 @@ class GameHost {
     def destroyRequests:[string]
     def eventCount:int 0
     def verbose:boolean false
+    def audio@(optional):GameAudio
 
     fn registerResource:void (r:ResourceDefNative) {
         if (r.kind == "image") {
@@ -83,6 +89,14 @@ class GameHost {
         eventCount = (eventCount + 1)
         if (e.kind == "playSound") {
             push soundsPlayed e.id
+            if audio {
+                def a:GameAudio (unwrap audio)
+                if (a.hasBuiltin(e.id)) {
+                    a.play(e.id)
+                } {
+                    if verbose { print ("[host] playSound (no builtin) " + e.id) }
+                }
+            }
             if verbose { print ("[host] playSound " + e.id) }
             return
         }

--- a/tests/game-runner.test.ts
+++ b/tests/game-runner.test.ts
@@ -83,6 +83,28 @@ describe("Game runner - scripted Pong", () => {
     const entities = out.match(/entities=(\d+)/);
     expect(entities, `no entity count in output: ${out}`).toBeTruthy();
     expect(parseInt(entities![1], 10)).toBe(52);
+
+    const audioPlays = out.match(/audioPlays=(\d+)/);
+    expect(audioPlays, `no audioPlays in output: ${out}`).toBeTruthy();
+    expect(parseInt(audioPlays![1], 10)).toBeGreaterThan(0);
+  });
+
+  it("plays built-in synth sounds via playSound events", () => {
+    const { compile, run } = compileAndRun(
+      "gallery/game_engine/scripting/audio_runner_demo.rgr"
+    );
+
+    expect(
+      compile.success,
+      `Compile failed: ${compile.error || compile.output}`
+    ).toBe(true);
+    expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+
+    const out = run?.output || "";
+    expect(out).toContain("audio-runner done");
+    expect(out).toContain("soundPlays=3");
+    expect(out).toContain("audioPlays=3");
+    expect(out).toContain("lastSound=win");
   });
 
   it("runs the scripted pacman game and eats dots", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds engine-level synthetic audio support without file-based resource management. Games emit `playSound` events with built-in sound ids; the engine synthesises mono PCM and delivers it to an optional host callback.

## Changes

- **`game_audio.rgr`** — `GameAudio` with built-in synth sounds (`blip`, `brick`, `bounce`, `wall`, `lose`, `win`) and `GameAudioSink` callback interface
- **`game_host.rgr`** — routes `playSound` events to `GameAudio` for built-in ids
- **`game_runtime.rgr` / `game_native_runtime.rgr`** — wire `GameAudio` into `GameHost`
- **`gfx_sdl.rgr` + `game_audio_sdl.rgr`** — SDL audio device + `SdlGameAudioSink` queues PCM for playback
- **`engine.d.ts`** — `BuiltinSoundId`, `GameEvent`, `PlaySoundEvent` types; `events?` on `GameState`
- **`game_helpers.tsx`** — `soundEvent(id)` helper
- **`breakout.game.tsx`** — sound events on wall/paddle/brick collisions, life lost, and win
- **Tests** — `audio_runner_demo.rgr` + assertions in `game-runner.test.ts`

## Usage (game scripts)

```typescript
import { soundEvent } from "./game_helpers";

// In update(), return transient events:
return {
  screen: "play",
  screens: { play: nextPlay },
  events: [soundEvent("brick")]
};
```

Built-in ids: `blip`, `brick`, `bounce`, `wall`, `lose`, `win`.

## Not in scope

- File-based sound resources / `resources()` loading (future work)
- Direct `audio.play()` global from scripts (events-only for now)

## Test plan

- [x] `npx vitest run tests/game-runner.test.ts` — all 6 tests pass
- [x] `npx vitest run tests/ts-to-ranger-host.test.ts` — host bridge parity preserved
- [x] `tsc --noEmit` in `gallery/game_engine/scripting`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49f7abeb-f511-47bc-8320-32736be72e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49f7abeb-f511-47bc-8320-32736be72e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

