### PR TITLE
WIP: AR split-screen peer car, gamepad input fixes, Pong 2P pads.

### DIFF
--- a/gallery/game_engine/games/ar/game.info
+++ b/gallery/game_engine/games/ar/game.info
@@ -1,0 +1,4 @@
+name=Autopeli
+splitScreen=auto
+autoscale=true
+soloScript=index.tsx

--- a/gallery/game_engine/games/ar/index.tsx
+++ b/gallery/game_engine/games/ar/index.tsx
@@ -14,16 +14,18 @@
 //
 // In a narrow 240 px pane it runs as single-player.
 // In a 480 px pane it enables a second player.
+// Split-screen (game.info): each pane is solo with its own camera; peerCar shows
+// the other player's car from the opposite pane.
 
 import { soundEvent } from "../../scripting/game_helpers";
 
 const BASE_W = 480;
-const WORLD_H = 3600;
+const WORLD_H = 6000;
 const VIEW_H = 270;
 
-const MAX_TRAFFIC = 6;
-const MAX_PICKUPS = 8;
-const MAX_OBSTACLES = 9;
+const MAX_TRAFFIC = 8;
+const MAX_PICKUPS = 20;
+const MAX_OBSTACLES = 13;
 const MAX_FX = 8;
 
 const START_Y = WORLD_H - 150;
@@ -45,49 +47,80 @@ const TURBO_ACCEL = 0.00070;
 const TURBO_DRAIN = 0.040;
 const TURBO_RECHARGE = 0.010;
 
