### PR TITLE
docs(game_engine): expand TSX engine issues (scope, imports, hot reload)

### DIFF
--- a/gallery/game_engine/scripting/TSX_ENGINE_ISSUES.md
+++ b/gallery/game_engine/scripting/TSX_ENGINE_ISSUES.md
@@ -65,6 +65,26 @@ function total() { return PALETTE.r + PALETTE.g; }
 
 ## Known limitations (open)
 
+### Recommended fix order (2026-07-10)
+
+These are the highest-impact open bugs for `gallery/game_engine` runtime scripts. Fix scope assignment, import resolution, and hot-reload duplication first — they produce hard-to-trace silent failures.
+
+| Priority | Issue | Why first |
+|----------|-------|-----------|
+| **P0** | [#14 Outer-scope assignment via `define()`](#14-outer-scope-assignment-via-define-not-assign) | Mutations create shadow locals; module state never updates |
+| **P0** | [#15 Transitive import paths](#15-transitive-import-relative-paths-resolved-from-wrong-directory) | `components/A.tsx → ./B` breaks when B is not in the main script dir |
+| **P0** | [#17 Hot reload duplicates](#17-hot-reload-patchscript-duplicates-imports-and-components) | `expandComponent()` may resolve a stale component after reload |
+| **P1** | [#16 Cyclic imports](#16-no-cycle-protection-on-import-graph) | `A → B → A` can recurse until stack overflow |
+| **P1** | [#18 Removed bindings stay live](#18-removed-declarations-left-intentionally-stale-on-hot-reload) | Deleted functions/vars still callable after patch |
+| **P1** | [#11 Return inside loops](#11-value-return-inside-for--while-loops-not-propagated) | Early exit in reducers silently wrong |
+| **P2** | [#19 Bare `return;` on JSX path](#19-bare-return-ignored-on-jsxevg-evaluation-path) | `return;` does not stop execution in render helpers |
+| **P2** | [#20 Import alias / default export](#20-import-alias-and-default-export-handling-incomplete) | `import { X as Y }` / `import Y from` fragile |
+| **P2** | [#21 Imported modules not isolated](#21-imported-modules-not-isolated-shared-modulescope) | Private helpers from two files can clobber each other |
+| **P2** | [#22 Engine reuse leaks state](#22-engine-reuse-leaks-state-between-parse-load-cycles) | `parse()` / `parseFile()` do not reset like `loadScript()` |
+| **P3** | [#13 `**` operator](#13--operator-precedence-and-evaluation) | Parsed but not evaluated |
+
+---
+
 ### 4. Non-ASCII characters inside `//` comments (native lexer) ✅ (2026-07-08)
 
 **Symptom:** Native SDL (`tmp/game-sdl/game_sdl`) floods `Unexpected token: c/o/X/…` when loading an otherwise valid script. Node runner may work.
@@ -181,15 +201,189 @@ function hud(props) {
 
 ### 11. Value-`return` inside `for` / `while` loops not propagated
 
-Documented in [`GAME_SCRIPTING.md`](./GAME_SCRIPTING.md). Loops run for side effects only in `runStatementValue`; early `return` inside a loop body does not exit the enclosing function.
+Documented in [`GAME_SCRIPTING.md`](./GAME_SCRIPTING.md).
+
+**Symptom:** `for (…) { return value; }` or `while (…) { return value; }` inside a value-returning function (`update`, `initState`, …) does **not** exit the enclosing function. Execution may continue after the loop or return `null`.
+
+**Cause:** `runStatementValue()` runs loop bodies for side effects only. The comment in `ComponentEngine.rgr` admits this:
+
+```rgr
+; Loops run for side effects; value-returns from inside a loop are not
+; propagated (uncommon in screen/reducer scripts).
+```
+
+Loop evaluators on the JSX/EVG path (`evaluateForStatement`, `evaluateWhileStatement`) propagate `hasReturn` from the loop body, but the **value-function path** (`evaluateFunctionBodyValue` → `runStatementValue`) does not wire `scriptDidReturn` through loop iterations the way `if` blocks do.
+
+**Fix direction:** Loop evaluators in the value path should check `scriptDidReturn` after each iteration (same mechanism as nested `callFunction` save/restore in issue #6).
+
+**Workaround:** Avoid `return` inside loops; use `if` + early `return` at statement level, or a flag variable.
 
 ### 12. Single-statement loop bodies without `{ … }`
 
 `evaluateStatementBlock()` only executes children of a `BlockStatement`. Prefer braced loop bodies in game scripts.
 
-### 13. `**` operator precedence
+### 13. `**` operator precedence and evaluation
 
-See project `ISSUES.md` #6 — parenthesise exponent expressions.
+See project `ISSUES.md` #6 — parenthesise exponent expressions. The parser accepts `**` (`ts_parser_simple.rgr`) but `evaluateBinaryExpr()` has no `**` case, so `2 ** 10` evaluates to `null`.
+
+---
+
+### 14. Outer-scope assignment via `define()`, not `assign`
+
+**Symptom:** Assigning to a variable declared in an outer scope (module or enclosing function) from an inner function creates a **new local binding** instead of updating the existing one.
+
+**Example:**
+
+```ts
+let counter = 0;
+function inc() {
+  counter += 1;   // or counter = counter + 1
+}
+```
+
+After `inc()`, `counter` at module scope is still `0`; a shadow `counter` exists only inside `inc()`.
+
+**Cause:** `evaluateUpdateExpr()` (and `++`/`--` paths) always call `context.define(name, value)`. `EvalContext.define()` only updates bindings in the **current** scope's variable list; if the name is not already defined locally, it **pushes a new entry** into the current scope. It does not walk the parent chain to find an existing binding.
+
+`lookup()` correctly walks `parent` scopes, so reads see the outer value but writes go to a fresh local.
+
+**Fix direction:** Add `EvalContext.assign(name, value)` that finds the scope owning the binding (walk parents with `has()`) and updates there; use `define()` only for declarations. Member/index assignment (`obj.x = v`) is separate and works when the object reference is written back.
+
+**Impact on games:** Current game scripts mostly return new state objects (reducer style) rather than mutating module-level `let` bindings, so this is latent — but any shared mutable module state (`let score`, counters, caches) will silently fail.
+
+---
+
+### 15. Transitive import relative paths resolved from wrong directory
+
+**Symptom:** Nested imports fail or load the wrong file when an imported module imports a sibling.
+
+**Example:** Main script `games/foo/index.tsx` imports `./components/A.tsx`. Inside `A.tsx`:
+
+```ts
+import { helper } from "./B";
+```
+
+`B.tsx` lives next to `A.tsx` in `components/`, but resolution looks in the **main script's** directory (`games/foo/`), not `components/`.
+
+**Cause:** `processImportDeclaration()` sets `resolvedImportDir = basePath` and calls `readImportSource(basePath, fullPath)` using the engine's global `basePath` (the entry script directory). After loading `A.tsx`, recursive `processImports(importAst)` runs **without** temporarily setting `basePath` (or an import stack) to `components/`. `resolvedImportDir` is updated on successful read but is not used as the base for nested relative imports.
+
+**Fix direction:** Save/restore `basePath` per import frame: `push basePath = dirname(currentModulePath)` before `processImports(importAst)`, pop after.
+
+**Workaround:** Flatten imports so all relative paths resolve from the entry script directory, or duplicate shared helpers.
+
+---
+
+### 16. No cycle protection on import graph
+
+**Symptom:** Circular imports (`A.tsx → B.tsx → A.tsx`) can recurse until stack overflow.
+
+**Cause:** `loadedFiles` is appended on each load (`push loadedFiles loadedFilePath`) for file-watching, but nothing checks whether a canonical path is already **loading** or **loaded** before re-entering `processImportDeclaration()`.
+
+**Fix direction:** Maintain `loading:Set<canonicalPath>` and `loaded:Set<canonicalPath>`; skip or error on re-entry; optionally return already-materialized bindings for loaded modules.
+
+---
+
+### 17. Hot reload (`patchScript`) duplicates imports and components
+
+**Symptom:** After hot reload, behaviour is inconsistent — old component version used, duplicate helpers, or growing `localComponents` list.
+
+**Cause:** `patchScript()` calls `processImports(newAst)` on every patch **without** clearing or replacing prior import state:
+
+- `localComponents` is not reset (unlike `loadScript()` which calls `clearLocalComponents()`).
+- `loadedFiles` keeps growing.
+- Each re-import **pushes** new `ImportedSymbol` entries; `expandComponent()` returns the **first** name match in `localComponents`, which may be the **old** AST node.
+- `updateLocalComponentNode()` only updates an existing symbol; newly pushed duplicates remain.
+
+**Fix direction:** On patch, either (a) re-run the `loadScript()` registration path for imports, or (b) upsert by `(sourcePath, exportName)` and remove stale symbols; always replace `functionNode` on name collision instead of appending.
+
+---
+
+### 18. Removed declarations left intentionally stale on hot reload
+
+**Symptom:** Deleting a top-level function, `const`, or import from source does not remove it from the runtime namespace after hot reload. Old bindings remain callable.
+
+**Cause:** Explicit comment in `patchScript()`:
+
+```rgr
+if (ch.changeKind == "removed") {
+    ; Dev reload rarely removes declarations; leave stale binding.
+}
+```
+
+The patcher detects removals but the evaluator deliberately does nothing. Same applies to imports re-processed by `processImports()` without unregistering removed modules.
+
+**Fix direction:** On `"removed"`, `moduleScope` / `localComponents` / import registry should drop the binding (or full reload when any import graph node changes).
+
+---
+
+### 19. Bare `return;` ignored on JSX/EVG evaluation path
+
+**Symptom:** `return;` (no expression) inside a JSX/render helper does not stop execution; statements after the return may still run.
+
+**Cause:** Multiple JSX-path handlers only treat `ReturnStatement` when `stmt.left` is present:
+
+```rgr
+if (stmt.nodeType == "ReturnStatement") {
+    if stmt.left {
+        ...
+        returnedEl.hasReturn = true
+    }
+}
+```
+
+A bare `return;` never sets `hasReturn` or returns early. The value-function path (`runStatementValue`) **does** set `scriptDidReturn = true` even without `stmt.left` — asymmetry between paths.
+
+**Workaround:** Always `return null;` or `return <Fragment />;` in JSX helpers.
+
+---
+
+### 20. Import alias and default export handling incomplete
+
+**Symptom:** Renamed or default imports may not bind the expected name, or fail to match exported symbols.
+
+**Risky patterns:**
+
+```ts
+import { Original as Local } from "./module";
+import Local from "./module";
+export default function () {}
+```
+
+**Cause:** `processImportDeclaration()` collects `importedNames` from `ImportSpecifier.name` (the **exported** name in the source module), but registers bindings under the export's `fnName`, not the local alias (`spec.value`). Default exports (`ImportDefaultSpecifier`) are pushed by local name but `materializeImportedModule()` / export matching logic primarily handles `ExportNamedDeclaration` and plain `FunctionDeclaration` by **source name** equality with `importedNames`.
+
+`ImportedSymbol.originalName` exists but is always set equal to `name`; alias mapping is unused.
+
+**Workaround:** Import without `as` aliases; use named exports matching the import identifier.
+
+---
+
+### 21. Imported modules not isolated (shared `moduleScope`)
+
+**Symptom:** Two imported files with the same private helper name interfere; non-exported bindings from one file visible to another.
+
+**Cause:** `materializeImportedModule()` binds **every** top-level function and variable from the imported AST into the shared `moduleScope` via `defineModuleBinding()`, including non-exported helpers. There is no per-module namespace.
+
+**Example:** `breakout_bricks.tsx` and `invaders_shared.tsx` both defining `function clamp(...)` — last import wins.
+
+**Fix direction:** Either isolate each file in a child scope and re-export only requested symbols, or prefix/mangle private bindings.
+
+**Note:** Current game imports use distinct helper names by convention; risk grows with more shared modules.
+
+---
+
+### 22. Engine reuse leaks state between parse/load cycles
+
+**Symptom:** Calling `parse()` or `parseFile()` multiple times on the same `ComponentEngine` instance accumulates stale imports, components, and file-watch entries. Differs from `loadScript()` which resets `moduleScope` and `localComponents`.
+
+**Cause:**
+
+- `parse()` does **not** reset `moduleScope`, `localComponents`, or `loadedFiles`.
+- `parseFile()` pushes to `loadedFiles` without clearing prior entries.
+- `parseFile()` assigns `basePath = dirPath` **without** normalizing a trailing `/`, unlike `setBasePath()` used by `GameRunner`.
+
+**Impact:** PDF/component tooling that reuses one engine instance may see cross-document leakage. `GameRunner` uses `loadScript()` (safe) but hot reload + `parse()` paths in tests/tools should reset explicitly.
+
+**Fix direction:** Extract a `resetModuleState()` shared by `loadScript()` and the start of `parse()`, or document that `ComponentEngine` is single-shot per document.
 
 ---
 
@@ -197,10 +391,13 @@ See project `ISSUES.md` #6 — parenthesise exponent expressions.
 
 | File | Role |
 |------|------|
-| `ComponentEngine.rgr` | Evaluator + JSX expansion |
-| `game_runtime.rgr` | Retained-mode GameRunner |
+| `ComponentEngine.rgr` | Evaluator + JSX expansion; `EvalContext`, `processImports`, `patchScript` |
+| `EvalValue.rgr` | Runtime value model (`setMember`, `setIndexAt`) |
+| `ts_ast_patch.rgr` | Hot-reload AST diff (`TSAstPatcher`) |
+| `game_runtime.rgr` | Retained-mode GameRunner (`loadScript`, `hotReloadScript`) |
 | `GAME_SCRIPTING.md` | Authoring guide for game scripts |
 | `invaders.game.tsx` | Stress test: module const arrays + while loops |
 | `games/invaders/index.tsx` | Untyped `update` / `hud` callbacks (parser-safe) |
 | `breakout.game.tsx` / `games/breakout/index.tsx` | Retained bricks + JSX `hud()` overlay |
+| `breakout_bricks.tsx` | Relative `import` between scripts |
 | `GAME_ENGINE_DESIGN.md` | Design notes: retained sprites + JSX HUD, performance |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands `gallery/game_engine/scripting/TSX_ENGINE_ISSUES.md` with ten newly identified **ComponentEngine** limitations that affect `*.game.tsx` runtime scripts, based on code review of `ComponentEngine.rgr`.

## Added issues (#14–#22)

| # | Topic |
|---|-------|
| 14 | Outer-scope assignment uses `define()` instead of parent-chain `assign()` |
| 15 | Transitive imports resolve relative paths from entry script dir, not importer dir |
| 16 | No cycle protection on import graph |
| 17 | `patchScript()` duplicates imports/components; `expandComponent()` may pick stale entry |
| 18 | Removed declarations intentionally left stale on hot reload |
| 19 | Bare `return;` ignored on JSX/EVG path |
| 20 | Import alias / default export handling incomplete |
| 21 | Imported modules share flat `moduleScope` (no isolation) |
| 22 | `parse()` / `parseFile()` leak state unlike `loadScript()` |

Also expands existing issues **#11** (loop `return`) and **#13** (`**` parsed but not evaluated).

## Priority table

Adds a **Recommended fix order** section (P0–P3) highlighting scope assignment, import resolution, and hot-reload duplication as the first fixes.

## Files changed

- `gallery/game_engine/scripting/TSX_ENGINE_ISSUES.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79282f2c-143e-4e7b-a7ba-09b55914eabf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79282f2c-143e-4e7b-a7ba-09b55914eabf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

