### PR TITLE
fix(tsx-engine): import paths, hot reload, and value-path loop returns

### DIFF
--- a/gallery/game_engine/scripting/TSX_ENGINE_ISSUES.md
+++ b/gallery/game_engine/scripting/TSX_ENGINE_ISSUES.md
@@ -199,24 +199,11 @@ function hud(props) {
 
 **Impact:** Harmless at runtime (types are ignored); noisy in test output.
 
-### 11. Value-`return` inside `for` / `while` loops not propagated
+### 11. Value-`return` inside `for` / `while` loops not propagated ✅ (2026-07-10)
 
-Documented in [`GAME_SCRIPTING.md`](./GAME_SCRIPTING.md).
+**Fix:** Value-path loop runners (`runWhileStatementValue`, `runForStatementValue`, `runForOfStatementValue`) execute bodies via `runBlockOrStatement()` and honour `scriptDidReturn`, `loopBreak`, `loopContinue`.
 
-**Symptom:** `for (…) { return value; }` or `while (…) { return value; }` inside a value-returning function (`update`, `initState`, …) does **not** exit the enclosing function. Execution may continue after the loop or return `null`.
-
-**Cause:** `runStatementValue()` runs loop bodies for side effects only. The comment in `ComponentEngine.rgr` admits this:
-
-```rgr
-; Loops run for side effects; value-returns from inside a loop are not
-; propagated (uncommon in screen/reducer scripts).
-```
-
-Loop evaluators on the JSX/EVG path (`evaluateForStatement`, `evaluateWhileStatement`) propagate `hasReturn` from the loop body, but the **value-function path** (`evaluateFunctionBodyValue` → `runStatementValue`) does not wire `scriptDidReturn` through loop iterations the way `if` blocks do.
-
-**Fix direction:** Loop evaluators in the value path should check `scriptDidReturn` after each iteration (same mechanism as nested `callFunction` save/restore in issue #6).
-
-**Workaround:** Avoid `return` inside loops; use `if` + early `return` at statement level, or a flag variable.
+**Regression:** `whileReturn=5` in [`tsx_engine_demo`](./tsx_engine_demo.rgr).
 
 ### 12. Single-statement loop bodies without `{ … }`
 
@@ -228,132 +215,47 @@ See project `ISSUES.md` #6 — parenthesise exponent expressions. The parser acc
 
 ---
 
-### 14. Outer-scope assignment via `define()`, not `assign`
+### 14. Outer-scope assignment via `define()`, not `assign` ✅ (2026-07-10, PR #156)
 
-**Symptom:** Assigning to a variable declared in an outer scope (module or enclosing function) from an inner function creates a **new local binding** instead of updating the existing one.
-
-**Example:**
-
-```ts
-let counter = 0;
-function inc() {
-  counter += 1;   // or counter = counter + 1
-}
-```
-
-After `inc()`, `counter` at module scope is still `0`; a shadow `counter` exists only inside `inc()`.
-
-**Cause:** `evaluateUpdateExpr()` (and `++`/`--` paths) always call `context.define(name, value)`. `EvalContext.define()` only updates bindings in the **current** scope's variable list; if the name is not already defined locally, it **pushes a new entry** into the current scope. It does not walk the parent chain to find an existing binding.
-
-`lookup()` correctly walks `parent` scopes, so reads see the outer value but writes go to a fresh local.
-
-**Fix direction:** Add `EvalContext.assign(name, value)` that finds the scope owning the binding (walk parents with `has()`) and updates there; use `define()` only for declarations. Member/index assignment (`obj.x = v`) is separate and works when the object reference is written back.
-
-**Impact on games:** Current game scripts mostly return new state objects (reducer style) rather than mutating module-level `let` bindings, so this is latent — but any shared mutable module state (`let score`, counters, caches) will silently fail.
+**Fix:** `EvalContext.assign()` / `assignExisting()`; `evaluateUpdateExpr()` uses `context.assign()`.
 
 ---
 
-### 15. Transitive import relative paths resolved from wrong directory
+### 15. Transitive import relative paths resolved from wrong directory ✅ (2026-07-10)
 
-**Symptom:** Nested imports fail or load the wrong file when an imported module imports a sibling.
+**Fix:** Save/restore `basePath` per import frame; `moduleDirFromRead()` resolves nested paths (e.g. `import_fixtures/mid.tsx`).
 
-**Example:** Main script `games/foo/index.tsx` imports `./components/A.tsx`. Inside `A.tsx`:
-
-```ts
-import { helper } from "./B";
-```
-
-`B.tsx` lives next to `A.tsx` in `components/`, but resolution looks in the **main script's** directory (`games/foo/`), not `components/`.
-
-**Cause:** `processImportDeclaration()` sets `resolvedImportDir = basePath` and calls `readImportSource(basePath, fullPath)` using the engine's global `basePath` (the entry script directory). After loading `A.tsx`, recursive `processImports(importAst)` runs **without** temporarily setting `basePath` (or an import stack) to `components/`. `resolvedImportDir` is updated on successful read but is not used as the base for nested relative imports.
-
-**Fix direction:** Save/restore `basePath` per import frame: `push basePath = dirname(currentModulePath)` before `processImports(importAst)`, pop after.
-
-**Workaround:** Flatten imports so all relative paths resolve from the entry script directory, or duplicate shared helpers.
+**Regression:** [`import_chain_demo.rgr`](./import_chain_demo.rgr).
 
 ---
 
-### 16. No cycle protection on import graph
+### 16. No cycle protection on import graph ✅ (2026-07-10)
 
-**Symptom:** Circular imports (`A.tsx → B.tsx → A.tsx`) can recurse until stack overflow.
-
-**Cause:** `loadedFiles` is appended on each load (`push loadedFiles loadedFilePath`) for file-watching, but nothing checks whether a canonical path is already **loading** or **loaded** before re-entering `processImportDeclaration()`.
-
-**Fix direction:** Maintain `loading:Set<canonicalPath>` and `loaded:Set<canonicalPath>`; skip or error on re-entry; optionally return already-materialized bindings for loaded modules.
+**Fix:** `importLoading` / `importLoaded` canonical-path sets; skip cycles and re-bind from existing `moduleScope`.
 
 ---
 
-### 17. Hot reload (`patchScript`) duplicates imports and components
+### 17. Hot reload (`patchScript`) duplicates imports and components ✅ (2026-07-10)
 
-**Symptom:** After hot reload, behaviour is inconsistent — old component version used, duplicate helpers, or growing `localComponents` list.
-
-**Cause:** `patchScript()` calls `processImports(newAst)` on every patch **without** clearing or replacing prior import state:
-
-- `localComponents` is not reset (unlike `loadScript()` which calls `clearLocalComponents()`).
-- `loadedFiles` keeps growing.
-- Each re-import **pushes** new `ImportedSymbol` entries; `expandComponent()` returns the **first** name match in `localComponents`, which may be the **old** AST node.
-- `updateLocalComponentNode()` only updates an existing symbol; newly pushed duplicates remain.
-
-**Fix direction:** On patch, either (a) re-run the `loadScript()` registration path for imports, or (b) upsert by `(sourcePath, exportName)` and remove stale symbols; always replace `functionNode` on name collision instead of appending.
+**Fix:** `patchScript()` clears import/component state before re-import; `upsertLocalComponent()`; `expandComponent()` uses last match.
 
 ---
 
-### 18. Removed declarations left intentionally stale on hot reload
+### 18. Removed declarations left stale on hot reload ✅ (2026-07-10)
 
-**Symptom:** Deleting a top-level function, `const`, or import from source does not remove it from the runtime namespace after hot reload. Old bindings remain callable.
-
-**Cause:** Explicit comment in `patchScript()`:
-
-```rgr
-if (ch.changeKind == "removed") {
-    ; Dev reload rarely removes declarations; leave stale binding.
-}
-```
-
-The patcher detects removals but the evaluator deliberately does nothing. Same applies to imports re-processed by `processImports()` without unregistering removed modules.
-
-**Fix direction:** On `"removed"`, `moduleScope` / `localComponents` / import registry should drop the binding (or full reload when any import graph node changes).
+**Fix:** `moduleScope.removeBinding()` + `removeLocalComponentByName()` on `"removed"` patch entries.
 
 ---
 
-### 19. Bare `return;` ignored on JSX/EVG evaluation path
+### 19. Bare `return;` ignored on JSX/EVG evaluation path ✅ (2026-07-10)
 
-**Symptom:** `return;` (no expression) inside a JSX/render helper does not stop execution; statements after the return may still run.
-
-**Cause:** Multiple JSX-path handlers only treat `ReturnStatement` when `stmt.left` is present:
-
-```rgr
-if (stmt.nodeType == "ReturnStatement") {
-    if stmt.left {
-        ...
-        returnedEl.hasReturn = true
-    }
-}
-```
-
-A bare `return;` never sets `hasReturn` or returns early. The value-function path (`runStatementValue`) **does** set `scriptDidReturn = true` even without `stmt.left` — asymmetry between paths.
-
-**Workaround:** Always `return null;` or `return <Fragment />;` in JSX helpers.
+**Fix:** JSX paths set `hasReturn` even when `ReturnStatement` has no expression.
 
 ---
 
 ### 20. Import alias and default export handling incomplete
 
-**Symptom:** Renamed or default imports may not bind the expected name, or fail to match exported symbols.
-
-**Risky patterns:**
-
-```ts
-import { Original as Local } from "./module";
-import Local from "./module";
-export default function () {}
-```
-
-**Cause:** `processImportDeclaration()` collects `importedNames` from `ImportSpecifier.name` (the **exported** name in the source module), but registers bindings under the export's `fnName`, not the local alias (`spec.value`). Default exports (`ImportDefaultSpecifier`) are pushed by local name but `materializeImportedModule()` / export matching logic primarily handles `ExportNamedDeclaration` and plain `FunctionDeclaration` by **source name** equality with `importedNames`.
-
-`ImportedSymbol.originalName` exists but is always set equal to `name`; alias mapping is unused.
-
-**Workaround:** Import without `as` aliases; use named exports matching the import identifier.
+**Status:** Named `import { X as Y }` aliases bind under local name `Y` (2026-07-10). **Default exports** (`import Local from "./module"`) still fragile.
 
 ---
 
@@ -371,19 +273,9 @@ export default function () {}
 
 ---
 
-### 22. Engine reuse leaks state between parse/load cycles
+### 22. Engine reuse leaks state between parse/load cycles ✅ (2026-07-10)
 
-**Symptom:** Calling `parse()` or `parseFile()` multiple times on the same `ComponentEngine` instance accumulates stale imports, components, and file-watch entries. Differs from `loadScript()` which resets `moduleScope` and `localComponents`.
-
-**Cause:**
-
-- `parse()` does **not** reset `moduleScope`, `localComponents`, or `loadedFiles`.
-- `parseFile()` pushes to `loadedFiles` without clearing prior entries.
-- `parseFile()` assigns `basePath = dirPath` **without** normalizing a trailing `/`, unlike `setBasePath()` used by `GameRunner`.
-
-**Impact:** PDF/component tooling that reuses one engine instance may see cross-document leakage. `GameRunner` uses `loadScript()` (safe) but hot reload + `parse()` paths in tests/tools should reset explicitly.
-
-**Fix direction:** Extract a `resetModuleState()` shared by `loadScript()` and the start of `parse()`, or document that `ComponentEngine` is single-shot per document.
+**Fix:** `resetParseState()` in `parse()` / `parseFile()`; `parseFile()` uses `setBasePath()`.
 
 ---
 

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -98,6 +98,14 @@ class GameRunner {
         engine.registerGlobal(name value)
     }
 
+    fn setPaneIndex:void (index:int) {
+        engine.registerGlobal("paneIndex" (EvalValue.fromInt(index)))
+    }
+
+    fn clearPaneIndex:void () {
+        engine.removeGlobal("paneIndex")
+    }
+
     fn setNativeBridge:void (bridge:EvalNativeBridge) {
         hostBridge = bridge
         compositeBridge.clearBridges()

--- a/gallery/game_engine/scripting/game_split_screen.rgr
+++ b/gallery/game_engine/scripting/game_split_screen.rgr
@@ -82,7 +82,7 @@ class SplitScreenHost {
         right.setProfileEnabled(on)
     }
 
-    fn loadScriptAt:void (runner:GameRunner bridge:GameHostNativeBridge tsxPath:string) {
+    fn loadScriptAt:void (runner:GameRunner bridge:GameHostNativeBridge tsxPath:string pane:int) {
         def dir:string ""
         def file:string tsxPath
         def slash:int (lastIndexOf tsxPath "/")
@@ -96,14 +96,15 @@ class SplitScreenHost {
         bridge.setGameDir(dir)
         runner.setNativeBridge(bridge)
         runner.loadScript(src)
+        runner.setPaneIndex(pane)
         runner.setupScene()
         runner.trackScriptFile(tsxPath)
     }
 
   ; Load the same script (or different paths) into both panes.
     fn loadPanes:void (leftPath:string rightPath:string) {
-        this.loadScriptAt(left leftBridge leftPath)
-        this.loadScriptAt(right rightBridge rightPath)
+        this.loadScriptAt(left leftBridge leftPath 0)
+        this.loadScriptAt(right rightBridge rightPath 1)
         leftScriptPath = leftPath
         rightScriptPath = rightPath
     }

--- a/gallery/game_engine/scripting/import_chain_demo.game.tsx
+++ b/gallery/game_engine/scripting/import_chain_demo.game.tsx
@@ -1,0 +1,5 @@
+import { readLeaf } from "./import_fixtures/mid";
+
+function getLeafValue() {
+  return readLeaf();
+}

--- a/gallery/game_engine/scripting/import_chain_demo.rgr
+++ b/gallery/game_engine/scripting/import_chain_demo.rgr
@@ -1,0 +1,20 @@
+; Regression: transitive relative imports resolve from the importer's directory.
+
+Import "../../pdf_writer/src/jsx/ComponentEngine.rgr"
+Import "../../pdf_writer/src/jsx/EvalValue.rgr"
+
+class ImportChainDemo {
+    sfn m@(main):void () {
+        def engine (new ComponentEngine())
+        engine.quiet = true
+        engine.setBasePath("gallery/game_engine/scripting/")
+
+        def buf:buffer (buffer_read_file "gallery/game_engine/scripting" "import_chain_demo.game.tsx")
+        def src:string (buffer_to_string buf)
+        engine.loadScript(src)
+
+        def leafVal:EvalValue (engine.callFunction("getLeafValue" (EvalValue.null())))
+        print ("importChain=" + (to_int (leafVal.numberValue)))
+        print "import-chain-demo done"
+    }
+}

--- a/gallery/game_engine/scripting/import_fixtures/leaf.tsx
+++ b/gallery/game_engine/scripting/import_fixtures/leaf.tsx
@@ -1,0 +1,1 @@
+export const LEAF_VAL = 7;

--- a/gallery/game_engine/scripting/import_fixtures/mid.tsx
+++ b/gallery/game_engine/scripting/import_fixtures/mid.tsx
@@ -1,0 +1,5 @@
+import { LEAF_VAL } from "./leaf";
+
+export function readLeaf() {
+  return LEAF_VAL;
+}

--- a/gallery/game_engine/scripting/tsx_engine_demo.game.tsx
+++ b/gallery/game_engine/scripting/tsx_engine_demo.game.tsx
@@ -112,3 +112,7 @@ function loopContinueSkip() {
   }
   return total;
 }
+
+function isSplitPane() {
+  return typeof paneIndex !== "undefined";
+}

--- a/gallery/game_engine/scripting/tsx_engine_demo.game.tsx
+++ b/gallery/game_engine/scripting/tsx_engine_demo.game.tsx
@@ -63,3 +63,21 @@ function helperSideEffect() {
 function bumpBag(b) {
   b.n = 1;
 }
+
+let moduleCounter = 0;
+
+function bumpModuleCounter() {
+  moduleCounter = moduleCounter + 1;
+  return moduleCounter;
+}
+
+function returnFromWhile() {
+  let i = 0;
+  while (i < 10) {
+    if (i == 5) {
+      return i;
+    }
+    i = i + 1;
+  }
+  return -1;
+}

--- a/gallery/game_engine/scripting/tsx_engine_demo.game.tsx
+++ b/gallery/game_engine/scripting/tsx_engine_demo.game.tsx
@@ -81,3 +81,34 @@ function returnFromWhile() {
   }
   return -1;
 }
+
+function nestedLoopBreak() {
+  let total = 0;
+  let o = 0;
+  while (o < 3) {
+    let inner = 0;
+    while (inner < 5) {
+      if (inner == 2) {
+        break;
+      }
+      total = total + 1;
+      inner = inner + 1;
+    }
+    total = total + 100;
+    o = o + 1;
+  }
+  return total;
+}
+
+function loopContinueSkip() {
+  let total = 0;
+  let i = 0;
+  while (i < 5) {
+    i = i + 1;
+    if (i == 3) {
+      continue;
+    }
+    total = total + i;
+  }
+  return total;
+}

--- a/gallery/game_engine/scripting/tsx_engine_demo.rgr
+++ b/gallery/game_engine/scripting/tsx_engine_demo.rgr
@@ -26,6 +26,8 @@ class TsxEngineDemo {
         def modCount1:EvalValue (engine.callFunction("bumpModuleCounter" (EvalValue.null())))
         def modCount2:EvalValue (engine.callFunction("bumpModuleCounter" (EvalValue.null())))
         def whileReturn:EvalValue (engine.callFunction("returnFromWhile" (EvalValue.null())))
+        def nestedBreak:EvalValue (engine.callFunction("nestedLoopBreak" (EvalValue.null())))
+        def continueSkip:EvalValue (engine.callFunction("loopContinueSkip" (EvalValue.null())))
 
         print ("whileLen=" + (to_int (whileLen.numberValue)))
         print ("constSum=" + (to_int (constSum.numberValue)))
@@ -38,6 +40,8 @@ class TsxEngineDemo {
         print ("helperSide=" + (to_int (helperSide.numberValue)))
         print ("modCount2=" + (to_int (modCount2.numberValue)))
         print ("whileReturn=" + (to_int (whileReturn.numberValue)))
+        print ("nestedBreak=" + (to_int (nestedBreak.numberValue)))
+        print ("continueSkip=" + (to_int (continueSkip.numberValue)))
         print "tsx-engine-demo done"
     }
 }

--- a/gallery/game_engine/scripting/tsx_engine_demo.rgr
+++ b/gallery/game_engine/scripting/tsx_engine_demo.rgr
@@ -28,6 +28,9 @@ class TsxEngineDemo {
         def whileReturn:EvalValue (engine.callFunction("returnFromWhile" (EvalValue.null())))
         def nestedBreak:EvalValue (engine.callFunction("nestedLoopBreak" (EvalValue.null())))
         def continueSkip:EvalValue (engine.callFunction("loopContinueSkip" (EvalValue.null())))
+        def splitNoPane:EvalValue (engine.callFunction("isSplitPane" (EvalValue.null())))
+        engine.registerGlobal("paneIndex" (EvalValue.fromInt(1)))
+        def splitWithPane:EvalValue (engine.callFunction("isSplitPane" (EvalValue.null())))
 
         print ("whileLen=" + (to_int (whileLen.numberValue)))
         print ("constSum=" + (to_int (constSum.numberValue)))
@@ -42,6 +45,16 @@ class TsxEngineDemo {
         print ("whileReturn=" + (to_int (whileReturn.numberValue)))
         print ("nestedBreak=" + (to_int (nestedBreak.numberValue)))
         print ("continueSkip=" + (to_int (continueSkip.numberValue)))
+        if (splitNoPane.toBool()) {
+            print "splitNoPane=1"
+        } {
+            print "splitNoPane=0"
+        }
+        if (splitWithPane.toBool()) {
+            print "splitWithPane=1"
+        } {
+            print "splitWithPane=0"
+        }
         print "tsx-engine-demo done"
     }
 }

--- a/gallery/game_engine/scripting/tsx_engine_demo.rgr
+++ b/gallery/game_engine/scripting/tsx_engine_demo.rgr
@@ -23,6 +23,9 @@ class TsxEngineDemo {
         def whileConst:EvalValue (engine.callFunction("whileWithModuleConst" (EvalValue.null())))
         def memberAssign:EvalValue (engine.callFunction("memberAssign" (EvalValue.null())))
         def helperSide:EvalValue (engine.callFunction("helperSideEffect" (EvalValue.null())))
+        def modCount1:EvalValue (engine.callFunction("bumpModuleCounter" (EvalValue.null())))
+        def modCount2:EvalValue (engine.callFunction("bumpModuleCounter" (EvalValue.null())))
+        def whileReturn:EvalValue (engine.callFunction("returnFromWhile" (EvalValue.null())))
 
         print ("whileLen=" + (to_int (whileLen.numberValue)))
         print ("constSum=" + (to_int (constSum.numberValue)))
@@ -33,6 +36,8 @@ class TsxEngineDemo {
         print ("whileConst=" + (to_int (whileConst.numberValue)))
         print ("memberAssign=" + (to_int (memberAssign.numberValue)))
         print ("helperSide=" + (to_int (helperSide.numberValue)))
+        print ("modCount2=" + (to_int (modCount2.numberValue)))
+        print ("whileReturn=" + (to_int (whileReturn.numberValue)))
         print "tsx-engine-demo done"
     }
 }

--- a/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
+++ b/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
@@ -101,6 +101,34 @@ class EvalContext {
         }
         this.define(name value)
     }
+
+    ; Remove a binding from the nearest scope that owns it (parent chain walk).
+    fn removeBinding:boolean (name:string) {
+        def i:int 0
+        while (i < (array_length variables)) {
+            if ((itemAt variables i) == name) {
+                def newVars:[string]
+                def newVals:[EvalValue]
+                def j:int 0
+                while (j < (array_length variables)) {
+                    if (j != i) {
+                        push newVars (itemAt variables j)
+                        push newVals (itemAt values j)
+                    }
+                    j = j + 1
+                }
+                variables = newVars
+                values = newVals
+                return true
+            }
+            i = i + 1
+        }
+        if parent {
+            def p:EvalContext (unwrap parent)
+            return (p.removeBinding(name))
+        }
+        return false
+    }
     
     fn moduleScope:EvalContext () {
         if moduleRoot {
@@ -174,6 +202,9 @@ class ComponentEngine {
     
     ; Track all loaded files for file watching
     def loadedFiles:[string]
+    ; Canonical import paths currently loading / fully materialized (cycle guard).
+    def importLoading:[string]
+    def importLoaded:[string]
     
     ; Evaluation context
     def context:EvalContext
@@ -193,6 +224,8 @@ class ComponentEngine {
     ; function body so nested calls are reentrancy-safe.
     def scriptDidReturn:boolean false
     def scriptReturnValue:EvalValue (EvalValue.null())
+    def loopBreak:boolean false
+    def loopContinue:boolean false
 
     ; When true, suppress verbose evaluation trace (game scripts, tests).
     def quiet:boolean false
@@ -217,6 +250,10 @@ class ComponentEngine {
         localComponents = loc
         def lf:[string]
         loadedFiles = lf
+        def il:[string]
+        importLoading = il
+        def id:[string]
+        importLoaded = id
         def host:EvalContext (new EvalContext())
         host.moduleRoot = host
         hostScope = host
@@ -317,16 +354,205 @@ class ComponentEngine {
     fn getLoadedFiles:[string] () {
         return loadedFiles
     }
+
+    fn normalizeDirPath:string (dirPath:string) {
+        if ((strlen dirPath) == 0) {
+            return "./"
+        }
+        def last:int (strlen dirPath)
+        def lastCh:string (substring dirPath (last - 1) last)
+        if (lastCh != "/") {
+            return (dirPath + "/")
+        }
+        return dirPath
+    }
+
+    ; Directory prefix of a resolved module path (e.g. "import_fixtures/mid.tsx" → "import_fixtures/").
+    fn dirnameOfModulePath:string (fullPath:string) {
+        def lastSlash:int -1
+        def i:int 0
+        while (i < (strlen fullPath)) {
+            def ch:string (substring fullPath i (i + 1))
+            if (ch == "/") {
+                lastSlash = i
+            }
+            i = i + 1
+        }
+        if (lastSlash < 0) {
+            return ""
+        }
+        return (substring fullPath 0 (lastSlash + 1))
+    }
+
+    fn moduleDirFromRead:string (searchDir:string fullPath:string) {
+        def subDir:string (this.dirnameOfModulePath(fullPath))
+        return (this.normalizeDirPath(searchDir + subDir))
+    }
+
+    fn isInStringList:boolean (value:string list:[string]) {
+        def i:int 0
+        while (i < (array_length list)) {
+            if ((itemAt list i) == value) {
+                return true
+            }
+            i = i + 1
+        }
+        return false
+    }
+
+    fn listWithoutString:[string] (list:[string] value:string) {
+        def out:[string]
+        def i:int 0
+        while (i < (array_length list)) {
+            def item:string (itemAt list i)
+            if (item != value) {
+                push out item
+            }
+            i = i + 1
+        }
+        return out
+    }
+
+    fn listWithStringIfMissing:[string] (list:[string] value:string) {
+        if (this.isInStringList(value list)) {
+            return list
+        }
+        def out:[string]
+        def i:int 0
+        while (i < (array_length list)) {
+            push out (itemAt list i)
+            i = i + 1
+        }
+        push out value
+        return out
+    }
+
+    fn clearImportState:void () {
+        def empty:[string]
+        importLoading = empty
+        importLoaded = empty
+    }
+
+    fn resetParseState:void () {
+        def scope:EvalContext (new EvalContext())
+        scope.parent = hostScope
+        scope.moduleRoot = scope
+        moduleScope = scope
+        context = scope
+        this.clearLocalComponents()
+        this.clearImportState()
+        def emptyFiles:[string]
+        loadedFiles = emptyFiles
+    }
+
+    fn upsertLocalComponent:void (sym:ImportedSymbol) {
+        def i:int 0
+        while (i < (array_length localComponents)) {
+            def existing:ImportedSymbol (itemAt localComponents i)
+            if (existing.name == sym.name) {
+                existing.functionNode = sym.functionNode
+                existing.originalName = sym.originalName
+                existing.sourcePath = sym.sourcePath
+                existing.symbolType = sym.symbolType
+                existing.helperFunctions = sym.helperFunctions
+                return
+            }
+            i = i + 1
+        }
+        push localComponents sym
+    }
+
+    fn removeLocalComponentByName:void (name:string) {
+        def out:[ImportedSymbol]
+        def i:int 0
+        while (i < (array_length localComponents)) {
+            def sym:ImportedSymbol (itemAt localComponents i)
+            if (sym.name != name) {
+                push out sym
+            }
+            i = i + 1
+        }
+        localComponents = out
+    }
+
+    fn localNameForImport:string (exportName:string exportNames:[string] localNames:[string]) {
+        def i:int 0
+        while (i < (array_length exportNames)) {
+            if ((itemAt exportNames i) == exportName) {
+                return (itemAt localNames i)
+            }
+            i = i + 1
+        }
+        return exportName
+    }
+
+    fn bindImportedFunction:void (exportName:string localName:string fnNode:TSNode helperFns:[TSNode] sourcePath:string) {
+        def sym (new ImportedSymbol())
+        sym.name = localName
+        sym.originalName = exportName
+        sym.sourcePath = sourcePath
+        sym.symbolType = "component"
+        sym.functionNode = fnNode
+        sym.helperFunctions = helperFns
+        this.upsertLocalComponent(sym)
+        this.defineModuleBinding(localName (EvalValue.function(fnNode)))
+        this.trace("Imported: " + localName + " (" + exportName + ") from " + sourcePath)
+    }
+
+    fn rebindImportDeclaration:void (node:TSNode) {
+        def exportNames:[string]
+        def localNames:[string]
+        def j:int 0
+        while (j < (array_length node.children)) {
+            def spec:TSNode (itemAt node.children j)
+            if (spec.nodeType == "ImportSpecifier") {
+                if (spec.kind != "type") {
+                    def exportName:string spec.name
+                    def localName:string spec.name
+                    if ((strlen spec.value) > 0) {
+                        localName = spec.value
+                    }
+                    push exportNames exportName
+                    push localNames localName
+                }
+            }
+            if (spec.nodeType == "ImportDefaultSpecifier") {
+                push exportNames "default"
+                push localNames spec.name
+            }
+            j = j + 1
+        }
+        def k:int 0
+        while (k < (array_length exportNames)) {
+            def exportName:string (itemAt exportNames k)
+            def localName:string (itemAt localNames k)
+            def existing:EvalValue (moduleScope.lookup(exportName))
+            if (existing.isFunction()) {
+                if (null? existing.functionNode) {
+                } {
+                    def fnNode:TSNode (unwrap existing.functionNode)
+                    def emptyHelpers:[TSNode]
+                    this.bindImportedFunction(exportName localName fnNode emptyHelpers "")
+                }
+            } {
+                if (false == (existing.isNull())) {
+                    this.defineModuleBinding(localName existing)
+                }
+            }
+            k = k + 1
+        }
+    }
     
     ; ==========================================================================
     ; Main Entry Points
     ; ==========================================================================
     
     fn parseFile:EVGElement (dirPath:string fileName:string) {
-        basePath = dirPath
+        this.resetParseState()
+        this.setBasePath(dirPath)
         
         ; Track main file for watching
-        def mainFilePath:string (dirPath + fileName)
+        def mainFilePath:string (basePath + fileName)
         push loadedFiles mainFilePath
         
         def fileContent:buffer (buffer_read_file dirPath fileName)
@@ -348,6 +574,7 @@ class ComponentEngine {
     }
     
     fn parse:EVGElement (src:string) {
+        this.resetParseState()
         source = src
         
         ; Tokenize and parse
@@ -449,6 +676,9 @@ class ComponentEngine {
         moduleScope = scope
         context = scope
         this.clearLocalComponents()
+        this.clearImportState()
+        def emptyFiles:[string]
+        loadedFiles = emptyFiles
         this.processImports(ast)
         ; Functions first so const initializers may call helpers.
         this.registerComponents(ast)
@@ -484,12 +714,16 @@ class ComponentEngine {
         }
         source = src
         programAst = newAst
+        this.clearLocalComponents()
+        this.clearImportState()
         this.processImports(newAst)
         def ci:int 0
         while (ci < (array_length patch.changes)) {
             def ch:TSAstPatchChange (itemAt patch.changes ci)
             if (ch.changeKind == "removed") {
-                ; Dev reload rarely removes declarations; leave stale binding.
+                moduleScope.removeBinding(ch.name)
+                this.removeLocalComponentByName(ch.name)
+                this.trace("Removed binding: " + ch.name)
             } {
                 if (ch.declKind == "function") {
                     if (ch.changeKind != "removed") {
@@ -594,17 +828,25 @@ class ComponentEngine {
         }
         
         ; Get imported symbols from node.children (import specifiers)
-        def importedNames:[string]
+        def importExportNames:[string]
+        def importLocalNames:[string]
         def j:int 0
         while (j < (array_length node.children)) {
             def spec:TSNode (itemAt node.children j)
             if (spec.nodeType == "ImportSpecifier") {
                 if (spec.kind != "type") {
-                    push importedNames spec.name
+                    def exportName:string spec.name
+                    def localName:string spec.name
+                    if ((strlen spec.value) > 0) {
+                        localName = spec.value
+                    }
+                    push importExportNames exportName
+                    push importLocalNames localName
                 }
             }
             if (spec.nodeType == "ImportDefaultSpecifier") {
-                push importedNames spec.name
+                push importExportNames "default"
+                push importLocalNames spec.name
             }
             j = j + 1
         }
@@ -617,13 +859,31 @@ class ComponentEngine {
             return
         }
         
-        ; Resolve import: script dir first, then registered asset/lib paths.
-        resolvedImportDir = basePath
-        def src:string (this.readImportSource(basePath fullPath))
-        def dirPath:string resolvedImportDir
+        ; Resolve import relative to the current importer's directory.
+        def importerBase:string (this.normalizeDirPath(basePath))
+        resolvedImportDir = importerBase
+        def canonicalPath:string (importerBase + fullPath)
+
+        if (this.isInStringList(canonicalPath importLoading)) {
+            this.trace("Import cycle skipped: " + canonicalPath)
+            this.rebindImportDeclaration(node)
+            return
+        }
+
+        if (this.isInStringList(canonicalPath importLoaded)) {
+            this.rebindImportDeclaration(node)
+            return
+        }
+
+        push importLoading canonicalPath
+
+        def src:string (this.readImportSource(importerBase fullPath))
+        def dirPath:string (this.moduleDirFromRead(importerBase fullPath))
+        resolvedImportDir = dirPath
         if ((strlen src) == 0) {
+            importLoading = (this.listWithoutString(importLoading canonicalPath))
             print ""
-            print ("ERROR: Could not load component module: " + basePath + fullPath)
+            print ("ERROR: Could not load component module: " + importerBase + fullPath)
             print ""
             print "Please ensure the imported file exists. You may need to:"
             print "  1. Check that the import path is correct in your TSX file"
@@ -641,7 +901,7 @@ class ComponentEngine {
 
         ; Track loaded file for file watching
         def loadedFilePath:string (dirPath + fullPath)
-        push loadedFiles loadedFilePath
+        loadedFiles = (this.listWithStringIfMissing(loadedFiles loadedFilePath))
         
         ; Parse the imported file
         def lexer (new TSLexer(src))
@@ -651,8 +911,11 @@ class ComponentEngine {
         importParser.tsxMode = true
         def importAst:TSNode (importParser.parseProgram())
         
-        ; Resolve transitive imports (e.g. invaders_shared → game_helpers).
+        ; Resolve transitive imports using this module's directory as basePath.
+        def savedBasePath:string basePath
+        basePath = dirPath
         this.processImports(importAst)
+        basePath = savedBasePath
         
         ; Register all top-level bindings from the imported module so script
         ; code can call imported functions and read imported constants.
@@ -666,8 +929,7 @@ class ComponentEngine {
             ; Collect non-exported function declarations as helpers
             if (hstmt.nodeType == "FunctionDeclaration") {
                 def hfnName:string hstmt.name
-                ; Only add if not in import list (those will be the main components)
-                if ((this.isInList(hfnName importedNames)) == false) {
+                if ((this.isInList(hfnName importExportNames)) == false) {
                     push helperFns hstmt
                     print ("  Found helper function: " + hfnName)
                 }
@@ -686,18 +948,9 @@ class ComponentEngine {
                     def declNode:TSNode (unwrap stmt.left)
                     if (declNode.nodeType == "FunctionDeclaration") {
                         def fnName:string declNode.name
-                        ; Check if this function is in our import list
-                        if (this.isInList(fnName importedNames)) {
-                            def sym (new ImportedSymbol())
-                            sym.name = fnName
-                            sym.originalName = fnName
-                            sym.sourcePath = fullPath
-                            sym.symbolType = "component"
-                            sym.functionNode = declNode
-                            sym.helperFunctions = helperFns
-                            push localComponents sym
-                            this.defineModuleBinding(fnName (EvalValue.function(declNode)))
-                            print ("Imported component: " + fnName + " from " + fullPath)
+                        if (this.isInList(fnName importExportNames)) {
+                            def localName:string (this.localNameForImport(fnName importExportNames importLocalNames))
+                            this.bindImportedFunction(fnName localName declNode helperFns fullPath)
                         }
                     }
                 }
@@ -706,22 +959,17 @@ class ComponentEngine {
             ; Also check for regular function declarations (may be exported separately)
             if (stmt.nodeType == "FunctionDeclaration") {
                 def fnName:string stmt.name
-                if (this.isInList(fnName importedNames)) {
-                    def sym (new ImportedSymbol())
-                    sym.name = fnName
-                    sym.originalName = fnName
-                    sym.sourcePath = fullPath
-                    sym.symbolType = "component"
-                    sym.functionNode = stmt
-                    sym.helperFunctions = helperFns
-                    push localComponents sym
-                    this.defineModuleBinding(fnName (EvalValue.function(stmt)))
-                    print ("Imported component: " + fnName + " from " + fullPath)
+                if (this.isInList(fnName importExportNames)) {
+                    def localName:string (this.localNameForImport(fnName importExportNames importLocalNames))
+                    this.bindImportedFunction(fnName localName stmt helperFns fullPath)
                 }
             }
             
             k = k + 1
         }
+
+        importLoading = (this.listWithoutString(importLoading canonicalPath))
+        importLoaded = (this.listWithStringIfMissing(importLoaded canonicalPath))
     }
 
     ; Bind every top-level function/const from an imported module into moduleScope.
@@ -864,7 +1112,7 @@ class ComponentEngine {
         sym.originalName = node.name
         sym.symbolType = "component"
         sym.functionNode = node
-        push localComponents sym
+        this.upsertLocalComponent(sym)
         this.defineModuleBinding(node.name (EvalValue.function(node)))
         this.trace("Registered local component: " + node.name)
     }
@@ -1138,6 +1386,10 @@ class ComponentEngine {
                 if stmt.left {
                     def returnExpr:TSNode (unwrap stmt.left)
                     return (this.evaluateJSX(returnExpr))
+                } {
+                    def bareReturn (new EVGElement())
+                    bareReturn.hasReturn = true
+                    return bareReturn
                 }
             }
             
@@ -1244,13 +1496,137 @@ class ComponentEngine {
     ; Void wrappers: assigning loop results to an unused local is dead-code-
     ; eliminated by clang++ (while/for become no-ops in native game_sdl).
     fn runForStatementValue:void (stmt:TSNode) {
-        this.evaluateForStatement(stmt)
+        def savedBreak:boolean loopBreak
+        def savedContinue:boolean loopContinue
+        loopBreak = false
+        loopContinue = false
+        if stmt.init {
+            def initNode:TSNode (unwrap stmt.init)
+            if (initNode.nodeType == "VariableDeclaration") {
+                this.processVariableDeclaration(initNode)
+            }
+        }
+        def maxIterations:int 100000
+        def iterations:int 0
+        while (iterations < maxIterations) {
+            if scriptDidReturn {
+                return
+            }
+            if stmt.left {
+                def testResult:EvalValue (this.evaluateExpr((unwrap stmt.left)))
+                if ((testResult.toBool()) == false) {
+                    return
+                }
+            }
+            loopContinue = false
+            if stmt.body {
+                this.runBlockOrStatement((unwrap stmt.body))
+            }
+            if scriptDidReturn {
+                return
+            }
+            if loopBreak {
+                return
+            }
+            if stmt.right {
+                this.evaluateUpdateExpr((unwrap stmt.right))
+            }
+            if loopContinue {
+                iterations = iterations + 1
+            } {
+                iterations = iterations + 1
+            }
+        }
+        loopBreak = savedBreak
+        loopContinue = savedContinue
     }
     fn runForOfStatementValue:void (stmt:TSNode) {
-        this.evaluateForOfStatement(stmt)
+        def savedBreak:boolean loopBreak
+        def savedContinue:boolean loopContinue
+        loopBreak = false
+        loopContinue = false
+        def varName:string ""
+        if stmt.left {
+            def leftNode:TSNode (unwrap stmt.left)
+            if (leftNode.nodeType == "VariableDeclaration") {
+                if ((array_length leftNode.children) > 0) {
+                    def decl:TSNode (itemAt leftNode.children 0)
+                    varName = decl.name
+                }
+            }
+        }
+        if stmt.right {
+            def rightNode:TSNode (unwrap stmt.right)
+            def arrayValue:EvalValue (this.evaluateExpr(rightNode))
+            if (arrayValue.isArray()) {
+                def i:int 0
+                while (i < (array_length arrayValue.arrayValue)) {
+                    if scriptDidReturn {
+                        return
+                    }
+                    if loopBreak {
+                        return
+                    }
+                    def item:EvalValue (itemAt arrayValue.arrayValue i)
+                    if ((strlen varName) > 0) {
+                        context.define(varName item)
+                    }
+                    loopContinue = false
+                    if stmt.body {
+                        this.runBlockOrStatement((unwrap stmt.body))
+                    }
+                    if scriptDidReturn {
+                        return
+                    }
+                    if loopBreak {
+                        return
+                    }
+                    if loopContinue {
+                        i = i + 1
+                    } {
+                        i = i + 1
+                    }
+                }
+            }
+        }
+        loopBreak = savedBreak
+        loopContinue = savedContinue
     }
     fn runWhileStatementValue:void (stmt:TSNode) {
-        this.evaluateWhileStatement(stmt)
+        def savedBreak:boolean loopBreak
+        def savedContinue:boolean loopContinue
+        loopBreak = false
+        loopContinue = false
+        def maxIterations:int 100000
+        def iterations:int 0
+        while (iterations < maxIterations) {
+            if scriptDidReturn {
+                return
+            }
+            if stmt.left {
+                def testResult:EvalValue (this.evaluateExpr((unwrap stmt.left)))
+                if ((testResult.toBool()) == false) {
+                    return
+                }
+            }
+            loopContinue = false
+            if stmt.body {
+                this.runBlockOrStatement((unwrap stmt.body))
+            }
+            if scriptDidReturn {
+                return
+            }
+            if loopBreak {
+                return
+            }
+            if loopContinue {
+                iterations = iterations + 1
+            } {
+                iterations = iterations + 1
+            }
+        }
+        loopBreak = savedBreak
+        loopContinue = savedContinue
     }
     
     ; --------------------------------------------------------------------------
@@ -1301,8 +1677,14 @@ class ComponentEngine {
             this.runStatementList(stmt.children)
             return
         }
-        ; Loops run for side effects; value-returns from inside a loop are not
-        ; propagated (uncommon in screen/reducer scripts).
+        if (stmt.nodeType == "BreakStatement") {
+            loopBreak = true
+            return
+        }
+        if (stmt.nodeType == "ContinueStatement") {
+            loopContinue = true
+            return
+        }
         if (stmt.nodeType == "ForStatement") {
             this.runForStatementValue(stmt)
             return
@@ -1422,6 +1804,9 @@ class ComponentEngine {
                 def returnedEl:EVGElement (this.evaluateJSX(returnExpr))
                 returnedEl.hasReturn = true
                 return returnedEl
+            } {
+                result.hasReturn = true
+                return result
             }
         }
         
@@ -1500,6 +1885,9 @@ class ComponentEngine {
                         def returnedEl:EVGElement (this.evaluateJSX(returnExpr))
                         returnedEl.hasReturn = true
                         return returnedEl
+                    } {
+                        result.hasReturn = true
+                        return result
                     }
                 }
                 
@@ -1966,31 +2354,32 @@ class ComponentEngine {
     }
     
     fn expandComponent:EVGElement (name:string jsxNode:TSNode) {
-        ; Find the component definition
+        ; Use the last registered match (hot reload upserts may leave older entries).
+        def foundIdx:int -1
         def i:int 0
         while (i < (array_length localComponents)) {
             def sym:ImportedSymbol (itemAt localComponents i)
             if (sym.name == name) {
-                ; Found the component - evaluate it
-                def props:EvalValue (this.evaluateProps(jsxNode))
-                if sym.functionNode {
-                    def fnNode:TSNode (unwrap sym.functionNode)
-                    
-                    ; Register helper functions from the component's file in the context
-                    def hi:int 0
-                    while (hi < (array_length sym.helperFunctions)) {
-                        def helperFn:TSNode (itemAt sym.helperFunctions hi)
-                        def helperName:string helperFn.name
-                        def helperValue:EvalValue (EvalValue.function(helperFn))
-                        context.define(helperName helperValue)
-                        print ("Registered helper function: " + helperName)
-                        hi = hi + 1
-                    }
-                    
-                    return (this.evaluateFunctionWithProps(fnNode props))
-                }
+                foundIdx = i
             }
             i = i + 1
+        }
+        if (foundIdx >= 0) {
+            def sym:ImportedSymbol (itemAt localComponents foundIdx)
+            def props:EvalValue (this.evaluateProps(jsxNode))
+            if sym.functionNode {
+                def fnNode:TSNode (unwrap sym.functionNode)
+                def hi:int 0
+                while (hi < (array_length sym.helperFunctions)) {
+                    def helperFn:TSNode (itemAt sym.helperFunctions hi)
+                    def helperName:string helperFn.name
+                    def helperValue:EvalValue (EvalValue.function(helperFn))
+                    context.define(helperName helperValue)
+                    print ("Registered helper function: " + helperName)
+                    hi = hi + 1
+                }
+                return (this.evaluateFunctionWithProps(fnNode props))
+            }
         }
         
         ; Not found - return empty element

--- a/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
+++ b/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
@@ -878,7 +878,11 @@ class ComponentEngine {
         push importLoading canonicalPath
 
         def src:string (this.readImportSource(importerBase fullPath))
-        def dirPath:string (this.moduleDirFromRead(importerBase fullPath))
+        ; readImportSource sets resolvedImportDir to the search dir where the
+        ; file was found (importer dir or an asset path); base the module dir on
+        ; that so bare/asset imports and nested subdirectories resolve correctly.
+        def foundDir:string resolvedImportDir
+        def dirPath:string (this.moduleDirFromRead(foundDir fullPath))
         resolvedImportDir = dirPath
         if ((strlen src) == 0) {
             importLoading = (this.listWithoutString(importLoading canonicalPath))
@@ -1508,35 +1512,42 @@ class ComponentEngine {
         }
         def maxIterations:int 100000
         def iterations:int 0
-        while (iterations < maxIterations) {
+        def looping:boolean true
+        while ((iterations < maxIterations) && looping) {
             if scriptDidReturn {
-                return
-            }
-            if stmt.left {
-                def testResult:EvalValue (this.evaluateExpr((unwrap stmt.left)))
-                if ((testResult.toBool()) == false) {
-                    return
+                looping = false
+            } {
+                def proceed:boolean true
+                if stmt.left {
+                    def testResult:EvalValue (this.evaluateExpr((unwrap stmt.left)))
+                    if ((testResult.toBool()) == false) {
+                        proceed = false
+                    }
+                }
+                if (proceed == false) {
+                    looping = false
+                } {
+                    loopContinue = false
+                    if stmt.body {
+                        this.runBlockOrStatement((unwrap stmt.body))
+                    }
+                    if scriptDidReturn {
+                        looping = false
+                    } {
+                        if loopBreak {
+                            looping = false
+                        } {
+                            ; `continue` still runs the update clause.
+                            if stmt.right {
+                                this.evaluateUpdateExpr((unwrap stmt.right))
+                            }
+                            iterations = iterations + 1
+                        }
+                    }
                 }
             }
-            loopContinue = false
-            if stmt.body {
-                this.runBlockOrStatement((unwrap stmt.body))
-            }
-            if scriptDidReturn {
-                return
-            }
-            if loopBreak {
-                return
-            }
-            if stmt.right {
-                this.evaluateUpdateExpr((unwrap stmt.right))
-            }
-            if loopContinue {
-                iterations = iterations + 1
-            } {
-                iterations = iterations + 1
-            }
         }
+        ; Consume break/continue at the loop boundary (do not leak to outer loop).
         loopBreak = savedBreak
         loopContinue = savedContinue
     }
@@ -1560,31 +1571,32 @@ class ComponentEngine {
             def arrayValue:EvalValue (this.evaluateExpr(rightNode))
             if (arrayValue.isArray()) {
                 def i:int 0
-                while (i < (array_length arrayValue.arrayValue)) {
+                def looping:boolean true
+                while ((i < (array_length arrayValue.arrayValue)) && looping) {
                     if scriptDidReturn {
-                        return
-                    }
-                    if loopBreak {
-                        return
-                    }
-                    def item:EvalValue (itemAt arrayValue.arrayValue i)
-                    if ((strlen varName) > 0) {
-                        context.define(varName item)
-                    }
-                    loopContinue = false
-                    if stmt.body {
-                        this.runBlockOrStatement((unwrap stmt.body))
-                    }
-                    if scriptDidReturn {
-                        return
-                    }
-                    if loopBreak {
-                        return
-                    }
-                    if loopContinue {
-                        i = i + 1
+                        looping = false
                     } {
-                        i = i + 1
+                        if loopBreak {
+                            looping = false
+                        } {
+                            def item:EvalValue (itemAt arrayValue.arrayValue i)
+                            if ((strlen varName) > 0) {
+                                context.define(varName item)
+                            }
+                            loopContinue = false
+                            if stmt.body {
+                                this.runBlockOrStatement((unwrap stmt.body))
+                            }
+                            if scriptDidReturn {
+                                looping = false
+                            } {
+                                if loopBreak {
+                                    looping = false
+                                } {
+                                    i = i + 1
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1599,30 +1611,35 @@ class ComponentEngine {
         loopContinue = false
         def maxIterations:int 100000
         def iterations:int 0
-        while (iterations < maxIterations) {
+        def looping:boolean true
+        while ((iterations < maxIterations) && looping) {
             if scriptDidReturn {
-                return
-            }
-            if stmt.left {
-                def testResult:EvalValue (this.evaluateExpr((unwrap stmt.left)))
-                if ((testResult.toBool()) == false) {
-                    return
-                }
-            }
-            loopContinue = false
-            if stmt.body {
-                this.runBlockOrStatement((unwrap stmt.body))
-            }
-            if scriptDidReturn {
-                return
-            }
-            if loopBreak {
-                return
-            }
-            if loopContinue {
-                iterations = iterations + 1
+                looping = false
             } {
-                iterations = iterations + 1
+                def proceed:boolean true
+                if stmt.left {
+                    def testResult:EvalValue (this.evaluateExpr((unwrap stmt.left)))
+                    if ((testResult.toBool()) == false) {
+                        proceed = false
+                    }
+                }
+                if (proceed == false) {
+                    looping = false
+                } {
+                    loopContinue = false
+                    if stmt.body {
+                        this.runBlockOrStatement((unwrap stmt.body))
+                    }
+                    if scriptDidReturn {
+                        looping = false
+                    } {
+                        if loopBreak {
+                            looping = false
+                        } {
+                            iterations = iterations + 1
+                        }
+                    }
+                }
             }
         }
         loopBreak = savedBreak
@@ -1638,7 +1655,15 @@ class ComponentEngine {
     fn runStatementList:void (stmts:[TSNode]) {
         def i:int 0
         while (i < (array_length stmts)) {
+            ; Stop the block on return or a pending loop break/continue so the
+            ; rest of the block is skipped (the enclosing loop consumes the flag).
             if scriptDidReturn {
+                return
+            }
+            if loopBreak {
+                return
+            }
+            if loopContinue {
                 return
             }
             this.runStatementValue((itemAt stmts i))

--- a/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
+++ b/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
@@ -620,6 +620,10 @@ class ComponentEngine {
         hostScope.define(name value)
     }
 
+    fn removeGlobal:void (name:string) {
+        hostScope.removeBinding(name)
+    }
+
     fn setNativeBridge:void (bridge:EvalNativeBridge) {
         nativeBridge = bridge
     }
@@ -2979,6 +2983,9 @@ class ComponentEngine {
         
         ; Identifier (variable lookup)
         if (node.nodeType == "Identifier") {
+            if (node.name == "undefined") {
+                return (EvalValue.undefined())
+            }
             return (context.lookup(node.name))
         }
         
@@ -3529,8 +3536,66 @@ class ComponentEngine {
         return (EvalValue.null())
     }
     
+    fn bindingExists:boolean (name:string) {
+        return (context.has(name))
+    }
+
+    fn typeofTag:string (val:EvalValue) {
+        if (val.isUndefined()) {
+            return "undefined"
+        }
+        if (val.isNull()) {
+            return "object"
+        }
+        if (val.isNumber()) {
+            return "number"
+        }
+        if (val.isString()) {
+            return "string"
+        }
+        if (val.isBoolean()) {
+            return "boolean"
+        }
+        if (val.isFunction()) {
+            return "function"
+        }
+        if (val.isArray()) {
+            return "object"
+        }
+        if (val.isObject()) {
+            return "object"
+        }
+        if (val.isElement()) {
+            return "object"
+        }
+        return "undefined"
+    }
+
+    fn evaluateTypeofExpr:EvalValue (node:TSNode) {
+        if node.left {
+            def argNode:TSNode (unwrap node.left)
+            if (argNode.nodeType == "Identifier") {
+                def name:string argNode.name
+                if (name == "undefined") {
+                    return (EvalValue.string("undefined"))
+                }
+                if (false == (this.bindingExists(name))) {
+                    return (EvalValue.string("undefined"))
+                }
+                def val:EvalValue (context.lookup(name))
+                return (EvalValue.string((this.typeofTag(val))))
+            }
+            def val:EvalValue (this.evaluateExpr(argNode))
+            return (EvalValue.string((this.typeofTag(val))))
+        }
+        return (EvalValue.string("undefined"))
+    }
+    
     fn evaluateUnaryExpr:EvalValue (node:TSNode) {
         def op:string node.value
+        if (op == "typeof") {
+            return (this.evaluateTypeofExpr(node))
+        }
         if node.left {
             def argExpr:TSNode (unwrap node.left)
             def arg:EvalValue (this.evaluateExpr(argExpr))

--- a/gallery/pdf_writer/src/jsx/EvalValue.rgr
+++ b/gallery/pdf_writer/src/jsx/EvalValue.rgr
@@ -16,6 +16,7 @@ Import "../../../ts_parser/ts_parser_simple.rgr"
 ; 5 = object
 ; 6 = function
 ; 7 = evgElement (for JSX elements as props)
+; 8 = undefined (distinct from null for typeof / optional globals)
 
 class EvalValue {
     def valueType:int 0         ; Type tag
@@ -94,6 +95,12 @@ class EvalValue {
         v.evgElement = el
         return v
     }
+
+    sfn undefined:EvalValue () {
+        def v:EvalValue (new EvalValue())
+        v.valueType = 8
+        return v
+    }
     
     ; Type checks
     fn isNull:boolean () {
@@ -127,6 +134,10 @@ class EvalValue {
     fn isElement:boolean () {
         return (valueType == 7)
     }
+
+    fn isUndefined:boolean () {
+        return (valueType == 8)
+    }
     
     ; Type coercion
     fn toNumber:double () {
@@ -150,6 +161,9 @@ class EvalValue {
     fn toString:string () {
         if (valueType == 0) {
             return "null"
+        }
+        if (valueType == 8) {
+            return "undefined"
         }
         if (valueType == 1) {
             ; Format number - remove trailing zeros
@@ -214,6 +228,9 @@ class EvalValue {
     
     fn toBool:boolean () {
         if (valueType == 0) {
+            return false
+        }
+        if (valueType == 8) {
             return false
         }
         if (valueType == 1) {
@@ -338,6 +355,9 @@ class EvalValue {
         }
         if (valueType == 0) {
             return true
+        }
+        if (valueType == 8) {
+            return (other.valueType == 8)
         }
         if (valueType == 1) {
             return (numberValue == other.numberValue)

--- a/gallery/ts_parser/ts_parser_simple.rgr
+++ b/gallery/ts_parser/ts_parser_simple.rgr
@@ -3565,7 +3565,7 @@ class TSParserSimple {
       return update
     }
     
-    if ((tokVal == "!") || (tokVal == "-")) {
+    if ((tokVal == "!") || (tokVal == "-") || (tokVal == "+")) {
       def opTok (this.peek())
       this.advance()
       def arg (this.parseUnary())
@@ -3573,6 +3573,20 @@ class TSParserSimple {
       def unary (new TSNode())
       unary.nodeType = "UnaryExpression"
       unary.value = opTok.value
+      unary.left = arg
+      unary.start = opTok.start
+      unary.line = opTok.line
+      unary.col = opTok.col
+      return unary
+    }
+
+    if (tokVal == "typeof") {
+      def opTok (this.peek())
+      this.advance()
+      def arg (this.parseUnary())
+      def unary (new TSNode())
+      unary.nodeType = "UnaryExpression"
+      unary.value = "typeof"
       unary.left = arg
       unary.start = opTok.start
       unary.line = opTok.line

--- a/tests/tsx-engine.test.ts
+++ b/tests/tsx-engine.test.ts
@@ -23,6 +23,24 @@ describe("TSX engine - ComponentEngine regressions", () => {
     expect(out).toContain("whileConst=15");
     expect(out).toContain("memberAssign=19");
     expect(out).toContain("helperSide=1");
+    expect(out).toContain("modCount2=2");
+    expect(out).toContain("whileReturn=5");
     expect(out).toContain("tsx-engine-demo done");
+  });
+
+  it("resolves transitive relative imports from the importer directory", () => {
+    const { compile, run } = compileAndRun(
+      "gallery/game_engine/scripting/import_chain_demo.rgr"
+    );
+
+    expect(
+      compile.success,
+      `Compile failed: ${compile.error || compile.output}`
+    ).toBe(true);
+    expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+
+    const out = run?.output || "";
+    expect(out).toContain("importChain=7");
+    expect(out).toContain("import-chain-demo done");
   });
 });

--- a/tests/tsx-engine.test.ts
+++ b/tests/tsx-engine.test.ts
@@ -25,6 +25,8 @@ describe("TSX engine - ComponentEngine regressions", () => {
     expect(out).toContain("helperSide=1");
     expect(out).toContain("modCount2=2");
     expect(out).toContain("whileReturn=5");
+    expect(out).toContain("nestedBreak=306");
+    expect(out).toContain("continueSkip=12");
     expect(out).toContain("tsx-engine-demo done");
   });
 

--- a/tests/tsx-engine.test.ts
+++ b/tests/tsx-engine.test.ts
@@ -27,6 +27,8 @@ describe("TSX engine - ComponentEngine regressions", () => {
     expect(out).toContain("whileReturn=5");
     expect(out).toContain("nestedBreak=306");
     expect(out).toContain("continueSkip=12");
+    expect(out).toContain("splitNoPane=0");
+    expect(out).toContain("splitWithPane=1");
     expect(out).toContain("tsx-engine-demo done");
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

TSX engine fixes for game scripting.

### Latest
- Merged latest `master` (includes PR #158 validated issues doc)
- Resolved `TSX_ENGINE_ISSUES.md` merge conflict

### Fixes (PR #159)
- Transitive imports, cycle guard, import aliases
- Hot reload: patchScript state reset, upsert components, removed bindings
- Value-path loop return/break/continue + statement-list propagation
- Bare JSX `return;` sets `hasReturn`
- `parse()` state reset
- **`typeof` operator** + **`paneIndex`** global for split-pane detection (`isSplitPane()` pattern)

### Regression tests
- `tsx_engine_demo`: `whileReturn=5`, `nestedBreak=306`, `continueSkip=12`, `splitNoPane=0`, `splitWithPane=1`
- `import_chain_demo`: `importChain=7`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79282f2c-143e-4e7b-a7ba-09b55914eabf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79282f2c-143e-4e7b-a7ba-09b55914eabf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

