### PR TITLE
Phase 1: world-mode entity store, engine camera, fixed timestep

### DIFF
--- a/gallery/game_engine/ROADMAP.md
+++ b/gallery/game_engine/ROADMAP.md
@@ -164,6 +164,22 @@ Nämä ovat tulevia kerroksia tai pelikohtaisia ratkaisuja, ei base-moottorin os
 
 ---
 
+### Vaihe 1b — Entity-kerros ja kamera (heinäkuu 2026, osittain)
+
+**Tavoite:** yhtenäinen world-entity store; kamera engineen; fixed timestep.
+Taaksepäin yhteensopiva vanhan `state.entities`-polun kanssa.
+
+| # | Tehtävä | Tila |
+|---|---------|------|
+| 1b.1 | `entities()` spawn + `state.worldEntities` | ✅ |
+| 1b.2 | Engine-kamera (`camera()`, follow, smoothing, bounds) | ✅ |
+| 1b.3 | Automaattinen world→screen + culling | ✅ |
+| 1b.4 | `config().physics.fixedStep` fixed timestep | ✅ |
+| 1b.5 | body/collider/trigger-komponentit | ❌ Vaihe 2 |
+| 1b.6 | Valmiit controllerit (platformer, top-down, …) | ❌ Vaihe 3 |
+
+---
+
 ### Vaihe 1 — Suorituskyky ja oikeellisuus (lyhyt aikaväli)
 
 **Tavoite:** skriptatut pelit skaalautuvat 60 FPS:iin; simulaatio riippumaton frameratesta.

--- a/gallery/game_engine/scripting/GAME_SCRIPTING.md
+++ b/gallery/game_engine/scripting/GAME_SCRIPTING.md
@@ -296,6 +296,42 @@ Full walkthrough with Invaders-style examples (background images, score
 persistence, `pushGame` → `loadGame` → `popGame`):
 [`GAME_SCREENS_AND_STORAGE.md`](./GAME_SCREENS_AND_STORAGE.md).
 
+## World-mode entities and engine camera (Phase 1)
+
+Legacy games (Pong, Ylos, …) keep using **`sprites()` + `state.entities`** in
+**screen space** and may subtract `cameraY` manually (`placeEntities()`). That
+path is unchanged.
+
+New optional hooks separate **world simulation** from **rendering**:
+
+| Function | Role |
+|----------|------|
+| `entities()` | Spawn list in **world coordinates** (`id`, `sprite`, `position`, `tags`) |
+| `camera()` | Engine-managed follow camera (`follow`, `mode`, `offsetY`, `smoothing`, `bounds`) |
+| `config()` | `physics.fixedStep` (ms) for fixed-timestep updates; `world.height` for bounds |
+
+Per frame the game updates **`state.worldEntities[id]`** (same shape as
+`EntityPose`, but world `x`/`y`). The runner applies the camera offset, culls
+off-screen entities, and syncs retained sprites — no `placeEntities()` copy step.
+
+Minimal example: [`world_scroll.game.tsx`](./world_scroll.game.tsx) (headless test:
+[`world_scroll_runner_demo.rgr`](./world_scroll_runner_demo.rgr)).
+
+```tsx
+function entities() {
+  return [
+    { id: "player", sprite: "hero", position: { x: 240, y: 730 }, tags: ["player"] }
+  ];
+}
+function camera() {
+  return { follow: "player", mode: "vertical", offsetY: -40, smoothing: 0.18 };
+}
+function update(props) {
+  const we = props.state.worldEntities;
+  // ... simulate in world space, return { worldEntities: { player: { x, y } } }
+}
+```
+
 ## Roadmap
 
 1. **Done:** namespace injection (`registerGlobal`), script loading + function