-const CHECKPOINTS = [2700, 1800, 900];
-const CHECKPOINT_BONUS = 18000;
+const CHECKPOINTS = [4800, 3600, 2400, 1200];
+const CHECKPOINT_BONUS = 20000;
 
 const ROAD_POINTS = [
-  { y: 3600, x: 240, half: 104, zone: 0 },
-  { y: 3380, x: 190, half: 102, zone: 0 },
-  { y: 3160, x: 300, half: 96, zone: 0 },
-  { y: 2940, x: 210, half: 92, zone: 0 },
+  // The first bends are close to the start so the road visibly turns immediately.
+  { y: 6000, x: 240, half: 106, zone: 0 },
+  { y: 5800, x: 170, half: 104, zone: 0 },
+  { y: 5580, x: 310, half: 100, zone: 0 },
+  { y: 5360, x: 185, half: 98, zone: 0 },
+  { y: 5140, x: 300, half: 94, zone: 0 },
+  { y: 4920, x: 220, half: 92, zone: 0 },
 
-  { y: 2700, x: 165, half: 84, zone: 1 },
-  { y: 2460, x: 295, half: 82, zone: 1 },
-  { y: 2220, x: 220, half: 78, zone: 1 },
-  { y: 1980, x: 315, half: 80, zone: 1 },
+  { y: 4700, x: 150, half: 84, zone: 1 },
+  { y: 4480, x: 315, half: 82, zone: 1 },
+  { y: 4260, x: 190, half: 80, zone: 1 },
+  { y: 4040, x: 325, half: 78, zone: 1 },
+  { y: 3820, x: 205, half: 82, zone: 1 },
+  { y: 3600, x: 285, half: 86, zone: 1 },
 
-  { y: 1740, x: 235, half: 100, zone: 2 },
-  { y: 1500, x: 155, half: 106, zone: 2 },
-  { y: 1260, x: 295, half: 102, zone: 2 },
-  { y: 1020, x: 225, half: 94, zone: 2 },
+  { y: 3380, x: 165, half: 102, zone: 2 },
+  { y: 3160, x: 310, half: 106, zone: 2 },
+  { y: 2940, x: 190, half: 102, zone: 2 },
+  { y: 2720, x: 325, half: 98, zone: 2 },
+  { y: 2500, x: 180, half: 96, zone: 2 },
+  { y: 2280, x: 285, half: 92, zone: 2 },
 
-  { y: 780, x: 325, half: 74, zone: 3 },
-  { y: 540, x: 180, half: 70, zone: 3 },
-  { y: 300, x: 295, half: 72, zone: 3 },
-  { y: 100, x: 240, half: 88, zone: 3 }
+  { y: 2060, x: 145, half: 76, zone: 3 },
+  { y: 1840, x: 325, half: 72, zone: 3 },
+  { y: 1620, x: 175, half: 70, zone: 3 },
+  { y: 1400, x: 315, half: 72, zone: 3 },
+  { y: 1180, x: 190, half: 74, zone: 3 },
+  { y: 960, x: 305, half: 76, zone: 3 },
+  { y: 740, x: 165, half: 78, zone: 3 },
+  { y: 520, x: 300, half: 82, zone: 3 },
+  { y: 300, x: 195, half: 86, zone: 3 },
+  { y: 100, x: 240, half: 92, zone: 3 }
 ];
 
 const TRAFFIC_DEFS = [
-  { xOff: -28, y: 3260, speed: 0.18, lane: -1 },
-  { xOff:  34, y: 2860, speed: 0.15, lane: 1 },
-  { xOff: -20, y: 2380, speed: 0.20, lane: -1 },
-  { xOff:  30, y: 1940, speed: 0.17, lane: 1 },
-  { xOff: -36, y: 1320, speed: 0.19, lane: -1 },
-  { xOff:  22, y: 720, speed: 0.16, lane: 1 }
+  { xOff: -30, y: 5640, speed: 0.18, lane: -1 },
+  { xOff:  34, y: 5160, speed: 0.15, lane: 1 },
+  { xOff: -22, y: 4520, speed: 0.20, lane: -1 },
+  { xOff:  30, y: 3980, speed: 0.17, lane: 1 },
+  { xOff: -36, y: 3260, speed: 0.19, lane: -1 },
+  { xOff:  24, y: 2660, speed: 0.16, lane: 1 },
+  { xOff: -28, y: 1780, speed: 0.21, lane: -1 },
+  { xOff:  32, y: 900, speed: 0.18, lane: 1 }
 ];
 
 const PICKUP_DEFS = [
-  { xOff: -42, y: 3340, kind: 0 },
-  { xOff:  40, y: 2920, kind: 1 },
-  { xOff: -36, y: 2480, kind: 0 },
-  { xOff:  28, y: 2050, kind: 1 },
-  { xOff: -45, y: 1600, kind: 0 },
-  { xOff:  38, y: 1180, kind: 1 },
-  { xOff: -30, y: 720, kind: 0 },
-  { xOff:  26, y: 340, kind: 1 }
+  // kind 0 = fuel/score, 1 = turbo, 2 = valuable gem
+  { xOff: -42, y: 5740, kind: 2 },
+  { xOff:  36, y: 5520, kind: 0 },
+  { xOff: -30, y: 5280, kind: 2 },
+  { xOff:  42, y: 4980, kind: 1 },
+  { xOff: -38, y: 4660, kind: 2 },
+
+  { xOff:  34, y: 4380, kind: 2 },
+  { xOff: -44, y: 4100, kind: 0 },
+  { xOff:  28, y: 3820, kind: 2 },
+  { xOff: -34, y: 3520, kind: 1 },
+  { xOff:  40, y: 3260, kind: 2 },
+
+  { xOff: -42, y: 2980, kind: 2 },
+  { xOff:  36, y: 2700, kind: 0 },
+  { xOff: -28, y: 2420, kind: 2 },
+  { xOff:  42, y: 2140, kind: 1 },
+  { xOff: -36, y: 1860, kind: 2 },
+
+  { xOff:  34, y: 1560, kind: 2 },
+  { xOff: -40, y: 1280, kind: 0 },
+  { xOff:  28, y: 980, kind: 2 },
+  { xOff: -34, y: 680, kind: 1 },
+  { xOff:  36, y: 380, kind: 2 }
 ];
 
 //
