### PR TITLE
Fix Raspberry Pi game_sdl build by linking GLES2 on ARM.

### DIFF
--- a/gallery/game_engine/scripts/build-game-sdl.sh
+++ b/gallery/game_engine/scripts/build-game-sdl.sh
@@ -70,8 +70,22 @@ echo "==> 2/3 $CXX -> native binary (SDL2 + OpenGL)"
 GL_FLAGS=""
 if [[ "$(uname -s)" == "Darwin" ]]; then
   GL_FLAGS="-framework OpenGL"
-elif ldconfig -p 2>/dev/null | grep -q 'libGL\.so'; then
-  GL_FLAGS="-lGL"
+else
+  ARCH="$(uname -m)"
+  if [[ "$ARCH" == "aarch64" || "$ARCH" == arm* ]]; then
+    # gfx_sdl.rgr uses GLES2/gl2.h on ARM (Raspberry Pi).
+    if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists glesv2; then
+      GL_FLAGS="$(pkg-config --libs glesv2)"
+    else
+      GL_FLAGS="-lGLESv2"
+    fi
+  elif ldconfig -p 2>/dev/null | grep -q 'libGL\.so'; then
+    GL_FLAGS="-lGL"
+  fi
+fi
+if [[ -z "$GL_FLAGS" ]]; then
+  echo "error: OpenGL not found. On Raspberry Pi: sudo apt-get install libgles2-mesa-dev" >&2
+  exit 1
 fi
 # shellcheck disable=SC2086
 "$CXX" -std=c++17 "$CPP_FILE" -o "$BIN_FILE" $SDL_FLAGS $GL_FLAGS

--- a/gallery/game_engine/scripts/deploy-pi.sh
+++ b/gallery/game_engine/scripts/deploy-pi.sh
@@ -24,8 +24,8 @@ AUDIO_DEV="${RANGER_AUDIO_DEVICE:-plughw:1,0}"
 echo "==> 1/4 Test SSH: $TARGET"
 ssh -o ConnectTimeout=10 -o BatchMode=yes "$TARGET" 'echo ok; uname -m'
 
-echo "==> 2/4 Install Pi packages (clang, SDL2, node, npm)"
-ssh "$TARGET" 'sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git clang pkg-config libsdl2-dev nodejs npm'
+echo "==> 2/4 Install Pi packages (clang, SDL2, GLES2, node, npm)"
+ssh "$TARGET" 'sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git clang pkg-config libsdl2-dev libgles2-mesa-dev nodejs npm'
 
 echo "==> 3/4 Rsync repo -> ~/$REMOTE_DIR"
 ssh "$TARGET" "mkdir -p ~/$REMOTE_DIR"


### PR DESCRIPTION
gfx_sdl uses GLES2 headers on ARM; link libGLESv2 instead of desktop libGL and install libgles2-mesa-dev in deploy-pi.sh.