### PR TITLE
Fix GL fullscreen blit scaling to drawable size

### DIFF
--- a/gallery/game_engine/gfx_sdl.rgr
+++ b/gallery/game_engine/gfx_sdl.rgr
@@ -618,9 +618,14 @@ static void rgfx_gpu_draw_quad_tex(GLuint tex, float x, float y, float qw, float
 
 static void rgfx_gpu_start_frame(int w, int h) {
     if (!g_rgfx_gpu_mode) { return; }
-    g_rgfx_fb_w = w;
-    g_rgfx_fb_h = h;
-    glViewport(0, 0, w, h);
+    int drawW = w;
+    int drawH = h;
+    if (g_rgfx_win != nullptr) {
+        SDL_GL_GetDrawableSize(g_rgfx_win, &drawW, &drawH);
+    }
+    g_rgfx_fb_w = drawW;
+    g_rgfx_fb_h = drawH;
+    glViewport(0, 0, drawW, drawH);
     glClearColor(0.f, 0.f, 0.f, 1.f);
     glClear(GL_COLOR_BUFFER_BIT);
 }
@@ -635,7 +640,7 @@ static void rgfx_gpu_blit_base(const uint8_t* pixels, int w, int h) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-    rgfx_gpu_draw_quad_tex(g_rgfx_base_tex, 0.f, 0.f, (float) w, (float) h);
+    rgfx_gpu_draw_quad_tex(g_rgfx_base_tex, 0.f, 0.f, (float) g_rgfx_fb_w, (float) g_rgfx_fb_h);
 }
 
 static void rgfx_gpu_draw_texture(int texId, int x, int y, int tw, int th) {
@@ -656,21 +661,21 @@ static void rgfx_gpu_finish_frame() {
 static void rgfx_gpu_present_split(const uint8_t* left, const uint8_t* right, int w, int h) {
     if (!g_rgfx_gpu_mode || left == nullptr || right == nullptr || w <= 0 || h <= 0) { return; }
     rgfx_gpu_start_frame(w, h);
-    const int halfW = w / 2;
+    const int halfW = g_rgfx_fb_w / 2;
     if (g_rgfx_base_tex == 0) { glGenTextures(1, &g_rgfx_base_tex); }
     glBindTexture(GL_TEXTURE_2D, g_rgfx_base_tex);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, left);
-    rgfx_gpu_draw_quad_tex(g_rgfx_base_tex, 0.f, 0.f, (float) halfW, (float) h);
+    rgfx_gpu_draw_quad_tex(g_rgfx_base_tex, 0.f, 0.f, (float) halfW, (float) g_rgfx_fb_h);
     if (g_rgfx_base_tex_r == 0) { glGenTextures(1, &g_rgfx_base_tex_r); }
     glBindTexture(GL_TEXTURE_2D, g_rgfx_base_tex_r);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, right);
-    rgfx_gpu_draw_quad_tex(g_rgfx_base_tex_r, (float) halfW, 0.f, (float) (w - halfW), (float) h);
+    rgfx_gpu_draw_quad_tex(g_rgfx_base_tex_r, (float) halfW, 0.f, (float) (g_rgfx_fb_w - halfW), (float) g_rgfx_fb_h);
     rgfx_gpu_finish_frame();
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In GPU/OpenGL mode, toggling fullscreen (F11 / Alt+Enter / `--fullscreen`) resized the SDL window correctly, but the present path still used the logical game buffer size (480×270) for `glViewport` and textured quad dimensions. The image appeared only in the bottom-left corner of the screen.

The software SDL_Renderer path was unaffected because `SDL_RenderCopy` stretches to the full renderer output size.

## Fix

In `gfx_sdl.rgr`, the OpenGL present path now queries `SDL_GL_GetDrawableSize` each frame and uses that for:

- `glViewport`
- `g_rgfx_fb_w` / `g_rgfx_fb_h` (coordinate space for NDC mapping)
- Full-screen and split-screen present quads

Texture uploads still use the game buffer dimensions (`w` × `h`); only the on-screen scaling target changed.

## Testing

- Ranger → C++ compilation succeeds for `game_sdl_runner.rgr`
- SDL2 runtime not available in the cloud agent environment; manual verification recommended: run a game with GPU mode, toggle fullscreen, confirm the image fills the screen
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea073ca7-158d-493b-99b8-b2bee40a6768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea073ca7-158d-493b-99b8-b2bee40a6768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