@@ -95,15 +128,19 @@ const PICKUP_DEFS = [
 // xOff is relative to the road centre, so these follow the bends.
 //
 const OBSTACLE_DEFS = [
-  { xOff: -34, y: 3240, kind: 0 },
-  { xOff:  22, y: 3000, kind: 2 },
-  { xOff:  44, y: 2700, kind: 0 },
-  { xOff: -18, y: 2320, kind: 1 },
-  { xOff:  28, y: 1980, kind: 2 },
-  { xOff: -42, y: 1560, kind: 0 },
-  { xOff:  16, y: 1180, kind: 1 },
-  { xOff: -24, y: 760, kind: 2 },
-  { xOff:  38, y: 420, kind: 0 }
+  { xOff: -34, y: 5600, kind: 0 },
+  { xOff:  24, y: 5320, kind: 2 },
+  { xOff:  46, y: 5000, kind: 0 },
+  { xOff: -20, y: 4620, kind: 1 },
+  { xOff:  30, y: 4200, kind: 2 },
+  { xOff: -44, y: 3780, kind: 0 },
+  { xOff:  18, y: 3380, kind: 1 },
+  { xOff: -26, y: 3000, kind: 2 },
+  { xOff:  40, y: 2540, kind: 0 },
+  { xOff: -32, y: 2080, kind: 1 },
+  { xOff:  20, y: 1640, kind: 2 },
+  { xOff: -38, y: 1080, kind: 0 },
+  { xOff:  30, y: 560, kind: 2 }
 ];
 
 const CAR_STRAIGHT = [
@@ -167,6 +204,15 @@ const PICKUP_TURBO = [
   "..OO.."
 ];
 
+const PICKUP_VALUE = [
+  "..OO..",
+  ".OXXO.",
+  "OXXXXO",
+  ".OXXO.",
+  "..OO..",
+  "...O.."
+];
+
 const SPARK = [
   ".O.O.",
   "..O..",
@@ -202,7 +248,14 @@ function worldW() {
   return bgWidth;
 }
 
+function isSplitPane() {
+  return paneIndex >= 0;
+}
+
 function isDualMode() {
+  if (isSplitPane()) {
+    return false;
+  }
   return worldW() > 300;
 }
 
@@ -243,8 +296,8 @@ function computeRoadAtRaw(y) {
 
       // One smooth procedural bend layered over the authored control points.
       const wave =
-        Math.sin(progress * 0.0085) * 30 +
-        Math.sin(progress * 0.0035 + 1.2) * 16;
+        Math.sin(progress * 0.0105) * 38 +
+        Math.sin(progress * 0.0042 + 1.2) * 22;
 
       const half = scaleX(lerp(a.half, b.half, t));
       const rawCenter = scaleX(lerp(a.x, b.x, t) + wave);
@@ -400,7 +453,7 @@ function drawRoadSlice(y, step) {
 
 function createStaticBg() {
   let y = 0;
-  const step = 8;
+  const step = 10;
 
   while (y < bgHeight) {
     drawRoadSlice(y, step);
@@ -487,17 +540,32 @@ function pickupSprite(id, kind) {
     };
   }
 
+  if (kind == 1) {
+    return {
+      id: id,
+      kind: "bitmap",
+      px: 2,
+      br: 70,
+      bg: 220,
+      bb: 255,
+      er: 20,
+      eg: 50,
+      eb: 70,
+      frames: [PICKUP_TURBO]
+    };
+  }
+
   return {
     id: id,
     kind: "bitmap",
-    px: 2,
-    br: 70,
-    bg: 220,
-    bb: 255,
-    er: 20,
-    eg: 50,
-    eb: 70,
-    frames: [PICKUP_TURBO]
+    px: 3,
+    br: 255,
+    bg: 90,
+    bb: 220,
+    er: 255,
+    eg: 230,
+    eb: 90,
+    frames: [PICKUP_VALUE]
   };
 }
 
@@ -642,9 +710,19 @@ function spawnFx(fx, x, y) {
   }
 }
 
+function localStartX() {
+  if (isSplitPane()) {
+    if (paneIndex == 1) {
+      return 270;
+    }
+    return 210;
+  }
+  return 210;
+}
+
 function initState() {
   const slots = playerSlots();
-  const p1 = makePlayer(210, 1);
+  const p1 = makePlayer(localStartX(), 1);
   const p2 = makePlayer(270, -1);
   const traffic = makeTraffic();
   const pickups = makePickups();
@@ -667,7 +745,7 @@ function initState() {
     pickups: pickups,
     fx: fx,
     entities: entities,
-    timeLeft: 75000,
+    timeLeft: 105000,
     winner: 0,
     message: "ARCTIC RUSH",
     messageTick: 1600
@@ -1057,7 +1135,7 @@ function applyPickups(pl, pickups, events) {
             finishTick: out.finishTick,
             invuln: out.invuln
           };
-        } else {
+        } else if (p.kind == 1) {
           out = {
             x: out.x,
             y: out.y,
@@ -1067,6 +1145,21 @@ function applyPickups(pl, pickups, events) {
             turbo: clamp(out.turbo + 50, 0, 100),
             damage: out.damage,
             score: out.score + 300,
+            checkpoint: out.checkpoint,
+            finished: out.finished,
+            finishTick: out.finishTick,
+            invuln: out.invuln
+          };
+        } else {
+          out = {
+            x: out.x,
+            y: out.y,
+            speed: out.speed,
+            steer: out.steer,
+            face: out.face,
+            turbo: clamp(out.turbo + 10, 0, 100),
+            damage: out.damage,
+            score: out.score + 1500,
             checkpoint: out.checkpoint,
             finished: out.finished,
             finishTick: out.finishTick,
@@ -1143,6 +1236,12 @@ function updateFx(fx, dt) {
 }
 
 function computeCamera(p1, p2, dual) {
+  if (isSplitPane()) {
+    let cam = p1.y - VIEW_H + 105;
+    cam = clamp(cam, 0, WORLD_H - VIEW_H);
+    return cam;
+  }
+
   let leadY = p1.y;
 
   if (dual && p2.y < leadY) {
@@ -1158,6 +1257,34 @@ function computeCamera(p1, p2, dual) {
 function inCameraRange(worldY, cam, margin) {
   const screenY = worldY - cam;
   return screenY >= 0 - margin && screenY <= VIEW_H + margin;
+}
+
+function peerCarAnim(peer) {
+  if (peer.steer < -0.18) { return 1; }
+  if (peer.steer > 0.18) { return 2; }
+  return 0;
+}
+
+function placePeerCar(entities, cam) {
+  if (false == isSplitPane()) {
+    return;
+  }
+  if (peerCar.active != 1) {
+    entities.p2 = { x: -40, y: -40, p0: 0, visible: 0 };
+    return;
+  }
+
+  const p2Lift = peerCar.finishTick > 0
+    ? Math.sin((peerCar.finishTick / 720) * Math.PI) * 24
+    : 0;
+  const visible = inCameraRange(peerCar.y, cam, 96) ? 1 : 0;
+
+  entities.p2 = {
+    x: peerCar.x,
+    y: peerCar.y - cam - p2Lift,
+    p0: peerCarAnim(peerCar),
+    visible: visible
+  };
 }
 
 function placeEntities(s, cam, slots) {
@@ -1186,6 +1313,7 @@ function placeEntities(s, cam, slots) {
     };
   } else {
     entities.p2 = { x: -40, y: -40, p0: 0, visible: 0 };
+    placePeerCar(entities, cam);
   }
 
   let i = 0;
@@ -1280,7 +1408,13 @@ function hud(props) {
   let second =
     "P1 " + p1Speed + " KM/H  TURBO [" + bar(s.p1.turbo, 100, 8) + "]  DMG " + s.p1.damage;
 
-  if (s.playerSlots == 2) {
+  if (isSplitPane()) {
+    if (paneIndex == 0) {
+      top = "LEFT  TIME " + sec + "   SCORE " + p1Score;
+    } else {
+      top = "RIGHT TIME " + sec + "   SCORE " + p1Score;
+    }
+  } else if (s.playerSlots == 2) {
     second =
       "P1 " + p1Speed + "  P2 " + speedKmh(s.p2.speed) +
       "  LEAD " + (((s.p2.y - s.p1.y) / 10) | 0);

--- a/gallery/game_engine/games/pong/index.tsx
+++ b/gallery/game_engine/games/pong/index.tsx
@@ -6,9 +6,9 @@
 // Switches to 2 when a second human takes the right paddle.
 //
 // Controls:
-//   1 player (vs CPU) — W/S or gamepad for left paddle
-//   Join as P2       — press arrow up/down once (right paddle; CPU stops)
-//   2 players        — P1 W/S, P2 arrows or gamepad
+//   1 player (vs CPU) — W/S, arrows, or either gamepad for left paddle
+//   Join as P2       — arrow up/down, Start, or the non-active gamepad
+//   2 players        — P1 WASD + gamepad 0, P2 arrows + gamepad 1
 //
 // Coordinates are in pixels of a 480x270 buffer. Motion is time-based (uses dt),
 // so it is framerate-independent.
@@ -57,8 +57,8 @@ function readPlayerInput(props, index) {
   return { up: up, down: down };
 }
 
-function p2WantsHuman(p2up, p2down) {
-  if (p2up || p2down) {
+function p2WantsHuman(p2) {
+  if (p2.up || p2.down || p2.start || p2.action) {
     return 1;
   }
   return 0;
@@ -167,7 +167,7 @@ function update(props) {
 
   let p2Human = s.p2Human;
   if (p2Human == 0) {
-    p2Human = p2WantsHuman(p2.up, p2.down);
+    p2Human = p2WantsHuman(p2);
   }
 
   let playerSlots = 1;

--- a/gallery/game_engine/scripting/engine.d.ts
+++ b/gallery/game_engine/scripting/engine.d.ts
@@ -339,6 +339,19 @@ declare function resetGameData(): void;
 declare const bgWidth: number;
 /** Static level buffer height (pixels), set during createStaticBg init. */
 declare const bgHeight: number;
+
+/** Split-screen pane index (-1=full screen, 0=left, 1=right); injected by host. */
+declare const paneIndex: number;
+
+/** Opposite pane's car in split-screen mode (updated each frame by the host). */
+declare const peerCar: {
+  active: number;
+  x?: number;
+  y?: number;
+  steer?: number;
+  finishTick?: number;
+};
+
 /** Draw an opaque rect into the static level buffer (world coordinates). */
 declare function bgFillRect(
   x: number,

--- a/gallery/game_engine/scripting/game_input.rgr
+++ b/gallery/game_engine/scripting/game_input.rgr
@@ -6,9 +6,11 @@
 ; per-player Buttons slots based on state.playerSlots (1–8, default 1).
 ;
 ; Mapping policy:
-;   1 player  — keyboard P1 + gamepad 0 merged into players[0];
-;               keyboard P2 (arrows) still on players[1] for join detection
-;   2 players — players[0]=keyboard WASD, players[1]=arrows + gamepad 0
+;   1 player  — keyboard P1 + active gamepad into players[0]; active pad switches
+;               when another connected pad sends steering input this frame;
+;               players[1] = keyboard P2 + other pads (join / second player detect)
+;   2 players — players[0]=keyboard P1 + gamepad 0, players[1]=arrows + gamepad 1
+;               (one pad: P2 gets gamepad 0 as before)
 ;   3–8       — players[i]=gamepad i, plus keyboard merged into players[0]
 ; ==============================================================================
 
@@ -94,6 +96,8 @@ class GameInputSnapshot {
     def maxPlayers:int 8
     def playerCount:int 1
     def padCount:int 0
+    ; Active gamepad index for 1-player mode (-1 = keyboard P1 only last frame).
+    def soloActivePad:int 0
     def p0:PlayerButtons (new PlayerButtons)
     def p1:PlayerButtons (new PlayerButtons)
     def p2:PlayerButtons (new PlayerButtons)
@@ -140,6 +144,52 @@ class GameInputSnapshot {
         return (this.sourceMask(src))
     }
 
+    fn resetSoloPad:void () {
+        soloActivePad = 0
+    }
+
+    ; Steering / action bits used to pick the active pad in 1-player mode.
+    fn steeringMask:int () {
+        def m:int (InputMask.UP())
+        m = (bit_or m (InputMask.DOWN()))
+        m = (bit_or m (InputMask.LEFT()))
+        m = (bit_or m (InputMask.RIGHT()))
+        m = (bit_or m (InputMask.ACTION()))
+        m = (bit_or m (InputMask.B()))
+        m = (bit_or m (InputMask.X()))
+        m = (bit_or m (InputMask.Y()))
+        m = (bit_or m (InputMask.START()))
+        return m
+    }
+
+    fn maskHasSteering:boolean (m:int) {
+        def steer:int (this.steeringMask())
+        return ((bit_and m steer) != 0)
+    }
+
+    ; When any pad or keyboard P1 sends steering, update soloActivePad (-1 = keys).
+    fn updateSoloActivePad:void (kbP1:int) {
+        def steer:int (this.steeringMask())
+        def sawInput:boolean false
+        def nextPad:int soloActivePad
+        if ((bit_and kbP1 steer) != 0) {
+            sawInput = true
+            nextPad = -1
+        }
+        def pi:int 0
+        while (pi < padCount) {
+            def pm:int (this.padSourceMask(pi))
+            if ((bit_and pm steer) != 0) {
+                sawInput = true
+                nextPad = pi
+            }
+            pi = (pi + 1)
+        }
+        if sawInput {
+            soloActivePad = nextPad
+        }
+    }
+
     fn buildMenu:void () {
         playerCount = 1
         padCount = (gfx_input_pad_count)
@@ -181,19 +231,49 @@ class GameInputSnapshot {
         def kbP2:int (this.sourceMask(1))
 
         if (playerCount == 1) {
-            def merged:int (bit_or kbP1 (this.padSourceMask(0)))
-            this.setPlayerMask(0 merged)
-            ; Expose P2 keyboard (arrows) even in 1-slot mode so scripted games
-            ; (e.g. Pong) can detect a second human joining before playerSlots=2.
-            this.setPlayerMask(1 kbP2)
+            if (padCount == 0) {
+                soloActivePad = -1
+            } {
+                if (soloActivePad < 0) {
+                    soloActivePad = 0
+                }
+                if (soloActivePad >= padCount) {
+                    soloActivePad = (padCount - 1)
+                }
+            }
+            this.updateSoloActivePad(kbP1)
+            def p0:int kbP1
+            if (soloActivePad >= 0) {
+                if (soloActivePad < padCount) {
+                    p0 = (bit_or kbP1 (this.padSourceMask(soloActivePad)))
+                }
+            }
+            this.setPlayerMask(0 p0)
+            ; Join / P2 detect: arrows + any pad not currently steering P1.
+            def p2Join:int kbP2
+            def pj:int 0
+            while (pj < padCount) {
+                if (pj != soloActivePad) {
+                    p2Join = (bit_or p2Join (this.padSourceMask(pj)))
+                }
+                pj = (pj + 1)
+            }
+            this.setPlayerMask(1 p2Join)
             playerCount = 2
             return
         }
 
         if (playerCount == 2) {
-            this.setPlayerMask(0 kbP1)
-            def p2:int (bit_or kbP2 (this.padSourceMask(0)))
-            this.setPlayerMask(1 p2)
+            if (padCount >= 2) {
+                def p0:int (bit_or kbP1 (this.padSourceMask(0)))
+                def p2:int (bit_or kbP2 (this.padSourceMask(1)))
+                this.setPlayerMask(0 p0)
+                this.setPlayerMask(1 p2)
+            } {
+                this.setPlayerMask(0 kbP1)
+                def p2:int (bit_or kbP2 (this.padSourceMask(0)))
+                this.setPlayerMask(1 p2)
+            }
             return
         }
 
@@ -264,13 +344,23 @@ class GameInputSnapshot {
             def hasPad 0
             if (playerCount == 1) {
                 if (padCount > 0) {
-                    hasPad = 1
+                    if (soloActivePad >= 0) {
+                        if (soloActivePad < padCount) {
+                            hasPad = 1
+                        }
+                    }
                 }
             } {
                 if (playerCount == 2) {
-                    if (i == 1) {
+                    if (i == 0) {
                         if (padCount > 0) {
                             hasPad = 1
+                        }
+                    } {
+                        if (i == 1) {
+                            if (padCount > 0) {
+                                hasPad = 1
+                            }
                         }
                     }
                 } {

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -101,6 +101,51 @@ class GameRunner {
         engine.registerGlobal(name value)
     }
 
+    fn inactivePeerCar:EvalValue () {
+        def k:[string]
+        def v:[EvalValue]
+        push k "active"
+        push v (EvalValue.fromInt(0))
+        return (EvalValue.object(k v))
+    }
+
+    ; Default globals for non-split games (paneIndex=-1, inactive peerCar).
+    fn registerDefaultPaneGlobals:void () {
+        engine.registerGlobal("paneIndex" (EvalValue.fromInt(-1)))
+        this.setPeerCar((this.inactivePeerCar()))
+    }
+
+    ; Split-screen pane setup: inject paneIndex (0=left, 1=right) and empty peerCar.
+    fn registerSplitPane:void (paneIndex:int) {
+        engine.registerGlobal("paneIndex" (EvalValue.fromInt(paneIndex)))
+        this.setPeerCar((this.inactivePeerCar()))
+    }
+
+    ; Opposite pane's local car (state.p1) for ghost rendering in split-screen races.
+    fn exportPeerCar:EvalValue () {
+        def p1:EvalValue (state.getMember("p1"))
+        if (false == (p1.isObject())) {
+            return (this.inactivePeerCar())
+        }
+        def k:[string]
+        def v:[EvalValue]
+        push k "active"
+        push v (EvalValue.fromInt(1))
+        push k "x"
+        push v (p1.getMember("x"))
+        push k "y"
+        push v (p1.getMember("y"))
+        push k "steer"
+        push v (p1.getMember("steer"))
+        push k "finishTick"
+        push v (p1.getMember("finishTick"))
+        return (EvalValue.object(k v))
+    }
+
+    fn setPeerCar:void (peer:EvalValue) {
+        engine.registerGlobal("peerCar" peer)
+    }
+
     fn setNativeBridge:void (bridge:EvalNativeBridge) {
         hostBridge = bridge
         compositeBridge.clearBridges()

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -70,6 +70,7 @@ class GameSdlRunner {
     def prevActionHeld:boolean false
     def gpuModeWanted:boolean true
     def gpuModeActive:boolean false
+    def gameInputSnap:GameInputSnapshot (new GameInputSnapshot)
 
     fn setProfileOnRunners:void () {
         runner.setProfileEnabled(profileEnabled)
@@ -194,6 +195,7 @@ class GameSdlRunner {
         runner.loadScript(src)
         this.presentLoadingScreen("LOADING")
         runner.setupScene()
+        runner.registerDefaultPaneGlobals()
         runner.trackScriptFile(tsxPath)
         currentScriptPath = tsxPath
         def enableHotReload:boolean hotReloadWanted
@@ -207,6 +209,7 @@ class GameSdlRunner {
             print ("[game-engine] hot reload enabled: " + tsxPath)
         }
         this.syncInputEdges()
+        gameInputSnap.resetSoloPad()
         gfx_clear_should_close
         this.setProfileOnRunners()
     }
@@ -223,10 +226,9 @@ class GameSdlRunner {
 
     fn pollGameInput:GameInputSnapshot () {
         gfx_input_poll
-        def snap:GameInputSnapshot (new GameInputSnapshot)
         def count:int (runner.resolvePlayerCount())
-        snap.buildFromSdl(count)
-        return snap
+        gameInputSnap.buildFromSdl(count)
+        return gameInputSnap
     }
 
     fn loadMenuGame:void () {
@@ -333,6 +335,7 @@ class GameSdlRunner {
         inGame = true
         splitScreenActive = true
         this.syncInputEdges()
+        gameInputSnap.resetSoloPad()
         gfx_clear_should_close
         print ("[split-screen] left=" + panePath)
         print ("[split-screen] right=" + panePath)

--- a/gallery/game_engine/scripting/game_split_screen.rgr
+++ b/gallery/game_engine/scripting/game_split_screen.rgr
@@ -82,7 +82,7 @@ class SplitScreenHost {
         right.setProfileEnabled(on)
     }
 
-    fn loadScriptAt:void (runner:GameRunner bridge:GameHostNativeBridge tsxPath:string) {
+    fn loadScriptAt:void (runner:GameRunner bridge:GameHostNativeBridge tsxPath:string paneIndex:int) {
         def dir:string ""
         def file:string tsxPath
         def slash:int (lastIndexOf tsxPath "/")
@@ -97,13 +97,14 @@ class SplitScreenHost {
         runner.setNativeBridge(bridge)
         runner.loadScript(src)
         runner.setupScene()
+        runner.registerSplitPane(paneIndex)
         runner.trackScriptFile(tsxPath)
     }
 
   ; Load the same script (or different paths) into both panes.
     fn loadPanes:void (leftPath:string rightPath:string) {
-        this.loadScriptAt(left leftBridge leftPath)
-        this.loadScriptAt(right rightBridge rightPath)
+        this.loadScriptAt(left leftBridge leftPath 0)
+        this.loadScriptAt(right rightBridge rightPath 1)
         leftScriptPath = leftPath
         rightScriptPath = rightPath
     }
@@ -126,6 +127,8 @@ class SplitScreenHost {
     }
 
     fn frameWithInput:void (dtMs:int) {
+        left.setPeerCar((right.exportPeerCar()))
+        right.setPeerCar((left.exportPeerCar()))
         def leftSnap:GameInputSnapshot (this.snapForPane(0))
         def rightSnap:GameInputSnapshot (this.snapForPane(1))
         left.frameWithInput(dtMs leftSnap)


### PR DESCRIPTION
Split-screen host syncs peerCar between panes; AR uses per-pane camera with ghost opponent. Input assign/solo pad switching for 1P and 2P gamepads. Avoid typeof in scripts (paneIndex=-1 default).