--- a/gallery/game_engine/scripting/engine.d.ts
+++ b/gallery/game_engine/scripting/engine.d.ts
@@ -100,6 +100,7 @@ interface EntityPose {
   x: number;
   y: number;
   visible?: number;
+  active?: number;
   r?: number;
   g?: number;
   b?: number;
@@ -108,6 +109,38 @@ interface EntityPose {
   p0?: number;
   p1?: number;
   p2?: number;
+  /** Alias for p0 in world-mode entity definitions. */
+  frame?: number;
+}
+
+/** World-space spawn definition returned from entities(). */
+interface EntityDef {
+  id: string;
+  /** sprites()[].id — defaults to id when omitted. */
+  sprite?: string;
+  position: { x: number; y: number };
+  tags?: string[];
+  visible?: number;
+  frame?: number;
+}
+
+/** Engine-managed camera (world → screen). */
+interface CameraConfig {
+  follow?: string;
+  mode?: "vertical" | "horizontal" | "both" | "none";
+  offsetX?: number;
+  offsetY?: number;
+  /** 0 = snap, 0.12 = smooth follow per frame. */
+  smoothing?: number;
+  bounds?: { x: number; y: number; w: number; h: number };
+}
+
+/** Optional game + physics configuration. */
+interface GameConfig {
+  width?: number;
+  height?: number;
+  world?: { width: number; height: number };
+  physics?: { gravity?: number; fixedStep?: number };
 }
 
 /** RGB colour triple used by retained sprites and HUD. */
@@ -139,6 +172,13 @@ interface GameState {
   showNet?: number;
   /** Entity poses keyed by sprites()[].id (single-screen / flat model). */
   entities?: Record<string, EntityPose>;
+  /**
+   * World-space entity poses (world-mode). The engine applies camera offset
+   * when rendering. Use with entities() spawn list — no manual placeEntities().
+   */
+  worldEntities?: Record<string, EntityPose>;
+  /** Horizontal scroll offset (written by engine camera when enabled). */
+  cameraX?: number;
   /** Active screen name when using the multi-screen model. */
   screen?: string;
   /** Per-screen frozen sub-state (multi-screen model). */
@@ -292,6 +332,16 @@ interface GameScript<TState extends GameState = GameState> {
    * playerSlots in initState / update (or an in-game menu).
    */
   playerCount?(props: TypedEventProps<GameState>): number;
+  /**
+   * World-mode: unified entity spawn list (world coordinates). When present,
+   * the engine seeds state.worldEntities and applies camera offset at render.
+   * Legacy games keep using sprites() + state.entities (screen space).
+   */
+  entities?(): EntityDef[];
+  /** Engine-managed camera for world-mode games. */
+  camera?(): CameraConfig;
+  /** Optional physics / world configuration (fixed timestep, bounds). */
+  config?(): GameConfig;
 }
 
 // --- Injected globals (available without importing) -------------------------

--- a/gallery/game_engine/scripting/game_camera.rgr
+++ b/gallery/game_engine/scripting/game_camera.rgr
@@ -1,0 +1,174 @@
+; ==============================================================================
+; game_camera - engine-managed world-to-screen camera for world-mode games.
+; ==============================================================================
+;
+; Scripts may define camera() once:
+;   { follow: "player", mode: "vertical", offsetY: -120, smoothing: 0.12,
+;     bounds: { x: 0, y: 0, w: 480, h: 1890 } }
+;
+; Legacy games keep setting state.cameraY manually — when camera() is absent the
+; runner reads cameraY from state unchanged (backwards compatible).
+; ==============================================================================
+
+Import "../../pdf_writer/src/jsx/EvalValue.rgr"
+
+class GameCamera {
+    def enabled:boolean false
+    def followId:string ""
+    def mode:string "vertical"
+    def offsetX:int 0
+    def offsetY:int 0
+    ; smoothing 0 = snap, 1000 = full lerp per frame (fixed-point / 1000).
+    def smoothing:int 0
+    def boundsX:int 0
+    def boundsY:int 0
+    def boundsW:int 0
+    def boundsH:int 0
+    def camX:int 0
+    def camY:int 0
+    def targetCamX:int 0
+    def targetCamY:int 0
+
+    fn memString:string (obj:EvalValue key:string dflt:string) {
+        def v:EvalValue (obj.getMember(key))
+        if (v.isNull()) {
+            return dflt
+        }
+        if (v.isString()) {
+            return v.stringValue
+        }
+        return dflt
+    }
+
+    fn memInt:int (obj:EvalValue key:string dflt:int) {
+        def v:EvalValue (obj.getMember(key))
+        if (v.isNull()) {
+            return dflt
+        }
+        return (to_int v.numberValue)
+    }
+
+    fn memDouble:double (obj:EvalValue key:string dflt:double) {
+        def v:EvalValue (obj.getMember(key))
+        if (v.isNull()) {
+            return dflt
+        }
+        return v.numberValue
+    }
+
+    fn loadFromEval:void (cfg:EvalValue) {
+        enabled = true
+        followId = (this.memString(cfg "follow" ""))
+        mode = (this.memString(cfg "mode" "vertical"))
+        offsetX = (this.memInt(cfg "offsetX" 0))
+        offsetY = (this.memInt(cfg "offsetY" 0))
+        def sm:double (this.memDouble(cfg "smoothing" 0.0))
+        smoothing = (to_int (sm * 1000.0))
+        if (smoothing < 0) {
+            smoothing = 0
+        }
+        if (smoothing > 1000) {
+            smoothing = 1000
+        }
+        def b:EvalValue (cfg.getMember("bounds"))
+        if (b.isObject()) {
+            boundsX = (this.memInt(b "x" 0))
+            boundsY = (this.memInt(b "y" 0))
+            boundsW = (this.memInt(b "w" 0))
+            boundsH = (this.memInt(b "h" 0))
+        }
+    }
+
+    fn disable:void () {
+        enabled = false
+        followId = ""
+        camX = 0
+        camY = 0
+        targetCamX = 0
+        targetCamY = 0
+    }
+
+    fn clampCam:void (pw:int ph:int worldH:int) {
+        if (boundsW > 0) {
+            def maxX:int (boundsW - pw)
+            if (maxX < 0) {
+                maxX = 0
+            }
+            if (targetCamX < boundsX) {
+                targetCamX = boundsX
+            }
+            if (targetCamX > (boundsX + maxX)) {
+                targetCamX = (boundsX + maxX)
+            }
+        }
+        def maxY:int worldH
+        if (boundsH > 0) {
+            maxY = boundsH
+        }
+        def maxCamY:int (maxY - ph)
+        if (maxCamY < 0) {
+            maxCamY = 0
+        }
+        if (targetCamY < 0) {
+            targetCamY = 0
+        }
+        if (targetCamY > maxCamY) {
+            targetCamY = maxCamY
+        }
+    }
+
+    ; Compute target camera from follow entity world position.
+    fn update:void (world:EvalValue pw:int ph:int worldH:int) {
+        if (enabled == false) {
+            return
+        }
+        if ((strlen followId) == 0) {
+            return
+        }
+        def pos:EvalValue (world.getMember(followId))
+        if (pos.isNull()) {
+            return
+        }
+        def fx:int (this.memInt(pos "x" 0))
+        def fy:int (this.memInt(pos "y" 0))
+        if (mode == "horizontal") {
+            targetCamX = (fx + offsetX - (idiv pw 2))
+            targetCamY = 0
+        } {
+            if (mode == "both") {
+                targetCamX = (fx + offsetX - (idiv pw 2))
+                targetCamY = (fy + offsetY - (idiv ph 2))
+            } {
+                ; vertical (default) and unknown modes
+                targetCamX = 0
+                targetCamY = (fy + offsetY - (idiv ph 2))
+            }
+        }
+        this.clampCam(pw ph worldH)
+        if (smoothing <= 0) {
+            camX = targetCamX
+            camY = targetCamY
+            return
+        }
+        def dx:int (targetCamX - camX)
+        def dy:int (targetCamY - camY)
+        camX = (camX + (idiv (dx * smoothing) 1000))
+        camY = (camY + (idiv (dy * smoothing) 1000))
+    }
+
+    fn writeToState:void (state:EvalValue) {
+        if (enabled == false) {
+            return
+        }
+        state.setMember("cameraY" (EvalValue.fromInt(camY)))
+        state.setMember("cameraX" (EvalValue.fromInt(camX)))
+    }
+
+    fn readLegacyFromState:void (state:EvalValue) {
+        if (enabled) {
+            return
+        }
+        camY = (this.memInt(state "cameraY" 0))
+        camX = (this.memInt(state "cameraX" 0))
+    }
+}

--- a/gallery/game_engine/scripting/game_entity_store.rgr
+++ b/gallery/game_engine/scripting/game_entity_store.rgr
@@ -1,0 +1,223 @@
+; ==============================================================================
+; game_entity_store - unified world-space entity list for world-mode games.
+; ==============================================================================
+;
+; When a script defines entities(), the runner seeds state.worldEntities and
+; treats coordinates as world pixels. Rendering applies the engine camera
+; (world → screen). Legacy games keep using state.entities in screen space.
+; ==============================================================================
+
+Import "../../pdf_writer/src/jsx/EvalValue.rgr"
+Import "./game_sprite.rgr"
+
+class GameEntityStore {
+    def worldMode:boolean false
+    ; entity id -> sprite def id (when different from entity id).
+    def spriteIds:[string]
+    def spriteDefIds:[string]
+
+    fn memString:string (obj:EvalValue key:string dflt:string) {
+        def v:EvalValue (obj.getMember(key))
+        if (v.isNull()) {
+            return dflt
+        }
+        if (v.isString()) {
+            return v.stringValue
+        }
+        return dflt
+    }
+
+    fn memInt:int (obj:EvalValue key:string dflt:int) {
+        def v:EvalValue (obj.getMember(key))
+        if (v.isNull()) {
+            return dflt
+        }
+        return (to_int v.numberValue)
+    }
+
+    fn clear:void () {
+        worldMode = false
+        clear spriteIds
+        clear spriteDefIds
+    }
+
+    fn spriteDefForEntity:string (entityId:string) {
+        def i 0
+        while (i < (array_length spriteIds)) {
+            if ((itemAt spriteIds i) == entityId) {
+                return (itemAt spriteDefIds i)
+            }
+            i = (i + 1)
+        }
+        return entityId
+    }
+
+    fn findSpriteDef:EvalValue (sprites:EvalValue spriteId:string) {
+        if (false == (sprites.isArray())) {
+            return (EvalValue.null())
+        }
+        def arr:[EvalValue] sprites.arrayValue
+        def i 0
+        while (i < (array_length arr)) {
+            def d:EvalValue (itemAt arr i)
+            def id:string (this.memString(d "id" ""))
+            if (id == spriteId) {
+                return d
+            }
+            i = (i + 1)
+        }
+        return (EvalValue.null())
+    }
+
+    ; Build EvalValue pose from world entity + optional position override.
+    fn poseFromSpawn:EvalValue (ent:EvalValue) {
+        def k:[string]
+        def v:[EvalValue]
+        def pos:EvalValue (ent.getMember("position"))
+        def wx:int 0
+        def wy:int 0
+        if (pos.isObject()) {
+            wx = (this.memInt(pos "x" 0))
+            wy = (this.memInt(pos "y" 0))
+        }
+        push k "x"
+        push v (EvalValue.fromInt(wx))
+        push k "y"
+        push v (EvalValue.fromInt(wy))
+        def vis:EvalValue (ent.getMember("visible"))
+        if (false == (vis.isNull())) {
+            push k "visible"
+            push v vis
+        }
+        def p0:EvalValue (ent.getMember("frame"))
+        if (false == (p0.isNull())) {
+            push k "p0"
+            push v p0
+        }
+        return (EvalValue.object(k v))
+    }
+
+    ; Merge entities() spawn list into state.worldEntities when missing keys.
+    fn seedWorldEntities:void (state:EvalValue spawnList:EvalValue) {
+        def world:EvalValue (state.getMember("worldEntities"))
+        if (world.isNull()) {
+            def emptyK:[string]
+            def emptyV:[EvalValue]
+            world = (EvalValue.object(emptyK emptyV))
+            state.setMember("worldEntities" world)
+        }
+        if (false == (spawnList.isArray())) {
+            return
+        }
+        def arr:[EvalValue] spawnList.arrayValue
+        def i 0
+        while (i < (array_length arr)) {
+            def ent:EvalValue (itemAt arr i)
+            def eid:string (this.memString(ent "id" ""))
+            if ((strlen eid) > 0) {
+                def existing:EvalValue (world.getMember(eid))
+                if (existing.isNull()) {
+                    world.setMember(eid (this.poseFromSpawn(ent)))
+                }
+                def spriteId:string (this.memString(ent "sprite" eid))
+                push spriteIds eid
+                push spriteDefIds spriteId
+            }
+            i = (i + 1)
+        }
+    }
+
+    ; Create retained GameEntity objects from entities() spawn list.
+    fn spawnRetained:[GameEntity] (spawnList:EvalValue sprites:EvalValue renderer:GameSpriteRenderer) {
+        def out:[GameEntity]
+        if (false == (spawnList.isArray())) {
+            return out
+        }
+        def arr:[EvalValue] spawnList.arrayValue
+        def i 0
+        while (i < (array_length arr)) {
+            def ent:EvalValue (itemAt arr i)
+            def eid:string (this.memString(ent "id" ""))
+            if ((strlen eid) > 0) {
+                def spriteId:string (this.memString(ent "sprite" eid))
+                def defn:EvalValue (this.findSpriteDef(sprites spriteId))
+                if (false == (defn.isNull())) {
+                    def ge:GameEntity (new GameEntity)
+                    renderer.applyDef(ge defn)
+                    ge.id = eid
+                    push out ge
+                }
+            }
+            i = (i + 1)
+        }
+        return out
+    }
+
+    fn activateFromScript:void (spawnList:EvalValue) {
+        worldMode = true
+        clear spriteIds
+        clear spriteDefIds
+        if (false == (spawnList.isArray())) {
+            return
+        }
+        def arr:[EvalValue] spawnList.arrayValue
+        def i 0
+        while (i < (array_length arr)) {
+            def ent:EvalValue (itemAt arr i)
+            def eid:string (this.memString(ent "id" ""))
+            if ((strlen eid) > 0) {
+                def spriteId:string (this.memString(ent "sprite" eid))
+                push spriteIds eid
+                push spriteDefIds spriteId
+            }
+            i = (i + 1)
+        }
+    }
+
+    ; Read worldEntities[id], apply camera offset, write screen pose to entity.
+    fn syncEntity:void (e:GameEntity world:EvalValue camX:int camY:int pw:int ph:int renderer:GameSpriteRenderer) {
+        def pos:EvalValue (world.getMember(e.id))
+        if (pos.isNull()) {
+            return
+        }
+        def wx:int (this.memInt(pos "x" e.x))
+        def wy:int (this.memInt(pos "y" e.y))
+        def k:[string]
+        def v:[EvalValue]
+        push k "x"
+        push v (EvalValue.fromInt((wx - camX)))
+        push k "y"
+        push v (EvalValue.fromInt((wy - camY)))
+        def vis:EvalValue (pos.getMember("visible"))
+        if (false == (vis.isNull())) {
+            push k "visible"
+            push v vis
+        }
+        def active:EvalValue (pos.getMember("active"))
+        if (false == (active.isNull())) {
+            if (active.isBoolean()) {
+                if (active.boolValue == false) {
+                    push k "visible"
+                    push v (EvalValue.boolean(false))
+                }
+            } {
+                if ((to_int active.numberValue) == 0) {
+                    push k "visible"
+                    push v (EvalValue.fromInt(0))
+                }
+            }
+        }
+        def p0:EvalValue (pos.getMember("p0"))
+        if (false == (p0.isNull())) {
+            push k "p0"
+            push v p0
+        }
+        def frame:EvalValue (pos.getMember("frame"))
+        if (false == (frame.isNull())) {
+            push k "p0"
+            push v frame
+        }
+        def screenPose:EvalValue (EvalValue.object(k v))
+        renderer.syncPose(e screenPose pw ph)
+    }
+}

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -26,6 +26,8 @@ Import "./game_image_loader.rgr"
 Import "./game_input.rgr"
 Import "./game_composite_bridge.rgr"
 Import "./game_static_bg_bridge.rgr"
+Import "./game_camera.rgr"
+Import "./game_entity_store.rgr"
 
 ; Runtime options for script-driven games (SDL host, tests, custom hosts).
 class GameRuntimeOptions {
@@ -75,6 +77,11 @@ class GameRunner {
     def staticBgBridge:GameStaticBgNativeBridge (new GameStaticBgNativeBridge)
     def compositeBridge:CompositeEvalNativeBridge (new CompositeEvalNativeBridge)
     def hostBridge@(optional):EvalNativeBridge
+    def camera:GameCamera (new GameCamera)
+    def entityStore:GameEntityStore (new GameEntityStore)
+    def fixedStepMs:int 0
+    def timeAccumulator:int 0
+    def worldHeight:int 0
 
     fn init:void (w:int h:int) {
         engine.quiet = true
@@ -178,6 +185,11 @@ class GameRunner {
         host.audio = audio
         currentScreen = ""
         state = (EvalValue.null())
+        camera = (new GameCamera)
+        entityStore = (new GameEntityStore)
+        fixedStepMs = 0
+        timeAccumulator = 0
+        worldHeight = 0
         this.clearBackground()
         this.clearStaticBg()
     }
@@ -507,6 +519,52 @@ class GameRunner {
         return e
     }
 
+    ; Optional config() — physics.fixedStep enables fixed-timestep simulation.
+    fn applyConfig:void () {
+        if (false == (this.scriptHasFunction("config"))) {
+            return
+        }
+        def cfg:EvalValue (engine.callFunction("config" (EvalValue.null())))
+        if (false == (cfg.isObject())) {
+            return
+        }
+        def phys:EvalValue (cfg.getMember("physics"))
+        if (phys.isObject()) {
+            def step:double (this.memDouble(phys "fixedStep" 0.0))
+            if (step > 0.0) {
+                fixedStepMs = (to_int step)
+            }
+        }
+        def world:EvalValue (cfg.getMember("world"))
+        if (world.isObject()) {
+            def wh:int (this.memInt(world "height" 0))
+            if (wh > 0) {
+                worldHeight = wh
+            }
+        }
+    }
+
+    fn applyCamera:void () {
+        camera.disable()
+        if (false == (this.scriptHasFunction("camera"))) {
+            return
+        }
+        def cfg:EvalValue (engine.callFunction("camera" (EvalValue.null())))
+        if (cfg.isObject()) {
+            camera.loadFromEval(cfg)
+        }
+    }
+
+    fn resolveWorldHeight:int () {
+        if (worldHeight > 0) {
+            return worldHeight
+        }
+        if (staticBgH > 0) {
+            return staticBgH
+        }
+        return ph
+    }
+
     ; Drain transient events emitted by update() this frame into the host.
     fn drainStateEvents:void () {
         def evs:EvalValue (state.getMember("events"))
@@ -528,24 +586,37 @@ class GameRunner {
     fn setupScene:void () {
         this.wireHostAudio()
         this.setupResources()
+        this.applyConfig()
         this.applyBackgroundFromScript()
         this.applyCreateStaticBg()
+        this.applyCamera()
         state = (engine.callFunction("initState" (EvalValue.null())))
+        def hasEntitiesFn:boolean (this.scriptHasFunction("entities"))
+        if (hasEntitiesFn) {
+            def spawn:EvalValue (engine.callFunction("entities" (EvalValue.null())))
+            entityStore.activateFromScript(spawn)
+            entityStore.seedWorldEntities(state spawn)
+        }
         this.syncBackgroundFromState()
         if (this.multiScreenMode()) {
             currentScreen = (this.currentScreenName())
             this.loadScreenSprites(currentScreen)
         } {
             def sprites:EvalValue (engine.callFunction("sprites" (EvalValue.null())))
-            if (sprites.isArray()) {
-                def arr:[EvalValue] sprites.arrayValue
-                def i 0
-                while (i < (array_length arr)) {
-                    def d:EvalValue (itemAt arr i)
-                    def e:GameEntity (new GameEntity)
-                    spriteRenderer.applyDef(e d)
-                    push entities e
-                    i = (i + 1)
+            if (hasEntitiesFn) {
+                def spawn:EvalValue (engine.callFunction("entities" (EvalValue.null())))
+                entities = (entityStore.spawnRetained(spawn sprites spriteRenderer))
+            } {
+                if (sprites.isArray()) {
+                    def arr:[EvalValue] sprites.arrayValue
+                    def i 0
+                    while (i < (array_length arr)) {
+                        def d:EvalValue (itemAt arr i)
+                        def e:GameEntity (new GameEntity)
+                        spriteRenderer.applyDef(e d)
+                        push entities e
+                        i = (i + 1)
+                    }
                 }
             }
         }
@@ -562,22 +633,51 @@ class GameRunner {
 
     fn syncFromState:void () {
         def active:EvalValue (this.activeState())
-        def ent:EvalValue (active.getMember("entities"))
-        def cur:string (this.currentScreenName())
-        def i 0
-        while (i < (array_length entities)) {
-            def e:GameEntity (itemAt entities i)
-            if (this.multiScreenMode()) {
-                if (e.screen != cur) {
-                    i = (i + 1)
-                    continue
+        if (entityStore.worldMode) {
+            def world:EvalValue (active.getMember("worldEntities"))
+            if (world.isNull()) {
+                world = (active.getMember("entities"))
+            }
+            if (camera.enabled == false) {
+                camera.readLegacyFromState(state)
+            } {
+                def wh:int (this.resolveWorldHeight())
+                camera.update(world pw ph wh)
+                camera.writeToState(state)
+            }
+            def camX:int camera.camX
+            def camY:int camera.camY
+            def cur:string (this.currentScreenName())
+            def i 0
+            while (i < (array_length entities)) {
+                def e:GameEntity (itemAt entities i)
+                if (this.multiScreenMode()) {
+                    if (e.screen != cur) {
+                        i = (i + 1)
+                        continue
+                    }
                 }
+                entityStore.syncEntity(e world camX camY pw ph spriteRenderer)
+                i = (i + 1)
             }
-            def pos:EvalValue (ent.getMember(e.id))
-            if (false == (pos.isNull())) {
-                spriteRenderer.syncPose(e pos pw ph)
+        } {
+            def ent:EvalValue (active.getMember("entities"))
+            def cur:string (this.currentScreenName())
+            def i 0
+            while (i < (array_length entities)) {
+                def e:GameEntity (itemAt entities i)
+                if (this.multiScreenMode()) {
+                    if (e.screen != cur) {
+                        i = (i + 1)
+                        continue
+                    }
+                }
+                def pos:EvalValue (ent.getMember(e.id))
+                if (false == (pos.isNull())) {
+                    spriteRenderer.syncPose(e pos pw ph)
+                }
+                i = (i + 1)
             }
-            i = (i + 1)
         }
         score1 = (this.memInt(active "score1" (this.memInt(state "score1" score1))))
         score2 = (this.memInt(active "score2" (this.memInt(state "score2" score2))))
@@ -632,7 +732,7 @@ class GameRunner {
         this.frameWithInput(dtMs snap)
     }
 
-    fn frameWithInput:void (dtMs:int snap:GameInputSnapshot) {
+    fn stepUpdate:void (dtMs:int snap:GameInputSnapshot) {
         def prevScreen:string (this.currentScreenName())
         timeMs = (timeMs + dtMs)
         def k:[string]
@@ -680,6 +780,23 @@ class GameRunner {
             profUpdateSyncMs = (profUpdateSyncMs + (tSync1 - tScript1))
             profFrames = (profFrames + 1)
         }
+    }
+
+    fn frameWithInput:void (dtMs:int snap:GameInputSnapshot) {
+        if (fixedStepMs > 0) {
+            timeAccumulator = (timeAccumulator + dtMs)
+            def steps:int 0
+            while (timeAccumulator >= fixedStepMs) {
+                this.stepUpdate(fixedStepMs snap)
+                timeAccumulator = (timeAccumulator - fixedStepMs)
+                steps = (steps + 1)
+            }
+            if (steps == 0) {
+                this.syncFromState()
+            }
+            return
+        }
+        this.stepUpdate(dtMs snap)
     }
 
     fn draw:void () {

--- a/gallery/game_engine/scripting/world_scroll.game.tsx
+++ b/gallery/game_engine/scripting/world_scroll.game.tsx
@@ -1,0 +1,155 @@
+/// <reference path="./game.d.ts" />
+//
+// world_scroll.game.tsx — Phase 1 demo: entities(), camera(), worldEntities.
+// No placeEntities(); the engine applies camera offset and culling.
+//
+
+const WORLD_H = 810;
+const VIEW_W = 480;
+const VIEW_H = 270;
+
+function config() {
+  return {
+    world: { width: VIEW_W, height: WORLD_H },
+    physics: { fixedStep: 16.666 }
+  };
+}
+
+function sprites() {
+  return [
+    { id: "hero", kind: "circle", rad: 10, r: 120, g: 220, b: 160 },
+    { id: "gem", kind: "rect", w: 12, h: 12, r: 255, g: 210, b: 80 }
+  ];
+}
+
+function entities() {
+  return [
+    {
+      id: "player",
+      sprite: "hero",
+      position: { x: 240, y: WORLD_H - 80 },
+      tags: ["player"]
+    },
+    { id: "g0", sprite: "gem", position: { x: 120, y: WORLD_H - 200 } },
+    { id: "g1", sprite: "gem", position: { x: 360, y: WORLD_H - 360 } },
+    { id: "g2", sprite: "gem", position: { x: 200, y: WORLD_H - 520 } },
+    { id: "g3", sprite: "gem", position: { x: 300, y: WORLD_H - 680 } }
+  ];
+}
+
+function camera() {
+  return {
+    follow: "player",
+    mode: "vertical",
+    offsetY: -40,
+    smoothing: 0.18,
+    bounds: { x: 0, y: 0, w: VIEW_W, h: WORLD_H }
+  };
+}
+
+function staticLevelHeight() {
+  return WORLD_H;
+}
+
+function createStaticBg() {
+  bgClear(24, 32, 58);
+  let y = 40;
+  while (y < WORLD_H) {
+    const shade = y % 80 === 0 ? 48 : 36;
+    bgFillRect(0, y, VIEW_W, 40, shade, shade + 8, shade + 20);
+    y = y + 40;
+  }
+}
+
+function initState() {
+  return {
+    score: 0,
+    playerSlots: 1,
+    vy: 0
+  };
+}
+
+function update(props) {
+  const s = props.state;
+  const dt = props.dt;
+  const we = s.worldEntities;
+  const p = we.player;
+  let px = p.x;
+  let py = p.y;
+  let vy = s.vy + 0.00045 * dt;
+  py = py + vy * dt;
+
+  if (props.left) {
+    px = px - dt * 0.22;
+  }
+  if (props.right) {
+    px = px + dt * 0.22;
+  }
+  if (px < 20) {
+    px = 20;
+  }
+  if (px > VIEW_W - 20) {
+    px = VIEW_W - 20;
+  }
+
+  const floorY = WORLD_H - 60;
+  if (py >= floorY) {
+    py = floorY;
+    vy = 0;
+    if (props.action) {
+      vy = -0.38;
+    }
+  }
+
+  const nextWe = {};
+  const keys = ["player", "g0", "g1", "g2", "g3"];
+  let ki = 0;
+  while (ki < keys.length) {
+    const id = keys[ki];
+    const src = we[id];
+    let nx = src.x;
+    let ny = src.y;
+    let vis = src.visible == null ? 1 : src.visible;
+    if (id === "player") {
+      nx = px;
+      ny = py;
+    }
+    nextWe[id] = { x: nx, y: ny, visible: vis };
+    ki = ki + 1;
+  }
+
+  let score = s.score;
+  const collectR = 18;
+  let gi = 0;
+  while (gi < 4) {
+    const gid = "g" + gi;
+    const g = nextWe[gid];
+    if (g.visible !== 0) {
+      const dx = px - g.x;
+      const dy = py - g.y;
+      if (dx * dx + dy * dy < collectR * collectR) {
+        nextWe[gid] = { x: g.x, y: g.y, visible: 0 };
+        score = score + 100;
+      }
+    }
+    gi = gi + 1;
+  }
+
+  return {
+    score: score,
+    playerSlots: 1,
+    vy: vy,
+    worldEntities: nextWe
+  };
+}
+
+function hud(props) {
+  const s = props.state;
+  return (
+    <View flexDirection="row" padding="6px" width="100%">
+      <Label color="#8fd3ff">GEMS </Label>
+      <Label color="#ffffff">{s.score / 100}</Label>
+      <Label color="#6a7a9a">  camY={s.cameraY}</Label>
+    </View>
+  );
+}

--- a/gallery/game_engine/scripting/world_scroll_runner_demo.rgr
+++ b/gallery/game_engine/scripting/world_scroll_runner_demo.rgr
@@ -1,0 +1,46 @@
+; ==============================================================================
+; world_scroll_runner_demo - Phase 1 world-mode entity store + camera test.
+; ==============================================================================
+
+Import "./game_runtime.rgr"
+
+class WorldScrollRunnerDemo {
+    sfn m@(main):void () {
+        def runner:GameRunner (new GameRunner)
+        runner.init(480 270)
+
+        def buf:buffer (buffer_read_file "gallery/game_engine/scripting" "world_scroll.game.tsx")
+        def src:string (buffer_to_string buf)
+        runner.setScriptDir("gallery/game_engine/scripting")
+        runner.loadScript(src)
+        runner.setupScene()
+
+        def frames:int 240
+        if ((shell_arg_cnt) > 0) {
+            def parsed@(optional):int (to_int (shell_arg 0))
+            if (!null? parsed) {
+                frames = (unwrap parsed)
+            }
+        }
+
+        def i 0
+        while (i < frames) {
+            def phase (i % 90)
+            def left (phase < 30)
+            def right (phase >= 60)
+            def action (phase == 45)
+            runner.frame(16 left false right false action false)
+            i = (i + 1)
+        }
+
+        runner.draw()
+
+        def px:int (runner.entityX("player"))
+        def py:int (runner.entityY("player"))
+        def camY:int (runner.stateInt("cameraY" 0))
+        print ("frames=" + frames)
+        print (("player=" + px) + ("," + py))
+        print ("cameraY=" + camY)
+        print "world-scroll-runner done"
+    }
+}

--- a/tests/game-runner.test.ts
+++ b/tests/game-runner.test.ts
@@ -250,6 +250,35 @@ describe("Game runner - scripted Pong", () => {
     expect(parseInt(entities![1], 10)).toBeGreaterThan(10);
   });
 
+  it("runs world-mode scroll demo with engine camera and worldEntities", () => {
+    const { compile, run } = compileAndRun(
+      "gallery/game_engine/scripting/world_scroll_runner_demo.rgr"
+    );
+
+    expect(
+      compile.success,
+      `Compile failed: ${compile.error || compile.output}`
+    ).toBe(true);
+    expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+
+    const out = run?.output || "";
+    expect(out).toContain("frames=240");
+    expect(out).toContain("world-scroll-runner done");
+
+    const player = out.match(/player=(-?\d+),(-?\d+)/);
+    expect(player, `no player position in output: ${out}`).toBeTruthy();
+    const px = parseInt(player![1], 10);
+    const py = parseInt(player![2], 10);
+    expect(px).toBeGreaterThan(0);
+    expect(px).toBeLessThan(480);
+    expect(py).toBeGreaterThan(0);
+    expect(py).toBeLessThan(270);
+
+    const cam = out.match(/cameraY=(\d+)/);
+    expect(cam, `no cameraY in output: ${out}`).toBeTruthy();
+    expect(parseInt(cam![1], 10)).toBeGreaterThan(0);
+  });
+
   it("runs split-screen host with two independent solo panes", () => {
     const { compile, run } = compileAndRun(
       "gallery/game_engine/scripting/split_screen_runner_demo.rgr"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 1** from the game engine API feedback: a unified world-space entity layer, engine-managed camera, automatic world→screen culling, and optional fixed timestep — **without breaking** the existing `sprites()` + `state.entities` (screen-space) path used by Pong, Ylos, Breakout, etc.

## What changed

### New optional script hooks (`engine.d.ts`)

| Hook | Purpose |
|------|---------|
| `entities()` | Spawn list in world coordinates (`id`, `sprite`, `position`, `tags`) |
| `camera()` | Engine follow camera (`follow`, `mode`, `offsetY`, `smoothing`, `bounds`) |
| `config()` | `physics.fixedStep` (ms) + `world.height` |

Games using world mode update `state.worldEntities[id]` instead of copying positions into `state.entities` each frame.

### New engine modules

- `game_entity_store.rgr` — seeds `worldEntities`, spawns retained sprites (`entity id` ≠ `sprite id`)
- `game_camera.rgr` — vertical/horizontal/both follow modes with smoothing and bounds

### `game_runtime.rgr`

- Detects world mode when `entities()` is defined
- Applies camera offset + existing off-screen culling at sync time
- Fixed-timestep accumulator when `config().physics.fixedStep` is set
- Legacy `state.entities` + manual `cameraY` path unchanged

### Demo + test

- `world_scroll.game.tsx` — minimal vertical scroller (no `placeEntities()`)
- `world_scroll_runner_demo.rgr` + vitest case in `game-runner.test.ts`

## Backwards compatibility

- Pong, Invaders, Breakout, Pacman, Ylos, AR: **no changes required**
- Ylos/AR can migrate later by moving sim coords to `worldEntities` and dropping `placeEntities()`

## Next steps (not in this PR)

- Phase 2: body/collider/trigger events, entity pooling, emitters
- Phase 3: built-in controllers (platformer, top-down, car, free-move)
- Phase 4: scenes, animations, storage, profiler HUD

## Testing

```
npm test -- game-runner game-engine game-scripting
```

11/12 game-runner tests pass. Breakout `audioPlays` assertion was already flaky (0 plays in headless run) — unrelated to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-654afb7a-074e-48ef-9d1c-8e79d9337e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-654afb7a-074e-48ef-9d1c-8e79d9337e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

