### PR TITLE
fix(game-engine): make SDL synth audio audible and stop event replay …

### DIFF
--- a/gallery/game_engine/scripting/event_drain_runner_demo.rgr
+++ b/gallery/game_engine/scripting/event_drain_runner_demo.rgr
@@ -1,0 +1,36 @@
+; ==============================================================================
+; event_drain_runner_demo - sticky state.events must not replay after drain.
+; ==============================================================================
+
+Import "./game_runtime.rgr"
+
+class EventDrainRunnerDemo {
+    sfn m@(main):void () {
+        def runner:GameRunner (new GameRunner)
+        runner.init(320 240)
+
+        def src:string ""
+        src = (src + "function initState() { return { entities: { dot: { x: 10, y: 10 } }, t: 0, events: [] }; }\n")
+        src = (src + "function sprites() { return [{ id: \"dot\", kind: \"circle\", rad: 4, r: 255, g: 200, b: 80 }]; }\n")
+        src = (src + "function update(props) {\n")
+        src = (src + "  const s = props.state;\n")
+        src = (src + "  const next = (s.t || 0) + 1;\n")
+        src = (src + "  let ev = s.events || [];\n")
+        src = (src + "  if (next == 1) { ev = [{ kind: \"playSound\", id: \"lose\" }]; }\n")
+        src = (src + "  return { entities: s.entities, t: next, events: ev };\n")
+        src = (src + "}\n")
+
+        runner.loadScript(src)
+        runner.setupScene()
+
+        def i 0
+        while (i < 6) {
+            runner.frame(16 false false false false false)
+            i = (i + 1)
+        }
+
+        def host:GameHost (runner.hostRef())
+        print (("soundPlays=" + (host.soundPlayCount())))
+        print "event-drain-runner done"
+    }
+}

--- a/gallery/game_engine/scripting/game_audio.rgr
+++ b/gallery/game_engine/scripting/game_audio.rgr
@@ -129,17 +129,6 @@ class GameAudio {
         return spec
     }
 
-    fn writeInt16LE:void (buf:buffer offset:int value:int) {
-        def v value
-        if (v < 0) {
-            v = (65536 + v)
-        }
-        def lo:int (bit_and v 255)
-        def hi:int (bit_and (to_int (v / 256)) 255)
-        buffer_set buf offset lo
-        buffer_set buf (offset + 1) hi
-    }
-
     fn sampleWave:double (wave:int phase:double noiseSeed:int) {
         if (wave == (SynthWave.square())) {
             if (phase < 0.5) {
@@ -186,7 +175,17 @@ class GameAudio {
             def iv:int (to_int amp)
             if (iv > 32767) { iv = 32767 }
             if (iv < -32768) { iv = -32768 }
-            this.writeInt16LE(pcm (i * 2) iv)
+            ; Inline LE int16 write: C++ passes buffer method args by value, so keep
+            ; buffer_set in the same method that owns the local pcm buffer.
+            def v:int iv
+            if (v < 0) {
+                v = (65536 + v)
+            }
+            def lo:int (bit_and v 255)
+            def hi:int (bit_and (to_int (v / 256)) 255)
+            def off:int (i * 2)
+            buffer_set pcm off lo
+            buffer_set pcm (off + 1) hi
             freq = (freq + slidePerFrame)
             if (freq < 40.0) { freq = 40.0 }
             phase = (phase + (freq / (to_double sampleRate)))

--- a/gallery/game_engine/scripting/game_audio_sdl.rgr
+++ b/gallery/game_engine/scripting/game_audio_sdl.rgr
@@ -6,7 +6,26 @@ Import "./game_audio.rgr"
 Import "../gfx_sdl.rgr"
 
 class SdlGameAudioSink extends GameAudioSink {
+    ; Reuse a class-field buffer so gfx_audio_queue gets a C++-compatible buffer
+    ; (local buffer_alloc temporaries do not match operator signatures yet).
+    def queuedPcm:buffer (buffer_alloc 16384)
+
+    fn raw:buffer () {
+        return queuedPcm
+    }
+
+    fn copyPcm:void (pcm:buffer byteCount:int) {
+        def i 0
+        while (i < byteCount) {
+            def v:int (buffer_get pcm i)
+            buffer_set queuedPcm i v
+            i = (i + 1)
+        }
+    }
+
     fn onSynthPlay:void (soundId:string sampleRate:int sampleCount:int pcm:buffer) {
-        gfx_audio_queue(pcm (sampleCount * 2))
+        def byteCount:int (sampleCount * 2)
+        this.copyPcm(pcm byteCount)
+        gfx_audio_queue (this.raw()) byteCount)
     }
 }

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -349,6 +349,10 @@ class GameRunner {
                 host.handleEvent((this.eventFromEval((itemAt arr i))))
                 i = (i + 1)
             }
+            if ((array_length arr) > 0) {
+                def cleared:[EvalValue]
+                state.setMember("events" (EvalValue.array(cleared)))
+            }
         }
     }
 

--- a/tests/game-runner.test.ts
+++ b/tests/game-runner.test.ts
@@ -107,6 +107,22 @@ describe("Game runner - scripted Pong", () => {
     expect(out).toContain("lastSound=win");
   });
 
+  it("does not replay sticky state.events on later frames", () => {
+    const { compile, run } = compileAndRun(
+      "gallery/game_engine/scripting/event_drain_runner_demo.rgr"
+    );
+
+    expect(
+      compile.success,
+      `Compile failed: ${compile.error || compile.output}`
+    ).toBe(true);
+    expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+
+    const out = run?.output || "";
+    expect(out).toContain("event-drain-runner done");
+    expect(out).toContain("soundPlays=1");
+  });
+
   it("runs the scripted pacman game and eats dots", () => {
     const { compile, run } = compileAndRun(
       "gallery/game_engine/scripting/pacman_runner_demo.rgr"


### PR DESCRIPTION
…loops.

Inline PCM writes for C++ buffer semantics, queue audio through a class-field SDL sink, and clear drained state.events so game-over sounds do not stutter.