### PR TITLE
Optimize EvalValue: hash map objects + in-place array writes

### DIFF
--- a/gallery/game_engine/scripting/game_persistence.rgr
+++ b/gallery/game_engine/scripting/game_persistence.rgr
@@ -94,13 +94,13 @@ class GamePersistence {
         if (v.isObject()) {
             def out2:string "{"
             def j:int 0
-            while (j < (array_length v.objectKeys)) {
+            def keyList:[string] (keys v.objectMap)
+            for keyList kk:string idx {
                 if (j > 0) {
                     out2 = (out2 + ",")
                 }
-                def key:string (itemAt v.objectKeys j)
-                def val:EvalValue (itemAt v.objectValues j)
-                def keyEsc:string (this.jsonEscape(key))
+                def val:EvalValue (unwrap (get v.objectMap kk))
+                def keyEsc:string (this.jsonEscape(kk))
                 out2 = (out2 + "\"" + keyEsc + "\":")
                 out2 = (out2 + (this.evalToJson(val)))
                 j = (j + 1)

--- a/gallery/pdf_writer/bin/eval_value_module.cjs
+++ b/gallery/pdf_writer/bin/eval_value_module.cjs
@@ -1004,6 +1004,8 @@ class EVGElement  {
     this.isLayoutComplete = false;     /** note: unused */
     this.unitsResolved = false;
     this.hasReturn = false;     /** note: unused */
+    this.hasBreak = false;     /** note: unused */
+    this.hasContinue = false;     /** note: unused */
     this.inheritedFontSize = 14.0;
     this.tagName = "div";
     this.elementType = 0;
@@ -1544,6 +1546,4541 @@ EVGElement.createPath = function() {
   el.elementType = 3;
   return el;
 };
+class Token  {
+  constructor() {
+    this.tokenType = "";
+    this.value = "";
+    this.line = 0;
+    this.col = 0;
+    this.start = 0;
+    this.end = 0;
+  }
+}
+class TSLexer  {
+  constructor(src) {
+    this.source = "";
+    this.pos = 0;
+    this.line = 1;
+    this.col = 1;
+    this.__len = 0;
+    this.source = src;
+    this.__len = this.countCodeUnits(src);
+  }
+  utf8WidthFromLead (lead) {
+    if ( lead <= 127 ) {
+      return 1;
+    }
+    if ( lead >= 192 ) {
+      if ( lead <= 223 ) {
+        return 2;
+      }
+    }
+    if ( lead >= 224 ) {
+      if ( lead <= 239 ) {
+        return 3;
+      }
+    }
+    if ( lead >= 240 ) {
+      if ( lead <= 247 ) {
+        return 4;
+      }
+    }
+    return 1;
+  };
+  countCodeUnits (text) {
+    const byteLen = text.length;
+    let bytePos = 0;
+    let count = 0;
+    while (bytePos < byteLen) {
+      const lead = text.charCodeAt(bytePos );
+      const w = this.utf8WidthFromLead(lead);
+      bytePos = bytePos + w;
+      count = count + 1;
+    };
+    return count;
+  };
+  peek () {
+    if ( this.pos >= this.__len ) {
+      return "";
+    }
+    return this.source[this.pos];
+  };
+  peekAt (offset) {
+    const idx = this.pos + offset;
+    if ( idx >= this.__len ) {
+      return "";
+    }
+    return this.source[idx];
+  };
+  advance () {
+    if ( this.pos >= this.__len ) {
+      return "";
+    }
+    const ch = this.source[this.pos];
+    this.pos = this.pos + 1;
+    if ( (ch == "\n") || (ch == "\r\n") ) {
+      this.line = this.line + 1;
+      this.col = 1;
+    } else {
+      this.col = this.col + 1;
+    }
+    return ch;
+  };
+  isDigit (ch) {
+    if ( ch == "0" ) {
+      return true;
+    }
+    if ( ch == "1" ) {
+      return true;
+    }
+    if ( ch == "2" ) {
+      return true;
+    }
+    if ( ch == "3" ) {
+      return true;
+    }
+    if ( ch == "4" ) {
+      return true;
+    }
+    if ( ch == "5" ) {
+      return true;
+    }
+    if ( ch == "6" ) {
+      return true;
+    }
+    if ( ch == "7" ) {
+      return true;
+    }
+    if ( ch == "8" ) {
+      return true;
+    }
+    if ( ch == "9" ) {
+      return true;
+    }
+    return false;
+  };
+  isAlpha (ch) {
+    if ( (ch.length) == 0 ) {
+      return false;
+    }
+    const code = ch.charCodeAt(0 );
+    if ( code >= 97 ) {
+      if ( code <= 122 ) {
+        return true;
+      }
+    }
+    if ( code >= 65 ) {
+      if ( code <= 90 ) {
+        return true;
+      }
+    }
+    if ( ch == "_" ) {
+      return true;
+    }
+    if ( ch == "$" ) {
+      return true;
+    }
+    if ( code > 127 ) {
+      return true;
+    }
+    return false;
+  };
+  isLetterCode (code) {
+    if ( code >= 97 ) {
+      if ( code <= 122 ) {
+        return true;
+      }
+    }
+    if ( code >= 65 ) {
+      if ( code <= 90 ) {
+        return true;
+      }
+    }
+    return false;
+  };
+  isAlphaNumCh (ch) {
+    if ( this.isDigit(ch) ) {
+      return true;
+    }
+    if ( ch == "_" ) {
+      return true;
+    }
+    if ( ch == "$" ) {
+      return true;
+    }
+    if ( (ch.length) == 0 ) {
+      return false;
+    }
+    const code = ch.charCodeAt(0 );
+    if ( code >= 97 ) {
+      if ( code <= 122 ) {
+        return true;
+      }
+    }
+    if ( code >= 65 ) {
+      if ( code <= 90 ) {
+        return true;
+      }
+    }
+    if ( code > 127 ) {
+      return true;
+    }
+    return false;
+  };
+  isWhitespace (ch) {
+    if ( ch == " " ) {
+      return true;
+    }
+    if ( ch == "\t" ) {
+      return true;
+    }
+    if ( ch == "\n" ) {
+      return true;
+    }
+    if ( ch == "\r" ) {
+      return true;
+    }
+    if ( ch == "\r\n" ) {
+      return true;
+    }
+    return false;
+  };
+  skipWhitespace () {
+    while (this.pos < this.__len) {
+      const ch = this.peek();
+      if ( this.isWhitespace(ch) ) {
+        this.advance();
+      } else {
+        return;
+      }
+    };
+  };
+  makeToken (tokType, value, startPos, startLine, startCol) {
+    const tok = new Token();
+    tok.tokenType = tokType;
+    tok.value = value;
+    tok.start = startPos;
+    tok.end = this.pos;
+    tok.line = startLine;
+    tok.col = startCol;
+    return tok;
+  };
+  readLineComment () {
+    const startPos = this.pos;
+    const startLine = this.line;
+    const startCol = this.col;
+    this.advance();
+    this.advance();
+    let value = "";
+    while (this.pos < this.__len) {
+      const ch = this.peek();
+      if ( ch == "\n" ) {
+        return this.makeToken("LineComment", value, startPos, startLine, startCol);
+      }
+      if ( ch == "\r\n" ) {
+        return this.makeToken("LineComment", value, startPos, startLine, startCol);
+      }
+      value = value + this.advance();
+    };
+    return this.makeToken("LineComment", value, startPos, startLine, startCol);
+  };
+  readBlockComment () {
+    const startPos = this.pos;
+    const startLine = this.line;
+    const startCol = this.col;
+    this.advance();
+    this.advance();
+    let value = "";
+    while (this.pos < this.__len) {
+      const ch = this.peek();
+      if ( ch == "*" ) {
+        if ( this.peekAt(1) == "/" ) {
+          this.advance();
+          this.advance();
+          return this.makeToken("BlockComment", value, startPos, startLine, startCol);
+        }
+      }
+      value = value + this.advance();
+    };
+    return this.makeToken("BlockComment", value, startPos, startLine, startCol);
+  };
+  readString (quote) {
+    const startPos = this.pos;
+    const startLine = this.line;
+    const startCol = this.col;
+    this.advance();
+    let value = "";
+    while (this.pos < this.__len) {
+      const ch = this.peek();
+      if ( ch == quote ) {
+        this.advance();
+        return this.makeToken("String", value, startPos, startLine, startCol);
+      }
+      if ( ch == "\\" ) {
+        this.advance();
+        const esc = this.advance();
+        if ( esc == "n" ) {
+          value = value + "\n";
+        } else {
+          if ( esc == "t" ) {
+            value = value + "\t";
+          } else {
+            if ( esc == "r" ) {
+              value = value + "\r";
+            } else {
+              if ( esc == "\\" ) {
+                value = value + "\\";
+              } else {
+                if ( esc == quote ) {
+                  value = value + quote;
+                } else {
+                  value = value + esc;
+                }
+              }
+            }
+          }
+        }
+      } else {
+        value = value + this.advance();
+      }
+    };
+    return this.makeToken("String", value, startPos, startLine, startCol);
+  };
+  readTemplateLiteral () {
+    const startPos = this.pos;
+    const startLine = this.line;
+    const startCol = this.col;
+    this.advance();
+    let value = "";
+    while (this.pos < this.__len) {
+      const ch = this.peek();
+      if ( ch == "`" ) {
+        this.advance();
+        return this.makeToken("Template", value, startPos, startLine, startCol);
+      }
+      if ( ch == "\\" ) {
+        this.advance();
+        const esc = this.advance();
+        if ( esc == "n" ) {
+          value = value + "\n";
+        } else {
+          if ( esc == "t" ) {
+            value = value + "\t";
+          } else {
+            if ( esc == "`" ) {
+              value = value + "`";
+            } else {
+              if ( esc == "$" ) {
+                value = value + "$";
+              } else {
+                value = value + esc;
+              }
+            }
+          }
+        }
+      } else {
+        value = value + this.advance();
+      }
+    };
+    return this.makeToken("Template", value, startPos, startLine, startCol);
+  };
+  readNumber () {
+    const startPos = this.pos;
+    const startLine = this.line;
+    const startCol = this.col;
+    let value = "";
+    while (this.pos < this.__len) {
+      const ch = this.peek();
+      if ( this.isDigit(ch) ) {
+        value = value + this.advance();
+      } else {
+        if ( ch == "_" ) {
+          value = value + this.advance();
+        } else {
+          if ( ch == "." ) {
+            value = value + this.advance();
+          } else {
+            if ( ch == "n" ) {
+              value = value + this.advance();
+              return this.makeToken("BigInt", value, startPos, startLine, startCol);
+            }
+            return this.makeToken("Number", value, startPos, startLine, startCol);
+          }
+        }
+      }
+    };
+    return this.makeToken("Number", value, startPos, startLine, startCol);
+  };
+  readIdentifier () {
+    const startPos = this.pos;
+    const startLine = this.line;
+    const startCol = this.col;
+    let value = "";
+    while (this.pos < this.__len) {
+      const ch = this.peek();
+      if ( this.isAlphaNumCh(ch) ) {
+        value = value + this.advance();
+      } else {
+        return this.makeToken(this.identType(value), value, startPos, startLine, startCol);
+      }
+    };
+    return this.makeToken(this.identType(value), value, startPos, startLine, startCol);
+  };
+  identType (value) {
+    if ( value == "var" ) {
+      return "Keyword";
+    }
+    if ( value == "let" ) {
+      return "Keyword";
+    }
+    if ( value == "const" ) {
+      return "Keyword";
+    }
+    if ( value == "function" ) {
+      return "Keyword";
+    }
+    if ( value == "return" ) {
+      return "Keyword";
+    }
+    if ( value == "if" ) {
+      return "Keyword";
+    }
+    if ( value == "else" ) {
+      return "Keyword";
+    }
+    if ( value == "while" ) {
+      return "Keyword";
+    }
+    if ( value == "for" ) {
+      return "Keyword";
+    }
+    if ( value == "in" ) {
+      return "Keyword";
+    }
+    if ( value == "of" ) {
+      return "Keyword";
+    }
+    if ( value == "switch" ) {
+      return "Keyword";
+    }
+    if ( value == "case" ) {
+      return "Keyword";
+    }
+    if ( value == "default" ) {
+      return "Keyword";
+    }
+    if ( value == "break" ) {
+      return "Keyword";
+    }
+    if ( value == "continue" ) {
+      return "Keyword";
+    }
+    if ( value == "try" ) {
+      return "Keyword";
+    }
+    if ( value == "catch" ) {
+      return "Keyword";
+    }
+    if ( value == "finally" ) {
+      return "Keyword";
+    }
+    if ( value == "throw" ) {
+      return "Keyword";
+    }
+    if ( value == "new" ) {
+      return "Keyword";
+    }
+    if ( value == "typeof" ) {
+      return "Keyword";
+    }
+    if ( value == "instanceof" ) {
+      return "Keyword";
+    }
+    if ( value == "this" ) {
+      return "Keyword";
+    }
+    if ( value == "class" ) {
+      return "Keyword";
+    }
+    if ( value == "extends" ) {
+      return "Keyword";
+    }
+    if ( value == "static" ) {
+      return "Keyword";
+    }
+    if ( value == "get" ) {
+      return "Keyword";
+    }
+    if ( value == "set" ) {
+      return "Keyword";
+    }
+    if ( value == "super" ) {
+      return "Keyword";
+    }
+    if ( value == "async" ) {
+      return "Keyword";
+    }
+    if ( value == "await" ) {
+      return "Keyword";
+    }
+    if ( value == "yield" ) {
+      return "Keyword";
+    }
+    if ( value == "import" ) {
+      return "Keyword";
+    }
+    if ( value == "export" ) {
+      return "Keyword";
+    }
+    if ( value == "from" ) {
+      return "Keyword";
+    }
+    if ( value == "as" ) {
+      return "Keyword";
+    }
+    if ( value == "delete" ) {
+      return "Keyword";
+    }
+    if ( value == "void" ) {
+      return "Keyword";
+    }
+    if ( value == "type" ) {
+      return "TSKeyword";
+    }
+    if ( value == "interface" ) {
+      return "TSKeyword";
+    }
+    if ( value == "namespace" ) {
+      return "TSKeyword";
+    }
+    if ( value == "module" ) {
+      return "TSKeyword";
+    }
+    if ( value == "declare" ) {
+      return "TSKeyword";
+    }
+    if ( value == "readonly" ) {
+      return "TSKeyword";
+    }
+    if ( value == "abstract" ) {
+      return "TSKeyword";
+    }
+    if ( value == "implements" ) {
+      return "TSKeyword";
+    }
+    if ( value == "private" ) {
+      return "TSKeyword";
+    }
+    if ( value == "protected" ) {
+      return "TSKeyword";
+    }
+    if ( value == "public" ) {
+      return "TSKeyword";
+    }
+    if ( value == "override" ) {
+      return "TSKeyword";
+    }
+    if ( value == "is" ) {
+      return "TSKeyword";
+    }
+    if ( value == "keyof" ) {
+      return "TSKeyword";
+    }
+    if ( value == "infer" ) {
+      return "TSKeyword";
+    }
+    if ( value == "asserts" ) {
+      return "TSKeyword";
+    }
+    if ( value == "satisfies" ) {
+      return "TSKeyword";
+    }
+    if ( value == "string" ) {
+      return "TSType";
+    }
+    if ( value == "number" ) {
+      return "TSType";
+    }
+    if ( value == "boolean" ) {
+      return "TSType";
+    }
+    if ( value == "any" ) {
+      return "TSType";
+    }
+    if ( value == "unknown" ) {
+      return "TSType";
+    }
+    if ( value == "never" ) {
+      return "TSType";
+    }
+    if ( value == "undefined" ) {
+      return "TSType";
+    }
+    if ( value == "object" ) {
+      return "TSType";
+    }
+    if ( value == "symbol" ) {
+      return "TSType";
+    }
+    if ( value == "bigint" ) {
+      return "TSType";
+    }
+    if ( value == "true" ) {
+      return "Boolean";
+    }
+    if ( value == "false" ) {
+      return "Boolean";
+    }
+    if ( value == "null" ) {
+      return "Null";
+    }
+    return "Identifier";
+  };
+  nextToken () {
+    this.skipWhitespace();
+    if ( this.pos >= this.__len ) {
+      return this.makeToken("EOF", "", this.pos, this.line, this.col);
+    }
+    const ch = this.peek();
+    const startPos = this.pos;
+    const startLine = this.line;
+    const startCol = this.col;
+    if ( ch == "/" ) {
+      const next = this.peekAt(1);
+      if ( next == "/" ) {
+        return this.readLineComment();
+      }
+      if ( next == "*" ) {
+        return this.readBlockComment();
+      }
+    }
+    if ( ch == "\"" ) {
+      return this.readString("\"");
+    }
+    if ( ch == "'" ) {
+      let wordApostrophe = false;
+      if ( this.pos > 0 ) {
+        if ( (this.pos + 1) < this.__len ) {
+          const prevCh = this.peekAt(-1);
+          const nextCh = this.peekAt(1);
+          if ( (prevCh.length) > 0 ) {
+            if ( (nextCh.length) > 0 ) {
+              const prevCode = prevCh.charCodeAt(0 );
+              const nextCode = nextCh.charCodeAt(0 );
+              if ( this.isLetterCode(prevCode) && this.isLetterCode(nextCode) ) {
+                wordApostrophe = true;
+              }
+            }
+          }
+        }
+      }
+      if ( wordApostrophe ) {
+        this.advance();
+        return this.makeToken("Punctuator", "'", startPos, startLine, startCol);
+      }
+      return this.readString("'");
+    }
+    if ( ch == "`" ) {
+      return this.readTemplateLiteral();
+    }
+    if ( this.isDigit(ch) ) {
+      return this.readNumber();
+    }
+    if ( this.isAlpha(ch) ) {
+      return this.readIdentifier();
+    }
+    const next_1 = this.peekAt(1);
+    if ( ch == "=" ) {
+      if ( next_1 == "=" ) {
+        if ( this.peekAt(2) == "=" ) {
+          this.advance();
+          this.advance();
+          this.advance();
+          return this.makeToken("Punctuator", "===", startPos, startLine, startCol);
+        }
+      }
+    }
+    if ( ch == "!" ) {
+      if ( next_1 == "=" ) {
+        if ( this.peekAt(2) == "=" ) {
+          this.advance();
+          this.advance();
+          this.advance();
+          return this.makeToken("Punctuator", "!==", startPos, startLine, startCol);
+        }
+      }
+    }
+    if ( ch == "=" ) {
+      if ( next_1 == ">" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "=>", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == "=" ) {
+      if ( next_1 == "=" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "==", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == "!" ) {
+      if ( next_1 == "=" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "!=", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == "<" ) {
+      if ( next_1 == "=" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "<=", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == ">" ) {
+      if ( next_1 == "=" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", ">=", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == "&" ) {
+      if ( next_1 == "&" ) {
+        this.advance();
+        this.advance();
+        if ( this.peek() == "=" ) {
+          this.advance();
+          return this.makeToken("Punctuator", "&&=", startPos, startLine, startCol);
+        }
+        return this.makeToken("Punctuator", "&&", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == "|" ) {
+      if ( next_1 == "|" ) {
+        this.advance();
+        this.advance();
+        if ( this.peek() == "=" ) {
+          this.advance();
+          return this.makeToken("Punctuator", "||=", startPos, startLine, startCol);
+        }
+        return this.makeToken("Punctuator", "||", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == "?" ) {
+      if ( next_1 == "?" ) {
+        this.advance();
+        this.advance();
+        if ( this.peek() == "=" ) {
+          this.advance();
+          return this.makeToken("Punctuator", "??=", startPos, startLine, startCol);
+        }
+        return this.makeToken("Punctuator", "??", startPos, startLine, startCol);
+      }
+      if ( next_1 == "." ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "?.", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == "+" ) {
+      if ( next_1 == "+" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "++", startPos, startLine, startCol);
+      }
+      if ( next_1 == "=" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "+=", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == "-" ) {
+      if ( next_1 == "-" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "--", startPos, startLine, startCol);
+      }
+      if ( next_1 == "=" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "-=", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == "*" ) {
+      if ( next_1 == "*" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "**", startPos, startLine, startCol);
+      }
+      if ( next_1 == "=" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "*=", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == "/" ) {
+      if ( next_1 == "=" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "/=", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == "%" ) {
+      if ( next_1 == "=" ) {
+        this.advance();
+        this.advance();
+        return this.makeToken("Punctuator", "%=", startPos, startLine, startCol);
+      }
+    }
+    if ( ch == "." ) {
+      if ( next_1 == "." ) {
+        if ( this.peekAt(2) == "." ) {
+          this.advance();
+          this.advance();
+          this.advance();
+          return this.makeToken("Punctuator", "...", startPos, startLine, startCol);
+        }
+      }
+    }
+    if ( (ch.length) == 0 ) {
+      return this.makeToken("EOF", "", this.pos, this.line, this.col);
+    }
+    this.advance();
+    return this.makeToken("Punctuator", ch, startPos, startLine, startCol);
+  };
+  tokenize () {
+    let tokens = [];
+    while (true) {
+      const tok = this.nextToken();
+      tokens.push(tok);
+      if ( tok.tokenType == "EOF" ) {
+        return tokens;
+      }
+    };
+    return tokens;
+  };
+}
+class TSNode  {
+  constructor() {
+    this.nodeType = "";
+    this.start = 0;
+    this.end = 0;
+    this.line = 0;
+    this.col = 0;
+    this.name = "";
+    this.value = "";
+    this.kind = "";
+    this.optional = false;
+    this.readonly = false;
+    this.prefix = false;
+    this.shorthand = false;
+    this.computed = false;
+    this.method = false;
+    this.generator = false;
+    this.async = false;
+    this.delegate = false;
+    this.await = false;
+    this.children = [];
+    this.params = [];
+    this.decorators = [];
+  }
+}
+class TSParserSimple  {
+  constructor() {
+    this.tokens = [];
+    this.pos = 0;
+    this.quiet = false;
+    this.tsxMode = false;
+  }
+  initParser (toks) {
+    this.tokens = toks;
+    this.pos = 0;
+    this.quiet = false;
+    if ( (toks.length) > 0 ) {
+      this.currentToken = toks[0];
+      this.skipIgnoredTokens();
+    }
+  };
+  setQuiet (q) {
+    this.quiet = q;
+  };
+  setTsxMode (enabled) {
+    this.tsxMode = enabled;
+  };
+  peek () {
+    return this.currentToken;
+  };
+  peekType () {
+    if ( typeof(this.currentToken) === "undefined" ) {
+      return "EOF";
+    }
+    const tok = this.currentToken;
+    return tok.tokenType;
+  };
+  peekValue () {
+    if ( typeof(this.currentToken) === "undefined" ) {
+      return "";
+    }
+    const tok = this.currentToken;
+    return tok.value;
+  };
+  advance () {
+    this.pos = this.pos + 1;
+    if ( this.pos < (this.tokens.length) ) {
+      this.currentToken = this.tokens[this.pos];
+    } else {
+      const eof = new Token();
+      eof.tokenType = "EOF";
+      eof.value = "";
+      this.currentToken = eof;
+    }
+    this.skipIgnoredTokens();
+  };
+  skipIgnoredTokens () {
+    while (this.pos < (this.tokens.length)) {
+      const tok = this.peek();
+      const tokType = tok.tokenType;
+      if ( (tokType == "LineComment") || (tokType == "BlockComment") ) {
+        this.pos = this.pos + 1;
+        if ( this.pos < (this.tokens.length) ) {
+          this.currentToken = this.tokens[this.pos];
+        } else {
+          const eof = new Token();
+          eof.tokenType = "EOF";
+          eof.value = "";
+          this.currentToken = eof;
+          return;
+        }
+      } else {
+        return;
+      }
+    };
+  };
+  expect (expectedType) {
+    const tok = this.peek();
+    if ( tok.tokenType != expectedType ) {
+      if ( this.quiet == false ) {
+        console.log((("Parse error: expected " + expectedType) + " but got ") + tok.tokenType);
+      }
+    }
+    this.advance();
+    return tok;
+  };
+  expectValue (expectedValue) {
+    const tok = this.peek();
+    if ( tok.value != expectedValue ) {
+      if ( this.quiet == false ) {
+        console.log(((("Parse error: expected '" + expectedValue) + "' but got '") + tok.value) + "'");
+      }
+    }
+    this.advance();
+    return tok;
+  };
+  isAtEnd () {
+    const t = this.peekType();
+    return t == "EOF";
+  };
+  matchType (tokenType) {
+    const t = this.peekType();
+    return t == tokenType;
+  };
+  matchValue (value) {
+    const v = this.peekValue();
+    return v == value;
+  };
+  parseProgram () {
+    const prog = new TSNode();
+    prog.nodeType = "Program";
+    while (this.isAtEnd() == false) {
+      const stmt = this.parseStatement();
+      prog.children.push(stmt);
+    };
+    return prog;
+  };
+  parseStatement () {
+    const tokVal = this.peekValue();
+    if ( tokVal == "@" ) {
+      let decorators = [];
+      while (this.matchValue("@")) {
+        const dec = this.parseDecorator();
+        decorators.push(dec);
+      };
+      const decorated = this.parseStatement();
+      decorated.decorators = decorators;
+      return decorated;
+    }
+    if ( tokVal == "declare" ) {
+      return this.parseDeclare();
+    }
+    if ( tokVal == "import" ) {
+      return this.parseImport();
+    }
+    if ( tokVal == "export" ) {
+      return this.parseExport();
+    }
+    if ( tokVal == "interface" ) {
+      return this.parseInterface();
+    }
+    if ( tokVal == "type" ) {
+      return this.parseTypeAlias();
+    }
+    if ( tokVal == "class" ) {
+      return this.parseClass();
+    }
+    if ( tokVal == "abstract" ) {
+      const nextVal = this.peekNextValue();
+      if ( nextVal == "class" ) {
+        return this.parseClass();
+      }
+    }
+    if ( tokVal == "enum" ) {
+      return this.parseEnum();
+    }
+    if ( tokVal == "namespace" ) {
+      return this.parseNamespace();
+    }
+    if ( tokVal == "const" ) {
+      const nextVal_1 = this.peekNextValue();
+      if ( nextVal_1 == "enum" ) {
+        return this.parseEnum();
+      }
+    }
+    if ( (tokVal == "let") || (tokVal == "const") ) {
+      return this.parseVarDecl();
+    }
+    if ( tokVal == "function" ) {
+      return this.parseFuncDecl(false);
+    }
+    if ( tokVal == "async" ) {
+      const nextVal_2 = this.peekNextValue();
+      if ( nextVal_2 == "function" ) {
+        this.advance();
+        return this.parseFuncDecl(true);
+      }
+    }
+    if ( tokVal == "return" ) {
+      return this.parseReturn();
+    }
+    if ( tokVal == "break" ) {
+      return this.parseBreak();
+    }
+    if ( tokVal == "continue" ) {
+      return this.parseContinue();
+    }
+    if ( tokVal == "throw" ) {
+      return this.parseThrow();
+    }
+    if ( tokVal == "if" ) {
+      return this.parseIfStatement();
+    }
+    if ( tokVal == "while" ) {
+      return this.parseWhileStatement();
+    }
+    if ( tokVal == "do" ) {
+      return this.parseDoWhileStatement();
+    }
+    if ( tokVal == "for" ) {
+      return this.parseForStatement();
+    }
+    if ( tokVal == "switch" ) {
+      return this.parseSwitchStatement();
+    }
+    if ( tokVal == "try" ) {
+      return this.parseTryStatement();
+    }
+    if ( tokVal == "{" ) {
+      return this.parseBlock();
+    }
+    if ( tokVal == ";" ) {
+      this.advance();
+      const empty = new TSNode();
+      empty.nodeType = "EmptyStatement";
+      return empty;
+    }
+    const tokType = this.peekType();
+    if ( tokType == "Identifier" ) {
+      const nextVal_3 = this.peekNextValue();
+      if ( nextVal_3 == ":" ) {
+        return this.parseLabeledStatement();
+      }
+    }
+    return this.parseExprStmt();
+  };
+  parseLabeledStatement () {
+    const node = new TSNode();
+    node.nodeType = "LabeledStatement";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    const labelTok = this.expect("Identifier");
+    node.name = labelTok.value;
+    this.expectValue(":");
+    const body = this.parseStatement();
+    node.body = body;
+    return node;
+  };
+  peekNextValue () {
+    const nextPos = this.pos + 1;
+    if ( nextPos < (this.tokens.length) ) {
+      const nextTok = this.tokens[nextPos];
+      return nextTok.value;
+    }
+    return "";
+  };
+  parseReturn () {
+    const node = new TSNode();
+    node.nodeType = "ReturnStatement";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("return");
+    const v = this.peekValue();
+    if ( (v != ";") && (this.isAtEnd() == false) ) {
+      const arg = this.parseExpr();
+      node.left = arg;
+    }
+    if ( this.matchValue(";") ) {
+      this.advance();
+    }
+    return node;
+  };
+  parseBreak () {
+    const node = new TSNode();
+    node.nodeType = "BreakStatement";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("break");
+    if ( this.matchValue(";") ) {
+      this.advance();
+    }
+    return node;
+  };
+  parseContinue () {
+    const node = new TSNode();
+    node.nodeType = "ContinueStatement";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("continue");
+    if ( this.matchValue(";") ) {
+      this.advance();
+    }
+    return node;
+  };
+  parseImport () {
+    const node = new TSNode();
+    node.nodeType = "ImportDeclaration";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("import");
+    if ( this.matchValue("type") ) {
+      this.advance();
+      node.kind = "type";
+    }
+    const v = this.peekValue();
+    if ( v == "{" ) {
+      this.advance();
+      let specifiers = [];
+      while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+        const spec = new TSNode();
+        spec.nodeType = "ImportSpecifier";
+        if ( this.matchValue("type") ) {
+          this.advance();
+          spec.kind = "type";
+        }
+        const importedName = this.expect("Identifier");
+        spec.name = importedName.value;
+        if ( this.matchValue("as") ) {
+          this.advance();
+          const localName = this.expect("Identifier");
+          spec.value = localName.value;
+        } else {
+          spec.value = importedName.value;
+        }
+        specifiers.push(spec);
+        if ( this.matchValue(",") ) {
+          this.advance();
+        }
+      };
+      this.expectValue("}");
+      node.children = specifiers;
+    }
+    if ( v == "*" ) {
+      this.advance();
+      this.expectValue("as");
+      const namespaceName = this.expect("Identifier");
+      const nsSpec = new TSNode();
+      nsSpec.nodeType = "ImportNamespaceSpecifier";
+      nsSpec.name = namespaceName.value;
+      node.children.push(nsSpec);
+    }
+    if ( this.matchType("Identifier") ) {
+      const defaultSpec = new TSNode();
+      defaultSpec.nodeType = "ImportDefaultSpecifier";
+      const defaultName = this.expect("Identifier");
+      defaultSpec.name = defaultName.value;
+      node.children.push(defaultSpec);
+      if ( this.matchValue(",") ) {
+        this.advance();
+        if ( this.matchValue("{") ) {
+          this.advance();
+          while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+            const spec_1 = new TSNode();
+            spec_1.nodeType = "ImportSpecifier";
+            const importedName_1 = this.expect("Identifier");
+            spec_1.name = importedName_1.value;
+            if ( this.matchValue("as") ) {
+              this.advance();
+              const localName_1 = this.expect("Identifier");
+              spec_1.value = localName_1.value;
+            } else {
+              spec_1.value = importedName_1.value;
+            }
+            node.children.push(spec_1);
+            if ( this.matchValue(",") ) {
+              this.advance();
+            }
+          };
+          this.expectValue("}");
+        }
+      }
+    }
+    if ( this.matchValue("from") ) {
+      this.advance();
+      const sourceStr = this.expect("String");
+      const source = new TSNode();
+      source.nodeType = "StringLiteral";
+      source.value = sourceStr.value;
+      node.left = source;
+    }
+    if ( this.matchValue(";") ) {
+      this.advance();
+    }
+    return node;
+  };
+  parseExport () {
+    const node = new TSNode();
+    node.nodeType = "ExportNamedDeclaration";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("export");
+    if ( this.matchValue("type") ) {
+      const nextV = this.peekNextValue();
+      if ( nextV == "{" ) {
+        this.advance();
+        node.kind = "type";
+      }
+    }
+    const v = this.peekValue();
+    if ( v == "default" ) {
+      node.nodeType = "ExportDefaultDeclaration";
+      this.advance();
+      const nextVal = this.peekValue();
+      if ( ((nextVal == "class") || (nextVal == "function")) || (nextVal == "interface") ) {
+        const decl = this.parseStatement();
+        node.left = decl;
+      } else {
+        const expr = this.parseExpr();
+        node.left = expr;
+      }
+      if ( this.matchValue(";") ) {
+        this.advance();
+      }
+      return node;
+    }
+    if ( v == "{" ) {
+      this.advance();
+      let specifiers = [];
+      while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+        const spec = new TSNode();
+        spec.nodeType = "ExportSpecifier";
+        const localName = this.expect("Identifier");
+        spec.name = localName.value;
+        if ( this.matchValue("as") ) {
+          this.advance();
+          const exportedName = this.expect("Identifier");
+          spec.value = exportedName.value;
+        } else {
+          spec.value = localName.value;
+        }
+        specifiers.push(spec);
+        if ( this.matchValue(",") ) {
+          this.advance();
+        }
+      };
+      this.expectValue("}");
+      node.children = specifiers;
+      if ( this.matchValue("from") ) {
+        this.advance();
+        const sourceStr = this.expect("String");
+        const source = new TSNode();
+        source.nodeType = "StringLiteral";
+        source.value = sourceStr.value;
+        node.left = source;
+      }
+      if ( this.matchValue(";") ) {
+        this.advance();
+      }
+      return node;
+    }
+    if ( v == "*" ) {
+      node.nodeType = "ExportAllDeclaration";
+      this.advance();
+      if ( this.matchValue("as") ) {
+        this.advance();
+        const exportName = this.expect("Identifier");
+        node.name = exportName.value;
+      }
+      this.expectValue("from");
+      const sourceStr_1 = this.expect("String");
+      const source_1 = new TSNode();
+      source_1.nodeType = "StringLiteral";
+      source_1.value = sourceStr_1.value;
+      node.left = source_1;
+      if ( this.matchValue(";") ) {
+        this.advance();
+      }
+      return node;
+    }
+    if ( (((((((v == "function") || (v == "class")) || (v == "interface")) || (v == "type")) || (v == "const")) || (v == "let")) || (v == "enum")) || (v == "abstract") ) {
+      const decl_1 = this.parseStatement();
+      node.left = decl_1;
+      return node;
+    }
+    if ( v == "async" ) {
+      const decl_2 = this.parseStatement();
+      node.left = decl_2;
+      return node;
+    }
+    return node;
+  };
+  parseInterface () {
+    const node = new TSNode();
+    node.nodeType = "TSInterfaceDeclaration";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("interface");
+    const nameTok = this.expect("Identifier");
+    node.name = nameTok.value;
+    if ( this.matchValue("<") ) {
+      const typeParams = this.parseTypeParams();
+      node.params = typeParams;
+    }
+    if ( this.matchValue("extends") ) {
+      this.advance();
+      let extendsList = [];
+      const extendsType = this.parseType();
+      extendsList.push(extendsType);
+      while (this.matchValue(",")) {
+        this.advance();
+        const nextType = this.parseType();
+        extendsList.push(nextType);
+      };
+      for ( let i = 0; i < extendsList.length; i++) {
+        var ext = extendsList[i];
+        const wrapper = new TSNode();
+        wrapper.nodeType = "TSExpressionWithTypeArguments";
+        wrapper.left = ext;
+        node.children.push(wrapper);
+      };
+    }
+    const body = this.parseInterfaceBody();
+    node.body = body;
+    return node;
+  };
+  parseInterfaceBody () {
+    const body = new TSNode();
+    body.nodeType = "TSInterfaceBody";
+    const startTok = this.peek();
+    body.start = startTok.start;
+    body.line = startTok.line;
+    body.col = startTok.col;
+    this.expectValue("{");
+    while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+      const prop = this.parsePropertySig();
+      body.children.push(prop);
+      if ( this.matchValue(";") || this.matchValue(",") ) {
+        this.advance();
+      }
+    };
+    this.expectValue("}");
+    return body;
+  };
+  parseTypeParams () {
+    let params = [];
+    this.expectValue("<");
+    while ((this.matchValue(">") == false) && (this.isAtEnd() == false)) {
+      if ( (params.length) > 0 ) {
+        this.expectValue(",");
+      }
+      const param = new TSNode();
+      param.nodeType = "TSTypeParameter";
+      const nameTok = this.expect("Identifier");
+      param.name = nameTok.value;
+      param.start = nameTok.start;
+      param.line = nameTok.line;
+      param.col = nameTok.col;
+      if ( this.matchValue("extends") ) {
+        this.advance();
+        const constraint = this.parseType();
+        param.typeAnnotation = constraint;
+      }
+      if ( this.matchValue("=") ) {
+        this.advance();
+        const defaultType = this.parseType();
+        param.init = defaultType;
+      }
+      params.push(param);
+    };
+    this.expectValue(">");
+    return params;
+  };
+  parsePropertySig () {
+    const startTok = this.peek();
+    const startPos = startTok.start;
+    const startLine = startTok.line;
+    const startCol = startTok.col;
+    let isReadonly = false;
+    if ( this.matchValue("readonly") ) {
+      isReadonly = true;
+      this.advance();
+    }
+    if ( this.matchValue("[") ) {
+      this.advance();
+      const paramTok = this.expect("Identifier");
+      return this.parseIndexSignatureRest(isReadonly, paramTok, startPos, startLine, startCol);
+    }
+    if ( this.matchValue("(") ) {
+      return this.parseCallSignature(startPos, startLine, startCol);
+    }
+    if ( this.matchValue("new") ) {
+      return this.parseConstructSignature(startPos, startLine, startCol);
+    }
+    const prop = new TSNode();
+    prop.nodeType = "TSPropertySignature";
+    prop.start = startPos;
+    prop.line = startLine;
+    prop.col = startCol;
+    prop.readonly = isReadonly;
+    const nameTok = this.expect("Identifier");
+    prop.name = nameTok.value;
+    if ( this.matchValue("?") ) {
+      prop.optional = true;
+      this.advance();
+    }
+    if ( this.matchValue(":") ) {
+      const typeAnnot = this.parseTypeAnnotation();
+      prop.typeAnnotation = typeAnnot;
+    }
+    return prop;
+  };
+  parseCallSignature (startPos, startLine, startCol) {
+    const sig = new TSNode();
+    sig.nodeType = "TSCallSignatureDeclaration";
+    sig.start = startPos;
+    sig.line = startLine;
+    sig.col = startCol;
+    if ( this.matchValue("<") ) {
+      const typeParams = this.parseTypeParams();
+      sig.params = typeParams;
+    }
+    this.expectValue("(");
+    while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+      if ( (sig.children.length) > 0 ) {
+        this.expectValue(",");
+      }
+      const param = this.parseParam();
+      sig.children.push(param);
+    };
+    this.expectValue(")");
+    if ( this.matchValue(":") ) {
+      const typeAnnot = this.parseTypeAnnotation();
+      sig.typeAnnotation = typeAnnot;
+    }
+    return sig;
+  };
+  parseConstructSignature (startPos, startLine, startCol) {
+    const sig = new TSNode();
+    sig.nodeType = "TSConstructSignatureDeclaration";
+    sig.start = startPos;
+    sig.line = startLine;
+    sig.col = startCol;
+    this.expectValue("new");
+    if ( this.matchValue("<") ) {
+      const typeParams = this.parseTypeParams();
+      sig.params = typeParams;
+    }
+    this.expectValue("(");
+    while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+      if ( (sig.children.length) > 0 ) {
+        this.expectValue(",");
+      }
+      const param = this.parseParam();
+      sig.children.push(param);
+    };
+    this.expectValue(")");
+    if ( this.matchValue(":") ) {
+      const typeAnnot = this.parseTypeAnnotation();
+      sig.typeAnnotation = typeAnnot;
+    }
+    return sig;
+  };
+  parseTypeAlias () {
+    const node = new TSNode();
+    node.nodeType = "TSTypeAliasDeclaration";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("type");
+    const nameTok = this.expect("Identifier");
+    node.name = nameTok.value;
+    if ( this.matchValue("<") ) {
+      const typeParams = this.parseTypeParams();
+      node.params = typeParams;
+    }
+    this.expectValue("=");
+    const typeExpr = this.parseType();
+    node.typeAnnotation = typeExpr;
+    if ( this.matchValue(";") ) {
+      this.advance();
+    }
+    return node;
+  };
+  parseDecorator () {
+    const node = new TSNode();
+    node.nodeType = "Decorator";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("@");
+    const expr = this.parsePostfix();
+    node.left = expr;
+    return node;
+  };
+  parseClass () {
+    const node = new TSNode();
+    node.nodeType = "ClassDeclaration";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    if ( this.matchValue("abstract") ) {
+      node.kind = "abstract";
+      this.advance();
+    }
+    this.expectValue("class");
+    const nameTok = this.expect("Identifier");
+    node.name = nameTok.value;
+    if ( this.matchValue("<") ) {
+      const typeParams = this.parseTypeParams();
+      node.params = typeParams;
+    }
+    if ( this.matchValue("extends") ) {
+      this.advance();
+      const superClass = this.parseType();
+      const extendsNode = new TSNode();
+      extendsNode.nodeType = "TSExpressionWithTypeArguments";
+      extendsNode.left = superClass;
+      node.left = extendsNode;
+    }
+    if ( this.matchValue("implements") ) {
+      this.advance();
+      const impl = this.parseType();
+      const implNode = new TSNode();
+      implNode.nodeType = "TSExpressionWithTypeArguments";
+      implNode.left = impl;
+      node.children.push(implNode);
+      while (this.matchValue(",")) {
+        this.advance();
+        const nextImpl = this.parseType();
+        const nextImplNode = new TSNode();
+        nextImplNode.nodeType = "TSExpressionWithTypeArguments";
+        nextImplNode.left = nextImpl;
+        node.children.push(nextImplNode);
+      };
+    }
+    const body = this.parseClassBody();
+    node.body = body;
+    return node;
+  };
+  parseClassBody () {
+    const body = new TSNode();
+    body.nodeType = "ClassBody";
+    const startTok = this.peek();
+    body.start = startTok.start;
+    body.line = startTok.line;
+    body.col = startTok.col;
+    this.expectValue("{");
+    while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+      const member = this.parseClassMember();
+      body.children.push(member);
+      if ( this.matchValue(";") ) {
+        this.advance();
+      }
+    };
+    this.expectValue("}");
+    return body;
+  };
+  parseClassMember () {
+    const member = new TSNode();
+    const startTok = this.peek();
+    member.start = startTok.start;
+    member.line = startTok.line;
+    member.col = startTok.col;
+    let decorators = [];
+    while (this.matchValue("@")) {
+      const dec = this.parseDecorator();
+      decorators.push(dec);
+    };
+    if ( (decorators.length) > 0 ) {
+      member.decorators = decorators;
+    }
+    let isStatic = false;
+    let isAbstract = false;
+    let isReadonly = false;
+    let isAsync = false;
+    let accessibility = "";
+    let keepParsing = true;
+    while (keepParsing) {
+      const tokVal = this.peekValue();
+      if ( tokVal == "public" ) {
+        accessibility = "public";
+        this.advance();
+      }
+      if ( tokVal == "private" ) {
+        accessibility = "private";
+        this.advance();
+      }
+      if ( tokVal == "protected" ) {
+        accessibility = "protected";
+        this.advance();
+      }
+      if ( tokVal == "static" ) {
+        isStatic = true;
+        this.advance();
+        if ( this.matchValue("{") ) {
+          member.nodeType = "StaticBlock";
+          member.body = this.parseBlock();
+          member.start = startTok.start;
+          member.line = startTok.line;
+          member.col = startTok.col;
+          return member;
+        }
+      }
+      if ( tokVal == "abstract" ) {
+        isAbstract = true;
+        this.advance();
+      }
+      if ( tokVal == "readonly" ) {
+        isReadonly = true;
+        this.advance();
+      }
+      if ( tokVal == "async" ) {
+        isAsync = true;
+        this.advance();
+      }
+      const newTokVal = this.peekValue();
+      if ( ((((((newTokVal != "public") && (newTokVal != "private")) && (newTokVal != "protected")) && (newTokVal != "static")) && (newTokVal != "abstract")) && (newTokVal != "readonly")) && (newTokVal != "async") ) {
+        keepParsing = false;
+      }
+    };
+    if ( this.matchValue("constructor") ) {
+      member.nodeType = "MethodDefinition";
+      member.kind = "constructor";
+      this.advance();
+      this.expectValue("(");
+      while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+        if ( (member.params.length) > 0 ) {
+          this.expectValue(",");
+        }
+        const param = this.parseConstructorParam();
+        member.params.push(param);
+      };
+      this.expectValue(")");
+      if ( this.matchValue("{") ) {
+        const bodyNode = this.parseBlock();
+        member.body = bodyNode;
+      }
+      return member;
+    }
+    const nameTok = this.expect("Identifier");
+    member.name = nameTok.value;
+    if ( accessibility != "" ) {
+      member.kind = accessibility;
+    }
+    member.readonly = isReadonly;
+    if ( this.matchValue("?") ) {
+      member.optional = true;
+      this.advance();
+    }
+    if ( this.matchValue("(") ) {
+      member.nodeType = "MethodDefinition";
+      if ( isStatic ) {
+        member.kind = "static";
+      }
+      if ( isAbstract ) {
+        member.kind = "abstract";
+      }
+      if ( isAsync ) {
+        member.async = true;
+      }
+      this.expectValue("(");
+      while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+        if ( (member.params.length) > 0 ) {
+          this.expectValue(",");
+        }
+        const param_1 = this.parseParam();
+        member.params.push(param_1);
+      };
+      this.expectValue(")");
+      if ( this.matchValue(":") ) {
+        const returnType = this.parseTypeAnnotation();
+        member.typeAnnotation = returnType;
+      }
+      if ( this.matchValue("{") ) {
+        const bodyNode_1 = this.parseBlock();
+        member.body = bodyNode_1;
+      }
+    } else {
+      member.nodeType = "PropertyDefinition";
+      if ( isStatic ) {
+        member.kind = "static";
+      }
+      if ( this.matchValue(":") ) {
+        const typeAnnot = this.parseTypeAnnotation();
+        member.typeAnnotation = typeAnnot;
+      }
+      if ( this.matchValue("=") ) {
+        this.advance();
+        const initExpr = this.parseExpr();
+        member.init = initExpr;
+      }
+    }
+    return member;
+  };
+  parseConstructorParam () {
+    const param = new TSNode();
+    param.nodeType = "Parameter";
+    const startTok = this.peek();
+    param.start = startTok.start;
+    param.line = startTok.line;
+    param.col = startTok.col;
+    const tokVal = this.peekValue();
+    if ( (((tokVal == "public") || (tokVal == "private")) || (tokVal == "protected")) || (tokVal == "readonly") ) {
+      param.kind = tokVal;
+      this.advance();
+      const nextVal = this.peekValue();
+      if ( nextVal == "readonly" ) {
+        param.readonly = true;
+        this.advance();
+      }
+    }
+    const nameTok = this.expect("Identifier");
+    param.name = nameTok.value;
+    if ( this.matchValue("?") ) {
+      param.optional = true;
+      this.advance();
+    }
+    if ( this.matchValue(":") ) {
+      const typeAnnot = this.parseTypeAnnotation();
+      param.typeAnnotation = typeAnnot;
+    }
+    if ( this.matchValue("=") ) {
+      this.advance();
+      const defaultVal = this.parseExpr();
+      param.init = defaultVal;
+    }
+    return param;
+  };
+  parseEnum () {
+    const node = new TSNode();
+    node.nodeType = "TSEnumDeclaration";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    if ( this.matchValue("const") ) {
+      node.kind = "const";
+      this.advance();
+    }
+    this.expectValue("enum");
+    const nameTok = this.expect("Identifier");
+    node.name = nameTok.value;
+    this.expectValue("{");
+    while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+      const member = new TSNode();
+      member.nodeType = "TSEnumMember";
+      const memberTok = this.expect("Identifier");
+      member.name = memberTok.value;
+      member.start = memberTok.start;
+      member.line = memberTok.line;
+      member.col = memberTok.col;
+      if ( this.matchValue("=") ) {
+        this.advance();
+        const initVal = this.parseExpr();
+        member.init = initVal;
+      }
+      node.children.push(member);
+      if ( this.matchValue(",") ) {
+        this.advance();
+      }
+    };
+    this.expectValue("}");
+    return node;
+  };
+  parseNamespace () {
+    const node = new TSNode();
+    node.nodeType = "TSModuleDeclaration";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("namespace");
+    const nameTok = this.expect("Identifier");
+    node.name = nameTok.value;
+    this.expectValue("{");
+    const body = new TSNode();
+    body.nodeType = "TSModuleBlock";
+    while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+      const stmt = this.parseStatement();
+      body.children.push(stmt);
+    };
+    this.expectValue("}");
+    node.body = body;
+    return node;
+  };
+  parseDeclare () {
+    const startTok = this.peek();
+    this.expectValue("declare");
+    const nextVal = this.peekValue();
+    if ( nextVal == "module" ) {
+      const node = new TSNode();
+      node.nodeType = "TSModuleDeclaration";
+      node.start = startTok.start;
+      node.line = startTok.line;
+      node.col = startTok.col;
+      node.kind = "declare";
+      this.advance();
+      const nameTok = this.peek();
+      if ( this.matchType("String") ) {
+        this.advance();
+        node.name = nameTok.value;
+      } else {
+        this.advance();
+        node.name = nameTok.value;
+      }
+      this.expectValue("{");
+      const body = new TSNode();
+      body.nodeType = "TSModuleBlock";
+      while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+        const stmt = this.parseStatement();
+        body.children.push(stmt);
+      };
+      this.expectValue("}");
+      node.body = body;
+      return node;
+    }
+    const node_1 = this.parseStatement();
+    node_1.kind = "declare";
+    return node_1;
+  };
+  parseIfStatement () {
+    const node = new TSNode();
+    node.nodeType = "IfStatement";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("if");
+    this.expectValue("(");
+    const test = this.parseExpr();
+    node.left = test;
+    this.expectValue(")");
+    const consequent = this.parseStatement();
+    node.body = consequent;
+    if ( this.matchValue("else") ) {
+      this.advance();
+      const alternate = this.parseStatement();
+      node.right = alternate;
+    }
+    return node;
+  };
+  parseWhileStatement () {
+    const node = new TSNode();
+    node.nodeType = "WhileStatement";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("while");
+    this.expectValue("(");
+    const test = this.parseExpr();
+    node.left = test;
+    this.expectValue(")");
+    const body = this.parseStatement();
+    node.body = body;
+    return node;
+  };
+  parseDoWhileStatement () {
+    const node = new TSNode();
+    node.nodeType = "DoWhileStatement";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("do");
+    const body = this.parseStatement();
+    node.body = body;
+    this.expectValue("while");
+    this.expectValue("(");
+    const test = this.parseExpr();
+    node.left = test;
+    this.expectValue(")");
+    if ( this.matchValue(";") ) {
+      this.advance();
+    }
+    return node;
+  };
+  parseThrow () {
+    const node = new TSNode();
+    node.nodeType = "ThrowStatement";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("throw");
+    const arg = this.parseExpr();
+    node.left = arg;
+    if ( this.matchValue(";") ) {
+      this.advance();
+    }
+    return node;
+  };
+  parseForStatement () {
+    const node = new TSNode();
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("for");
+    let isAwait = false;
+    if ( this.matchValue("await") ) {
+      this.advance();
+      isAwait = true;
+    }
+    this.expectValue("(");
+    const tokVal = this.peekValue();
+    if ( ((tokVal == "let") || (tokVal == "const")) || (tokVal == "var") ) {
+      const kind = tokVal;
+      this.advance();
+      const varName = this.expect("Identifier");
+      const nextVal = this.peekValue();
+      if ( nextVal == "of" ) {
+        node.nodeType = "ForOfStatement";
+        node.await = isAwait;
+        this.advance();
+        const left = new TSNode();
+        left.nodeType = "VariableDeclaration";
+        left.kind = kind;
+        const declarator = new TSNode();
+        declarator.nodeType = "VariableDeclarator";
+        declarator.name = varName.value;
+        left.children.push(declarator);
+        node.left = left;
+        const right = this.parseExpr();
+        node.right = right;
+        this.expectValue(")");
+        const body = this.parseStatement();
+        node.body = body;
+        return node;
+      }
+      if ( nextVal == "in" ) {
+        node.nodeType = "ForInStatement";
+        this.advance();
+        const left_1 = new TSNode();
+        left_1.nodeType = "VariableDeclaration";
+        left_1.kind = kind;
+        const declarator_1 = new TSNode();
+        declarator_1.nodeType = "VariableDeclarator";
+        declarator_1.name = varName.value;
+        left_1.children.push(declarator_1);
+        node.left = left_1;
+        const right_1 = this.parseExpr();
+        node.right = right_1;
+        this.expectValue(")");
+        const body_1 = this.parseStatement();
+        node.body = body_1;
+        return node;
+      }
+      node.nodeType = "ForStatement";
+      const initDecl = new TSNode();
+      initDecl.nodeType = "VariableDeclaration";
+      initDecl.kind = kind;
+      const declarator_2 = new TSNode();
+      declarator_2.nodeType = "VariableDeclarator";
+      declarator_2.name = varName.value;
+      if ( this.matchValue(":") ) {
+        const typeAnnot = this.parseTypeAnnotation();
+        declarator_2.typeAnnotation = typeAnnot;
+      }
+      if ( this.matchValue("=") ) {
+        this.advance();
+        const initVal = this.parseExpr();
+        declarator_2.init = initVal;
+      }
+      initDecl.children.push(declarator_2);
+      node.init = initDecl;
+    } else {
+      node.nodeType = "ForStatement";
+      if ( this.matchValue(";") == false ) {
+        const initExpr = this.parseExpr();
+        node.init = initExpr;
+      }
+    }
+    this.expectValue(";");
+    if ( this.matchValue(";") == false ) {
+      const test = this.parseExpr();
+      node.left = test;
+    }
+    this.expectValue(";");
+    if ( this.matchValue(")") == false ) {
+      const update = this.parseExpr();
+      node.right = update;
+    }
+    this.expectValue(")");
+    const body_2 = this.parseStatement();
+    node.body = body_2;
+    return node;
+  };
+  parseSwitchStatement () {
+    const node = new TSNode();
+    node.nodeType = "SwitchStatement";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("switch");
+    this.expectValue("(");
+    const discriminant = this.parseExpr();
+    node.left = discriminant;
+    this.expectValue(")");
+    this.expectValue("{");
+    while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+      const caseNode = new TSNode();
+      if ( this.matchValue("case") ) {
+        caseNode.nodeType = "SwitchCase";
+        this.advance();
+        const test = this.parseExpr();
+        caseNode.left = test;
+        this.expectValue(":");
+      }
+      if ( this.matchValue("default") ) {
+        caseNode.nodeType = "SwitchCase";
+        caseNode.kind = "default";
+        this.advance();
+        this.expectValue(":");
+      }
+      while ((((this.matchValue("case") == false) && (this.matchValue("default") == false)) && (this.matchValue("}") == false)) && (this.isAtEnd() == false)) {
+        if ( this.matchValue("break") ) {
+          const breakNode = new TSNode();
+          breakNode.nodeType = "BreakStatement";
+          this.advance();
+          if ( this.matchValue(";") ) {
+            this.advance();
+          }
+          caseNode.children.push(breakNode);
+        } else {
+          const stmt = this.parseStatement();
+          caseNode.children.push(stmt);
+        }
+      };
+      node.children.push(caseNode);
+    };
+    this.expectValue("}");
+    return node;
+  };
+  parseTryStatement () {
+    const node = new TSNode();
+    node.nodeType = "TryStatement";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("try");
+    const tryBlock = this.parseBlock();
+    node.body = tryBlock;
+    if ( this.matchValue("catch") ) {
+      const catchNode = new TSNode();
+      catchNode.nodeType = "CatchClause";
+      this.advance();
+      if ( this.matchValue("(") ) {
+        this.advance();
+        const param = this.expect("Identifier");
+        catchNode.name = param.value;
+        if ( this.matchValue(":") ) {
+          const typeAnnot = this.parseTypeAnnotation();
+          catchNode.typeAnnotation = typeAnnot;
+        }
+        this.expectValue(")");
+      }
+      const catchBlock = this.parseBlock();
+      catchNode.body = catchBlock;
+      node.left = catchNode;
+    }
+    if ( this.matchValue("finally") ) {
+      this.advance();
+      const finallyBlock = this.parseBlock();
+      node.right = finallyBlock;
+    }
+    return node;
+  };
+  parseVarDecl () {
+    const node = new TSNode();
+    node.nodeType = "VariableDeclaration";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    node.kind = startTok.value;
+    this.advance();
+    const declarator = new TSNode();
+    declarator.nodeType = "VariableDeclarator";
+    const nextVal = this.peekValue();
+    if ( nextVal == "{" ) {
+      const pattern = this.parseObjectPattern();
+      declarator.left = pattern;
+      declarator.start = pattern.start;
+      declarator.line = pattern.line;
+      declarator.col = pattern.col;
+    } else {
+      if ( nextVal == "[" ) {
+        const pattern_1 = this.parseArrayPattern();
+        declarator.left = pattern_1;
+        declarator.start = pattern_1.start;
+        declarator.line = pattern_1.line;
+        declarator.col = pattern_1.col;
+      } else {
+        const nameTok = this.expect("Identifier");
+        declarator.name = nameTok.value;
+        declarator.start = nameTok.start;
+        declarator.line = nameTok.line;
+        declarator.col = nameTok.col;
+      }
+    }
+    if ( this.matchValue(":") ) {
+      const typeAnnot = this.parseTypeAnnotation();
+      declarator.typeAnnotation = typeAnnot;
+    }
+    if ( this.matchValue("=") ) {
+      this.advance();
+      const initExpr = this.parseExpr();
+      declarator.init = initExpr;
+    }
+    node.children.push(declarator);
+    if ( this.matchValue(";") ) {
+      this.advance();
+    }
+    return node;
+  };
+  parseObjectPattern () {
+    const node = new TSNode();
+    node.nodeType = "ObjectPattern";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("{");
+    while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+      if ( (node.children.length) > 0 ) {
+        this.expectValue(",");
+        if ( this.matchValue("}") ) {
+          break;
+        }
+      }
+      if ( this.matchValue("...") ) {
+        this.advance();
+        const restProp = new TSNode();
+        restProp.nodeType = "RestElement";
+        const restName = this.expect("Identifier");
+        restProp.name = restName.value;
+        node.children.push(restProp);
+      } else {
+        const prop = new TSNode();
+        prop.nodeType = "Property";
+        const keyTok = this.expect("Identifier");
+        prop.name = keyTok.value;
+        if ( this.matchValue(":") ) {
+          this.advance();
+          const valueTok = this.expect("Identifier");
+          const valueId = new TSNode();
+          valueId.nodeType = "Identifier";
+          valueId.name = valueTok.value;
+          prop.right = valueId;
+        } else {
+          prop.shorthand = true;
+        }
+        if ( this.matchValue("=") ) {
+          this.advance();
+          const defaultExpr = this.parseExpr();
+          prop.init = defaultExpr;
+          prop.left = defaultExpr;
+        }
+        node.children.push(prop);
+      }
+    };
+    this.expectValue("}");
+    return node;
+  };
+  parseArrayPattern () {
+    const node = new TSNode();
+    node.nodeType = "ArrayPattern";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("[");
+    while ((this.matchValue("]") == false) && (this.isAtEnd() == false)) {
+      if ( (node.children.length) > 0 ) {
+        this.expectValue(",");
+        if ( this.matchValue("]") ) {
+          break;
+        }
+      }
+      if ( this.matchValue(",") ) {
+        const hole = new TSNode();
+        hole.nodeType = "Elision";
+        node.children.push(hole);
+      } else {
+        if ( this.matchValue("...") ) {
+          this.advance();
+          const restElem = new TSNode();
+          restElem.nodeType = "RestElement";
+          const restName = this.expect("Identifier");
+          restElem.name = restName.value;
+          node.children.push(restElem);
+        } else {
+          const elem = new TSNode();
+          const elemTok = this.expect("Identifier");
+          elem.nodeType = "Identifier";
+          elem.name = elemTok.value;
+          if ( this.matchValue("=") ) {
+            this.advance();
+            const defaultExpr = this.parseExpr();
+            const assignPat = new TSNode();
+            assignPat.nodeType = "AssignmentPattern";
+            assignPat.left = elem;
+            assignPat.right = defaultExpr;
+            node.children.push(assignPat);
+          } else {
+            node.children.push(elem);
+          }
+        }
+      }
+    };
+    this.expectValue("]");
+    return node;
+  };
+  parseFuncDecl (isAsync) {
+    const node = new TSNode();
+    node.nodeType = "FunctionDeclaration";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    if ( isAsync ) {
+      node.async = true;
+    }
+    this.expectValue("function");
+    if ( this.matchValue("*") ) {
+      this.advance();
+      node.generator = true;
+    }
+    const nameTok = this.expect("Identifier");
+    node.name = nameTok.value;
+    if ( this.matchValue("<") ) {
+      const typeParams = this.parseTypeParams();
+      for ( let i = 0; i < typeParams.length; i++) {
+        var tp = typeParams[i];
+        node.children.push(tp);
+      };
+    }
+    this.expectValue("(");
+    while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+      if ( (node.params.length) > 0 ) {
+        this.expectValue(",");
+      }
+      const param = this.parseParam();
+      node.params.push(param);
+    };
+    this.expectValue(")");
+    if ( this.matchValue(":") ) {
+      const returnType = this.parseTypeAnnotation();
+      node.typeAnnotation = returnType;
+    }
+    const body = this.parseBlock();
+    node.body = body;
+    return node;
+  };
+  parseParam () {
+    let decorators = [];
+    while (this.matchValue("@")) {
+      const dec = this.parseDecorator();
+      decorators.push(dec);
+    };
+    let isRest = false;
+    if ( this.matchValue("...") ) {
+      this.advance();
+      isRest = true;
+    }
+    if ( this.matchValue("{") ) {
+      const pattern = this.parseObjectPattern();
+      for ( let i = 0; i < decorators.length; i++) {
+        var d = decorators[i];
+        pattern.decorators.push(d);
+      };
+      if ( isRest ) {
+        const restElem = new TSNode();
+        restElem.nodeType = "RestElement";
+        restElem.left = pattern;
+        return restElem;
+      }
+      return pattern;
+    }
+    if ( this.matchValue("[") ) {
+      const pattern_1 = this.parseArrayPattern();
+      for ( let i_1 = 0; i_1 < decorators.length; i_1++) {
+        var d_1 = decorators[i_1];
+        pattern_1.decorators.push(d_1);
+      };
+      if ( isRest ) {
+        const restElem_1 = new TSNode();
+        restElem_1.nodeType = "RestElement";
+        restElem_1.left = pattern_1;
+        return restElem_1;
+      }
+      return pattern_1;
+    }
+    const param = new TSNode();
+    if ( isRest ) {
+      param.nodeType = "RestElement";
+      param.kind = "rest";
+    } else {
+      param.nodeType = "Parameter";
+    }
+    for ( let i_2 = 0; i_2 < decorators.length; i_2++) {
+      var d_2 = decorators[i_2];
+      param.decorators.push(d_2);
+    };
+    const nameTok = this.expect("Identifier");
+    param.name = nameTok.value;
+    param.start = nameTok.start;
+    param.line = nameTok.line;
+    param.col = nameTok.col;
+    if ( this.matchValue("?") ) {
+      param.optional = true;
+      this.advance();
+    }
+    if ( this.matchValue(":") ) {
+      const typeAnnot = this.parseTypeAnnotation();
+      param.typeAnnotation = typeAnnot;
+    }
+    if ( this.matchValue("=") ) {
+      this.advance();
+      param.init = this.parseExpr();
+    }
+    return param;
+  };
+  parseBlock () {
+    const block = new TSNode();
+    block.nodeType = "BlockStatement";
+    const startTok = this.peek();
+    block.start = startTok.start;
+    block.line = startTok.line;
+    block.col = startTok.col;
+    this.expectValue("{");
+    while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+      const stmt = this.parseStatement();
+      block.children.push(stmt);
+    };
+    this.expectValue("}");
+    return block;
+  };
+  parseExprStmt () {
+    const stmt = new TSNode();
+    stmt.nodeType = "ExpressionStatement";
+    const startTok = this.peek();
+    stmt.start = startTok.start;
+    stmt.line = startTok.line;
+    stmt.col = startTok.col;
+    const expr = this.parseExpr();
+    stmt.left = expr;
+    if ( this.matchValue(";") ) {
+      this.advance();
+    }
+    return stmt;
+  };
+  parseTypeAnnotation () {
+    const annot = new TSNode();
+    annot.nodeType = "TSTypeAnnotation";
+    const startTok = this.peek();
+    annot.start = startTok.start;
+    annot.line = startTok.line;
+    annot.col = startTok.col;
+    this.expectValue(":");
+    const nextVal = this.peekValue();
+    if ( nextVal == "asserts" ) {
+      const assertsTok = this.peek();
+      this.advance();
+      const predicate = new TSNode();
+      predicate.nodeType = "TSTypePredicate";
+      predicate.start = assertsTok.start;
+      predicate.line = assertsTok.line;
+      predicate.col = assertsTok.col;
+      predicate.value = "asserts";
+      const paramTok = this.expect("Identifier");
+      predicate.name = paramTok.value;
+      if ( this.matchValue("is") ) {
+        this.advance();
+        const assertType = this.parseType();
+        predicate.typeAnnotation = assertType;
+      }
+      annot.typeAnnotation = predicate;
+      return annot;
+    }
+    if ( this.matchType("Identifier") ) {
+      const savedPos = this.pos;
+      const savedTok = this.currentToken;
+      const paramTok_1 = this.peek();
+      this.advance();
+      if ( this.matchValue("is") ) {
+        this.advance();
+        const predicate_1 = new TSNode();
+        predicate_1.nodeType = "TSTypePredicate";
+        predicate_1.start = paramTok_1.start;
+        predicate_1.line = paramTok_1.line;
+        predicate_1.col = paramTok_1.col;
+        predicate_1.name = paramTok_1.value;
+        const typeExpr = this.parseType();
+        predicate_1.typeAnnotation = typeExpr;
+        annot.typeAnnotation = predicate_1;
+        return annot;
+      }
+      this.pos = savedPos;
+      this.currentToken = savedTok;
+    }
+    const typeExpr_1 = this.parseType();
+    annot.typeAnnotation = typeExpr_1;
+    return annot;
+  };
+  parseType () {
+    return this.parseConditionalType();
+  };
+  parseConditionalType () {
+    const checkType = this.parseUnionType();
+    if ( this.matchValue("extends") ) {
+      this.advance();
+      const extendsType = this.parseUnionType();
+      if ( this.matchValue("?") ) {
+        this.advance();
+        const conditional = new TSNode();
+        conditional.nodeType = "TSConditionalType";
+        conditional.start = checkType.start;
+        conditional.line = checkType.line;
+        conditional.col = checkType.col;
+        conditional.left = checkType;
+        conditional.params.push(extendsType);
+        conditional.body = this.parseUnionType();
+        this.expectValue(":");
+        conditional.right = this.parseUnionType();
+        return conditional;
+      }
+      return checkType;
+    }
+    return checkType;
+  };
+  parseUnionType () {
+    const left = this.parseIntersectionType();
+    if ( this.matchValue("|") ) {
+      const union = new TSNode();
+      union.nodeType = "TSUnionType";
+      union.start = left.start;
+      union.line = left.line;
+      union.col = left.col;
+      union.children.push(left);
+      while (this.matchValue("|")) {
+        this.advance();
+        const right = this.parseIntersectionType();
+        union.children.push(right);
+      };
+      return union;
+    }
+    return left;
+  };
+  parseIntersectionType () {
+    const left = this.parseArrayType();
+    if ( this.matchValue("&") ) {
+      const intersection = new TSNode();
+      intersection.nodeType = "TSIntersectionType";
+      intersection.start = left.start;
+      intersection.line = left.line;
+      intersection.col = left.col;
+      intersection.children.push(left);
+      while (this.matchValue("&")) {
+        this.advance();
+        const right = this.parseArrayType();
+        intersection.children.push(right);
+      };
+      return intersection;
+    }
+    return left;
+  };
+  parseArrayType () {
+    let elemType = this.parsePrimaryType();
+    while (this.matchValue("[")) {
+      if ( this.checkNext("]") ) {
+        this.advance();
+        this.advance();
+        const arrayType = new TSNode();
+        arrayType.nodeType = "TSArrayType";
+        arrayType.start = elemType.start;
+        arrayType.line = elemType.line;
+        arrayType.col = elemType.col;
+        arrayType.left = elemType;
+        elemType = arrayType;
+      } else {
+        this.advance();
+        const indexType = this.parseType();
+        this.expectValue("]");
+        const indexedAccess = new TSNode();
+        indexedAccess.nodeType = "TSIndexedAccessType";
+        indexedAccess.start = elemType.start;
+        indexedAccess.line = elemType.line;
+        indexedAccess.col = elemType.col;
+        indexedAccess.left = elemType;
+        indexedAccess.right = indexType;
+        elemType = indexedAccess;
+      }
+    };
+    return elemType;
+  };
+  checkNext (value) {
+    const nextPos = this.pos + 1;
+    if ( nextPos < (this.tokens.length) ) {
+      const nextTok = this.tokens[nextPos];
+      const v = nextTok.value;
+      return v == value;
+    }
+    return false;
+  };
+  parsePrimaryType () {
+    const tokVal = this.peekValue();
+    const tok = this.peek();
+    if ( tokVal == "keyof" ) {
+      this.advance();
+      const operand = this.parsePrimaryType();
+      const node = new TSNode();
+      node.nodeType = "TSTypeOperator";
+      node.value = "keyof";
+      node.start = tok.start;
+      node.line = tok.line;
+      node.col = tok.col;
+      node.typeAnnotation = operand;
+      return node;
+    }
+    if ( tokVal == "typeof" ) {
+      this.advance();
+      const operand_1 = this.parsePrimaryType();
+      const node_1 = new TSNode();
+      node_1.nodeType = "TSTypeQuery";
+      node_1.value = "typeof";
+      node_1.start = tok.start;
+      node_1.line = tok.line;
+      node_1.col = tok.col;
+      node_1.typeAnnotation = operand_1;
+      return node_1;
+    }
+    if ( tokVal == "infer" ) {
+      this.advance();
+      const paramTok = this.expect("Identifier");
+      const node_2 = new TSNode();
+      node_2.nodeType = "TSInferType";
+      node_2.start = tok.start;
+      node_2.line = tok.line;
+      node_2.col = tok.col;
+      const typeParam = new TSNode();
+      typeParam.nodeType = "TSTypeParameter";
+      typeParam.name = paramTok.value;
+      node_2.typeAnnotation = typeParam;
+      return node_2;
+    }
+    if ( tokVal == "string" ) {
+      this.advance();
+      const node_3 = new TSNode();
+      node_3.nodeType = "TSStringKeyword";
+      node_3.start = tok.start;
+      node_3.end = tok.end;
+      node_3.line = tok.line;
+      node_3.col = tok.col;
+      return node_3;
+    }
+    if ( tokVal == "number" ) {
+      this.advance();
+      const node_4 = new TSNode();
+      node_4.nodeType = "TSNumberKeyword";
+      node_4.start = tok.start;
+      node_4.end = tok.end;
+      node_4.line = tok.line;
+      node_4.col = tok.col;
+      return node_4;
+    }
+    if ( tokVal == "boolean" ) {
+      this.advance();
+      const node_5 = new TSNode();
+      node_5.nodeType = "TSBooleanKeyword";
+      node_5.start = tok.start;
+      node_5.end = tok.end;
+      node_5.line = tok.line;
+      node_5.col = tok.col;
+      return node_5;
+    }
+    if ( tokVal == "any" ) {
+      this.advance();
+      const node_6 = new TSNode();
+      node_6.nodeType = "TSAnyKeyword";
+      node_6.start = tok.start;
+      node_6.end = tok.end;
+      node_6.line = tok.line;
+      node_6.col = tok.col;
+      return node_6;
+    }
+    if ( tokVal == "unknown" ) {
+      this.advance();
+      const node_7 = new TSNode();
+      node_7.nodeType = "TSUnknownKeyword";
+      node_7.start = tok.start;
+      node_7.end = tok.end;
+      node_7.line = tok.line;
+      node_7.col = tok.col;
+      return node_7;
+    }
+    if ( tokVal == "object" ) {
+      this.advance();
+      const node_8 = new TSNode();
+      node_8.nodeType = "TSObjectKeyword";
+      node_8.start = tok.start;
+      node_8.end = tok.end;
+      node_8.line = tok.line;
+      node_8.col = tok.col;
+      return node_8;
+    }
+    if ( tokVal == "void" ) {
+      this.advance();
+      const node_9 = new TSNode();
+      node_9.nodeType = "TSVoidKeyword";
+      node_9.start = tok.start;
+      node_9.end = tok.end;
+      node_9.line = tok.line;
+      node_9.col = tok.col;
+      return node_9;
+    }
+    if ( tokVal == "null" ) {
+      this.advance();
+      const node_10 = new TSNode();
+      node_10.nodeType = "TSNullKeyword";
+      node_10.start = tok.start;
+      node_10.end = tok.end;
+      node_10.line = tok.line;
+      node_10.col = tok.col;
+      return node_10;
+    }
+    if ( tokVal == "never" ) {
+      this.advance();
+      const node_11 = new TSNode();
+      node_11.nodeType = "TSNeverKeyword";
+      node_11.start = tok.start;
+      node_11.end = tok.end;
+      node_11.line = tok.line;
+      node_11.col = tok.col;
+      return node_11;
+    }
+    if ( tokVal == "undefined" ) {
+      this.advance();
+      const node_12 = new TSNode();
+      node_12.nodeType = "TSUndefinedKeyword";
+      node_12.start = tok.start;
+      node_12.end = tok.end;
+      node_12.line = tok.line;
+      node_12.col = tok.col;
+      return node_12;
+    }
+    const tokType = this.peekType();
+    if ( tokType == "Identifier" ) {
+      return this.parseTypeRef();
+    }
+    if ( tokType == "String" ) {
+      this.advance();
+      const node_13 = new TSNode();
+      node_13.nodeType = "TSLiteralType";
+      node_13.start = tok.start;
+      node_13.end = tok.end;
+      node_13.line = tok.line;
+      node_13.col = tok.col;
+      node_13.value = tok.value;
+      node_13.kind = "string";
+      return node_13;
+    }
+    if ( tokType == "Number" ) {
+      this.advance();
+      const node_14 = new TSNode();
+      node_14.nodeType = "TSLiteralType";
+      node_14.start = tok.start;
+      node_14.end = tok.end;
+      node_14.line = tok.line;
+      node_14.col = tok.col;
+      node_14.value = tok.value;
+      node_14.kind = "number";
+      return node_14;
+    }
+    if ( (tokVal == "true") || (tokVal == "false") ) {
+      this.advance();
+      const node_15 = new TSNode();
+      node_15.nodeType = "TSLiteralType";
+      node_15.start = tok.start;
+      node_15.end = tok.end;
+      node_15.line = tok.line;
+      node_15.col = tok.col;
+      node_15.value = tokVal;
+      node_15.kind = "boolean";
+      return node_15;
+    }
+    if ( tokType == "Template" ) {
+      this.advance();
+      const node_16 = new TSNode();
+      node_16.nodeType = "TSTemplateLiteralType";
+      node_16.start = tok.start;
+      node_16.end = tok.end;
+      node_16.line = tok.line;
+      node_16.col = tok.col;
+      node_16.value = tok.value;
+      return node_16;
+    }
+    if ( tokVal == "new" ) {
+      return this.parseConstructorType();
+    }
+    if ( tokVal == "import" ) {
+      return this.parseImportType();
+    }
+    if ( tokVal == "(" ) {
+      return this.parseParenOrFunctionType();
+    }
+    if ( tokVal == "[" ) {
+      return this.parseTupleType();
+    }
+    if ( tokVal == "{" ) {
+      return this.parseTypeLiteral();
+    }
+    if ( this.quiet == false ) {
+      console.log("Unknown type: " + tokVal);
+    }
+    this.advance();
+    const errNode = new TSNode();
+    errNode.nodeType = "TSAnyKeyword";
+    return errNode;
+  };
+  parseTypeRef () {
+    const ref = new TSNode();
+    ref.nodeType = "TSTypeReference";
+    const tok = this.peek();
+    ref.start = tok.start;
+    ref.line = tok.line;
+    ref.col = tok.col;
+    const nameTok = this.expect("Identifier");
+    ref.name = nameTok.value;
+    if ( this.matchValue("<") ) {
+      this.advance();
+      while ((this.matchValue(">") == false) && (this.isAtEnd() == false)) {
+        if ( (ref.params.length) > 0 ) {
+          this.expectValue(",");
+        }
+        const typeArg = this.parseType();
+        ref.params.push(typeArg);
+      };
+      this.expectValue(">");
+    }
+    return ref;
+  };
+  parseTupleType () {
+    const tuple = new TSNode();
+    tuple.nodeType = "TSTupleType";
+    const startTok = this.peek();
+    tuple.start = startTok.start;
+    tuple.line = startTok.line;
+    tuple.col = startTok.col;
+    this.expectValue("[");
+    while ((this.matchValue("]") == false) && (this.isAtEnd() == false)) {
+      if ( (tuple.children.length) > 0 ) {
+        this.expectValue(",");
+      }
+      if ( this.matchValue("...") ) {
+        const restTok = this.peek();
+        this.advance();
+        let restName = "";
+        if ( this.matchType("Identifier") ) {
+          const savedPos = this.pos;
+          const savedTok = this.currentToken;
+          const nameTok = this.peek();
+          this.advance();
+          if ( this.matchValue(":") ) {
+            restName = nameTok.value;
+            this.advance();
+          } else {
+            this.pos = savedPos;
+            this.currentToken = savedTok;
+          }
+        }
+        const innerType = this.parseType();
+        const restType = new TSNode();
+        restType.nodeType = "TSRestType";
+        restType.start = restTok.start;
+        restType.line = restTok.line;
+        restType.col = restTok.col;
+        restType.typeAnnotation = innerType;
+        if ( restName != "" ) {
+          restType.name = restName;
+        }
+        tuple.children.push(restType);
+      } else {
+        let isNamed = false;
+        let elemName = "";
+        let elemOptional = false;
+        const elemStart = this.peek();
+        if ( this.matchType("Identifier") ) {
+          const savedPos_1 = this.pos;
+          const savedTok_1 = this.currentToken;
+          const nameTok_1 = this.peek();
+          this.advance();
+          if ( this.matchValue("?") ) {
+            this.advance();
+            elemOptional = true;
+          }
+          if ( this.matchValue(":") ) {
+            isNamed = true;
+            elemName = nameTok_1.value;
+            this.advance();
+          } else {
+            this.pos = savedPos_1;
+            this.currentToken = savedTok_1;
+            elemOptional = false;
+          }
+        }
+        const elemType = this.parseType();
+        if ( isNamed ) {
+          const namedElem = new TSNode();
+          namedElem.nodeType = "TSNamedTupleMember";
+          namedElem.start = elemStart.start;
+          namedElem.line = elemStart.line;
+          namedElem.col = elemStart.col;
+          namedElem.name = elemName;
+          namedElem.optional = elemOptional;
+          namedElem.typeAnnotation = elemType;
+          tuple.children.push(namedElem);
+        } else {
+          if ( this.matchValue("?") ) {
+            this.advance();
+            const optType = new TSNode();
+            optType.nodeType = "TSOptionalType";
+            optType.start = elemType.start;
+            optType.line = elemType.line;
+            optType.col = elemType.col;
+            optType.typeAnnotation = elemType;
+            tuple.children.push(optType);
+          } else {
+            tuple.children.push(elemType);
+          }
+        }
+      }
+    };
+    this.expectValue("]");
+    return tuple;
+  };
+  parseParenOrFunctionType () {
+    const startTok = this.peek();
+    const startPos = startTok.start;
+    const startLine = startTok.line;
+    const startCol = startTok.col;
+    this.expectValue("(");
+    if ( this.matchValue(")") ) {
+      this.advance();
+      if ( this.matchValue("=>") ) {
+        this.advance();
+        const returnType = this.parseType();
+        const funcType = new TSNode();
+        funcType.nodeType = "TSFunctionType";
+        funcType.start = startPos;
+        funcType.line = startLine;
+        funcType.col = startCol;
+        funcType.typeAnnotation = returnType;
+        return funcType;
+      }
+      const voidNode = new TSNode();
+      voidNode.nodeType = "TSVoidKeyword";
+      return voidNode;
+    }
+    const isIdentifier = this.matchType("Identifier");
+    if ( isIdentifier ) {
+      const savedPos = this.pos;
+      const savedToken = this.currentToken;
+      this.advance();
+      if ( this.matchValue(":") || this.matchValue("?") ) {
+        this.pos = savedPos;
+        this.currentToken = savedToken;
+        return this.parseFunctionType(startPos, startLine, startCol);
+      }
+      if ( this.matchValue(",") ) {
+        const savedPos2 = this.pos;
+        const savedToken2 = this.currentToken;
+        let depth = 1;
+        while ((depth > 0) && (this.isAtEnd() == false)) {
+          if ( this.matchValue("(") ) {
+            depth = depth + 1;
+          }
+          if ( this.matchValue(")") ) {
+            depth = depth - 1;
+          }
+          if ( depth > 0 ) {
+            this.advance();
+          }
+        };
+        if ( this.matchValue(")") ) {
+          this.advance();
+          if ( this.matchValue("=>") ) {
+            this.pos = savedPos;
+            this.currentToken = savedToken;
+            return this.parseFunctionType(startPos, startLine, startCol);
+          }
+        }
+        this.pos = savedPos;
+        this.currentToken = savedToken;
+      }
+      this.pos = savedPos;
+      this.currentToken = savedToken;
+    }
+    const innerType = this.parseType();
+    this.expectValue(")");
+    if ( this.matchValue("=>") ) {
+      this.advance();
+      const returnType_1 = this.parseType();
+      const funcType_1 = new TSNode();
+      funcType_1.nodeType = "TSFunctionType";
+      funcType_1.start = startPos;
+      funcType_1.line = startLine;
+      funcType_1.col = startCol;
+      funcType_1.typeAnnotation = returnType_1;
+      return funcType_1;
+    }
+    return innerType;
+  };
+  parseFunctionType (startPos, startLine, startCol) {
+    const funcType = new TSNode();
+    funcType.nodeType = "TSFunctionType";
+    funcType.start = startPos;
+    funcType.line = startLine;
+    funcType.col = startCol;
+    while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+      if ( (funcType.params.length) > 0 ) {
+        this.expectValue(",");
+      }
+      const param = new TSNode();
+      param.nodeType = "Parameter";
+      const nameTok = this.expect("Identifier");
+      param.name = nameTok.value;
+      param.start = nameTok.start;
+      param.line = nameTok.line;
+      param.col = nameTok.col;
+      if ( this.matchValue("?") ) {
+        param.optional = true;
+        this.advance();
+      }
+      if ( this.matchValue(":") ) {
+        const typeAnnot = this.parseTypeAnnotation();
+        param.typeAnnotation = typeAnnot;
+      }
+      funcType.params.push(param);
+    };
+    this.expectValue(")");
+    if ( this.matchValue("=>") ) {
+      this.advance();
+      const returnType = this.parseType();
+      funcType.typeAnnotation = returnType;
+    }
+    return funcType;
+  };
+  parseConstructorType () {
+    const ctorType = new TSNode();
+    ctorType.nodeType = "TSConstructorType";
+    const startTok = this.peek();
+    ctorType.start = startTok.start;
+    ctorType.line = startTok.line;
+    ctorType.col = startTok.col;
+    this.expectValue("new");
+    if ( this.matchValue("<") ) {
+      const typeParams = this.parseTypeParams();
+      ctorType.children = typeParams;
+    }
+    this.expectValue("(");
+    while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+      if ( (ctorType.params.length) > 0 ) {
+        this.expectValue(",");
+      }
+      const param = this.parseParam();
+      ctorType.params.push(param);
+    };
+    this.expectValue(")");
+    if ( this.matchValue("=>") ) {
+      this.advance();
+      const returnType = this.parseType();
+      ctorType.typeAnnotation = returnType;
+    }
+    return ctorType;
+  };
+  parseImportType () {
+    const importType = new TSNode();
+    importType.nodeType = "TSImportType";
+    const startTok = this.peek();
+    importType.start = startTok.start;
+    importType.line = startTok.line;
+    importType.col = startTok.col;
+    this.expectValue("import");
+    this.expectValue("(");
+    const sourceTok = this.expect("String");
+    importType.value = sourceTok.value;
+    this.expectValue(")");
+    if ( this.matchValue(".") ) {
+      this.advance();
+      const memberTok = this.expect("Identifier");
+      importType.name = memberTok.value;
+      if ( this.matchValue("<") ) {
+        this.advance();
+        while ((this.matchValue(">") == false) && (this.isAtEnd() == false)) {
+          if ( (importType.params.length) > 0 ) {
+            this.expectValue(",");
+          }
+          const typeArg = this.parseType();
+          importType.params.push(typeArg);
+        };
+        this.expectValue(">");
+      }
+    }
+    return importType;
+  };
+  parseTypeLiteral () {
+    const literal = new TSNode();
+    literal.nodeType = "TSTypeLiteral";
+    const startTok = this.peek();
+    literal.start = startTok.start;
+    literal.line = startTok.line;
+    literal.col = startTok.col;
+    this.expectValue("{");
+    while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+      const member = this.parseTypeLiteralMember();
+      literal.children.push(member);
+      if ( this.matchValue(";") || this.matchValue(",") ) {
+        this.advance();
+      }
+    };
+    this.expectValue("}");
+    return literal;
+  };
+  parseTypeLiteralMember () {
+    const startTok = this.peek();
+    const startPos = startTok.start;
+    const startLine = startTok.line;
+    const startCol = startTok.col;
+    let isReadonly = false;
+    if ( this.matchValue("readonly") ) {
+      isReadonly = true;
+      this.advance();
+    }
+    let readonlyModifier = "";
+    if ( this.matchValue("+") || this.matchValue("-") ) {
+      readonlyModifier = this.peekValue();
+      this.advance();
+      if ( this.matchValue("readonly") ) {
+        isReadonly = true;
+        this.advance();
+      }
+    }
+    if ( this.matchValue("[") ) {
+      this.advance();
+      const paramName = this.expect("Identifier");
+      if ( this.matchValue("in") ) {
+        return this.parseMappedType(isReadonly, readonlyModifier, paramName.value, startPos, startLine, startCol);
+      }
+      return this.parseIndexSignatureRest(isReadonly, paramName, startPos, startLine, startCol);
+    }
+    const nameTok = this.expect("Identifier");
+    const memberName = nameTok.value;
+    let isOptional = false;
+    if ( this.matchValue("?") ) {
+      isOptional = true;
+      this.advance();
+    }
+    if ( this.matchValue("(") ) {
+      return this.parseMethodSignature(memberName, isOptional, startPos, startLine, startCol);
+    }
+    const prop = new TSNode();
+    prop.nodeType = "TSPropertySignature";
+    prop.start = startPos;
+    prop.line = startLine;
+    prop.col = startCol;
+    prop.name = memberName;
+    prop.readonly = isReadonly;
+    prop.optional = isOptional;
+    if ( this.matchValue(":") ) {
+      const typeAnnot = this.parseTypeAnnotation();
+      prop.typeAnnotation = typeAnnot;
+    }
+    return prop;
+  };
+  parseMappedType (isReadonly, readonlyMod, paramName, startPos, startLine, startCol) {
+    const mapped = new TSNode();
+    mapped.nodeType = "TSMappedType";
+    mapped.start = startPos;
+    mapped.line = startLine;
+    mapped.col = startCol;
+    mapped.readonly = isReadonly;
+    if ( readonlyMod != "" ) {
+      mapped.kind = readonlyMod;
+    }
+    this.expectValue("in");
+    const typeParam = new TSNode();
+    typeParam.nodeType = "TSTypeParameter";
+    typeParam.name = paramName;
+    const constraint = this.parseType();
+    typeParam.typeAnnotation = constraint;
+    mapped.params.push(typeParam);
+    if ( this.matchValue("as") ) {
+      this.advance();
+      const nameType = this.parseType();
+      mapped.right = nameType;
+    }
+    this.expectValue("]");
+    let optionalMod = "";
+    if ( this.matchValue("+") || this.matchValue("-") ) {
+      optionalMod = this.peekValue();
+      this.advance();
+    }
+    if ( this.matchValue("?") ) {
+      mapped.optional = true;
+      if ( optionalMod != "" ) {
+        mapped.value = optionalMod;
+      }
+      this.advance();
+    }
+    if ( this.matchValue(":") ) {
+      this.advance();
+      const valueType = this.parseType();
+      mapped.typeAnnotation = valueType;
+    }
+    return mapped;
+  };
+  parseIndexSignatureRest (isReadonly, paramTok, startPos, startLine, startCol) {
+    const indexSig = new TSNode();
+    indexSig.nodeType = "TSIndexSignature";
+    indexSig.start = startPos;
+    indexSig.line = startLine;
+    indexSig.col = startCol;
+    indexSig.readonly = isReadonly;
+    const param = new TSNode();
+    param.nodeType = "Parameter";
+    param.name = paramTok.value;
+    param.start = paramTok.start;
+    param.line = paramTok.line;
+    param.col = paramTok.col;
+    if ( this.matchValue(":") ) {
+      const typeAnnot = this.parseTypeAnnotation();
+      param.typeAnnotation = typeAnnot;
+    }
+    indexSig.params.push(param);
+    this.expectValue("]");
+    if ( this.matchValue(":") ) {
+      const typeAnnot_1 = this.parseTypeAnnotation();
+      indexSig.typeAnnotation = typeAnnot_1;
+    }
+    return indexSig;
+  };
+  parseMethodSignature (methodName, isOptional, startPos, startLine, startCol) {
+    const method = new TSNode();
+    method.nodeType = "TSMethodSignature";
+    method.start = startPos;
+    method.line = startLine;
+    method.col = startCol;
+    method.name = methodName;
+    method.optional = isOptional;
+    this.expectValue("(");
+    while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+      if ( (method.params.length) > 0 ) {
+        this.expectValue(",");
+      }
+      const param = this.parseParam();
+      method.params.push(param);
+    };
+    this.expectValue(")");
+    if ( this.matchValue(":") ) {
+      const returnType = this.parseTypeAnnotation();
+      method.typeAnnotation = returnType;
+    }
+    return method;
+  };
+  parseExpr () {
+    return this.parseAssign();
+  };
+  parseAssign () {
+    const left = this.parseNullishCoalescing();
+    const tokVal = this.peekValue();
+    if ( tokVal == "=" ) {
+      this.advance();
+      const right = this.parseAssign();
+      const assign = new TSNode();
+      assign.nodeType = "AssignmentExpression";
+      assign.value = "=";
+      assign.left = left;
+      assign.right = right;
+      assign.start = left.start;
+      assign.line = left.line;
+      assign.col = left.col;
+      return assign;
+    }
+    if ( ((((tokVal == "+=") || (tokVal == "-=")) || (tokVal == "*=")) || (tokVal == "/=")) || (tokVal == "%=") ) {
+      this.advance();
+      const right_1 = this.parseAssign();
+      const assign_1 = new TSNode();
+      assign_1.nodeType = "AssignmentExpression";
+      assign_1.value = tokVal;
+      assign_1.left = left;
+      assign_1.right = right_1;
+      assign_1.start = left.start;
+      assign_1.line = left.line;
+      assign_1.col = left.col;
+      return assign_1;
+    }
+    if ( ((tokVal == "&&=") || (tokVal == "||=")) || (tokVal == "??=") ) {
+      this.advance();
+      const right_2 = this.parseAssign();
+      const assign_2 = new TSNode();
+      assign_2.nodeType = "AssignmentExpression";
+      assign_2.value = tokVal;
+      assign_2.left = left;
+      assign_2.right = right_2;
+      assign_2.start = left.start;
+      assign_2.line = left.line;
+      assign_2.col = left.col;
+      return assign_2;
+    }
+    return left;
+  };
+  parseNullishCoalescing () {
+    let left = this.parseTernary();
+    while (this.matchValue("??")) {
+      this.advance();
+      const right = this.parseTernary();
+      const nullish = new TSNode();
+      nullish.nodeType = "LogicalExpression";
+      nullish.value = "??";
+      nullish.left = left;
+      nullish.right = right;
+      nullish.start = left.start;
+      nullish.line = left.line;
+      nullish.col = left.col;
+      left = nullish;
+    };
+    return left;
+  };
+  parseTernary () {
+    const testExpr = this.parseLogicalOr();
+    if ( this.matchValue("?") ) {
+      this.advance();
+      const consequentExpr = this.parseAssign();
+      if ( this.matchValue(":") ) {
+        this.advance();
+        const alternateExpr = this.parseAssign();
+        const cond = new TSNode();
+        cond.nodeType = "ConditionalExpression";
+        cond.start = testExpr.start;
+        cond.line = testExpr.line;
+        cond.col = testExpr.col;
+        cond.left = testExpr;
+        cond.test = testExpr;
+        cond.consequent = consequentExpr;
+        cond.alternate = alternateExpr;
+        return cond;
+      }
+    }
+    return testExpr;
+  };
+  parseLogicalOr () {
+    let left = this.parseLogicalAnd();
+    while (this.matchValue("||")) {
+      this.advance();
+      const right = this.parseLogicalAnd();
+      const expr = new TSNode();
+      expr.nodeType = "BinaryExpression";
+      expr.value = "||";
+      expr.left = left;
+      expr.right = right;
+      expr.start = left.start;
+      expr.line = left.line;
+      expr.col = left.col;
+      left = expr;
+    };
+    return left;
+  };
+  parseLogicalAnd () {
+    let left = this.parseBitwiseOr();
+    while (this.matchValue("&&")) {
+      this.advance();
+      const right = this.parseBitwiseOr();
+      const expr = new TSNode();
+      expr.nodeType = "BinaryExpression";
+      expr.value = "&&";
+      expr.left = left;
+      expr.right = right;
+      expr.start = left.start;
+      expr.line = left.line;
+      expr.col = left.col;
+      left = expr;
+    };
+    return left;
+  };
+  parseBitwiseOr () {
+    let left = this.parseBitwiseXor();
+    while (this.matchValue("|")) {
+      this.advance();
+      const right = this.parseBitwiseXor();
+      const expr = new TSNode();
+      expr.nodeType = "BinaryExpression";
+      expr.value = "|";
+      expr.left = left;
+      expr.right = right;
+      expr.start = left.start;
+      expr.line = left.line;
+      expr.col = left.col;
+      left = expr;
+    };
+    return left;
+  };
+  parseBitwiseXor () {
+    let left = this.parseBitwiseAnd();
+    while (this.matchValue("^")) {
+      this.advance();
+      const right = this.parseBitwiseAnd();
+      const expr = new TSNode();
+      expr.nodeType = "BinaryExpression";
+      expr.value = "^";
+      expr.left = left;
+      expr.right = right;
+      expr.start = left.start;
+      expr.line = left.line;
+      expr.col = left.col;
+      left = expr;
+    };
+    return left;
+  };
+  parseBitwiseAnd () {
+    let left = this.parseEquality();
+    while (this.matchValue("&")) {
+      this.advance();
+      const right = this.parseEquality();
+      const expr = new TSNode();
+      expr.nodeType = "BinaryExpression";
+      expr.value = "&";
+      expr.left = left;
+      expr.right = right;
+      expr.start = left.start;
+      expr.line = left.line;
+      expr.col = left.col;
+      left = expr;
+    };
+    return left;
+  };
+  parseEquality () {
+    let left = this.parseComparison();
+    let tokVal = this.peekValue();
+    while ((((tokVal == "==") || (tokVal == "!=")) || (tokVal == "===")) || (tokVal == "!==")) {
+      const opTok = this.peek();
+      this.advance();
+      const right = this.parseComparison();
+      const expr = new TSNode();
+      expr.nodeType = "BinaryExpression";
+      expr.value = opTok.value;
+      expr.left = left;
+      expr.right = right;
+      expr.start = left.start;
+      expr.line = left.line;
+      expr.col = left.col;
+      left = expr;
+      tokVal = this.peekValue();
+    };
+    return left;
+  };
+  parseComparison () {
+    let left = this.parseAdditive();
+    let tokVal = this.peekValue();
+    while ((((tokVal == "<") || (tokVal == ">")) || (tokVal == "<=")) || (tokVal == ">=")) {
+      if ( tokVal == "<" ) {
+        if ( this.tsxMode == true ) {
+          if ( left.nodeType == "Identifier" ) {
+            if ( this.startsWithLowerCase(left.name) ) {
+              if ( this.looksLikeGenericCall() ) {
+                return left;
+              }
+            }
+          }
+        }
+      }
+      const opTok = this.peek();
+      this.advance();
+      const right = this.parseAdditive();
+      const expr = new TSNode();
+      expr.nodeType = "BinaryExpression";
+      expr.value = opTok.value;
+      expr.left = left;
+      expr.right = right;
+      expr.start = left.start;
+      expr.line = left.line;
+      expr.col = left.col;
+      left = expr;
+      tokVal = this.peekValue();
+    };
+    return left;
+  };
+  parseAdditive () {
+    let left = this.parseMultiplicative();
+    let tokVal = this.peekValue();
+    while ((tokVal == "+") || (tokVal == "-")) {
+      const opTok = this.peek();
+      this.advance();
+      const right = this.parseMultiplicative();
+      const binExpr = new TSNode();
+      binExpr.nodeType = "BinaryExpression";
+      binExpr.value = opTok.value;
+      binExpr.left = left;
+      binExpr.right = right;
+      binExpr.start = left.start;
+      binExpr.line = left.line;
+      binExpr.col = left.col;
+      left = binExpr;
+      tokVal = this.peekValue();
+    };
+    return left;
+  };
+  parseMultiplicative () {
+    let left = this.parseUnary();
+    let tokVal = this.peekValue();
+    while ((((tokVal == "*") || (tokVal == "/")) || (tokVal == "%")) || (tokVal == "**")) {
+      const opTok = this.peek();
+      this.advance();
+      const right = this.parseUnary();
+      const binExpr = new TSNode();
+      binExpr.nodeType = "BinaryExpression";
+      binExpr.value = opTok.value;
+      binExpr.left = left;
+      binExpr.right = right;
+      binExpr.start = left.start;
+      binExpr.line = left.line;
+      binExpr.col = left.col;
+      left = binExpr;
+      tokVal = this.peekValue();
+    };
+    return left;
+  };
+  parseUnary () {
+    const tokVal = this.peekValue();
+    if ( (tokVal == "++") || (tokVal == "--") ) {
+      const opTok = this.peek();
+      this.advance();
+      const arg = this.parseUnary();
+      const update = new TSNode();
+      update.nodeType = "UpdateExpression";
+      update.value = opTok.value;
+      update.left = arg;
+      update.prefix = true;
+      update.start = opTok.start;
+      update.line = opTok.line;
+      update.col = opTok.col;
+      return update;
+    }
+    if ( ((tokVal == "!") || (tokVal == "-")) || (tokVal == "+") ) {
+      const opTok_1 = this.peek();
+      this.advance();
+      const arg_1 = this.parseUnary();
+      const unary = new TSNode();
+      unary.nodeType = "UnaryExpression";
+      unary.value = opTok_1.value;
+      unary.left = arg_1;
+      unary.start = opTok_1.start;
+      unary.line = opTok_1.line;
+      unary.col = opTok_1.col;
+      return unary;
+    }
+    if ( tokVal == "typeof" ) {
+      const opTok_2 = this.peek();
+      this.advance();
+      const arg_2 = this.parseUnary();
+      const unary_1 = new TSNode();
+      unary_1.nodeType = "UnaryExpression";
+      unary_1.value = "typeof";
+      unary_1.left = arg_2;
+      unary_1.start = opTok_2.start;
+      unary_1.line = opTok_2.line;
+      unary_1.col = opTok_2.col;
+      return unary_1;
+    }
+    if ( tokVal == "yield" ) {
+      const yieldTok = this.peek();
+      this.advance();
+      const yieldExpr = new TSNode();
+      yieldExpr.nodeType = "YieldExpression";
+      yieldExpr.start = yieldTok.start;
+      yieldExpr.line = yieldTok.line;
+      yieldExpr.col = yieldTok.col;
+      if ( this.matchValue("*") ) {
+        this.advance();
+        yieldExpr.delegate = true;
+      }
+      const nextVal = this.peekValue();
+      if ( (((nextVal != ";") && (nextVal != "}")) && (nextVal != ",")) && (nextVal != ")") ) {
+        yieldExpr.left = this.parseAssign();
+      }
+      return yieldExpr;
+    }
+    if ( tokVal == "await" ) {
+      const awaitTok = this.peek();
+      this.advance();
+      const arg_3 = this.parseUnary();
+      const awaitExpr = new TSNode();
+      awaitExpr.nodeType = "AwaitExpression";
+      awaitExpr.left = arg_3;
+      awaitExpr.start = awaitTok.start;
+      awaitExpr.line = awaitTok.line;
+      awaitExpr.col = awaitTok.col;
+      return awaitExpr;
+    }
+    if ( tokVal == "<" ) {
+      if ( this.tsxMode == true ) {
+        const peekNext = this.peekNextValue();
+        const peekNextT = this.peekNextType();
+        if ( peekNext == ">" ) {
+          return this.parsePostfix();
+        }
+        if ( peekNextT == "Identifier" ) {
+          const peekTwoAhead = this.peekAheadValue(2);
+          if ( peekTwoAhead != "extends" ) {
+            return this.parsePostfix();
+          }
+        }
+      }
+      const startTok = this.peek();
+      this.advance();
+      const nextType = this.peekType();
+      if ( ((nextType == "Identifier") || (nextType == "Keyword")) || (nextType == "TSType") ) {
+        const typeNode = this.parseType();
+        if ( this.matchValue(">") ) {
+          this.advance();
+          const arg_4 = this.parseUnary();
+          const assertion = new TSNode();
+          assertion.nodeType = "TSTypeAssertion";
+          assertion.typeAnnotation = typeNode;
+          assertion.left = arg_4;
+          assertion.start = startTok.start;
+          assertion.line = startTok.line;
+          assertion.col = startTok.col;
+          return assertion;
+        }
+      }
+    }
+    return this.parsePostfix();
+  };
+  parsePostfix () {
+    let expr = this.parsePrimary();
+    let keepParsing = true;
+    while (keepParsing) {
+      let tokVal = this.peekValue();
+      if ( tokVal == "<" ) {
+        let shouldParseAsGenericCall = false;
+        if ( this.tsxMode == false ) {
+          const next1 = this.peekAheadValue(1);
+          const next2 = this.peekAheadValue(2);
+          if ( ((next2 == ">") || (next2 == ",")) || (next2 == "extends") ) {
+            shouldParseAsGenericCall = true;
+          }
+        } else {
+          if ( expr.nodeType == "Identifier" ) {
+            if ( this.startsWithLowerCase(expr.name) ) {
+              if ( this.looksLikeGenericCall() ) {
+                shouldParseAsGenericCall = true;
+              }
+            }
+          }
+          if ( expr.nodeType == "MemberExpression" ) {
+            if ( this.looksLikeGenericCall() ) {
+              shouldParseAsGenericCall = true;
+            }
+          }
+        }
+        if ( shouldParseAsGenericCall ) {
+          this.advance();
+          const call = new TSNode();
+          call.nodeType = "CallExpression";
+          call.left = expr;
+          call.start = expr.start;
+          call.line = expr.line;
+          call.col = expr.col;
+          while ((this.matchValue(">") == false) && (this.isAtEnd() == false)) {
+            if ( (call.params.length) > 0 ) {
+              this.expectValue(",");
+            }
+            const typeArg = this.parseType();
+            call.params.push(typeArg);
+          };
+          this.expectValue(">");
+          if ( this.matchValue("(") ) {
+            this.advance();
+            while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+              if ( (call.children.length) > 0 ) {
+                this.expectValue(",");
+              }
+              if ( this.matchValue("...") ) {
+                this.advance();
+                const spreadArg = this.parseExpr();
+                const spread = new TSNode();
+                spread.nodeType = "SpreadElement";
+                spread.left = spreadArg;
+                call.children.push(spread);
+              } else {
+                const arg = this.parseExpr();
+                call.children.push(arg);
+              }
+            };
+            this.expectValue(")");
+            expr = call;
+          }
+        }
+      }
+      tokVal = this.peekValue();
+      if ( tokVal == "(" ) {
+        this.advance();
+        const call_1 = new TSNode();
+        call_1.nodeType = "CallExpression";
+        call_1.left = expr;
+        call_1.start = expr.start;
+        call_1.line = expr.line;
+        call_1.col = expr.col;
+        while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+          if ( (call_1.children.length) > 0 ) {
+            this.expectValue(",");
+          }
+          if ( this.matchValue("...") ) {
+            this.advance();
+            const spreadArg_1 = this.parseExpr();
+            const spread_1 = new TSNode();
+            spread_1.nodeType = "SpreadElement";
+            spread_1.left = spreadArg_1;
+            call_1.children.push(spread_1);
+          } else {
+            const arg_1 = this.parseExpr();
+            call_1.children.push(arg_1);
+          }
+        };
+        this.expectValue(")");
+        expr = call_1;
+      }
+      if ( tokVal == "." ) {
+        this.advance();
+        const propTok = this.expect("Identifier");
+        const member = new TSNode();
+        member.nodeType = "MemberExpression";
+        member.left = expr;
+        member.name = propTok.value;
+        member.start = expr.start;
+        member.line = expr.line;
+        member.col = expr.col;
+        expr = member;
+      }
+      if ( tokVal == "?." ) {
+        this.advance();
+        const nextTokVal = this.peekValue();
+        if ( nextTokVal == "(" ) {
+          this.advance();
+          const optCall = new TSNode();
+          optCall.nodeType = "OptionalCallExpression";
+          optCall.optional = true;
+          optCall.left = expr;
+          optCall.start = expr.start;
+          optCall.line = expr.line;
+          optCall.col = expr.col;
+          while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+            if ( (optCall.children.length) > 0 ) {
+              this.expectValue(",");
+            }
+            const arg_2 = this.parseExpr();
+            optCall.children.push(arg_2);
+          };
+          this.expectValue(")");
+          expr = optCall;
+        }
+        if ( nextTokVal == "[" ) {
+          this.advance();
+          const indexExpr = this.parseExpr();
+          this.expectValue("]");
+          const optIndex = new TSNode();
+          optIndex.nodeType = "OptionalMemberExpression";
+          optIndex.optional = true;
+          optIndex.left = expr;
+          optIndex.right = indexExpr;
+          optIndex.start = expr.start;
+          optIndex.line = expr.line;
+          optIndex.col = expr.col;
+          expr = optIndex;
+        }
+        if ( this.matchType("Identifier") ) {
+          const propTok_1 = this.expect("Identifier");
+          const optMember = new TSNode();
+          optMember.nodeType = "OptionalMemberExpression";
+          optMember.optional = true;
+          optMember.left = expr;
+          optMember.name = propTok_1.value;
+          optMember.start = expr.start;
+          optMember.line = expr.line;
+          optMember.col = expr.col;
+          expr = optMember;
+        }
+      }
+      if ( tokVal == "[" ) {
+        this.advance();
+        const indexExpr_1 = this.parseExpr();
+        this.expectValue("]");
+        const computed = new TSNode();
+        computed.nodeType = "MemberExpression";
+        computed.computed = true;
+        computed.left = expr;
+        computed.right = indexExpr_1;
+        computed.start = expr.start;
+        computed.line = expr.line;
+        computed.col = expr.col;
+        expr = computed;
+      }
+      if ( tokVal == "!" ) {
+        const tok = this.peek();
+        this.advance();
+        const nonNull = new TSNode();
+        nonNull.nodeType = "TSNonNullExpression";
+        nonNull.left = expr;
+        nonNull.start = expr.start;
+        nonNull.line = expr.line;
+        nonNull.col = tok.col;
+        expr = nonNull;
+      }
+      if ( tokVal == "as" ) {
+        this.advance();
+        const asType = this.parseType();
+        const assertion = new TSNode();
+        assertion.nodeType = "TSAsExpression";
+        assertion.left = expr;
+        assertion.typeAnnotation = asType;
+        assertion.start = expr.start;
+        assertion.line = expr.line;
+        assertion.col = expr.col;
+        expr = assertion;
+      }
+      if ( tokVal == "satisfies" ) {
+        this.advance();
+        const satisfiesType = this.parseType();
+        const satisfiesExpr = new TSNode();
+        satisfiesExpr.nodeType = "TSSatisfiesExpression";
+        satisfiesExpr.left = expr;
+        satisfiesExpr.typeAnnotation = satisfiesType;
+        satisfiesExpr.start = expr.start;
+        satisfiesExpr.line = expr.line;
+        satisfiesExpr.col = expr.col;
+        expr = satisfiesExpr;
+      }
+      const tokType = this.peekType();
+      if ( tokType == "Template" ) {
+        const quasi = this.parseTemplateLiteral();
+        const tagged = new TSNode();
+        tagged.nodeType = "TaggedTemplateExpression";
+        tagged.left = expr;
+        tagged.right = quasi;
+        tagged.start = expr.start;
+        tagged.line = expr.line;
+        tagged.col = expr.col;
+        expr = tagged;
+      }
+      if ( (tokVal == "++") || (tokVal == "--") ) {
+        const opTok = this.peek();
+        this.advance();
+        const update = new TSNode();
+        update.nodeType = "UpdateExpression";
+        update.value = opTok.value;
+        update.left = expr;
+        update.prefix = false;
+        update.start = expr.start;
+        update.line = expr.line;
+        update.col = expr.col;
+        expr = update;
+      }
+      const newTokVal = this.peekValue();
+      const newTokType = this.peekType();
+      if ( (((((((((newTokVal != "(") && (newTokVal != ".")) && (newTokVal != "?.")) && (newTokVal != "[")) && (newTokVal != "!")) && (newTokVal != "as")) && (newTokVal != "satisfies")) && (newTokVal != "++")) && (newTokVal != "--")) && (newTokType != "Template") ) {
+        keepParsing = false;
+      }
+    };
+    return expr;
+  };
+  parsePrimary () {
+    const tokType = this.peekType();
+    const tokVal = this.peekValue();
+    const tok = this.peek();
+    if ( (tokType == "Identifier") || (tokType == "TSType") ) {
+      this.advance();
+      const id = new TSNode();
+      id.nodeType = "Identifier";
+      id.name = tok.value;
+      id.start = tok.start;
+      id.end = tok.end;
+      id.line = tok.line;
+      id.col = tok.col;
+      return id;
+    }
+    if ( tokType == "Number" ) {
+      this.advance();
+      const num = new TSNode();
+      num.nodeType = "NumericLiteral";
+      num.value = tok.value;
+      num.start = tok.start;
+      num.end = tok.end;
+      num.line = tok.line;
+      num.col = tok.col;
+      return num;
+    }
+    if ( tokType == "BigInt" ) {
+      this.advance();
+      const bigint = new TSNode();
+      bigint.nodeType = "BigIntLiteral";
+      bigint.value = tok.value;
+      bigint.start = tok.start;
+      bigint.end = tok.end;
+      bigint.line = tok.line;
+      bigint.col = tok.col;
+      return bigint;
+    }
+    if ( tokType == "String" ) {
+      this.advance();
+      const str = new TSNode();
+      str.nodeType = "StringLiteral";
+      str.value = tok.value;
+      str.start = tok.start;
+      str.end = tok.end;
+      str.line = tok.line;
+      str.col = tok.col;
+      return str;
+    }
+    if ( tokType == "Template" ) {
+      return this.parseTemplateLiteral();
+    }
+    if ( (tokVal == "true") || (tokVal == "false") ) {
+      this.advance();
+      const bool = new TSNode();
+      bool.nodeType = "BooleanLiteral";
+      bool.value = tokVal;
+      bool.start = tok.start;
+      bool.end = tok.end;
+      bool.line = tok.line;
+      bool.col = tok.col;
+      return bool;
+    }
+    if ( tokVal == "null" ) {
+      this.advance();
+      const nullLit = new TSNode();
+      nullLit.nodeType = "NullLiteral";
+      nullLit.start = tok.start;
+      nullLit.end = tok.end;
+      nullLit.line = tok.line;
+      nullLit.col = tok.col;
+      return nullLit;
+    }
+    if ( tokVal == "undefined" ) {
+      this.advance();
+      const undefId = new TSNode();
+      undefId.nodeType = "Identifier";
+      undefId.name = "undefined";
+      undefId.start = tok.start;
+      undefId.end = tok.end;
+      undefId.line = tok.line;
+      undefId.col = tok.col;
+      return undefId;
+    }
+    if ( tokVal == "[" ) {
+      return this.parseArrayLiteral();
+    }
+    if ( tokVal == "{" ) {
+      return this.parseObjectLiteral();
+    }
+    if ( (this.tsxMode == true) && (tokVal == "<") ) {
+      const nextType = this.peekNextType();
+      const nextVal = this.peekNextValue();
+      if ( nextVal == ">" ) {
+        return this.parseJSXFragment();
+      }
+      if ( (nextType == "Identifier") || (nextType == "Keyword") ) {
+        const peekTwoAhead = this.peekAheadValue(2);
+        if ( peekTwoAhead != "extends" ) {
+          return this.parseJSXElement();
+        }
+      }
+    }
+    if ( tokVal == "(" ) {
+      return this.parseParenOrArrow();
+    }
+    if ( tokVal == "async" ) {
+      const nextVal_1 = this.peekNextValue();
+      const nextType_1 = this.peekNextType();
+      if ( (nextVal_1 == "(") || (nextType_1 == "Identifier") ) {
+        return this.parseArrowFunction();
+      }
+    }
+    if ( tokVal == "new" ) {
+      return this.parseNewExpression();
+    }
+    if ( tokVal == "import" ) {
+      const importTok = this.peek();
+      this.advance();
+      if ( this.matchValue(".") ) {
+        this.advance();
+        if ( this.matchValue("meta") ) {
+          this.advance();
+          const metaProp = new TSNode();
+          metaProp.nodeType = "MetaProperty";
+          metaProp.name = "import";
+          metaProp.value = "meta";
+          metaProp.start = importTok.start;
+          metaProp.line = importTok.line;
+          metaProp.col = importTok.col;
+          return metaProp;
+        }
+      }
+      if ( this.matchValue("(") ) {
+        this.advance();
+        const source = this.parseExpr();
+        this.expectValue(")");
+        const importExpr = new TSNode();
+        importExpr.nodeType = "ImportExpression";
+        importExpr.left = source;
+        importExpr.start = importTok.start;
+        importExpr.line = importTok.line;
+        importExpr.col = importTok.col;
+        return importExpr;
+      }
+    }
+    if ( tokVal == "this" ) {
+      this.advance();
+      const thisExpr = new TSNode();
+      thisExpr.nodeType = "ThisExpression";
+      thisExpr.start = tok.start;
+      thisExpr.end = tok.end;
+      thisExpr.line = tok.line;
+      thisExpr.col = tok.col;
+      return thisExpr;
+    }
+    if ( this.quiet == false ) {
+      console.log("Unexpected token: " + tokVal);
+    }
+    this.advance();
+    const errId = new TSNode();
+    errId.nodeType = "Identifier";
+    errId.name = "error";
+    return errId;
+  };
+  parseTemplateLiteral () {
+    const node = new TSNode();
+    node.nodeType = "TemplateLiteral";
+    const tok = this.peek();
+    node.start = tok.start;
+    node.line = tok.line;
+    node.col = tok.col;
+    this.advance();
+    const quasi = new TSNode();
+    quasi.nodeType = "TemplateElement";
+    quasi.value = tok.value;
+    node.children.push(quasi);
+    return node;
+  };
+  parseArrayLiteral () {
+    const node = new TSNode();
+    node.nodeType = "ArrayExpression";
+    const tok = this.peek();
+    node.start = tok.start;
+    node.line = tok.line;
+    node.col = tok.col;
+    this.expectValue("[");
+    while ((this.matchValue("]") == false) && (this.isAtEnd() == false)) {
+      if ( this.matchValue("...") ) {
+        this.advance();
+        const spreadArg = this.parseExpr();
+        const spread = new TSNode();
+        spread.nodeType = "SpreadElement";
+        spread.left = spreadArg;
+        node.children.push(spread);
+      } else {
+        if ( this.matchValue(",") ) {
+        } else {
+          const elem = this.parseExpr();
+          node.children.push(elem);
+        }
+      }
+      if ( this.matchValue(",") ) {
+        this.advance();
+      }
+    };
+    this.expectValue("]");
+    return node;
+  };
+  parseObjectLiteral () {
+    const node = new TSNode();
+    node.nodeType = "ObjectExpression";
+    const tok = this.peek();
+    node.start = tok.start;
+    node.line = tok.line;
+    node.col = tok.col;
+    this.expectValue("{");
+    while ((this.matchValue("}") == false) && (this.isAtEnd() == false)) {
+      if ( this.matchValue("...") ) {
+        this.advance();
+        const spreadArg = this.parseExpr();
+        const spread = new TSNode();
+        spread.nodeType = "SpreadElement";
+        spread.left = spreadArg;
+        node.children.push(spread);
+      } else {
+        const prop = new TSNode();
+        prop.nodeType = "Property";
+        let isComputed = false;
+        let isMethod = false;
+        let isGetter = false;
+        let isSetter = false;
+        let currVal = this.peekValue();
+        let nextType = this.peekNextType();
+        let nextVal = this.peekNextValue();
+        if ( currVal == "async" ) {
+          if ( ((nextType == "Identifier") || (nextVal == "[")) || (nextVal == "(") ) {
+            this.advance();
+            prop.async = true;
+            currVal = this.peekValue();
+            nextType = this.peekNextType();
+            nextVal = this.peekNextValue();
+          }
+        }
+        if ( currVal == "get" ) {
+          if ( (nextType == "Identifier") || (nextVal == "[") ) {
+            this.advance();
+            isGetter = true;
+            prop.kind = "get";
+          }
+        }
+        if ( currVal == "set" ) {
+          if ( (nextType == "Identifier") || (nextVal == "[") ) {
+            this.advance();
+            isSetter = true;
+            prop.kind = "set";
+          }
+        }
+        const keyTok = this.peek();
+        if ( this.matchValue("[") ) {
+          this.advance();
+          const keyExpr = this.parseExpr();
+          this.expectValue("]");
+          prop.right = keyExpr;
+          isComputed = true;
+          prop.computed = true;
+        }
+        if ( this.matchType("Identifier") ) {
+          prop.name = keyTok.value;
+          this.advance();
+        }
+        if ( this.matchType("String") ) {
+          prop.name = keyTok.value;
+          this.advance();
+        }
+        if ( this.matchType("Number") ) {
+          prop.name = keyTok.value;
+          this.advance();
+        }
+        if ( this.matchValue("(") ) {
+          isMethod = true;
+          prop.method = true;
+          const fnNode = new TSNode();
+          fnNode.nodeType = "FunctionExpression";
+          this.advance();
+          while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+            if ( (fnNode.params.length) > 0 ) {
+              this.expectValue(",");
+            }
+            fnNode.params.push(this.parseParam());
+          };
+          this.expectValue(")");
+          if ( this.matchValue(":") ) {
+            this.advance();
+            fnNode.typeAnnotation = this.parseType();
+          }
+          if ( this.matchValue("{") ) {
+            fnNode.body = this.parseBlock();
+          }
+          prop.left = fnNode;
+          if ( (isGetter == false) && (isSetter == false) ) {
+            prop.kind = "init";
+          }
+        }
+        if ( isMethod == false ) {
+          if ( this.matchValue(":") ) {
+            this.advance();
+            const valueExpr = this.parseExpr();
+            prop.left = valueExpr;
+            prop.kind = "init";
+          } else {
+            if ( isComputed == false ) {
+              const shorthandVal = new TSNode();
+              shorthandVal.nodeType = "Identifier";
+              shorthandVal.name = prop.name;
+              prop.left = shorthandVal;
+              prop.shorthand = true;
+              prop.kind = "init";
+            }
+          }
+        }
+        node.children.push(prop);
+      }
+      if ( this.matchValue(",") ) {
+        this.advance();
+      }
+    };
+    this.expectValue("}");
+    return node;
+  };
+  parseParenOrArrow () {
+    const startTok = this.peek();
+    const savedPos = this.pos;
+    const savedTok = this.currentToken;
+    this.advance();
+    let parenDepth = 1;
+    while ((parenDepth > 0) && (this.isAtEnd() == false)) {
+      const v = this.peekValue();
+      if ( v == "(" ) {
+        parenDepth = parenDepth + 1;
+      }
+      if ( v == ")" ) {
+        parenDepth = parenDepth - 1;
+      }
+      if ( parenDepth > 0 ) {
+        this.advance();
+      }
+    };
+    if ( this.matchValue(")") == false ) {
+      this.pos = savedPos;
+      this.currentToken = savedTok;
+      this.advance();
+      const expr = this.parseExpr();
+      this.expectValue(")");
+      return expr;
+    }
+    this.advance();
+    if ( this.matchValue(":") ) {
+      this.advance();
+      this.parseType();
+    }
+    if ( this.matchValue("=>") ) {
+      this.pos = savedPos;
+      this.currentToken = savedTok;
+      return this.parseArrowFunction();
+    }
+    this.pos = savedPos;
+    this.currentToken = savedTok;
+    this.advance();
+    const expr_1 = this.parseExpr();
+    this.expectValue(")");
+    return expr_1;
+  };
+  parseArrowFunction () {
+    const node = new TSNode();
+    node.nodeType = "ArrowFunctionExpression";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    if ( this.matchValue("async") ) {
+      this.advance();
+      node.kind = "async";
+    }
+    if ( this.matchValue("(") ) {
+      this.advance();
+      while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+        if ( (node.params.length) > 0 ) {
+          this.expectValue(",");
+        }
+        const param = this.parseParam();
+        node.params.push(param);
+      };
+      this.expectValue(")");
+    } else {
+      const paramTok = this.expect("Identifier");
+      const param_1 = new TSNode();
+      param_1.nodeType = "Parameter";
+      param_1.name = paramTok.value;
+      node.params.push(param_1);
+    }
+    if ( this.matchValue(":") ) {
+      this.advance();
+      const retType = this.parseType();
+      node.typeAnnotation = retType;
+    }
+    this.expectValue("=>");
+    if ( this.matchValue("{") ) {
+      const body = this.parseBlock();
+      node.body = body;
+    } else {
+      const body_1 = this.parseExpr();
+      node.body = body_1;
+    }
+    return node;
+  };
+  parseNewExpression () {
+    const node = new TSNode();
+    node.nodeType = "NewExpression";
+    const tok = this.peek();
+    node.start = tok.start;
+    node.line = tok.line;
+    node.col = tok.col;
+    this.expectValue("new");
+    if ( this.matchValue(".") ) {
+      this.advance();
+      if ( this.matchValue("target") ) {
+        this.advance();
+        node.nodeType = "MetaProperty";
+        node.name = "new";
+        node.value = "target";
+        return node;
+      }
+    }
+    const callee = this.parsePrimary();
+    node.left = callee;
+    if ( this.matchValue("<") ) {
+      let depth = 1;
+      this.advance();
+      while ((depth > 0) && (this.isAtEnd() == false)) {
+        const v = this.peekValue();
+        if ( v == "<" ) {
+          depth = depth + 1;
+        }
+        if ( v == ">" ) {
+          depth = depth - 1;
+        }
+        this.advance();
+      };
+    }
+    if ( this.matchValue("(") ) {
+      this.advance();
+      while ((this.matchValue(")") == false) && (this.isAtEnd() == false)) {
+        if ( (node.children.length) > 0 ) {
+          this.expectValue(",");
+        }
+        const arg = this.parseExpr();
+        node.children.push(arg);
+      };
+      this.expectValue(")");
+    }
+    return node;
+  };
+  peekNextType () {
+    const nextPos = this.pos + 1;
+    if ( nextPos < (this.tokens.length) ) {
+      const nextTok = this.tokens[nextPos];
+      return nextTok.tokenType;
+    }
+    return "EOF";
+  };
+  peekAheadValue (offset) {
+    const aheadPos = this.pos + offset;
+    if ( aheadPos < (this.tokens.length) ) {
+      const tok = this.tokens[aheadPos];
+      return tok.value;
+    }
+    return "";
+  };
+  startsWithLowerCase (s) {
+    if ( (s.length) == 0 ) {
+      return false;
+    }
+    const code = s.charCodeAt(0 );
+    if ( (code >= 97) && (code <= 122) ) {
+      return true;
+    }
+    return false;
+  };
+  looksLikeGenericCall () {
+    let depth = 1;
+    let offset = 1;
+    const maxLookahead = 20;
+    while ((depth > 0) && (offset < maxLookahead)) {
+      const ahead = this.peekAheadValue(offset);
+      if ( ahead == "" ) {
+        return false;
+      }
+      if ( ahead == "<" ) {
+        depth = depth + 1;
+      }
+      if ( ahead == ">" ) {
+        depth = depth - 1;
+      }
+      if ( (((ahead == "{") || (ahead == "}")) || (ahead == ";")) || (ahead == "=>") ) {
+        return false;
+      }
+      offset = offset + 1;
+    };
+    if ( depth == 0 ) {
+      const afterClose = this.peekAheadValue(offset);
+      if ( afterClose == "(" ) {
+        return true;
+      }
+    }
+    return false;
+  };
+  parseJSXElement () {
+    const node = new TSNode();
+    node.nodeType = "JSXElement";
+    const tok = this.peek();
+    node.start = tok.start;
+    node.line = tok.line;
+    node.col = tok.col;
+    const opening = this.parseJSXOpeningElement();
+    node.left = opening;
+    if ( opening.kind == "self-closing" ) {
+      node.nodeType = "JSXElement";
+      return node;
+    }
+    const tagName = opening.name;
+    while (this.isAtEnd() == false) {
+      const v = this.peekValue();
+      if ( v == "<" ) {
+        const nextVal = this.peekNextValue();
+        if ( nextVal == "/" ) {
+          break;
+        }
+        const child = this.parseJSXElement();
+        node.children.push(child);
+      } else {
+        if ( v == "{" ) {
+          const exprChild = this.parseJSXExpressionContainer();
+          node.children.push(exprChild);
+        } else {
+          const t = this.peekType();
+          if ( ((t != "EOF") && (v != "<")) && (v != "{") ) {
+            const textChild = this.parseJSXText();
+            node.children.push(textChild);
+          } else {
+            break;
+          }
+        }
+      }
+    };
+    const closing = this.parseJSXClosingElement();
+    node.right = closing;
+    return node;
+  };
+  parseJSXOpeningElement () {
+    const node = new TSNode();
+    node.nodeType = "JSXOpeningElement";
+    const tok = this.peek();
+    node.start = tok.start;
+    node.line = tok.line;
+    node.col = tok.col;
+    this.expectValue("<");
+    const tagName = this.parseJSXElementName();
+    node.name = tagName.name;
+    node.left = tagName;
+    while (this.isAtEnd() == false) {
+      const v = this.peekValue();
+      if ( (v == ">") || (v == "/") ) {
+        break;
+      }
+      const attr = this.parseJSXAttribute();
+      node.children.push(attr);
+    };
+    if ( this.matchValue("/") ) {
+      this.advance();
+      node.kind = "self-closing";
+    }
+    this.expectValue(">");
+    return node;
+  };
+  parseJSXClosingElement () {
+    const node = new TSNode();
+    node.nodeType = "JSXClosingElement";
+    const tok = this.peek();
+    node.start = tok.start;
+    node.line = tok.line;
+    node.col = tok.col;
+    this.expectValue("<");
+    this.expectValue("/");
+    const tagName = this.parseJSXElementName();
+    node.name = tagName.name;
+    node.left = tagName;
+    this.expectValue(">");
+    return node;
+  };
+  parseJSXElementName () {
+    const node = new TSNode();
+    node.nodeType = "JSXIdentifier";
+    const tok = this.peek();
+    node.start = tok.start;
+    node.line = tok.line;
+    node.col = tok.col;
+    let namePart = tok.value;
+    this.advance();
+    while (this.matchValue(".")) {
+      this.advance();
+      const nextTok = this.peek();
+      namePart = (namePart + ".") + nextTok.value;
+      this.advance();
+      node.nodeType = "JSXMemberExpression";
+    };
+    node.name = namePart;
+    return node;
+  };
+  parseJSXAttribute () {
+    const node = new TSNode();
+    node.nodeType = "JSXAttribute";
+    const tok = this.peek();
+    node.start = tok.start;
+    node.line = tok.line;
+    node.col = tok.col;
+    if ( this.matchValue("{") ) {
+      this.advance();
+      if ( this.matchValue("...") ) {
+        this.advance();
+        node.nodeType = "JSXSpreadAttribute";
+        const arg = this.parseExpr();
+        node.left = arg;
+        this.expectValue("}");
+        return node;
+      }
+    }
+    const attrName = tok.value;
+    node.name = attrName;
+    this.advance();
+    if ( this.matchValue("=") ) {
+      this.advance();
+      const valTok = this.peekValue();
+      if ( valTok == "{" ) {
+        const exprValue = this.parseJSXExpressionContainer();
+        node.right = exprValue;
+      } else {
+        const strTok = this.peek();
+        const strNode = new TSNode();
+        strNode.nodeType = "StringLiteral";
+        strNode.value = strTok.value;
+        strNode.start = strTok.start;
+        strNode.end = strTok.end;
+        strNode.line = strTok.line;
+        strNode.col = strTok.col;
+        this.advance();
+        node.right = strNode;
+      }
+    }
+    return node;
+  };
+  parseJSXExpressionContainer () {
+    const node = new TSNode();
+    node.nodeType = "JSXExpressionContainer";
+    const tok = this.peek();
+    node.start = tok.start;
+    node.line = tok.line;
+    node.col = tok.col;
+    this.expectValue("{");
+    if ( this.matchValue("}") ) {
+      const empty = new TSNode();
+      empty.nodeType = "JSXEmptyExpression";
+      node.left = empty;
+    } else {
+      const expr = this.parseExpr();
+      node.left = expr;
+    }
+    this.expectValue("}");
+    return node;
+  };
+  parseJSXText () {
+    const node = new TSNode();
+    node.nodeType = "JSXText";
+    const tok = this.peek();
+    node.start = tok.start;
+    node.line = tok.line;
+    node.col = tok.col;
+    node.value = tok.value;
+    this.advance();
+    return node;
+  };
+  parseJSXFragment () {
+    const node = new TSNode();
+    node.nodeType = "JSXFragment";
+    const tok = this.peek();
+    node.start = tok.start;
+    node.line = tok.line;
+    node.col = tok.col;
+    this.expectValue("<");
+    this.expectValue(">");
+    while (this.isAtEnd() == false) {
+      const v = this.peekValue();
+      if ( v == "<" ) {
+        const nextVal = this.peekNextValue();
+        if ( nextVal == "/" ) {
+          break;
+        }
+        const child = this.parseJSXElement();
+        node.children.push(child);
+      } else {
+        if ( v == "{" ) {
+          const exprChild = this.parseJSXExpressionContainer();
+          node.children.push(exprChild);
+        } else {
+          const t = this.peekType();
+          if ( ((t != "EOF") && (v != "<")) && (v != "{") ) {
+            const textChild = this.parseJSXText();
+            node.children.push(textChild);
+          } else {
+            break;
+          }
+        }
+      }
+    };
+    this.expectValue("<");
+    this.expectValue("/");
+    this.expectValue(">");
+    return node;
+  };
+}
 class EvalValue  {
   constructor() {
     this.valueType = 0;
@@ -1551,8 +6088,7 @@ class EvalValue  {
     this.stringValue = "";
     this.boolValue = false;
     this.arrayValue = [];
-    this.objectKeys = [];
-    this.objectValues = [];
+    this.objectMap = {};
     this.functionName = "";
     this.functionBody = "";     /** note: unused */
   }
@@ -1580,6 +6116,9 @@ class EvalValue  {
   isElement () {
     return this.valueType == 7;
   };
+  isUndefined () {
+    return this.valueType == 8;
+  };
   toNumber () {
     if ( this.valueType == 1 ) {
       return this.numberValue;
@@ -1599,6 +6138,9 @@ class EvalValue  {
   toString () {
     if ( this.valueType == 0 ) {
       return "null";
+    }
+    if ( this.valueType == 8 ) {
+      return "undefined";
     }
     if ( this.valueType == 1 ) {
       const s = (this.numberValue.toString());
@@ -1633,15 +6175,16 @@ class EvalValue  {
     }
     if ( this.valueType == 5 ) {
       let result_1 = "{";
+      const keyList = Object.keys(this.objectMap);
       let i_1 = 0;
-      while (i_1 < (this.objectKeys.length)) {
+      for ( let idx = 0; idx < keyList.length; idx++) {
+        var kk = keyList[idx];
         if ( i_1 > 0 ) {
           result_1 = result_1 + ", ";
         }
-        const key = this.objectKeys[i_1];
-        const val = this.objectValues[i_1];
+        const val = (( this.objectMap.hasOwnProperty(kk) ? this.objectMap[kk] : undefined ));
         const valStr = (val).toString();
-        result_1 = ((result_1 + key) + ": ") + valStr;
+        result_1 = ((result_1 + kk) + ": ") + valStr;
         i_1 = i_1 + 1;
       };
       return result_1 + "}";
@@ -1660,6 +6203,9 @@ class EvalValue  {
   };
   toBool () {
     if ( this.valueType == 0 ) {
+      return false;
+    }
+    if ( this.valueType == 8 ) {
       return false;
     }
     if ( this.valueType == 1 ) {
@@ -1687,13 +6233,9 @@ class EvalValue  {
   };
   getMember (key) {
     if ( this.valueType == 5 ) {
-      let i = 0;
-      while (i < (this.objectKeys.length)) {
-        if ( (this.objectKeys[i]) == key ) {
-          return this.objectValues[i];
-        }
-        i = i + 1;
-      };
+      if ( ( typeof(this.objectMap[key] ) != "undefined" && this.objectMap.hasOwnProperty(key) ) ) {
+        return (( this.objectMap.hasOwnProperty(key) ? this.objectMap[key] : undefined ));
+      }
     }
     if ( this.valueType == 4 ) {
       if ( key == "length" ) {
@@ -1706,6 +6248,21 @@ class EvalValue  {
       }
     }
     return EvalValue.null();
+  };
+  setMember (key, value) {
+    if ( this.valueType != 5 ) {
+      return;
+    }
+    this.objectMap[key] = value;
+  };
+  setIndexAt (index, value) {
+    if ( this.valueType != 4 ) {
+      return;
+    }
+    while (index >= (this.arrayValue.length)) {
+      this.arrayValue.push(EvalValue.null());
+    };
+    this.arrayValue[index] = value;
   };
   getIndex (index) {
     if ( this.valueType == 4 ) {
@@ -1727,6 +6284,9 @@ class EvalValue  {
     }
     if ( this.valueType == 0 ) {
       return true;
+    }
+    if ( this.valueType == 8 ) {
+      return other.valueType == 8;
     }
     if ( this.valueType == 1 ) {
       return this.numberValue == other.numberValue;
@@ -1778,14 +6338,31 @@ EvalValue.array = function(items) {
 EvalValue.object = function(keys, values) {
   const v = new EvalValue();
   v.valueType = 5;
-  v.objectKeys = keys;
-  v.objectValues = values;
+  let i = 0;
+  while (i < (keys.length)) {
+    if ( i < (values.length) ) {
+      v.objectMap[keys[i]] = values[i];
+    }
+    i = i + 1;
+  };
+  return v;
+};
+EvalValue.function = function(fnNode) {
+  const v = new EvalValue();
+  v.valueType = 6;
+  v.functionNode = fnNode;
+  v.functionName = fnNode.name;
   return v;
 };
 EvalValue.element = function(el) {
   const v = new EvalValue();
   v.valueType = 7;
   v.evgElement = el;
+  return v;
+};
+EvalValue.undefined = function() {
+  const v = new EvalValue();
+  v.valueType = 8;
   return v;
 };
 class EvalValueModule  {
@@ -1798,5 +6375,9 @@ module.exports.EVGBox = EVGBox;
 module.exports.EVGGradientStop = EVGGradientStop;
 module.exports.EVGGradient = EVGGradient;
 module.exports.EVGElement = EVGElement;
+module.exports.Token = Token;
+module.exports.TSLexer = TSLexer;
+module.exports.TSNode = TSNode;
+module.exports.TSParserSimple = TSParserSimple;
 module.exports.EvalValue = EvalValue;
 module.exports.EvalValueModule = EvalValueModule;

--- a/gallery/pdf_writer/bin/evg_component_tool.js
+++ b/gallery/pdf_writer/bin/evg_component_tool.js
@@ -14694,33 +14694,15 @@ class ImportedSymbol  {
 }
 class EvalContext  {
   constructor() {
-    this.variables = [];
-    this.values = [];
-    let v = [];
-    this.variables = v;
-    let vl = [];
-    this.values = vl;
+    this.bindings = {};
   }
   define (name, value) {
-    let i = 0;
-    while (i < (this.variables.length)) {
-      if ( (this.variables[i]) == name ) {
-        this.values[i] = value;
-        return;
-      }
-      i = i + 1;
-    };
-    this.variables.push(name);
-    this.values.push(value);
+    this.bindings[name] = value;
   };
   lookup (name) {
-    let i = 0;
-    while (i < (this.variables.length)) {
-      if ( (this.variables[i]) == name ) {
-        return this.values[i];
-      }
-      i = i + 1;
-    };
+    if ( ( typeof(this.bindings[name] ) != "undefined" && this.bindings.hasOwnProperty(name) ) ) {
+      return (( this.bindings.hasOwnProperty(name) ? this.bindings[name] : undefined ));
+    }
     if ( typeof(this.parent) != "undefined" ) {
       const p = this.parent;
       return p.lookup(name);
@@ -14728,14 +14710,10 @@ class EvalContext  {
     return EvalValue.null();
   };
   assignExisting (name, value) {
-    let i = 0;
-    while (i < (this.variables.length)) {
-      if ( (this.variables[i]) == name ) {
-        this.values[i] = value;
-        return true;
-      }
-      i = i + 1;
-    };
+    if ( ( typeof(this.bindings[name] ) != "undefined" && this.bindings.hasOwnProperty(name) ) ) {
+      this.bindings[name] = value;
+      return true;
+    }
     if ( typeof(this.parent) != "undefined" ) {
       const p = this.parent;
       return p.assignExisting(name, value);
@@ -14749,25 +14727,18 @@ class EvalContext  {
     this.define(name, value);
   };
   removeBinding (name) {
-    let i = 0;
-    while (i < (this.variables.length)) {
-      if ( (this.variables[i]) == name ) {
-        let newVars = [];
-        let newVals = [];
-        let j = 0;
-        while (j < (this.variables.length)) {
-          if ( j != i ) {
-            newVars.push(this.variables[j]);
-            newVals.push(this.values[j]);
-          }
-          j = j + 1;
-        };
-        this.variables = newVars;
-        this.values = newVals;
-        return true;
-      }
-      i = i + 1;
-    };
+    if ( ( typeof(this.bindings[name] ) != "undefined" && this.bindings.hasOwnProperty(name) ) ) {
+      let newBindings = {};
+      const keyList = Object.keys(this.bindings);
+      for ( let idx = 0; idx < keyList.length; idx++) {
+        var kk = keyList[idx];
+        if ( kk != name ) {
+          newBindings[kk] = (( this.bindings.hasOwnProperty(kk) ? this.bindings[kk] : undefined ));
+        }
+      };
+      this.bindings = newBindings;
+      return true;
+    }
     if ( typeof(this.parent) != "undefined" ) {
       const p = this.parent;
       return p.removeBinding(name);
@@ -14781,13 +14752,9 @@ class EvalContext  {
     return this;
   };
   has (name) {
-    let i = 0;
-    while (i < (this.variables.length)) {
-      if ( (this.variables[i]) == name ) {
-        return true;
-      }
-      i = i + 1;
-    };
+    if ( ( typeof(this.bindings[name] ) != "undefined" && this.bindings.hasOwnProperty(name) ) ) {
+      return true;
+    }
     if ( typeof(this.parent) != "undefined" ) {
       const p = this.parent;
       return (p).has(name);

--- a/gallery/pdf_writer/bin/evg_component_tool.js
+++ b/gallery/pdf_writer/bin/evg_component_tool.js
@@ -17,8 +17,41 @@ class TSLexer  {
     this.col = 1;
     this.__len = 0;
     this.source = src;
-    this.__len = src.length;
+    this.__len = this.countCodeUnits(src);
   }
+  utf8WidthFromLead (lead) {
+    if ( lead <= 127 ) {
+      return 1;
+    }
+    if ( lead >= 192 ) {
+      if ( lead <= 223 ) {
+        return 2;
+      }
+    }
+    if ( lead >= 224 ) {
+      if ( lead <= 239 ) {
+        return 3;
+      }
+    }
+    if ( lead >= 240 ) {
+      if ( lead <= 247 ) {
+        return 4;
+      }
+    }
+    return 1;
+  };
+  countCodeUnits (text) {
+    const byteLen = text.length;
+    let bytePos = 0;
+    let count = 0;
+    while (bytePos < byteLen) {
+      const lead = text.charCodeAt(bytePos );
+      const w = this.utf8WidthFromLead(lead);
+      bytePos = bytePos + w;
+      count = count + 1;
+    };
+    return count;
+  };
   peek () {
     if ( this.pos >= this.__len ) {
       return "";
@@ -83,7 +116,7 @@ class TSLexer  {
     if ( (ch.length) == 0 ) {
       return false;
     }
-    const code = this.source.charCodeAt(this.pos );
+    const code = ch.charCodeAt(0 );
     if ( code >= 97 ) {
       if ( code <= 122 ) {
         return true;
@@ -105,6 +138,19 @@ class TSLexer  {
     }
     return false;
   };
+  isLetterCode (code) {
+    if ( code >= 97 ) {
+      if ( code <= 122 ) {
+        return true;
+      }
+    }
+    if ( code >= 65 ) {
+      if ( code <= 90 ) {
+        return true;
+      }
+    }
+    return false;
+  };
   isAlphaNumCh (ch) {
     if ( this.isDigit(ch) ) {
       return true;
@@ -118,7 +164,7 @@ class TSLexer  {
     if ( (ch.length) == 0 ) {
       return false;
     }
-    const code = this.source.charCodeAt(this.pos );
+    const code = ch.charCodeAt(0 );
     if ( code >= 97 ) {
       if ( code <= 122 ) {
         return true;
@@ -565,6 +611,26 @@ class TSLexer  {
       return this.readString("\"");
     }
     if ( ch == "'" ) {
+      let wordApostrophe = false;
+      if ( this.pos > 0 ) {
+        if ( (this.pos + 1) < this.__len ) {
+          const prevCh = this.peekAt(-1);
+          const nextCh = this.peekAt(1);
+          if ( (prevCh.length) > 0 ) {
+            if ( (nextCh.length) > 0 ) {
+              const prevCode = prevCh.charCodeAt(0 );
+              const nextCode = nextCh.charCodeAt(0 );
+              if ( this.isLetterCode(prevCode) && this.isLetterCode(nextCode) ) {
+                wordApostrophe = true;
+              }
+            }
+          }
+        }
+      }
+      if ( wordApostrophe ) {
+        this.advance();
+        return this.makeToken("Punctuator", "'", startPos, startLine, startCol);
+      }
       return this.readString("'");
     }
     if ( ch == "`" ) {
@@ -729,6 +795,9 @@ class TSLexer  {
           return this.makeToken("Punctuator", "...", startPos, startLine, startCol);
         }
       }
+    }
+    if ( (ch.length) == 0 ) {
+      return this.makeToken("EOF", "", this.pos, this.line, this.col);
     }
     this.advance();
     return this.makeToken("Punctuator", ch, startPos, startLine, startCol);
@@ -946,6 +1015,12 @@ class TSParserSimple  {
     if ( tokVal == "return" ) {
       return this.parseReturn();
     }
+    if ( tokVal == "break" ) {
+      return this.parseBreak();
+    }
+    if ( tokVal == "continue" ) {
+      return this.parseContinue();
+    }
     if ( tokVal == "throw" ) {
       return this.parseThrow();
     }
@@ -1020,6 +1095,32 @@ class TSParserSimple  {
       const arg = this.parseExpr();
       node.left = arg;
     }
+    if ( this.matchValue(";") ) {
+      this.advance();
+    }
+    return node;
+  };
+  parseBreak () {
+    const node = new TSNode();
+    node.nodeType = "BreakStatement";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("break");
+    if ( this.matchValue(";") ) {
+      this.advance();
+    }
+    return node;
+  };
+  parseContinue () {
+    const node = new TSNode();
+    node.nodeType = "ContinueStatement";
+    const startTok = this.peek();
+    node.start = startTok.start;
+    node.line = startTok.line;
+    node.col = startTok.col;
+    this.expectValue("continue");
     if ( this.matchValue(";") ) {
       this.advance();
     }
@@ -2529,63 +2630,61 @@ class TSParserSimple  {
       node_7.col = tok.col;
       return node_7;
     }
-    if ( tokVal == "void" ) {
+    if ( tokVal == "object" ) {
       this.advance();
       const node_8 = new TSNode();
-      node_8.nodeType = "TSVoidKeyword";
+      node_8.nodeType = "TSObjectKeyword";
       node_8.start = tok.start;
       node_8.end = tok.end;
       node_8.line = tok.line;
       node_8.col = tok.col;
       return node_8;
     }
-    if ( tokVal == "null" ) {
+    if ( tokVal == "void" ) {
       this.advance();
       const node_9 = new TSNode();
-      node_9.nodeType = "TSNullKeyword";
+      node_9.nodeType = "TSVoidKeyword";
       node_9.start = tok.start;
       node_9.end = tok.end;
       node_9.line = tok.line;
       node_9.col = tok.col;
       return node_9;
     }
-    if ( tokVal == "never" ) {
+    if ( tokVal == "null" ) {
       this.advance();
       const node_10 = new TSNode();
-      node_10.nodeType = "TSNeverKeyword";
+      node_10.nodeType = "TSNullKeyword";
       node_10.start = tok.start;
       node_10.end = tok.end;
       node_10.line = tok.line;
       node_10.col = tok.col;
       return node_10;
     }
-    if ( tokVal == "undefined" ) {
+    if ( tokVal == "never" ) {
       this.advance();
       const node_11 = new TSNode();
-      node_11.nodeType = "TSUndefinedKeyword";
+      node_11.nodeType = "TSNeverKeyword";
       node_11.start = tok.start;
       node_11.end = tok.end;
       node_11.line = tok.line;
       node_11.col = tok.col;
       return node_11;
     }
+    if ( tokVal == "undefined" ) {
+      this.advance();
+      const node_12 = new TSNode();
+      node_12.nodeType = "TSUndefinedKeyword";
+      node_12.start = tok.start;
+      node_12.end = tok.end;
+      node_12.line = tok.line;
+      node_12.col = tok.col;
+      return node_12;
+    }
     const tokType = this.peekType();
     if ( tokType == "Identifier" ) {
       return this.parseTypeRef();
     }
     if ( tokType == "String" ) {
-      this.advance();
-      const node_12 = new TSNode();
-      node_12.nodeType = "TSLiteralType";
-      node_12.start = tok.start;
-      node_12.end = tok.end;
-      node_12.line = tok.line;
-      node_12.col = tok.col;
-      node_12.value = tok.value;
-      node_12.kind = "string";
-      return node_12;
-    }
-    if ( tokType == "Number" ) {
       this.advance();
       const node_13 = new TSNode();
       node_13.nodeType = "TSLiteralType";
@@ -2594,10 +2693,10 @@ class TSParserSimple  {
       node_13.line = tok.line;
       node_13.col = tok.col;
       node_13.value = tok.value;
-      node_13.kind = "number";
+      node_13.kind = "string";
       return node_13;
     }
-    if ( (tokVal == "true") || (tokVal == "false") ) {
+    if ( tokType == "Number" ) {
       this.advance();
       const node_14 = new TSNode();
       node_14.nodeType = "TSLiteralType";
@@ -2605,20 +2704,32 @@ class TSParserSimple  {
       node_14.end = tok.end;
       node_14.line = tok.line;
       node_14.col = tok.col;
-      node_14.value = tokVal;
-      node_14.kind = "boolean";
+      node_14.value = tok.value;
+      node_14.kind = "number";
       return node_14;
     }
-    if ( tokType == "Template" ) {
+    if ( (tokVal == "true") || (tokVal == "false") ) {
       this.advance();
       const node_15 = new TSNode();
-      node_15.nodeType = "TSTemplateLiteralType";
+      node_15.nodeType = "TSLiteralType";
       node_15.start = tok.start;
       node_15.end = tok.end;
       node_15.line = tok.line;
       node_15.col = tok.col;
-      node_15.value = tok.value;
+      node_15.value = tokVal;
+      node_15.kind = "boolean";
       return node_15;
+    }
+    if ( tokType == "Template" ) {
+      this.advance();
+      const node_16 = new TSNode();
+      node_16.nodeType = "TSTemplateLiteralType";
+      node_16.start = tok.start;
+      node_16.end = tok.end;
+      node_16.line = tok.line;
+      node_16.col = tok.col;
+      node_16.value = tok.value;
+      return node_16;
     }
     if ( tokVal == "new" ) {
       return this.parseConstructorType();
@@ -3192,13 +3303,64 @@ class TSParserSimple  {
     return left;
   };
   parseLogicalAnd () {
-    let left = this.parseEquality();
+    let left = this.parseBitwiseOr();
     while (this.matchValue("&&")) {
+      this.advance();
+      const right = this.parseBitwiseOr();
+      const expr = new TSNode();
+      expr.nodeType = "BinaryExpression";
+      expr.value = "&&";
+      expr.left = left;
+      expr.right = right;
+      expr.start = left.start;
+      expr.line = left.line;
+      expr.col = left.col;
+      left = expr;
+    };
+    return left;
+  };
+  parseBitwiseOr () {
+    let left = this.parseBitwiseXor();
+    while (this.matchValue("|")) {
+      this.advance();
+      const right = this.parseBitwiseXor();
+      const expr = new TSNode();
+      expr.nodeType = "BinaryExpression";
+      expr.value = "|";
+      expr.left = left;
+      expr.right = right;
+      expr.start = left.start;
+      expr.line = left.line;
+      expr.col = left.col;
+      left = expr;
+    };
+    return left;
+  };
+  parseBitwiseXor () {
+    let left = this.parseBitwiseAnd();
+    while (this.matchValue("^")) {
+      this.advance();
+      const right = this.parseBitwiseAnd();
+      const expr = new TSNode();
+      expr.nodeType = "BinaryExpression";
+      expr.value = "^";
+      expr.left = left;
+      expr.right = right;
+      expr.start = left.start;
+      expr.line = left.line;
+      expr.col = left.col;
+      left = expr;
+    };
+    return left;
+  };
+  parseBitwiseAnd () {
+    let left = this.parseEquality();
+    while (this.matchValue("&")) {
       this.advance();
       const right = this.parseEquality();
       const expr = new TSNode();
       expr.nodeType = "BinaryExpression";
-      expr.value = "&&";
+      expr.value = "&";
       expr.left = left;
       expr.right = right;
       expr.start = left.start;
@@ -3315,7 +3477,7 @@ class TSParserSimple  {
       update.col = opTok.col;
       return update;
     }
-    if ( (tokVal == "!") || (tokVal == "-") ) {
+    if ( ((tokVal == "!") || (tokVal == "-")) || (tokVal == "+") ) {
       const opTok_1 = this.peek();
       this.advance();
       const arg_1 = this.parseUnary();
@@ -3327,6 +3489,19 @@ class TSParserSimple  {
       unary.line = opTok_1.line;
       unary.col = opTok_1.col;
       return unary;
+    }
+    if ( tokVal == "typeof" ) {
+      const opTok_2 = this.peek();
+      this.advance();
+      const arg_2 = this.parseUnary();
+      const unary_1 = new TSNode();
+      unary_1.nodeType = "UnaryExpression";
+      unary_1.value = "typeof";
+      unary_1.left = arg_2;
+      unary_1.start = opTok_2.start;
+      unary_1.line = opTok_2.line;
+      unary_1.col = opTok_2.col;
+      return unary_1;
     }
     if ( tokVal == "yield" ) {
       const yieldTok = this.peek();
@@ -3349,10 +3524,10 @@ class TSParserSimple  {
     if ( tokVal == "await" ) {
       const awaitTok = this.peek();
       this.advance();
-      const arg_2 = this.parseUnary();
+      const arg_3 = this.parseUnary();
       const awaitExpr = new TSNode();
       awaitExpr.nodeType = "AwaitExpression";
-      awaitExpr.left = arg_2;
+      awaitExpr.left = arg_3;
       awaitExpr.start = awaitTok.start;
       awaitExpr.line = awaitTok.line;
       awaitExpr.col = awaitTok.col;
@@ -3379,11 +3554,11 @@ class TSParserSimple  {
         const typeNode = this.parseType();
         if ( this.matchValue(">") ) {
           this.advance();
-          const arg_3 = this.parseUnary();
+          const arg_4 = this.parseUnary();
           const assertion = new TSNode();
           assertion.nodeType = "TSTypeAssertion";
           assertion.typeAnnotation = typeNode;
-          assertion.left = arg_3;
+          assertion.left = arg_4;
           assertion.start = startTok.start;
           assertion.line = startTok.line;
           assertion.col = startTok.col;
@@ -5340,8 +5515,8 @@ class EVGElement  {
     this.imageViewBoxH = 1.0;     /** note: unused */
     this.imageViewBoxSet = false;     /** note: unused */
     this.objectFit = "cover";
-    this.sourceWidth = 0.0;     /** note: unused */
-    this.sourceHeight = 0.0;     /** note: unused */
+    this.sourceWidth = 0.0;
+    this.sourceHeight = 0.0;
     this.svgPath = "";
     this.viewBox = "";
     this.strokeWidth = 0.0;
@@ -5365,6 +5540,8 @@ class EVGElement  {
     this.isLayoutComplete = false;
     this.unitsResolved = false;
     this.hasReturn = false;
+    this.hasBreak = false;
+    this.hasContinue = false;
     this.inheritedFontSize = 14.0;
     this.tagName = "div";
     this.elementType = 0;
@@ -7504,6 +7681,8 @@ class EVGLayout  {
     if ( root.height.isSet == false ) {
       root.height = EVGUnit.px(this.pageHeight);
     }
+    root.calculatedX = 0.0;
+    root.calculatedY = 0.0;
     this.layoutElement(root, 0.0, 0.0, this.pageWidth, this.pageHeight);
     this.log("EVGLayout: Layout complete");
   };
@@ -7512,6 +7691,25 @@ class EVGLayout  {
     let width = parentWidth;
     if ( element.width.isSet ) {
       width = element.width.pixels;
+    }
+    if ( element.width.isSet == false ) {
+      const textContent = element.textContent;
+      if ( (textContent.length) > 0 ) {
+        if ( element.getChildCount() == 0 ) {
+          let fontSize = element.inheritedFontSize;
+          if ( element.fontSize.isSet ) {
+            fontSize = element.fontSize.pixels;
+          }
+          if ( fontSize <= 0.0 ) {
+            fontSize = 14.0;
+          }
+          const contentW = this.measureTextContentWidth(textContent, fontSize);
+          const measuredW = ((contentW + element.box.paddingLeftPx) + element.box.paddingRightPx) + (element.box.borderWidthPx * 2.0);
+          if ( measuredW < parentWidth ) {
+            width = measuredW;
+          }
+        }
+      }
     }
     let height = 0.0;
     let autoHeight = true;
@@ -7533,25 +7731,45 @@ class EVGLayout  {
       if ( (imgSrc.length) > 0 ) {
         const dims = this.imageMeasurer.getImageDimensions(imgSrc);
         if ( dims.isValid ) {
+          element.sourceWidth = dims.width;
+          element.sourceHeight = dims.height;
           if ( element.width.isSet && (element.height.isSet == false) ) {
-            height = width / dims.aspectRatio;
-            autoHeight = false;
-            this.log((("  Image aspect ratio: " + ((dims.aspectRatio.toString()))) + " -> height=") + ((height.toString())));
-          }
-          if ( (element.width.isSet == false) && element.height.isSet ) {
-            width = height * dims.aspectRatio;
-            this.log((("  Image aspect ratio: " + ((dims.aspectRatio.toString()))) + " -> width=") + ((width.toString())));
-          }
-          if ( (element.width.isSet == false) && (element.height.isSet == false) ) {
-            width = dims.width;
-            height = dims.height;
-            if ( width > parentWidth ) {
-              const scale = parentWidth / width;
-              width = parentWidth;
-              height = height * scale;
+            if ( parentHeight > 0.0 ) {
+              height = parentHeight;
+              this.log((("  Image container using parent height: " + ((width.toString()))) + "x") + ((height.toString())));
+            } else {
+              height = width / dims.aspectRatio;
+              this.log((("  Image aspect ratio: " + ((dims.aspectRatio.toString()))) + " -> height=") + ((height.toString())));
             }
             autoHeight = false;
-            this.log((("  Image natural size: " + ((width.toString()))) + "x") + ((height.toString())));
+          }
+          if ( (element.width.isSet == false) && element.height.isSet ) {
+            if ( parentWidth > 0.0 ) {
+              width = parentWidth;
+              this.log((("  Image container using parent width: " + ((width.toString()))) + "x") + ((height.toString())));
+            } else {
+              width = height * dims.aspectRatio;
+              this.log((("  Image aspect ratio: " + ((dims.aspectRatio.toString()))) + " -> width=") + ((width.toString())));
+            }
+          }
+          if ( (element.width.isSet == false) && (element.height.isSet == false) ) {
+            if ( (parentWidth > 0.0) && (parentHeight > 0.0) ) {
+              width = parentWidth;
+              height = parentHeight;
+              this.log((("  Image filling parent: " + ((width.toString()))) + "x") + ((height.toString())));
+            } else {
+              width = dims.width;
+              height = dims.height;
+              if ( width > parentWidth ) {
+                if ( parentWidth > 0.0 ) {
+                  const scale = parentWidth / width;
+                  width = parentWidth;
+                  height = height * scale;
+                }
+              }
+              this.log((("  Image natural size: " + ((width.toString()))) + "x") + ((height.toString())));
+            }
+            autoHeight = false;
           }
         }
       }
@@ -7580,22 +7798,22 @@ class EVGLayout  {
     if ( childCount > 0 ) {
       contentHeight = this.layoutChildren(element);
     } else {
-      const textContent = element.textContent;
-      if ( (textContent.length) > 0 ) {
-        let fontSize = element.inheritedFontSize;
+      const textContent_1 = element.textContent;
+      if ( (textContent_1.length) > 0 ) {
+        let fontSize_1 = element.inheritedFontSize;
         if ( element.fontSize.isSet ) {
-          fontSize = element.fontSize.pixels;
+          fontSize_1 = element.fontSize.pixels;
         }
-        if ( fontSize <= 0.0 ) {
-          fontSize = 14.0;
+        if ( fontSize_1 <= 0.0 ) {
+          fontSize_1 = 14.0;
         }
         let lineHeightFactor = element.lineHeight;
         if ( lineHeightFactor <= 0.0 ) {
           lineHeightFactor = 1.2;
         }
-        const lineSpacing = fontSize * lineHeightFactor;
+        const lineSpacing = fontSize_1 * lineHeightFactor;
         const availableWidth = (width - element.box.paddingLeftPx) - element.box.paddingRightPx;
-        const lineCount = this.estimateLineCount(textContent, availableWidth, fontSize);
+        const lineCount = this.estimateLineCount(textContent_1, availableWidth, fontSize_1);
         contentHeight = lineSpacing * (lineCount);
       }
     }
@@ -7639,6 +7857,7 @@ class EVGLayout  {
       let j = 0;
       while (j < childCount) {
         const c = parent.getChild(j);
+        c.inheritProperties(parent);
         c.resolveUnits(innerWidth, innerHeight);
         if ( c.width.isSet ) {
           fixedWidth = ((fixedWidth + c.width.pixels) + c.box.marginLeftPx) + c.box.marginRightPx;
@@ -7647,7 +7866,9 @@ class EVGLayout  {
             totalFlex = totalFlex + c.flex;
             fixedWidth = (fixedWidth + c.box.marginLeftPx) + c.box.marginRightPx;
           } else {
-            fixedWidth = ((fixedWidth + innerWidth) + c.box.marginLeftPx) + c.box.marginRightPx;
+            const avail = (innerWidth - c.box.marginLeftPx) - c.box.marginRightPx;
+            const estW = this.estimateChildWidth(c, avail);
+            fixedWidth = ((fixedWidth + estW) + c.box.marginLeftPx) + c.box.marginRightPx;
           }
         }
         j = j + 1;
@@ -7698,7 +7919,7 @@ class EVGLayout  {
         continue;
       }
       const availableForChild = (innerWidth - child.box.marginLeftPx) - child.box.marginRightPx;
-      let childWidth = availableForChild;
+      let childWidth = this.estimateChildWidth(child, availableForChild);
       if ( child.width.isSet ) {
         if ( child.width.pixels >= innerWidth ) {
           childWidth = availableForChild;
@@ -7727,11 +7948,12 @@ class EVGLayout  {
       this.layoutElement(child, child.calculatedX, child.calculatedY, childWidth, innerHeight);
       const childHeight = child.calculatedHeight;
       const childTotalHeight = (childHeight + child.box.marginTopPx) + child.box.marginBottomPx;
+      const placedWidth = (child.calculatedWidth + child.box.marginLeftPx) + child.box.marginRightPx;
       if ( isColumn ) {
         currentY = currentY + childTotalHeight;
         totalHeight = totalHeight + childTotalHeight;
       } else {
-        currentX = currentX + childTotalWidth;
+        currentX = currentX + placedWidth;
         rowElements.push(child);
         if ( childTotalHeight > rowHeight ) {
           rowHeight = childTotalHeight;
@@ -7764,7 +7986,12 @@ class EVGLayout  {
       return;
     }
     const verticalAlign = parent.justifyContent;
-    const horizontalAlign = parent.alignItems;
+    let horizontalAlign = parent.alignItems;
+    if ( (parent.align.length) > 0 ) {
+      if ( parent.align != "left" ) {
+        horizontalAlign = parent.align;
+      }
+    }
     let availableHeight = innerHeight;
     if ( parent.height.isSet ) {
       availableHeight = parent.calculatedInnerHeight;
@@ -7776,17 +8003,51 @@ class EVGLayout  {
     if ( (verticalAlign == "flex-end") || (verticalAlign == "end") ) {
       offsetY = availableHeight - contentHeight;
     }
-    if ( verticalAlign == "space-between" ) {
-      offsetY = 0.0;
+    let flowCount = 0;
+    let fc = 0;
+    while (fc < childCount) {
+      const fchild = parent.getChild(fc);
+      if ( fchild.isAbsolute == false ) {
+        flowCount = flowCount + 1;
+      }
+      fc = fc + 1;
+    };
+    let freeSpaceY = availableHeight - contentHeight;
+    if ( freeSpaceY < 0.0 ) {
+      freeSpaceY = 0.0;
     }
+    let distributeGapY = 0.0;
+    let distributeFirstY = 0.0;
+    if ( verticalAlign == "space-between" ) {
+      if ( flowCount > 1 ) {
+        distributeGapY = freeSpaceY / ((flowCount - 1));
+      }
+    }
+    if ( verticalAlign == "space-around" ) {
+      if ( flowCount > 0 ) {
+        distributeGapY = freeSpaceY / (flowCount);
+        distributeFirstY = distributeGapY / 2.0;
+      }
+    }
+    if ( verticalAlign == "space-evenly" ) {
+      distributeGapY = freeSpaceY / ((flowCount + 1));
+      distributeFirstY = distributeGapY;
+    }
+    const usesDistributeY = (distributeGapY > 0.0) || (distributeFirstY > 0.0);
     let i = 0;
+    let flowIndex = 0;
     while (i < childCount) {
       const child = parent.getChild(i);
       if ( child.isAbsolute == false ) {
-        if ( offsetY != 0.0 ) {
-          child.calculatedY = child.calculatedY + offsetY;
-          this.propagateOffsetToChildren(child, 0.0, offsetY);
+        let elemOffsetY = offsetY;
+        if ( usesDistributeY ) {
+          elemOffsetY = distributeFirstY + (distributeGapY * (flowIndex));
         }
+        if ( elemOffsetY != 0.0 ) {
+          child.calculatedY = child.calculatedY + elemOffsetY;
+          this.propagateOffsetToChildren(child, 0.0, elemOffsetY);
+        }
+        flowIndex = flowIndex + 1;
         const childTotalWidth = (child.calculatedWidth + child.box.marginLeftPx) + child.box.marginRightPx;
         let offsetX = 0.0;
         if ( horizontalAlign == "center" ) {
@@ -7823,7 +8084,9 @@ class EVGLayout  {
       horizontalAlign = crossAxisAlign;
     }
     if ( (parent.align.length) > 0 ) {
-      horizontalAlign = parent.align;
+      if ( parent.align != "left" ) {
+        horizontalAlign = parent.align;
+      }
     }
     let offsetX = 0.0;
     if ( horizontalAlign == "center" ) {
@@ -7832,6 +8095,26 @@ class EVGLayout  {
     if ( (horizontalAlign == "flex-end") || (horizontalAlign == "right") ) {
       offsetX = innerWidth - rowWidth;
     }
+    let freeSpace = innerWidth - rowWidth;
+    if ( freeSpace < 0.0 ) {
+      freeSpace = 0.0;
+    }
+    let distributeGap = 0.0;
+    let distributeFirst = 0.0;
+    if ( horizontalAlign == "space-between" ) {
+      if ( elementCount > 1 ) {
+        distributeGap = freeSpace / ((elementCount - 1));
+      }
+    }
+    if ( horizontalAlign == "space-around" ) {
+      distributeGap = freeSpace / (elementCount);
+      distributeFirst = distributeGap / 2.0;
+    }
+    if ( horizontalAlign == "space-evenly" ) {
+      distributeGap = freeSpace / ((elementCount + 1));
+      distributeFirst = distributeGap;
+    }
+    const usesDistribute = (distributeGap > 0.0) || (distributeFirst > 0.0);
     let verticalAlignVal = crossAxisAlign;
     if ( isColumn ) {
       verticalAlignVal = mainAxisAlign;
@@ -7851,9 +8134,13 @@ class EVGLayout  {
     i = 0;
     while (i < elementCount) {
       const el_1 = rowElements[i];
-      if ( offsetX != 0.0 ) {
-        el_1.calculatedX = el_1.calculatedX + offsetX;
-        this.propagateOffsetToChildren(el_1, offsetX, 0.0);
+      let elemOffsetX = offsetX;
+      if ( usesDistribute ) {
+        elemOffsetX = distributeFirst + (distributeGap * (i));
+      }
+      if ( elemOffsetX != 0.0 ) {
+        el_1.calculatedX = el_1.calculatedX + elemOffsetX;
+        this.propagateOffsetToChildren(el_1, elemOffsetX, 0.0);
       }
       const childTotalHeight = (el_1.calculatedHeight + el_1.box.marginTopPx) + el_1.box.marginBottomPx;
       let offsetY = 0.0;
@@ -7936,6 +8223,50 @@ class EVGLayout  {
       this.printLayout(child, indent + 1);
       i = i + 1;
     };
+  };
+  estimateChildWidth (child, maxInnerWidth) {
+    if ( child.width.isSet ) {
+      return child.width.pixels;
+    }
+    if ( child.calculatedFlexWidth > 0.0 ) {
+      return child.calculatedFlexWidth;
+    }
+    const textContent = child.textContent;
+    if ( (textContent.length) > 0 ) {
+      if ( child.getChildCount() == 0 ) {
+        let fontSize = child.inheritedFontSize;
+        if ( child.fontSize.isSet ) {
+          fontSize = child.fontSize.pixels;
+        }
+        if ( fontSize <= 0.0 ) {
+          fontSize = 14.0;
+        }
+        const contentW = this.measureTextContentWidth(textContent, fontSize);
+        const measuredW = ((contentW + child.box.paddingLeftPx) + child.box.paddingRightPx) + (child.box.borderWidthPx * 2.0);
+        if ( measuredW < maxInnerWidth ) {
+          return measuredW;
+        }
+      }
+    }
+    return maxInnerWidth;
+  };
+  measureTextContentWidth (text, fontSize) {
+    if ( (text.length) == 0 ) {
+      return 0.0;
+    }
+    const fontFamily = "Helvetica";
+    const lines = text.split("\n");
+    let maxW = 0.0;
+    let i = 0;
+    while (i < (lines.length)) {
+      const line = lines[i];
+      const lineW = this.measurer.measureTextWidth(line, fontFamily, fontSize);
+      if ( lineW > maxW ) {
+        maxW = lineW;
+      }
+      i = i + 1;
+    };
+    return maxW;
   };
   estimateLineCount (text, maxWidth, fontSize) {
     if ( (text.length) == 0 ) {
@@ -8863,10 +9194,19 @@ class FontManager  {
       }
       i = i + 1;
     };
-    const fullPath_1 = (this.fontsDirectory + "/") + relativePath;
+    let separator = "/";
+    const dirLen = this.fontsDirectory.length;
+    if ( dirLen > 0 ) {
+      const lastChar = this.fontsDirectory.substring((dirLen - 1), dirLen );
+      if ( lastChar == "/" ) {
+        separator = "";
+      }
+    }
+    const fullPath_1 = (this.fontsDirectory + separator) + relativePath;
+    console.log("FontManager: Trying to load font from: " + fullPath_1);
     const font_1 = new TrueTypeFont();
     if ( font_1.loadFromFile(fullPath_1) == false ) {
-      console.log("FontManager: Failed to load font: " + relativePath);
+      console.log(((("FontManager: Failed to load font: " + relativePath) + " (full path: ") + fullPath_1) + ")");
       return false;
     }
     this.fonts.push(font_1);
@@ -8882,19 +9222,62 @@ class FontManager  {
     this.loadFont(((familyDir + "/") + familyDir) + "-Regular.ttf");
   };
   getFont (fontFamily) {
+    const slashIdx = fontFamily.indexOf("/");
+    let searchFamily = fontFamily;
+    let searchStyle = "";
+    if ( slashIdx >= 0 ) {
+      searchFamily = fontFamily.substring(0, slashIdx );
+      const afterSlash = fontFamily.substring((slashIdx + 1), (fontFamily.length) );
+      const dashIdx = afterSlash.indexOf("-");
+      if ( dashIdx >= 0 ) {
+        searchStyle = afterSlash.substring((dashIdx + 1), (afterSlash.length) );
+      }
+    } else {
+      const dashIdx_1 = fontFamily.indexOf("-");
+      if ( dashIdx_1 >= 0 ) {
+        searchFamily = fontFamily.substring(0, dashIdx_1 );
+        searchStyle = fontFamily.substring((dashIdx_1 + 1), (fontFamily.length) );
+      }
+    }
     let i = 0;
     while (i < (this.fonts.length)) {
       const f = this.fonts[i];
-      if ( f.fontFamily == fontFamily ) {
-        return f;
+      if ( f.fontFamily == searchFamily ) {
+        if ( (searchStyle.length) > 0 ) {
+          if ( f.fontStyle == searchStyle ) {
+            return f;
+          }
+        } else {
+          return f;
+        }
       }
       i = i + 1;
     };
     i = 0;
     while (i < (this.fonts.length)) {
       const f_1 = this.fonts[i];
-      if ( (f_1.fontFamily.indexOf(fontFamily)) >= 0 ) {
-        return f_1;
+      if ( f_1.fontFamily == searchFamily ) {
+        if ( (searchStyle.length) > 0 ) {
+          if ( (f_1.fontStyle.indexOf(searchStyle)) >= 0 ) {
+            return f_1;
+          }
+        }
+      }
+      i = i + 1;
+    };
+    i = 0;
+    while (i < (this.fonts.length)) {
+      const f_2 = this.fonts[i];
+      if ( f_2.fontFamily == fontFamily ) {
+        return f_2;
+      }
+      i = i + 1;
+    };
+    i = 0;
+    while (i < (this.fonts.length)) {
+      const f_3 = this.fonts[i];
+      if ( (f_3.fontFamily.indexOf(fontFamily)) >= 0 ) {
+        return f_3;
       }
       i = i + 1;
     };
@@ -8948,7 +9331,7 @@ class FontManager  {
 }
 class TTFTextMeasurer  extends EVGTextMeasurer {
   constructor(fm) {
-    super()
+    super(fm)
     this.fontManager = fm;
   }
   measureText (text, fontFamily, fontSize) {
@@ -9481,6 +9864,15 @@ class ImageBuffer  {
     this.pixels = (function(){ var b = new ArrayBuffer(size); b._view = new DataView(b); return b; })();
     this.fill(255, 255, 255, 255);
   };
+  initClear (w, h) {
+    this.width = w;
+    this.height = h;
+    this.pixels = (function(){ var b = new ArrayBuffer(((w * h) * 4)); b._view = new DataView(b); return b; })();
+  };
+  fillTransparent () {
+    const size = (this.width * this.height) * 4;
+    (function(b,v,s,e){ var arr = new Uint8Array(b); for(var i=s;i<e;i++) arr[i]=v; })(this.pixels,0,0,size);
+  };
   getPixelOffset (x, y) {
     return ((y * this.width) + x) * 4;
   };
@@ -9527,6 +9919,18 @@ class ImageBuffer  {
       this.pixels._view.setUint8(off + 2, b);
       this.pixels._view.setUint8(off + 3, 255);
     }
+  };
+  setPixelRGBA (x, y, r, g, b, a) {
+    if ( this.isValidCoord(x, y) ) {
+      const off = this.getPixelOffset(x, y);
+      this.pixels._view.setUint8(off, r);
+      this.pixels._view.setUint8(off + 1, g);
+      this.pixels._view.setUint8(off + 2, b);
+      this.pixels._view.setUint8(off + 3, a);
+    }
+  };
+  getRawBuffer () {
+    return this.pixels;
   };
   fill (r, g, b, a) {
     const size = (this.width * this.height) * 4;
@@ -10197,6 +10601,37 @@ class JPEGDecoder  {
       i_2 = i_2 + 1;
     };
   }
+  reset () {
+    this.width = 0;
+    this.height = 0;
+    this.numComponents = 0;
+    this.precision = 8;
+    this.scanDataStart = 0;
+    this.scanDataLen = 0;
+    this.mcuWidth = 8;
+    this.mcuHeight = 8;
+    this.mcusPerRow = 0;
+    this.mcusPerCol = 0;
+    this.maxHSamp = 1;
+    this.maxVSamp = 1;
+    this.restartInterval = 0;
+    this.components.length = 0;
+    this.huffman.dcTable0.resetArrays();
+    this.huffman.dcTable1.resetArrays();
+    this.huffman.acTable0.resetArrays();
+    this.huffman.acTable1.resetArrays();
+    let i = 0;
+    while (i < 4) {
+      const qt = this.quantTables[i];
+      qt.values.length = 0;
+      let j = 0;
+      while (j < 64) {
+        qt.values.push(1);
+        j = j + 1;
+      };
+      i = i + 1;
+    };
+  };
   readUint16BE (pos) {
     const high = this.data._view.getUint8(pos);
     const low = this.data._view.getUint8((pos + 1));
@@ -10426,6 +10861,7 @@ class JPEGDecoder  {
     return coeffs;
   };
   decode (dirPath, fileName) {
+    this.reset();
     this.data = (function(){ var b = require('fs').readFileSync(dirPath + '/' + fileName); var ab = new ArrayBuffer(b.length); var v = new Uint8Array(ab); for(var i=0;i<b.length;i++)v[i]=b[i]; ab._view = new DataView(ab); return ab; })();
     this.dataLen = this.data.byteLength;
     console.log(((("Decoding JPEG: " + fileName) + " (") + ((this.dataLen.toString()))) + " bytes)");
@@ -12241,13 +12677,13 @@ class EVGPDFRenderer  {
     if ( section.width.isSet ) {
       return section.width.pixels;
     }
-    return 595.0;
+    return this.pageWidth;
   };
   getSectionPageHeight (section) {
     if ( section.height.isSet ) {
       return section.height.pixels;
     }
-    return 842.0;
+    return this.pageHeight;
   };
   getSectionMargin (section) {
     const m = section.box.marginTop;
@@ -12921,11 +13357,31 @@ class EVGPDFRenderer  {
       this.streamBuffer.writeString("q\n");
       this.applyClipPath(el.clipPath, x, pdfY, w, h);
     }
+    let hasOverflowClip = false;
+    if ( el.overflow == "hidden" ) {
+      hasOverflowClip = true;
+      this.streamBuffer.writeString("q\n");
+      if ( borderRadius > 0.0 ) {
+        this.drawRoundedRectPath(x, pdfY, w, h, borderRadius);
+        this.streamBuffer.writeString("W n\n");
+      } else {
+        this.streamBuffer.writeString(((((((((x.toString())) + " ") + ((pdfY.toString()))) + " ") + ((w.toString()))) + " ") + ((h.toString()))) + " re W n\n");
+      }
+    }
     if ( el.tagName != "text" ) {
       this.renderShadow(el, x, pdfY, w, h, borderRadius);
     }
     if ( (el.backgroundGradient.length) > 0 ) {
-      this.renderGradientBackground(el, x, pdfY, w, h, borderRadius);
+      let hasOpacity = false;
+      if ( el.backgroundGradient.includes("rgba") ) {
+        hasOpacity = true;
+      }
+      if ( el.backgroundGradient.includes("transparent") ) {
+        hasOpacity = true;
+      }
+      if ( hasOpacity == false ) {
+        this.renderGradientBackground(el, x, pdfY, w, h, borderRadius);
+      }
     } else {
       const bgColor = el.backgroundColor;
       if ( this.debug ) {
@@ -12958,6 +13414,9 @@ class EVGPDFRenderer  {
     if ( hasClipPath ) {
       this.streamBuffer.writeString("Q\n");
     }
+    if ( hasOverflowClip ) {
+      this.streamBuffer.writeString("Q\n");
+    }
   };
   getImagePdfName (src) {
     let i = 0;
@@ -12972,14 +13431,83 @@ class EVGPDFRenderer  {
     this.embeddedImages.push(newImg);
     return "/Im" + (((this.embeddedImages.length).toString()));
   };
+  getEmbeddedImage (src) {
+    let i = 0;
+    while (i < (this.embeddedImages.length)) {
+      const embImg = this.embeddedImages[i];
+      if ( embImg.src == src ) {
+        return embImg;
+      }
+      i = i + 1;
+    };
+    const empty = new EmbeddedImage("");
+    return empty;
+  };
   renderImage (el, x, y, w, h) {
     const src = el.src;
     if ( (src.length) == 0 ) {
       return;
     }
     const imgName = this.getImagePdfName(src);
+    let origW = 0.0;
+    let origH = 0.0;
+    const dims = this.loadImageDimensions(src);
+    if ( dims.isValid ) {
+      origW = dims.width;
+      origH = dims.height;
+    }
+    let renderW = w;
+    let renderH = h;
+    let offsetX = 0.0;
+    let offsetY = 0.0;
+    console.log((((((((("renderImage: src=" + src) + " container=") + ((w.toString()))) + "x") + ((h.toString()))) + " origImg=") + ((origW.toString()))) + "x") + ((origH.toString())));
+    if ( origW > 0.0 ) {
+      if ( origH > 0.0 ) {
+        let objectFit = el.objectFit;
+        if ( (objectFit.length) == 0 ) {
+          objectFit = "cover";
+        }
+        const containerRatio = w / h;
+        const imageRatio = origW / origH;
+        console.log((((("  objectFit=" + objectFit) + " containerRatio=") + ((containerRatio.toString()))) + " imageRatio=") + ((imageRatio.toString())));
+        if ( objectFit == "cover" ) {
+          if ( imageRatio > containerRatio ) {
+            renderH = h;
+            renderW = h * imageRatio;
+            offsetX = (w - renderW) / 2.0;
+          } else {
+            renderW = w;
+            renderH = w / imageRatio;
+            offsetY = (h - renderH) / 2.0;
+          }
+        }
+        if ( objectFit == "contain" ) {
+          if ( imageRatio > containerRatio ) {
+            renderW = w;
+            renderH = w / imageRatio;
+            offsetY = (h - renderH) / 2.0;
+          } else {
+            renderH = h;
+            renderW = h * imageRatio;
+            offsetX = (w - renderW) / 2.0;
+          }
+        }
+      }
+    }
     this.streamBuffer.writeString("q\n");
-    this.streamBuffer.writeString(((((((this.formatNum(w) + " 0 0 ") + this.formatNum(h)) + " ") + this.formatNum(x)) + " ") + this.formatNum(y)) + " cm\n");
+    let borderRadius = 0.0;
+    if ( el.box.borderRadius.isSet ) {
+      borderRadius = el.box.borderRadius.pixels;
+    }
+    if ( borderRadius > 0.0 ) {
+      this.drawRoundedRectPath(x, y, w, h, borderRadius);
+      this.streamBuffer.writeString("W n\n");
+    } else {
+      this.streamBuffer.writeString(((((((this.formatNum(x) + " ") + this.formatNum(y)) + " ") + this.formatNum(w)) + " ") + this.formatNum(h)) + " re W n\n");
+    }
+    const finalX = x + offsetX;
+    const finalY = y + offsetY;
+    this.streamBuffer.writeString(((((((this.formatNum(renderW) + " 0 0 ") + this.formatNum(renderH)) + " ") + this.formatNum(finalX)) + " ") + this.formatNum(finalY)) + " cm\n");
     this.streamBuffer.writeString(imgName + " Do\n");
     this.streamBuffer.writeString("Q\n");
   };
@@ -13371,6 +13899,12 @@ class EVGPDFRenderer  {
     }
     const lines = this.wrapText(text, w, fontSize, fontFamily);
     const fontName = this.getPdfFontName(fontFamily);
+    const ttfFontDebug = this.fontManager.getFont(fontFamily);
+    if ( ttfFontDebug.unitsPerEm > 0 ) {
+      console.log(((((("PDF Font: requested='" + fontFamily) + "' -> resolved='") + ttfFontDebug.fontFamily) + "' style='") + ttfFontDebug.fontStyle) + "'");
+    } else {
+      console.log(("PDF Font: requested='" + fontFamily) + "' -> FALLBACK (font not found)");
+    }
     let hasShadow = false;
     let shadowOffsetX = 0.0;
     let shadowOffsetY = 0.0;
@@ -13584,6 +14118,287 @@ class EVGPDFRenderer  {
     return result;
   };
 }
+class TSTopLevelDecl  {
+  constructor() {
+    this.name = "";
+    this.declKind = "";
+    this.node = new TSNode();
+    this.text = "";
+  }
+}
+class TSAstPatchChange  {
+  constructor() {
+    this.changeKind = "";
+    this.name = "";
+    this.declKind = "";
+  }
+}
+class TSAstPatchResult  {
+  constructor() {
+    this.changes = [];
+    this.functionsChanged = false;
+    this.variablesChanged = false;
+    this.sceneAffecting = false;
+    this.hasChanges = false;
+  }
+}
+class TSAstPatcher  {
+  constructor() {
+  }
+  nodeSpanEnd (node) {
+    let best = node.end;
+    if ( best < node.start ) {
+      best = node.start;
+    }
+    if ( typeof(node.body) != "undefined" ) {
+      const bodyEnd = this.nodeSpanEnd((node.body));
+      if ( bodyEnd > best ) {
+        best = bodyEnd;
+      }
+    }
+    if ( typeof(node.left) != "undefined" ) {
+      const leftEnd = this.nodeSpanEnd((node.left));
+      if ( leftEnd > best ) {
+        best = leftEnd;
+      }
+    }
+    if ( typeof(node.right) != "undefined" ) {
+      const rightEnd = this.nodeSpanEnd((node.right));
+      if ( rightEnd > best ) {
+        best = rightEnd;
+      }
+    }
+    if ( typeof(node.init) != "undefined" ) {
+      const initEnd = this.nodeSpanEnd((node.init));
+      if ( initEnd > best ) {
+        best = initEnd;
+      }
+    }
+    if ( typeof(node.test) != "undefined" ) {
+      const testEnd = this.nodeSpanEnd((node.test));
+      if ( testEnd > best ) {
+        best = testEnd;
+      }
+    }
+    if ( typeof(node.consequent) != "undefined" ) {
+      const consEnd = this.nodeSpanEnd((node.consequent));
+      if ( consEnd > best ) {
+        best = consEnd;
+      }
+    }
+    if ( typeof(node.alternate) != "undefined" ) {
+      const altEnd = this.nodeSpanEnd((node.alternate));
+      if ( altEnd > best ) {
+        best = altEnd;
+      }
+    }
+    let i = 0;
+    while (i < (node.children.length)) {
+      const childEnd = this.nodeSpanEnd((node.children[i]));
+      if ( childEnd > best ) {
+        best = childEnd;
+      }
+      i = i + 1;
+    };
+    return best;
+  };
+  declText (src, node) {
+    let start = node.start;
+    let end = this.nodeSpanEnd(node);
+    const __len = src.length;
+    if ( start < 0 ) {
+      start = 0;
+    }
+    if ( end > __len ) {
+      end = __len;
+    }
+    if ( end <= start ) {
+      return "";
+    }
+    return src.substring(start, end );
+  };
+  isSceneAffectingFunction (name) {
+    if ( name == "initState" ) {
+      return true;
+    }
+    if ( name == "sprites" ) {
+      return true;
+    }
+    if ( name == "resources" ) {
+      return true;
+    }
+    if ( name == "screens" ) {
+      return true;
+    }
+    if ( name == "createStaticBg" ) {
+      return true;
+    }
+    if ( name == "staticLevelHeight" ) {
+      return true;
+    }
+    if ( name == "backgroundImage" ) {
+      return true;
+    }
+    return false;
+  };
+  collectFromNode (src, node, decls) {
+    if ( node.nodeType == "FunctionDeclaration" ) {
+      if ( node.name == "render" ) {
+        return;
+      }
+      const d = new TSTopLevelDecl();
+      d.name = node.name;
+      d.declKind = "function";
+      d.node = node;
+      d.text = this.declText(src, node);
+      decls.push(d);
+      return;
+    }
+    if ( node.nodeType == "VariableDeclaration" ) {
+      let i = 0;
+      while (i < (node.children.length)) {
+        const decl = node.children[i];
+        if ( decl.nodeType == "VariableDeclarator" ) {
+          const d2 = new TSTopLevelDecl();
+          d2.name = decl.name;
+          d2.declKind = "variable";
+          d2.node = node;
+          d2.text = this.declText(src, node);
+          decls.push(d2);
+        }
+        i = i + 1;
+      };
+      return;
+    }
+    if ( node.nodeType == "ExportNamedDeclaration" ) {
+      if ( typeof(node.left) != "undefined" ) {
+        this.collectFromNode(src, node.left, decls);
+      }
+      return;
+    }
+    if ( node.nodeType == "ExportDefaultDeclaration" ) {
+      if ( typeof(node.left) != "undefined" ) {
+        this.collectFromNode(src, node.left, decls);
+      }
+    }
+  };
+  collectTopLevelDecls (ast, src) {
+    let decls = [];
+    let i = 0;
+    while (i < (ast.children.length)) {
+      const node = ast.children[i];
+      this.collectFromNode(src, node, decls);
+      i = i + 1;
+    };
+    return decls;
+  };
+  findDeclByName (decls, name) {
+    const empty = new TSNode();
+    let i = 0;
+    while (i < (decls.length)) {
+      const d = decls[i];
+      if ( d.name == name ) {
+        return d.node;
+      }
+      i = i + 1;
+    };
+    return empty;
+  };
+  findDeclMeta (decls, name) {
+    let i = 0;
+    while (i < (decls.length)) {
+      const d = decls[i];
+      if ( d.name == name ) {
+        return d.node;
+      }
+      i = i + 1;
+    };
+    const empty = new TSNode();
+    return empty;
+  };
+  hasDeclByName (decls, name) {
+    let i = 0;
+    while (i < (decls.length)) {
+      const d = decls[i];
+      if ( d.name == name ) {
+        return true;
+      }
+      i = i + 1;
+    };
+    return false;
+  };
+  findDeclText (decls, name) {
+    let i = 0;
+    while (i < (decls.length)) {
+      const d = decls[i];
+      if ( d.name == name ) {
+        return d.text;
+      }
+      i = i + 1;
+    };
+    return "";
+  };
+  findDeclKind (decls, name) {
+    let i = 0;
+    while (i < (decls.length)) {
+      const d = decls[i];
+      if ( d.name == name ) {
+        return d.declKind;
+      }
+      i = i + 1;
+    };
+    return "";
+  };
+  pushChange (result, kind, name, declKind, newNode) {
+    const ch = new TSAstPatchChange();
+    ch.changeKind = kind;
+    ch.name = name;
+    ch.declKind = declKind;
+    ch.newNode = newNode;
+    result.changes.push(ch);
+    result.hasChanges = true;
+    if ( declKind == "function" ) {
+      result.functionsChanged = true;
+      if ( this.isSceneAffectingFunction(name) ) {
+        result.sceneAffecting = true;
+      }
+    }
+    if ( declKind == "variable" ) {
+      result.variablesChanged = true;
+      result.sceneAffecting = true;
+    }
+  };
+  diffTopLevel (oldAst, oldSrc, newAst, newSrc) {
+    const result = new TSAstPatchResult();
+    let emptyChanges = [];
+    result.changes = emptyChanges;
+    const oldDecls = this.collectTopLevelDecls(oldAst, oldSrc);
+    const newDecls = this.collectTopLevelDecls(newAst, newSrc);
+    let i = 0;
+    while (i < (newDecls.length)) {
+      const nd = newDecls[i];
+      if ( this.hasDeclByName(oldDecls, nd.name) == false ) {
+        this.pushChange(result, "added", nd.name, nd.declKind, nd.node);
+      } else {
+        const oldText = this.findDeclText(oldDecls, nd.name);
+        if ( oldText != nd.text ) {
+          this.pushChange(result, "modified", nd.name, nd.declKind, nd.node);
+        }
+      }
+      i = i + 1;
+    };
+    let j = 0;
+    while (j < (oldDecls.length)) {
+      const od = oldDecls[j];
+      if ( this.hasDeclByName(newDecls, od.name) == false ) {
+        const emptyNode = new TSNode();
+        this.pushChange(result, "removed", od.name, od.declKind, emptyNode);
+      }
+      j = j + 1;
+    };
+    return result;
+  };
+}
 class EvalValue  {
   constructor() {
     this.valueType = 0;
@@ -13591,8 +14406,7 @@ class EvalValue  {
     this.stringValue = "";
     this.boolValue = false;
     this.arrayValue = [];
-    this.objectKeys = [];
-    this.objectValues = [];
+    this.objectMap = {};
     this.functionName = "";
     this.functionBody = "";     /** note: unused */
   }
@@ -13620,6 +14434,9 @@ class EvalValue  {
   isElement () {
     return this.valueType == 7;
   };
+  isUndefined () {
+    return this.valueType == 8;
+  };
   toNumber () {
     if ( this.valueType == 1 ) {
       return this.numberValue;
@@ -13639,6 +14456,9 @@ class EvalValue  {
   toString () {
     if ( this.valueType == 0 ) {
       return "null";
+    }
+    if ( this.valueType == 8 ) {
+      return "undefined";
     }
     if ( this.valueType == 1 ) {
       const s = (this.numberValue.toString());
@@ -13673,15 +14493,16 @@ class EvalValue  {
     }
     if ( this.valueType == 5 ) {
       let result_1 = "{";
+      const keyList = Object.keys(this.objectMap);
       let i_1 = 0;
-      while (i_1 < (this.objectKeys.length)) {
+      for ( let idx = 0; idx < keyList.length; idx++) {
+        var kk = keyList[idx];
         if ( i_1 > 0 ) {
           result_1 = result_1 + ", ";
         }
-        const key = this.objectKeys[i_1];
-        const val = this.objectValues[i_1];
+        const val = (( this.objectMap.hasOwnProperty(kk) ? this.objectMap[kk] : undefined ));
         const valStr = (val).toString();
-        result_1 = ((result_1 + key) + ": ") + valStr;
+        result_1 = ((result_1 + kk) + ": ") + valStr;
         i_1 = i_1 + 1;
       };
       return result_1 + "}";
@@ -13700,6 +14521,9 @@ class EvalValue  {
   };
   toBool () {
     if ( this.valueType == 0 ) {
+      return false;
+    }
+    if ( this.valueType == 8 ) {
       return false;
     }
     if ( this.valueType == 1 ) {
@@ -13727,13 +14551,9 @@ class EvalValue  {
   };
   getMember (key) {
     if ( this.valueType == 5 ) {
-      let i = 0;
-      while (i < (this.objectKeys.length)) {
-        if ( (this.objectKeys[i]) == key ) {
-          return this.objectValues[i];
-        }
-        i = i + 1;
-      };
+      if ( ( typeof(this.objectMap[key] ) != "undefined" && this.objectMap.hasOwnProperty(key) ) ) {
+        return (( this.objectMap.hasOwnProperty(key) ? this.objectMap[key] : undefined ));
+      }
     }
     if ( this.valueType == 4 ) {
       if ( key == "length" ) {
@@ -13746,6 +14566,21 @@ class EvalValue  {
       }
     }
     return EvalValue.null();
+  };
+  setMember (key, value) {
+    if ( this.valueType != 5 ) {
+      return;
+    }
+    this.objectMap[key] = value;
+  };
+  setIndexAt (index, value) {
+    if ( this.valueType != 4 ) {
+      return;
+    }
+    while (index >= (this.arrayValue.length)) {
+      this.arrayValue.push(EvalValue.null());
+    };
+    this.arrayValue[index] = value;
   };
   getIndex (index) {
     if ( this.valueType == 4 ) {
@@ -13767,6 +14602,9 @@ class EvalValue  {
     }
     if ( this.valueType == 0 ) {
       return true;
+    }
+    if ( this.valueType == 8 ) {
+      return other.valueType == 8;
     }
     if ( this.valueType == 1 ) {
       return this.numberValue == other.numberValue;
@@ -13818,8 +14656,13 @@ EvalValue.array = function(items) {
 EvalValue.object = function(keys, values) {
   const v = new EvalValue();
   v.valueType = 5;
-  v.objectKeys = keys;
-  v.objectValues = values;
+  let i = 0;
+  while (i < (keys.length)) {
+    if ( i < (values.length) ) {
+      v.objectMap[keys[i]] = values[i];
+    }
+    i = i + 1;
+  };
   return v;
 };
 EvalValue.function = function(fnNode) {
@@ -13833,6 +14676,11 @@ EvalValue.element = function(el) {
   const v = new EvalValue();
   v.valueType = 7;
   v.evgElement = el;
+  return v;
+};
+EvalValue.undefined = function() {
+  const v = new EvalValue();
+  v.valueType = 8;
   return v;
 };
 class ImportedSymbol  {
@@ -13879,6 +14727,59 @@ class EvalContext  {
     }
     return EvalValue.null();
   };
+  assignExisting (name, value) {
+    let i = 0;
+    while (i < (this.variables.length)) {
+      if ( (this.variables[i]) == name ) {
+        this.values[i] = value;
+        return true;
+      }
+      i = i + 1;
+    };
+    if ( typeof(this.parent) != "undefined" ) {
+      const p = this.parent;
+      return p.assignExisting(name, value);
+    }
+    return false;
+  };
+  assign (name, value) {
+    if ( this.assignExisting(name, value) ) {
+      return;
+    }
+    this.define(name, value);
+  };
+  removeBinding (name) {
+    let i = 0;
+    while (i < (this.variables.length)) {
+      if ( (this.variables[i]) == name ) {
+        let newVars = [];
+        let newVals = [];
+        let j = 0;
+        while (j < (this.variables.length)) {
+          if ( j != i ) {
+            newVars.push(this.variables[j]);
+            newVals.push(this.values[j]);
+          }
+          j = j + 1;
+        };
+        this.variables = newVars;
+        this.values = newVals;
+        return true;
+      }
+      i = i + 1;
+    };
+    if ( typeof(this.parent) != "undefined" ) {
+      const p = this.parent;
+      return p.removeBinding(name);
+    }
+    return false;
+  };
+  moduleScope () {
+    if ( typeof(this.moduleRoot) != "undefined" ) {
+      return this.moduleRoot;
+    }
+    return this;
+  };
   has (name) {
     let i = 0;
     while (i < (this.variables.length)) {
@@ -13896,7 +14797,22 @@ class EvalContext  {
   createChild () {
     const child = new EvalContext();
     child.parent = this;
+    if ( typeof(this.moduleRoot) != "undefined" ) {
+      child.moduleRoot = this.moduleRoot;
+    } else {
+      child.moduleRoot = this;
+    }
     return child;
+  };
+}
+class EvalNativeBridge  {
+  constructor() {
+  }
+  has (name) {
+    return false;
+  };
+  invoke (name, args) {
+    return EvalValue.null();
   };
 }
 class ComponentEngine  {
@@ -13916,7 +14832,16 @@ class ComponentEngine  {
     this.imports = [];
     this.localComponents = [];
     this.loadedFiles = [];
+    this.importLoading = [];
+    this.importLoaded = [];
     this.primitives = [];
+    this.scriptDidReturn = false;
+    this.scriptReturnValue = EvalValue.null();
+    this.loopBreak = false;
+    this.loopContinue = false;
+    this.quiet = false;
+    this.astPatcher = new TSAstPatcher();
+    this.resolvedImportDir = "./";
     const p = new TSParserSimple();
     this.parser = p;
     this.parser.tsxMode = true;
@@ -13926,8 +14851,18 @@ class ComponentEngine  {
     this.localComponents = loc;
     let lf = [];
     this.loadedFiles = lf;
-    const ctx = new EvalContext();
-    this.context = ctx;
+    let il = [];
+    this.importLoading = il;
+    let id = [];
+    this.importLoaded = id;
+    const host = new EvalContext();
+    host.moduleRoot = host;
+    this.hostScope = host;
+    const mod = new EvalContext();
+    mod.parent = this.hostScope;
+    mod.moduleRoot = mod;
+    this.moduleScope = mod;
+    this.context = mod;
     let prim = [];
     this.primitives = prim;
     let ap_1 = [];
@@ -13952,6 +14887,24 @@ class ComponentEngine  {
     this.primitives.push("path");
     this.primitives.push("layer");
   }
+  trace (msg) {
+    if ( this.quiet == false ) {
+      console.log(msg);
+    }
+  };
+  addAssetPath (path) {
+    if ( (path.length) == 0 ) {
+      return;
+    }
+    let i = 0;
+    while (i < (this.assetPaths.length)) {
+      if ( (this.assetPaths[i]) == path ) {
+        return;
+      }
+      i = i + 1;
+    };
+    this.assetPaths.push(path);
+  };
   setAssetPaths (paths) {
     let start = 0;
     let i = 0;
@@ -13984,15 +14937,201 @@ class ComponentEngine  {
   getLoadedFiles () {
     return this.loadedFiles;
   };
+  normalizeDirPath (dirPath) {
+    if ( (dirPath.length) == 0 ) {
+      return "./";
+    }
+    const last = dirPath.length;
+    const lastCh = dirPath.substring((last - 1), last );
+    if ( lastCh != "/" ) {
+      return dirPath + "/";
+    }
+    return dirPath;
+  };
+  dirnameOfModulePath (fullPath) {
+    let lastSlash = -1;
+    let i = 0;
+    while (i < (fullPath.length)) {
+      const ch = fullPath.substring(i, (i + 1) );
+      if ( ch == "/" ) {
+        lastSlash = i;
+      }
+      i = i + 1;
+    };
+    if ( lastSlash < 0 ) {
+      return "";
+    }
+    return fullPath.substring(0, (lastSlash + 1) );
+  };
+  moduleDirFromRead (searchDir, fullPath) {
+    const subDir = this.dirnameOfModulePath(fullPath);
+    return this.normalizeDirPath((searchDir + subDir));
+  };
+  isInStringList (value, list) {
+    let i = 0;
+    while (i < (list.length)) {
+      if ( (list[i]) == value ) {
+        return true;
+      }
+      i = i + 1;
+    };
+    return false;
+  };
+  listWithoutString (list, value) {
+    let out = [];
+    let i = 0;
+    while (i < (list.length)) {
+      const item = list[i];
+      if ( item != value ) {
+        out.push(item);
+      }
+      i = i + 1;
+    };
+    return out;
+  };
+  listWithStringIfMissing (list, value) {
+    if ( this.isInStringList(value, list) ) {
+      return list;
+    }
+    let out = [];
+    let i = 0;
+    while (i < (list.length)) {
+      out.push(list[i]);
+      i = i + 1;
+    };
+    out.push(value);
+    return out;
+  };
+  clearImportState () {
+    let empty = [];
+    this.importLoading = empty;
+    this.importLoaded = empty;
+  };
+  resetParseState () {
+    const scope = new EvalContext();
+    scope.parent = this.hostScope;
+    scope.moduleRoot = scope;
+    this.moduleScope = scope;
+    this.context = scope;
+    this.clearLocalComponents();
+    this.clearImportState();
+    let emptyFiles = [];
+    this.loadedFiles = emptyFiles;
+  };
+  upsertLocalComponent (sym) {
+    let i = 0;
+    while (i < (this.localComponents.length)) {
+      const existing = this.localComponents[i];
+      if ( existing.name == sym.name ) {
+        existing.functionNode = sym.functionNode;
+        existing.originalName = sym.originalName;
+        existing.sourcePath = sym.sourcePath;
+        existing.symbolType = sym.symbolType;
+        existing.helperFunctions = sym.helperFunctions;
+        return;
+      }
+      i = i + 1;
+    };
+    this.localComponents.push(sym);
+  };
+  removeLocalComponentByName (name) {
+    let out = [];
+    let i = 0;
+    while (i < (this.localComponents.length)) {
+      const sym = this.localComponents[i];
+      if ( sym.name != name ) {
+        out.push(sym);
+      }
+      i = i + 1;
+    };
+    this.localComponents = out;
+  };
+  localNameForImport (exportName, exportNames, localNames) {
+    let i = 0;
+    while (i < (exportNames.length)) {
+      if ( (exportNames[i]) == exportName ) {
+        return localNames[i];
+      }
+      i = i + 1;
+    };
+    return exportName;
+  };
+  bindImportedFunction (exportName, localName, fnNode, helperFns, sourcePath) {
+    const sym = new ImportedSymbol();
+    sym.name = localName;
+    sym.originalName = exportName;
+    sym.sourcePath = sourcePath;
+    sym.symbolType = "component";
+    sym.functionNode = fnNode;
+    sym.helperFunctions = helperFns;
+    this.upsertLocalComponent(sym);
+    this.defineModuleBinding(localName, EvalValue.function(fnNode));
+    this.trace((((("Imported: " + localName) + " (") + exportName) + ") from ") + sourcePath);
+  };
+  rebindImportDeclaration (node) {
+    let exportNames = [];
+    let localNames = [];
+    let j = 0;
+    while (j < (node.children.length)) {
+      const spec = node.children[j];
+      if ( spec.nodeType == "ImportSpecifier" ) {
+        if ( spec.kind != "type" ) {
+          const exportName = spec.name;
+          let localName = spec.name;
+          if ( (spec.value.length) > 0 ) {
+            localName = spec.value;
+          }
+          exportNames.push(exportName);
+          localNames.push(localName);
+        }
+      }
+      if ( spec.nodeType == "ImportDefaultSpecifier" ) {
+        exportNames.push("default");
+        localNames.push(spec.name);
+      }
+      j = j + 1;
+    };
+    let k = 0;
+    while (k < (exportNames.length)) {
+      const exportName_1 = exportNames[k];
+      const localName_1 = localNames[k];
+      const existing = this.moduleScope.lookup(exportName_1);
+      if ( existing.isFunction() ) {
+        if ( typeof(existing.functionNode) === "undefined" ) {
+        } else {
+          const fnNode = existing.functionNode;
+          let emptyHelpers = [];
+          this.bindImportedFunction(exportName_1, localName_1, fnNode, emptyHelpers, "");
+        }
+      } else {
+        if ( false == existing.isNull() ) {
+          this.defineModuleBinding(localName_1, existing);
+        }
+      }
+      k = k + 1;
+    };
+  };
   parseFile (dirPath, fileName) {
-    this.basePath = dirPath;
-    const mainFilePath = dirPath + fileName;
+    this.resetParseState();
+    this.setBasePath(dirPath);
+    const mainFilePath = this.basePath + fileName;
     this.loadedFiles.push(mainFilePath);
     const fileContent = (function(){ var b = require('fs').readFileSync(dirPath + '/' + fileName); var ab = new ArrayBuffer(b.length); var v = new Uint8Array(ab); for(var i=0;i<b.length;i++)v[i]=b[i]; ab._view = new DataView(ab); return ab; })();
     const src = (function(b){ var v = new Uint8Array(b); return String.fromCharCode.apply(null, v); })(fileContent);
     return this.parse(src);
   };
+  setBasePath (dirPath) {
+    this.basePath = dirPath;
+    if ( (dirPath.length) > 0 ) {
+      const last = dirPath.length;
+      const lastCh = dirPath.substring((last - 1), last );
+      if ( lastCh != "/" ) {
+        this.basePath = dirPath + "/";
+      }
+    }
+  };
   parse (src) {
+    this.resetParseState();
     this.source = src;
     const lexer = new TSLexer(src);
     const tokens = lexer.tokenize();
@@ -14010,6 +15149,148 @@ class ComponentEngine  {
     }
     return this.evaluateFunction(renderFn);
   };
+  registerGlobal (name, value) {
+    this.hostScope.define(name, value);
+  };
+  removeGlobal (name) {
+    this.hostScope.removeBinding(name);
+  };
+  setNativeBridge (bridge) {
+    this.nativeBridge = bridge;
+  };
+  collectCallArgs (node) {
+    let args = [];
+    let i = 0;
+    while (i < (node.children.length)) {
+      const argNode = node.children[i];
+      args.push(this.evaluateExpr(argNode));
+      i = i + 1;
+    };
+    return args;
+  };
+  defineModuleBinding (name, value) {
+    this.moduleScope.define(name, value);
+  };
+  getGlobal (name) {
+    const v = this.context.lookup(name);
+    if ( false == v.isNull() ) {
+      return v;
+    }
+    return this.hostScope.lookup(name);
+  };
+  parseProgramFromSrc (src) {
+    const lexer = new TSLexer(src);
+    const tokens = lexer.tokenize();
+    this.parser.initParser(tokens);
+    this.parser.tsxMode = true;
+    return this.parser.parseProgram();
+  };
+  clearLocalComponents () {
+    let empty = [];
+    this.localComponents = empty;
+  };
+  loadScript (src) {
+    this.source = src;
+    const ast = this.parseProgramFromSrc(src);
+    this.programAst = ast;
+    const scope = new EvalContext();
+    scope.parent = this.hostScope;
+    scope.moduleRoot = scope;
+    this.moduleScope = scope;
+    this.context = scope;
+    this.clearLocalComponents();
+    this.clearImportState();
+    let emptyFiles = [];
+    this.loadedFiles = emptyFiles;
+    this.processImports(ast);
+    this.registerComponents(ast);
+    this.processVariables(ast);
+  };
+  updateLocalComponentNode (name, node) {
+    let i = 0;
+    while (i < (this.localComponents.length)) {
+      const sym = this.localComponents[i];
+      if ( sym.name == name ) {
+        sym.functionNode = node;
+        return;
+      }
+      i = i + 1;
+    };
+    this.registerFunctionDeclaration(node);
+  };
+  patchScript (src) {
+    if ( typeof(this.programAst) === "undefined" ) {
+      this.loadScript(src);
+      return true;
+    }
+    const oldAst = this.programAst;
+    const oldSrc = this.source;
+    const newAst = this.parseProgramFromSrc(src);
+    const patch = this.astPatcher.diffTopLevel(oldAst, oldSrc, newAst, src);
+    if ( patch.hasChanges == false ) {
+      return false;
+    }
+    this.source = src;
+    this.programAst = newAst;
+    this.clearLocalComponents();
+    this.clearImportState();
+    this.processImports(newAst);
+    let ci = 0;
+    while (ci < (patch.changes.length)) {
+      const ch = patch.changes[ci];
+      if ( ch.changeKind == "removed" ) {
+        this.moduleScope.removeBinding(ch.name);
+        this.removeLocalComponentByName(ch.name);
+        this.trace("Removed binding: " + ch.name);
+      } else {
+        if ( ch.declKind == "function" ) {
+          if ( ch.changeKind != "removed" ) {
+            if ( typeof(ch.newNode) != "undefined" ) {
+              const fnNode = ch.newNode;
+              this.updateLocalComponentNode(ch.name, fnNode);
+              this.moduleScope.define(ch.name, EvalValue.function(fnNode));
+              this.trace("Patched function: " + ch.name);
+            }
+          }
+        }
+        if ( ch.declKind == "variable" ) {
+          if ( ch.changeKind != "removed" ) {
+            if ( typeof(ch.newNode) != "undefined" ) {
+              const varNode = ch.newNode;
+              this.processModuleVariableDeclaration(varNode);
+              this.trace("Patched variable: " + ch.name);
+            }
+          }
+        }
+      }
+      ci = ci + 1;
+    };
+    return patch.sceneAffecting;
+  };
+  callFunction (name, props) {
+    const fnValue = this.context.lookup(name);
+    if ( false == fnValue.isFunction() ) {
+      return EvalValue.null();
+    }
+    if ( typeof(fnValue.functionNode) === "undefined" ) {
+      return EvalValue.null();
+    }
+    const fnNode = fnValue.functionNode;
+    return this.evaluateFunctionCall(fnNode, props);
+  };
+  callRender (name, props) {
+    const fnValue = this.context.lookup(name);
+    if ( false == fnValue.isFunction() ) {
+      const empty = new EVGElement();
+      return empty;
+    }
+    if ( typeof(fnValue.functionNode) === "undefined" ) {
+      const empty2 = new EVGElement();
+      return empty2;
+    }
+    const fnNode = fnValue.functionNode;
+    return this.evaluateFunctionWithProps(fnNode, props);
+  };
   processImports (ast) {
     let i = 0;
     while (i < (ast.children.length)) {
@@ -14021,6 +15302,9 @@ class ComponentEngine  {
     };
   };
   processImportDeclaration (node) {
+    if ( node.kind == "type" ) {
+      return;
+    }
     let modulePath = "";
     if ( typeof(node.left) != "undefined" ) {
       const srcNode = node.left;
@@ -14035,15 +15319,28 @@ class ComponentEngine  {
     if ( (modulePath.indexOf("evg_")) >= 0 ) {
       return;
     }
-    let importedNames = [];
+    if ( (modulePath.indexOf(".d.ts")) >= 0 ) {
+      return;
+    }
+    let importExportNames = [];
+    let importLocalNames = [];
     let j = 0;
     while (j < (node.children.length)) {
       const spec = node.children[j];
       if ( spec.nodeType == "ImportSpecifier" ) {
-        importedNames.push(spec.name);
+        if ( spec.kind != "type" ) {
+          const exportName = spec.name;
+          let localName = spec.name;
+          if ( (spec.value.length) > 0 ) {
+            localName = spec.value;
+          }
+          importExportNames.push(exportName);
+          importLocalNames.push(localName);
+        }
       }
       if ( spec.nodeType == "ImportDefaultSpecifier" ) {
-        importedNames.push(spec.name);
+        importExportNames.push("default");
+        importLocalNames.push(spec.name);
       }
       j = j + 1;
     };
@@ -14051,15 +15348,27 @@ class ComponentEngine  {
     if ( (fullPath.length) == 0 ) {
       return;
     }
-    const dirPath = this.basePath;
-    console.log(("Loading import: " + dirPath) + fullPath);
-    const loadedFilePath = dirPath + fullPath;
-    this.loadedFiles.push(loadedFilePath);
-    const fileContent = (function(){ var b = require('fs').readFileSync(dirPath + '/' + fullPath); var ab = new ArrayBuffer(b.length); var v = new Uint8Array(ab); for(var i=0;i<b.length;i++)v[i]=b[i]; ab._view = new DataView(ab); return ab; })();
-    const src = (function(b){ var v = new Uint8Array(b); return String.fromCharCode.apply(null, v); })(fileContent);
+    const importerBase = this.normalizeDirPath(this.basePath);
+    this.resolvedImportDir = importerBase;
+    const canonicalPath = importerBase + fullPath;
+    if ( this.isInStringList(canonicalPath, this.importLoading) ) {
+      this.trace("Import cycle skipped: " + canonicalPath);
+      this.rebindImportDeclaration(node);
+      return;
+    }
+    if ( this.isInStringList(canonicalPath, this.importLoaded) ) {
+      this.rebindImportDeclaration(node);
+      return;
+    }
+    this.importLoading.push(canonicalPath);
+    const src = this.readImportSource(importerBase, fullPath);
+    const foundDir = this.resolvedImportDir;
+    const dirPath = this.moduleDirFromRead(foundDir, fullPath);
+    this.resolvedImportDir = dirPath;
     if ( (src.length) == 0 ) {
+      this.importLoading = this.listWithoutString(this.importLoading, canonicalPath);
       console.log("");
-      console.log(("ERROR: Could not load component module: " + dirPath) + fullPath);
+      console.log(("ERROR: Could not load component module: " + importerBase) + fullPath);
       console.log("");
       console.log("Please ensure the imported file exists. You may need to:");
       console.log("  1. Check that the import path is correct in your TSX file");
@@ -14072,19 +15381,27 @@ class ComponentEngine  {
       console.log("");
       return;
     }
+    console.log(("Loading import: " + dirPath) + fullPath);
+    const loadedFilePath = dirPath + fullPath;
+    this.loadedFiles = this.listWithStringIfMissing(this.loadedFiles, loadedFilePath);
     const lexer = new TSLexer(src);
     const tokens = lexer.tokenize();
     const importParser = new TSParserSimple();
     importParser.initParser(tokens);
     importParser.tsxMode = true;
     const importAst = importParser.parseProgram();
+    const savedBasePath = this.basePath;
+    this.basePath = dirPath;
+    this.processImports(importAst);
+    this.basePath = savedBasePath;
+    this.materializeImportedModule(importAst);
     let helperFns = [];
     let hk = 0;
     while (hk < (importAst.children.length)) {
       const hstmt = importAst.children[hk];
       if ( hstmt.nodeType == "FunctionDeclaration" ) {
         const hfnName = hstmt.name;
-        if ( this.isInList(hfnName, importedNames) == false ) {
+        if ( this.isInList(hfnName, importExportNames) == false ) {
           helperFns.push(hstmt);
           console.log("  Found helper function: " + hfnName);
         }
@@ -14099,36 +15416,82 @@ class ComponentEngine  {
           const declNode = stmt.left;
           if ( declNode.nodeType == "FunctionDeclaration" ) {
             const fnName = declNode.name;
-            if ( this.isInList(fnName, importedNames) ) {
-              const sym = new ImportedSymbol();
-              sym.name = fnName;
-              sym.originalName = fnName;
-              sym.sourcePath = fullPath;
-              sym.symbolType = "component";
-              sym.functionNode = declNode;
-              sym.helperFunctions = helperFns;
-              this.localComponents.push(sym);
-              console.log((("Imported component: " + fnName) + " from ") + fullPath);
+            if ( this.isInList(fnName, importExportNames) ) {
+              const localName_1 = this.localNameForImport(fnName, importExportNames, importLocalNames);
+              this.bindImportedFunction(fnName, localName_1, declNode, helperFns, fullPath);
             }
           }
         }
       }
       if ( stmt.nodeType == "FunctionDeclaration" ) {
         const fnName_1 = stmt.name;
-        if ( this.isInList(fnName_1, importedNames) ) {
-          const sym_1 = new ImportedSymbol();
-          sym_1.name = fnName_1;
-          sym_1.originalName = fnName_1;
-          sym_1.sourcePath = fullPath;
-          sym_1.symbolType = "component";
-          sym_1.functionNode = stmt;
-          sym_1.helperFunctions = helperFns;
-          this.localComponents.push(sym_1);
-          console.log((("Imported component: " + fnName_1) + " from ") + fullPath);
+        if ( this.isInList(fnName_1, importExportNames) ) {
+          const localName_2 = this.localNameForImport(fnName_1, importExportNames, importLocalNames);
+          this.bindImportedFunction(fnName_1, localName_2, stmt, helperFns, fullPath);
         }
       }
       k = k + 1;
     };
+    this.importLoading = this.listWithoutString(this.importLoading, canonicalPath);
+    this.importLoaded = this.listWithStringIfMissing(this.importLoaded, canonicalPath);
+  };
+  materializeImportedModule (ast) {
+    const saved = this.context;
+    this.context = this.moduleScope;
+    let i = 0;
+    while (i < (ast.children.length)) {
+      const node = ast.children[i];
+      this.materializeImportedNode(node);
+      i = i + 1;
+    };
+    this.context = saved;
+  };
+  materializeImportedNode (node) {
+    if ( node.nodeType == "FunctionDeclaration" ) {
+      if ( node.name != "render" ) {
+        this.defineModuleBinding(node.name, EvalValue.function(node));
+      }
+      return;
+    }
+    if ( node.nodeType == "VariableDeclaration" ) {
+      this.processModuleVariableDeclaration(node);
+      return;
+    }
+    if ( node.nodeType == "ExportNamedDeclaration" ) {
+      if ( typeof(node.left) != "undefined" ) {
+        this.materializeImportedNode(node.left);
+      }
+      return;
+    }
+    if ( node.nodeType == "ExportDefaultDeclaration" ) {
+      if ( typeof(node.left) != "undefined" ) {
+        this.materializeImportedNode(node.left);
+      }
+    }
+  };
+  readImportSource (dirPath, fullPath) {
+    if ( require("fs").existsSync(dirPath + "/" + fullPath ) ) {
+      const content = (function(){ var b = require('fs').readFileSync(dirPath + '/' + fullPath); var ab = new ArrayBuffer(b.length); var v = new Uint8Array(ab); for(var i=0;i<b.length;i++)v[i]=b[i]; ab._view = new DataView(ab); return ab; })();
+      const src = (function(b){ var v = new Uint8Array(b); return String.fromCharCode.apply(null, v); })(content);
+      if ( (src.length) > 0 ) {
+        this.resolvedImportDir = dirPath;
+        return src;
+      }
+    }
+    let i = 0;
+    while (i < (this.assetPaths.length)) {
+      const assetDir = this.assetPaths[i];
+      if ( require("fs").existsSync(assetDir + "/" + fullPath ) ) {
+        const tryBuf = (function(){ var b = require('fs').readFileSync(assetDir + '/' + fullPath); var ab = new ArrayBuffer(b.length); var v = new Uint8Array(ab); for(var i=0;i<b.length;i++)v[i]=b[i]; ab._view = new DataView(ab); return ab; })();
+        const trySrc = (function(b){ var v = new Uint8Array(b); return String.fromCharCode.apply(null, v); })(tryBuf);
+        if ( (trySrc.length) > 0 ) {
+          this.resolvedImportDir = assetDir;
+          return trySrc;
+        }
+      }
+      i = i + 1;
+    };
+    return "";
   };
   resolveModulePath (modulePath) {
     if ( (modulePath.indexOf("./")) == 0 ) {
@@ -14164,20 +15527,39 @@ class ComponentEngine  {
     let i = 0;
     while (i < (ast.children.length)) {
       const node = ast.children[i];
-      if ( node.nodeType == "FunctionDeclaration" ) {
-        if ( node.name != "render" ) {
-          const sym = new ImportedSymbol();
-          sym.name = node.name;
-          sym.originalName = node.name;
-          sym.symbolType = "component";
-          sym.functionNode = node;
-          this.localComponents.push(sym);
-          this.context.define(node.name, EvalValue.function(node));
-          console.log("Registered local component: " + node.name);
-        }
-      }
+      this.registerTopLevelNode(node);
       i = i + 1;
     };
+  };
+  registerTopLevelNode (node) {
+    if ( node.nodeType == "FunctionDeclaration" ) {
+      this.registerFunctionDeclaration(node);
+      return;
+    }
+    if ( node.nodeType == "ExportNamedDeclaration" ) {
+      if ( typeof(node.left) != "undefined" ) {
+        this.registerTopLevelNode(node.left);
+      }
+      return;
+    }
+    if ( node.nodeType == "ExportDefaultDeclaration" ) {
+      if ( typeof(node.left) != "undefined" ) {
+        this.registerTopLevelNode(node.left);
+      }
+    }
+  };
+  registerFunctionDeclaration (node) {
+    if ( node.name == "render" ) {
+      return;
+    }
+    const sym = new ImportedSymbol();
+    sym.name = node.name;
+    sym.originalName = node.name;
+    sym.symbolType = "component";
+    sym.functionNode = node;
+    this.upsertLocalComponent(sym);
+    this.defineModuleBinding(node.name, EvalValue.function(node));
+    this.trace("Registered local component: " + node.name);
   };
   findRenderFunction (ast) {
     const empty = new TSNode();
@@ -14197,11 +15579,45 @@ class ComponentEngine  {
     let i = 0;
     while (i < (ast.children.length)) {
       const node = ast.children[i];
-      if ( node.nodeType == "VariableDeclaration" ) {
-        this.processVariableDeclaration(node);
+      this.processTopLevelVarNode(node);
+      i = i + 1;
+    };
+  };
+  processTopLevelVarNode (node) {
+    if ( node.nodeType == "VariableDeclaration" ) {
+      this.processModuleVariableDeclaration(node);
+      return;
+    }
+    if ( node.nodeType == "ExportNamedDeclaration" ) {
+      if ( typeof(node.left) != "undefined" ) {
+        this.processTopLevelVarNode(node.left);
+      }
+      return;
+    }
+    if ( node.nodeType == "ExportDefaultDeclaration" ) {
+      if ( typeof(node.left) != "undefined" ) {
+        this.processTopLevelVarNode(node.left);
+      }
+    }
+  };
+  processModuleVariableDeclaration (node) {
+    const saved = this.context;
+    this.context = this.moduleScope;
+    let i = 0;
+    while (i < (node.children.length)) {
+      const decl = node.children[i];
+      if ( decl.nodeType == "VariableDeclarator" ) {
+        const varName = decl.name;
+        if ( typeof(decl.init) != "undefined" ) {
+          const initNode = decl.init;
+          const value = this.evaluateExpr(initNode);
+          this.moduleScope.define(varName, value);
+          this.trace((("Defined module binding: " + varName) + " = ") + (value).toString());
+        }
       }
       i = i + 1;
     };
+    this.context = saved;
   };
   processVariableDeclaration (node) {
     let i = 0;
@@ -14213,7 +15629,7 @@ class ComponentEngine  {
           const initNode = decl.init;
           const value = this.evaluateExpr(initNode);
           this.context.define(varName, value);
-          console.log((("Defined variable: " + varName) + " = ") + (value).toString());
+          this.trace((("Defined variable: " + varName) + " = ") + (value).toString());
         }
       }
       i = i + 1;
@@ -14238,6 +15654,12 @@ class ComponentEngine  {
   };
   evaluateFunctionCall (fnNode, props) {
     const savedContext = this.context;
+    let savedDidReturn = this.scriptDidReturn;
+    let savedReturnValue = this.scriptReturnValue;
+    savedDidReturn = this.scriptDidReturn;
+    savedReturnValue = this.scriptReturnValue;
+    this.scriptDidReturn = false;
+    this.scriptReturnValue = EvalValue.null();
     this.context = this.context.createChild();
     if ( props.valueType != 0 ) {
       this.bindFunctionParams(fnNode, props);
@@ -14245,6 +15667,8 @@ class ComponentEngine  {
     const body = this.getFunctionBody(fnNode);
     const result = this.evaluateFunctionBodyValue(body);
     this.context = savedContext;
+    this.scriptDidReturn = savedDidReturn;
+    this.scriptReturnValue = savedReturnValue;
     return result;
   };
   bindFunctionParams (fnNode, props) {
@@ -14314,6 +15738,12 @@ class ComponentEngine  {
           return forOfResult;
         }
       }
+      if ( stmt.nodeType == "WhileStatement" ) {
+        const whileResult = this.evaluateWhileStatement(stmt);
+        if ( whileResult.hasReturn ) {
+          return whileResult;
+        }
+      }
       if ( stmt.nodeType == "ExpressionStatement" ) {
         if ( typeof(stmt.left) != "undefined" ) {
           const exprNode = stmt.left;
@@ -14324,6 +15754,10 @@ class ComponentEngine  {
         if ( typeof(stmt.left) != "undefined" ) {
           const returnExpr = stmt.left;
           return this.evaluateJSX(returnExpr);
+        } else {
+          const bareReturn = new EVGElement();
+          bareReturn.hasReturn = true;
+          return bareReturn;
         }
       }
       i = i + 1;
@@ -14334,11 +15768,20 @@ class ComponentEngine  {
     return empty;
   };
   evaluateFunctionBodyValue (body) {
+    if ( body.nodeType == "BlockStatement" ) {
+      const savedDidReturn = this.scriptDidReturn;
+      const savedReturnValue = this.scriptReturnValue;
+      this.scriptDidReturn = false;
+      this.scriptReturnValue = EvalValue.null();
+      this.runStatementList(body.children);
+      const blockOut = this.scriptReturnValue;
+      this.scriptDidReturn = savedDidReturn;
+      this.scriptReturnValue = savedReturnValue;
+      return blockOut;
+    }
     let i = 0;
-    console.log(("evaluateFunctionBodyValue: body has " + (((body.children.length).toString()))) + " children");
     while (i < (body.children.length)) {
       const stmt = body.children[i];
-      console.log((("  Statement " + ((i.toString()))) + ": ") + stmt.nodeType);
       if ( stmt.nodeType == "VariableDeclaration" ) {
         this.processVariableDeclaration(stmt);
       }
@@ -14348,14 +15791,13 @@ class ComponentEngine  {
         }
       }
       if ( stmt.nodeType == "ForStatement" ) {
-        const forResult = this.evaluateForStatement(stmt);
-        if ( forResult.hasReturn ) {
-        }
+        this.runForStatementValue(stmt);
       }
       if ( stmt.nodeType == "ForOfStatement" ) {
-        const forOfResult = this.evaluateForOfStatement(stmt);
-        if ( forOfResult.hasReturn ) {
-        }
+        this.runForOfStatementValue(stmt);
+      }
+      if ( stmt.nodeType == "WhileStatement" ) {
+        this.runWhileStatementValue(stmt);
       }
       if ( stmt.nodeType == "ExpressionStatement" ) {
         if ( typeof(stmt.left) != "undefined" ) {
@@ -14381,6 +15823,239 @@ class ComponentEngine  {
     }
     return EvalValue.null();
   };
+  runForStatementValue (stmt) {
+    const savedBreak = this.loopBreak;
+    const savedContinue = this.loopContinue;
+    this.loopBreak = false;
+    this.loopContinue = false;
+    if ( typeof(stmt.init) != "undefined" ) {
+      const initNode = stmt.init;
+      if ( initNode.nodeType == "VariableDeclaration" ) {
+        this.processVariableDeclaration(initNode);
+      }
+    }
+    const maxIterations = 100000;
+    let iterations = 0;
+    let looping = true;
+    while ((iterations < maxIterations) && looping) {
+      if ( this.scriptDidReturn ) {
+        looping = false;
+      } else {
+        let proceed = true;
+        if ( typeof(stmt.left) != "undefined" ) {
+          const testResult = this.evaluateExpr((stmt.left));
+          if ( testResult.toBool() == false ) {
+            proceed = false;
+          }
+        }
+        if ( proceed == false ) {
+          looping = false;
+        } else {
+          this.loopContinue = false;
+          if ( typeof(stmt.body) != "undefined" ) {
+            this.runBlockOrStatement(stmt.body);
+          }
+          if ( this.scriptDidReturn ) {
+            looping = false;
+          } else {
+            if ( this.loopBreak ) {
+              looping = false;
+            } else {
+              if ( typeof(stmt.right) != "undefined" ) {
+                this.evaluateUpdateExpr(stmt.right);
+              }
+              iterations = iterations + 1;
+            }
+          }
+        }
+      }
+    };
+    this.loopBreak = savedBreak;
+    this.loopContinue = savedContinue;
+  };
+  runForOfStatementValue (stmt) {
+    const savedBreak = this.loopBreak;
+    const savedContinue = this.loopContinue;
+    this.loopBreak = false;
+    this.loopContinue = false;
+    let varName = "";
+    if ( typeof(stmt.left) != "undefined" ) {
+      const leftNode = stmt.left;
+      if ( leftNode.nodeType == "VariableDeclaration" ) {
+        if ( (leftNode.children.length) > 0 ) {
+          const decl = leftNode.children[0];
+          varName = decl.name;
+        }
+      }
+    }
+    if ( typeof(stmt.right) != "undefined" ) {
+      const rightNode = stmt.right;
+      const arrayValue = this.evaluateExpr(rightNode);
+      if ( (arrayValue).isArray() ) {
+        let i = 0;
+        let looping = true;
+        while ((i < (arrayValue.arrayValue.length)) && looping) {
+          if ( this.scriptDidReturn ) {
+            looping = false;
+          } else {
+            if ( this.loopBreak ) {
+              looping = false;
+            } else {
+              const item = arrayValue.arrayValue[i];
+              if ( (varName.length) > 0 ) {
+                this.context.define(varName, item);
+              }
+              this.loopContinue = false;
+              if ( typeof(stmt.body) != "undefined" ) {
+                this.runBlockOrStatement(stmt.body);
+              }
+              if ( this.scriptDidReturn ) {
+                looping = false;
+              } else {
+                if ( this.loopBreak ) {
+                  looping = false;
+                } else {
+                  i = i + 1;
+                }
+              }
+            }
+          }
+        };
+      }
+    }
+    this.loopBreak = savedBreak;
+    this.loopContinue = savedContinue;
+  };
+  runWhileStatementValue (stmt) {
+    const savedBreak = this.loopBreak;
+    const savedContinue = this.loopContinue;
+    this.loopBreak = false;
+    this.loopContinue = false;
+    const maxIterations = 100000;
+    let iterations = 0;
+    let looping = true;
+    while ((iterations < maxIterations) && looping) {
+      if ( this.scriptDidReturn ) {
+        looping = false;
+      } else {
+        let proceed = true;
+        if ( typeof(stmt.left) != "undefined" ) {
+          const testResult = this.evaluateExpr((stmt.left));
+          if ( testResult.toBool() == false ) {
+            proceed = false;
+          }
+        }
+        if ( proceed == false ) {
+          looping = false;
+        } else {
+          this.loopContinue = false;
+          if ( typeof(stmt.body) != "undefined" ) {
+            this.runBlockOrStatement(stmt.body);
+          }
+          if ( this.scriptDidReturn ) {
+            looping = false;
+          } else {
+            if ( this.loopBreak ) {
+              looping = false;
+            } else {
+              iterations = iterations + 1;
+            }
+          }
+        }
+      }
+    };
+    this.loopBreak = savedBreak;
+    this.loopContinue = savedContinue;
+  };
+  runStatementList (stmts) {
+    let i = 0;
+    while (i < (stmts.length)) {
+      if ( this.scriptDidReturn ) {
+        return;
+      }
+      if ( this.loopBreak ) {
+        return;
+      }
+      if ( this.loopContinue ) {
+        return;
+      }
+      this.runStatementValue(stmts[i]);
+      i = i + 1;
+    };
+  };
+  runStatementValue (stmt) {
+    if ( this.scriptDidReturn ) {
+      return;
+    }
+    if ( stmt.nodeType == "ReturnStatement" ) {
+      if ( typeof(stmt.left) != "undefined" ) {
+        this.scriptReturnValue = this.evaluateExpr((stmt.left));
+      } else {
+        this.scriptReturnValue = EvalValue.null();
+      }
+      this.scriptDidReturn = true;
+      return;
+    }
+    if ( stmt.nodeType == "VariableDeclaration" ) {
+      this.processVariableDeclaration(stmt);
+      return;
+    }
+    if ( stmt.nodeType == "ExpressionStatement" ) {
+      if ( typeof(stmt.left) != "undefined" ) {
+        this.evaluateExprForSideEffect(stmt.left);
+      }
+      return;
+    }
+    if ( stmt.nodeType == "IfStatement" ) {
+      this.runIfValue(stmt);
+      return;
+    }
+    if ( stmt.nodeType == "BlockStatement" ) {
+      this.runStatementList(stmt.children);
+      return;
+    }
+    if ( stmt.nodeType == "BreakStatement" ) {
+      this.loopBreak = true;
+      return;
+    }
+    if ( stmt.nodeType == "ContinueStatement" ) {
+      this.loopContinue = true;
+      return;
+    }
+    if ( stmt.nodeType == "ForStatement" ) {
+      this.runForStatementValue(stmt);
+      return;
+    }
+    if ( stmt.nodeType == "ForOfStatement" ) {
+      this.runForOfStatementValue(stmt);
+      return;
+    }
+    if ( stmt.nodeType == "WhileStatement" ) {
+      this.runWhileStatementValue(stmt);
+      return;
+    }
+  };
+  runIfValue (node) {
+    if ( typeof(node.left) != "undefined" ) {
+      const cond = this.evaluateExpr((node.left));
+      if ( cond.toBool() ) {
+        if ( typeof(node.body) != "undefined" ) {
+          this.runBlockOrStatement(node.body);
+        }
+      } else {
+        if ( typeof(node.right) != "undefined" ) {
+          this.runBlockOrStatement(node.right);
+        }
+      }
+    }
+  };
+  runBlockOrStatement (blk) {
+    if ( blk.nodeType == "BlockStatement" ) {
+      this.runStatementList(blk.children);
+    } else {
+      this.runStatementValue(blk);
+    }
+  };
   evaluateIfStatement (node) {
     const result = new EVGElement();
     result.hasReturn = false;
@@ -14394,16 +16069,38 @@ class ComponentEngine  {
           if ( blockResult.hasReturn ) {
             return blockResult;
           }
+          if ( blockResult.hasBreak ) {
+            return blockResult;
+          }
+          if ( blockResult.hasContinue ) {
+            return blockResult;
+          }
         }
       } else {
         if ( typeof(node.right) != "undefined" ) {
           const elseBlock = node.right;
           if ( elseBlock.nodeType == "IfStatement" ) {
-            return this.evaluateIfStatement(elseBlock);
-          }
-          const blockResult_1 = this.evaluateStatementBlock(elseBlock);
-          if ( blockResult_1.hasReturn ) {
-            return blockResult_1;
+            const elseIfResult = this.evaluateIfStatement(elseBlock);
+            if ( elseIfResult.hasReturn ) {
+              return elseIfResult;
+            }
+            if ( elseIfResult.hasBreak ) {
+              return elseIfResult;
+            }
+            if ( elseIfResult.hasContinue ) {
+              return elseIfResult;
+            }
+          } else {
+            const blockResult_1 = this.evaluateStatementBlock(elseBlock);
+            if ( blockResult_1.hasReturn ) {
+              return blockResult_1;
+            }
+            if ( blockResult_1.hasBreak ) {
+              return blockResult_1;
+            }
+            if ( blockResult_1.hasContinue ) {
+              return blockResult_1;
+            }
           }
         }
       }
@@ -14413,12 +16110,23 @@ class ComponentEngine  {
   evaluateStatementBlock (block) {
     const result = new EVGElement();
     result.hasReturn = false;
+    if ( block.nodeType == "ContinueStatement" ) {
+      result.hasContinue = true;
+      return result;
+    }
+    if ( block.nodeType == "BreakStatement" ) {
+      result.hasBreak = true;
+      return result;
+    }
     if ( block.nodeType == "ReturnStatement" ) {
       if ( typeof(block.left) != "undefined" ) {
         const returnExpr = block.left;
         const returnedEl = this.evaluateJSX(returnExpr);
         returnedEl.hasReturn = true;
         return returnedEl;
+      } else {
+        result.hasReturn = true;
+        return result;
       }
     }
     if ( block.nodeType == "BlockStatement" ) {
@@ -14433,10 +16141,22 @@ class ComponentEngine  {
           if ( ifResult.hasReturn ) {
             return ifResult;
           }
+          if ( ifResult.hasBreak ) {
+            return ifResult;
+          }
+          if ( ifResult.hasContinue ) {
+            return ifResult;
+          }
         }
         if ( stmt.nodeType == "ForStatement" ) {
           const forResult = this.evaluateForStatement(stmt);
           if ( forResult.hasReturn ) {
+            return forResult;
+          }
+          if ( forResult.hasBreak ) {
+            return forResult;
+          }
+          if ( forResult.hasContinue ) {
             return forResult;
           }
         }
@@ -14444,6 +16164,24 @@ class ComponentEngine  {
           const forOfResult = this.evaluateForOfStatement(stmt);
           if ( forOfResult.hasReturn ) {
             return forOfResult;
+          }
+          if ( forOfResult.hasBreak ) {
+            return forOfResult;
+          }
+          if ( forOfResult.hasContinue ) {
+            return forOfResult;
+          }
+        }
+        if ( stmt.nodeType == "WhileStatement" ) {
+          const whileResult = this.evaluateWhileStatement(stmt);
+          if ( whileResult.hasReturn ) {
+            return whileResult;
+          }
+          if ( whileResult.hasBreak ) {
+            return whileResult;
+          }
+          if ( whileResult.hasContinue ) {
+            return whileResult;
           }
         }
         if ( stmt.nodeType == "ExpressionStatement" ) {
@@ -14458,7 +16196,18 @@ class ComponentEngine  {
             const returnedEl_1 = this.evaluateJSX(returnExpr_1);
             returnedEl_1.hasReturn = true;
             return returnedEl_1;
+          } else {
+            result.hasReturn = true;
+            return result;
           }
+        }
+        if ( stmt.nodeType == "ContinueStatement" ) {
+          result.hasContinue = true;
+          return result;
+        }
+        if ( stmt.nodeType == "BreakStatement" ) {
+          result.hasBreak = true;
+          return result;
         }
         i = i + 1;
       };
@@ -14491,21 +16240,23 @@ class ComponentEngine  {
                 const argNode = node.children[0];
                 const argValue = this.evaluateExpr(argNode);
                 objValue.arrayValue.push(argValue);
-                this.context.define(objName, objValue);
+                this.context.assign(objName, objValue);
               }
+              return;
             }
           }
         }
       }
     }
+    this.evaluateCallExpr(node);
   };
   evaluateForStatement (node) {
     const result = new EVGElement();
     result.hasReturn = false;
-    console.log("evaluateForStatement called");
+    this.trace("evaluateForStatement called");
     if ( typeof(node.init) != "undefined" ) {
       const initNode = node.init;
-      console.log("For init nodeType: " + initNode.nodeType);
+      this.trace("For init nodeType: " + initNode.nodeType);
       if ( initNode.nodeType == "VariableDeclaration" ) {
         this.processVariableDeclaration(initNode);
       }
@@ -14526,12 +16277,25 @@ class ComponentEngine  {
         if ( bodyResult.hasReturn ) {
           return bodyResult;
         }
+        if ( bodyResult.hasBreak ) {
+          return result;
+        }
+        if ( bodyResult.hasContinue ) {
+          if ( typeof(node.right) != "undefined" ) {
+            const updateNode = node.right;
+            this.evaluateUpdateExpr(updateNode);
+          }
+          iterations = iterations + 1;
+        } else {
+          if ( typeof(node.right) != "undefined" ) {
+            const updateNode_1 = node.right;
+            this.evaluateUpdateExpr(updateNode_1);
+          }
+          iterations = iterations + 1;
+        }
+      } else {
+        iterations = iterations + 1;
       }
-      if ( typeof(node.right) != "undefined" ) {
-        const updateNode = node.right;
-        this.evaluateUpdateExpr(updateNode);
-      }
-      iterations = iterations + 1;
     };
     return result;
   };
@@ -14562,11 +16326,55 @@ class ComponentEngine  {
             if ( bodyResult.hasReturn ) {
               return bodyResult;
             }
+            if ( bodyResult.hasBreak ) {
+              return result;
+            }
+            if ( bodyResult.hasContinue ) {
+              i = i + 1;
+            } else {
+              i = i + 1;
+            }
+          } else {
+            i = i + 1;
           }
-          i = i + 1;
         };
       }
     }
+    return result;
+  };
+  evaluateWhileStatement (node) {
+    const result = new EVGElement();
+    result.hasReturn = false;
+    const maxIterations = 100000;
+    let iterations = 0;
+    while (iterations < maxIterations) {
+      if ( typeof(node.left) != "undefined" ) {
+        const testNode = node.left;
+        const testResult = this.evaluateExpr(testNode);
+        if ( testResult.toBool() == false ) {
+          return result;
+        }
+      } else {
+        return result;
+      }
+      if ( typeof(node.body) != "undefined" ) {
+        const bodyNode = node.body;
+        const bodyResult = this.evaluateStatementBlock(bodyNode);
+        if ( bodyResult.hasReturn ) {
+          return bodyResult;
+        }
+        if ( bodyResult.hasBreak ) {
+          return result;
+        }
+        if ( bodyResult.hasContinue ) {
+          iterations = iterations + 1;
+        } else {
+          iterations = iterations + 1;
+        }
+      } else {
+        iterations = iterations + 1;
+      }
+    };
     return result;
   };
   evaluateUpdateExpr (node) {
@@ -14578,10 +16386,10 @@ class ComponentEngine  {
           const current = this.context.lookup(varName);
           const currentNum = current.toNumber();
           if ( node.value == "++" ) {
-            this.context.define(varName, EvalValue.number((currentNum + 1.0)));
+            this.context.assign(varName, EvalValue.number((currentNum + 1.0)));
           }
           if ( node.value == "--" ) {
-            this.context.define(varName, EvalValue.number((currentNum - 1.0)));
+            this.context.assign(varName, EvalValue.number((currentNum - 1.0)));
           }
         }
       }
@@ -14596,31 +16404,68 @@ class ComponentEngine  {
             const rightNode = node.right;
             const rightValue = this.evaluateExpr(rightNode);
             if ( op == "=" ) {
-              this.context.define(varName_1, rightValue);
+              this.context.assign(varName_1, rightValue);
             }
             if ( op == "+=" ) {
               const current_1 = this.context.lookup(varName_1);
               const isLeftStr = current_1.isString();
               const isRightStr = rightValue.isString();
               if ( isLeftStr || isRightStr ) {
-                this.context.define(varName_1, EvalValue.string(((current_1).toString() + (rightValue).toString())));
+                this.context.assign(varName_1, EvalValue.string(((current_1).toString() + (rightValue).toString())));
               } else {
-                this.context.define(varName_1, EvalValue.number((current_1.toNumber() + rightValue.toNumber())));
+                this.context.assign(varName_1, EvalValue.number((current_1.toNumber() + rightValue.toNumber())));
               }
             }
             if ( op == "-=" ) {
               const current_2 = this.context.lookup(varName_1);
-              this.context.define(varName_1, EvalValue.number((current_2.toNumber() - rightValue.toNumber())));
+              this.context.assign(varName_1, EvalValue.number((current_2.toNumber() - rightValue.toNumber())));
             }
             if ( op == "*=" ) {
               const current_3 = this.context.lookup(varName_1);
-              this.context.define(varName_1, EvalValue.number((current_3.toNumber() * rightValue.toNumber())));
+              this.context.assign(varName_1, EvalValue.number((current_3.toNumber() * rightValue.toNumber())));
             }
             if ( op == "/=" ) {
               const current_4 = this.context.lookup(varName_1);
               const rightNum = rightValue.toNumber();
               if ( rightNum != 0.0 ) {
-                this.context.define(varName_1, EvalValue.number((current_4.toNumber() / rightNum)));
+                this.context.assign(varName_1, EvalValue.number((current_4.toNumber() / rightNum)));
+              }
+            }
+          }
+        }
+        if ( leftNode.nodeType == "MemberExpression" ) {
+          const op_1 = node.value;
+          if ( op_1 == "=" ) {
+            if ( typeof(node.right) != "undefined" ) {
+              const rightNode_1 = node.right;
+              const rightValue_1 = this.evaluateExpr(rightNode_1);
+              let obj = EvalValue.null();
+              let objName = "";
+              if ( typeof(leftNode.left) != "undefined" ) {
+                const objNode = leftNode.left;
+                if ( objNode.nodeType == "Identifier" ) {
+                  objName = objNode.name;
+                  obj = this.context.lookup(objName);
+                } else {
+                  obj = this.evaluateExpr(objNode);
+                }
+              }
+              if ( leftNode.computed ) {
+                if ( typeof(leftNode.right) != "undefined" ) {
+                  const indexExpr = leftNode.right;
+                  const indexVal = this.evaluateExpr(indexExpr);
+                  if ( indexVal.isNumber() ) {
+                    obj.setIndexAt(Math.floor( indexVal.toNumber()), rightValue_1);
+                  }
+                  if ( indexVal.isString() ) {
+                    obj.setMember(indexVal.stringValue, rightValue_1);
+                  }
+                }
+              } else {
+                obj.setMember(leftNode.name, rightValue_1);
+              }
+              if ( (objName.length) > 0 ) {
+                this.context.assign(objName, obj);
               }
             }
           }
@@ -14642,6 +16487,12 @@ class ComponentEngine  {
       if ( typeof(node.left) != "undefined" ) {
         const inner = node.left;
         return this.evaluateJSX(inner);
+      }
+    }
+    const val = this.evaluateExpr(node);
+    if ( val.isElement() ) {
+      if ( typeof(val.evgElement) != "undefined" ) {
+        return val.evgElement;
       }
     }
     return element;
@@ -14707,27 +16558,32 @@ class ComponentEngine  {
     return false;
   };
   expandComponent (name, jsxNode) {
+    let foundIdx = -1;
     let i = 0;
     while (i < (this.localComponents.length)) {
       const sym = this.localComponents[i];
       if ( sym.name == name ) {
-        const props = this.evaluateProps(jsxNode);
-        if ( typeof(sym.functionNode) != "undefined" ) {
-          const fnNode = sym.functionNode;
-          let hi = 0;
-          while (hi < (sym.helperFunctions.length)) {
-            const helperFn = sym.helperFunctions[hi];
-            const helperName = helperFn.name;
-            const helperValue = EvalValue.function(helperFn);
-            this.context.define(helperName, helperValue);
-            console.log("Registered helper function: " + helperName);
-            hi = hi + 1;
-          };
-          return this.evaluateFunctionWithProps(fnNode, props);
-        }
+        foundIdx = i;
       }
       i = i + 1;
     };
+    if ( foundIdx >= 0 ) {
+      const sym_1 = this.localComponents[foundIdx];
+      const props = this.evaluateProps(jsxNode);
+      if ( typeof(sym_1.functionNode) != "undefined" ) {
+        const fnNode = sym_1.functionNode;
+        let hi = 0;
+        while (hi < (sym_1.helperFunctions.length)) {
+          const helperFn = sym_1.helperFunctions[hi];
+          const helperName = helperFn.name;
+          const helperValue = EvalValue.function(helperFn);
+          this.context.define(helperName, helperValue);
+          console.log("Registered helper function: " + helperName);
+          hi = hi + 1;
+        };
+        return this.evaluateFunctionWithProps(fnNode, props);
+      }
+    }
     console.log("Warning: Unknown component: " + name);
     const empty = new EVGElement();
     empty.tagName = "div";
@@ -15163,6 +17019,9 @@ class ComponentEngine  {
       return EvalValue.null();
     }
     if ( node.nodeType == "Identifier" ) {
+      if ( node.name == "undefined" ) {
+        return EvalValue.undefined();
+      }
       return this.context.lookup(node.name);
     }
     if ( node.nodeType == "BinaryExpression" ) {
@@ -15187,6 +17046,16 @@ class ComponentEngine  {
       if ( typeof(node.left) != "undefined" ) {
         const inner = node.left;
         return this.evaluateExpr(inner);
+      }
+    }
+    if ( node.nodeType == "TSAsExpression" ) {
+      if ( typeof(node.left) != "undefined" ) {
+        return this.evaluateExpr((node.left));
+      }
+    }
+    if ( node.nodeType == "TSNonNullExpression" ) {
+      if ( typeof(node.left) != "undefined" ) {
+        return this.evaluateExpr((node.left));
       }
     }
     if ( node.nodeType == "JSXElement" ) {
@@ -15224,7 +17093,7 @@ class ComponentEngine  {
             }
           }
         }
-        console.log((("Method call: " + methodName) + " on value type=") + ((obj.valueType.toString())));
+        this.trace((("Method call: " + methodName) + " on value type=") + ((obj.valueType.toString())));
         if ( methodName == "toFixed" ) {
           const numVal = obj.toNumber();
           let decimals = 0;
@@ -15375,38 +17244,44 @@ class ComponentEngine  {
           }
           return EvalValue.string((str_3 + padding_1));
         }
-        if ( obj.isObject() ) {
-          let objName = "";
-          if ( typeof(callee.left) != "undefined" ) {
-            const objNode_1 = callee.left;
-            if ( objNode_1.nodeType == "Identifier" ) {
-              objName = objNode_1.name;
-            }
+        let mathObjName = "";
+        if ( typeof(callee.left) != "undefined" ) {
+          const mathObjNode = callee.left;
+          if ( mathObjNode.nodeType == "Identifier" ) {
+            mathObjName = mathObjNode.name;
           }
-          if ( objName == "Math" ) {
-            if ( (node.children.length) > 0 ) {
-              const argNode_5 = node.children[0];
-              const argVal_5 = this.evaluateExpr(argNode_5);
-              const num = argVal_5.toNumber();
-              if ( methodName == "round" ) {
-                return EvalValue.number(((Math.floor( (num + 0.5)))));
+        }
+        if ( mathObjName == "Math" ) {
+          if ( (node.children.length) > 0 ) {
+            const argNode_5 = node.children[0];
+            const argVal_5 = this.evaluateExpr(argNode_5);
+            const num = argVal_5.toNumber();
+            if ( methodName == "round" ) {
+              return EvalValue.number(((Math.floor( (num + 0.5)))));
+            }
+            if ( methodName == "floor" ) {
+              return EvalValue.number(((Math.floor( num))));
+            }
+            if ( methodName == "ceil" ) {
+              const intPart = Math.floor( num);
+              if ( num > (intPart) ) {
+                return EvalValue.number(((intPart + 1)));
               }
-              if ( methodName == "floor" ) {
-                return EvalValue.number(((Math.floor( num))));
+              return EvalValue.number((intPart));
+            }
+            if ( methodName == "abs" ) {
+              if ( num < 0.0 ) {
+                return EvalValue.number((0.0 - num));
               }
-              if ( methodName == "ceil" ) {
-                const intPart = Math.floor( num);
-                if ( num > (intPart) ) {
-                  return EvalValue.number(((intPart + 1)));
-                }
-                return EvalValue.number((intPart));
-              }
-              if ( methodName == "abs" ) {
-                if ( num < 0.0 ) {
-                  return EvalValue.number((0.0 - num));
-                }
-                return EvalValue.number(num);
-              }
+              return EvalValue.number(num);
+            }
+            if ( methodName == "sin" ) {
+              const s = Math.sin(num);
+              return EvalValue.number(s);
+            }
+            if ( methodName == "cos" ) {
+              const c = Math.cos(num);
+              return EvalValue.number(c);
             }
           }
         }
@@ -15415,7 +17290,7 @@ class ComponentEngine  {
       }
       if ( callee.nodeType == "Identifier" ) {
         const fnName = callee.name;
-        console.log("Evaluating function call: " + fnName);
+        this.trace("Evaluating function call: " + fnName);
         if ( fnName == "usePrintSettings" ) {
           return this.evaluateUsePrintSettings();
         }
@@ -15423,24 +17298,37 @@ class ComponentEngine  {
           let srcArg = "";
           if ( (node.children.length) > 0 ) {
             const argNode_6 = node.children[0];
-            console.log("useImage arg nodeType: " + argNode_6.nodeType);
+            this.trace("useImage arg nodeType: " + argNode_6.nodeType);
             const argValue = this.evaluateExpr(argNode_6);
-            console.log((("useImage arg value: " + (argValue).toString()) + " type=") + ((argValue.valueType.toString())));
+            this.trace((("useImage arg value: " + (argValue).toString()) + " type=") + ((argValue.valueType.toString())));
             srcArg = argValue.stringValue;
-            console.log("useImage srcArg: " + srcArg);
+            this.trace("useImage srcArg: " + srcArg);
           }
           return this.evaluateUseImage(srcArg);
         }
+        if ( typeof(this.nativeBridge) != "undefined" ) {
+          const bridge = this.nativeBridge;
+          if ( (bridge).has(fnName) ) {
+            const nativeArgs = this.collectCallArgs(node);
+            return bridge.invoke(fnName, nativeArgs);
+          }
+        }
         const fnValue = this.context.lookup(fnName);
-        console.log((((("Lookup function '" + fnName) + "' -> type=") + ((fnValue.valueType.toString()))) + " isFunction=") + ((fnValue.isFunction().toString())));
+        this.trace((((("Lookup function '" + fnName) + "' -> type=") + ((fnValue.valueType.toString()))) + " isFunction=") + ((fnValue.isFunction().toString())));
         if ( fnValue.isFunction() ) {
           if ( typeof(fnValue.functionNode) != "undefined" ) {
             const fnNode = fnValue.functionNode;
             const savedContext = this.context;
+            let savedDidReturn = this.scriptDidReturn;
+            let savedReturnValue = this.scriptReturnValue;
+            savedDidReturn = this.scriptDidReturn;
+            savedReturnValue = this.scriptReturnValue;
+            this.scriptDidReturn = false;
+            this.scriptReturnValue = EvalValue.null();
             this.context = this.context.createChild();
             const numArgs = node.children.length;
             const numParams = fnNode.params.length;
-            console.log(((((("Function " + fnName) + " called with ") + ((numArgs.toString()))) + " args, has ") + ((numParams.toString()))) + " params");
+            this.trace(((((("Function " + fnName) + " called with ") + ((numArgs.toString()))) + " args, has ") + ((numParams.toString()))) + " params");
             let argIdx = 0;
             while (argIdx < numParams) {
               if ( argIdx < numArgs ) {
@@ -15448,7 +17336,7 @@ class ComponentEngine  {
                 const argValue_1 = this.evaluateExpr(argNode_7);
                 const paramNode = fnNode.params[argIdx];
                 const paramName = paramNode.name;
-                console.log((("Binding param '" + paramName) + "' = ") + (argValue_1).toString());
+                this.trace((("Binding param '" + paramName) + "' = ") + (argValue_1).toString());
                 this.context.define(paramName, argValue_1);
               }
               argIdx = argIdx + 1;
@@ -15456,6 +17344,8 @@ class ComponentEngine  {
             const body = this.getFunctionBody(fnNode);
             const result_1 = this.evaluateFunctionBodyValue(body);
             this.context = savedContext;
+            this.scriptDidReturn = savedDidReturn;
+            this.scriptReturnValue = savedReturnValue;
             return result_1;
           }
         }
@@ -15491,67 +17381,150 @@ class ComponentEngine  {
         }
       }
     }
-    let left_2 = EvalValue.null();
+    if ( op == "??" ) {
+      if ( typeof(node.left) != "undefined" ) {
+        const leftExpr_2 = node.left;
+        const left_2 = this.evaluateExpr(leftExpr_2);
+        if ( false == left_2.isNull() ) {
+          return left_2;
+        }
+        if ( typeof(node.right) != "undefined" ) {
+          const rightExpr_2 = node.right;
+          return this.evaluateExpr(rightExpr_2);
+        }
+      }
+    }
+    let left_3 = EvalValue.null();
     let right = EvalValue.null();
     if ( typeof(node.left) != "undefined" ) {
-      const leftExpr_2 = node.left;
-      left_2 = this.evaluateExpr(leftExpr_2);
+      const leftExpr_3 = node.left;
+      left_3 = this.evaluateExpr(leftExpr_3);
     }
     if ( typeof(node.right) != "undefined" ) {
-      const rightExpr_2 = node.right;
-      right = this.evaluateExpr(rightExpr_2);
+      const rightExpr_3 = node.right;
+      right = this.evaluateExpr(rightExpr_3);
     }
     if ( op == "+" ) {
-      const isLeftStr = left_2.isString();
+      const isLeftStr = left_3.isString();
       const isRightStr = right.isString();
       if ( isLeftStr || isRightStr ) {
-        return EvalValue.string(((left_2).toString() + (right).toString()));
+        return EvalValue.string(((left_3).toString() + (right).toString()));
       }
-      return EvalValue.number((left_2.toNumber() + right.toNumber()));
+      return EvalValue.number((left_3.toNumber() + right.toNumber()));
     }
     if ( op == "-" ) {
-      return EvalValue.number((left_2.toNumber() - right.toNumber()));
+      return EvalValue.number((left_3.toNumber() - right.toNumber()));
     }
     if ( op == "*" ) {
-      return EvalValue.number((left_2.toNumber() * right.toNumber()));
+      return EvalValue.number((left_3.toNumber() * right.toNumber()));
     }
     if ( op == "/" ) {
       const rightNum = right.toNumber();
       if ( rightNum != 0.0 ) {
-        return EvalValue.number((left_2.toNumber() / rightNum));
+        return EvalValue.number((left_3.toNumber() / rightNum));
       }
       return EvalValue.number(0.0);
     }
     if ( op == "%" ) {
-      const leftInt = Math.floor( left_2.toNumber());
+      const leftInt = Math.floor( left_3.toNumber());
       const rightInt = Math.floor( right.toNumber());
       if ( rightInt != 0 ) {
         return EvalValue.fromInt((leftInt % rightInt));
       }
       return EvalValue.number(0.0);
     }
+    if ( op == "|" ) {
+      const leftInt_1 = Math.floor( left_3.toNumber());
+      const rightInt_1 = Math.floor( right.toNumber());
+      return EvalValue.fromInt(((leftInt_1 | rightInt_1)));
+    }
+    if ( op == "&" ) {
+      const leftInt_2 = Math.floor( left_3.toNumber());
+      const rightInt_2 = Math.floor( right.toNumber());
+      return EvalValue.fromInt(((leftInt_2 & rightInt_2)));
+    }
+    if ( op == "^" ) {
+      const leftInt_3 = Math.floor( left_3.toNumber());
+      const rightInt_3 = Math.floor( right.toNumber());
+      return EvalValue.fromInt(((leftInt_3 ^ rightInt_3)));
+    }
     if ( op == "<" ) {
-      return EvalValue.boolean((left_2.toNumber() < right.toNumber()));
+      return EvalValue.boolean((left_3.toNumber() < right.toNumber()));
     }
     if ( op == ">" ) {
-      return EvalValue.boolean((left_2.toNumber() > right.toNumber()));
+      return EvalValue.boolean((left_3.toNumber() > right.toNumber()));
     }
     if ( op == "<=" ) {
-      return EvalValue.boolean((left_2.toNumber() <= right.toNumber()));
+      return EvalValue.boolean((left_3.toNumber() <= right.toNumber()));
     }
     if ( op == ">=" ) {
-      return EvalValue.boolean((left_2.toNumber() >= right.toNumber()));
+      return EvalValue.boolean((left_3.toNumber() >= right.toNumber()));
     }
     if ( (op == "==") || (op == "===") ) {
-      return EvalValue.boolean(left_2.equals(right));
+      return EvalValue.boolean(left_3.equals(right));
     }
     if ( (op == "!=") || (op == "!==") ) {
-      return EvalValue.boolean((left_2.equals(right) == false));
+      return EvalValue.boolean((left_3.equals(right) == false));
     }
     return EvalValue.null();
   };
+  bindingExists (name) {
+    return (this.context).has(name);
+  };
+  typeofTag (val) {
+    if ( val.isUndefined() ) {
+      return "undefined";
+    }
+    if ( val.isNull() ) {
+      return "object";
+    }
+    if ( val.isNumber() ) {
+      return "number";
+    }
+    if ( val.isString() ) {
+      return "string";
+    }
+    if ( val.isBoolean() ) {
+      return "boolean";
+    }
+    if ( val.isFunction() ) {
+      return "function";
+    }
+    if ( (val).isArray() ) {
+      return "object";
+    }
+    if ( val.isObject() ) {
+      return "object";
+    }
+    if ( val.isElement() ) {
+      return "object";
+    }
+    return "undefined";
+  };
+  evaluateTypeofExpr (node) {
+    if ( typeof(node.left) != "undefined" ) {
+      const argNode = node.left;
+      if ( argNode.nodeType == "Identifier" ) {
+        const name = argNode.name;
+        if ( name == "undefined" ) {
+          return EvalValue.string("undefined");
+        }
+        if ( false == this.bindingExists(name) ) {
+          return EvalValue.string("undefined");
+        }
+        const val = this.context.lookup(name);
+        return EvalValue.string(this.typeofTag(val));
+      }
+      const val_1 = this.evaluateExpr(argNode);
+      return EvalValue.string(this.typeofTag(val_1));
+    }
+    return EvalValue.string("undefined");
+  };
   evaluateUnaryExpr (node) {
     const op = node.value;
+    if ( op == "typeof" ) {
+      return this.evaluateTypeofExpr(node);
+    }
     if ( typeof(node.left) != "undefined" ) {
       const argExpr = node.left;
       const arg = this.evaluateExpr(argExpr);
@@ -15588,17 +17561,24 @@ class ComponentEngine  {
   evaluateMemberExpr (node) {
     if ( typeof(node.left) != "undefined" ) {
       const leftExpr = node.left;
-      const obj = this.evaluateExpr(leftExpr);
       const propName = node.name;
-      console.log((((("evaluateMemberExpr: propName=" + propName) + " computed=") + ((node.computed.toString()))) + " obj.type=") + ((obj.valueType.toString())));
+      if ( leftExpr.nodeType == "Identifier" ) {
+        if ( leftExpr.name == "Math" ) {
+          if ( propName == "PI" ) {
+            const pi = Math.PI;
+            return EvalValue.number(pi);
+          }
+        }
+      }
+      const obj = this.evaluateExpr(leftExpr);
       if ( node.computed ) {
         if ( typeof(node.right) != "undefined" ) {
           const indexExpr = node.right;
           const indexVal = this.evaluateExpr(indexExpr);
-          console.log((("  Index value: " + (indexVal).toString()) + " type=") + ((indexVal.valueType.toString())));
+          this.trace((("  Index value: " + (indexVal).toString()) + " type=") + ((indexVal.valueType.toString())));
           if ( indexVal.isNumber() ) {
             const idx = Math.floor( indexVal.toNumber());
-            console.log((("  Getting index " + ((idx.toString()))) + " from array of length ") + (((obj.arrayValue.length).toString())));
+            this.trace((("  Getting index " + ((idx.toString()))) + " from array of length ") + (((obj.arrayValue.length).toString())));
             return obj.getIndex(idx);
           }
           if ( indexVal.isString() ) {

--- a/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
+++ b/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
@@ -29,42 +29,18 @@ class ImportedSymbol {
 ; EvalContext - Variable scope for expression evaluation
 ; =============================================================================
 class EvalContext {
-    def variables:[string]
-    def values:[EvalValue]
+    def bindings:[string:EvalValue]
     def parent@(optional):EvalContext
     ; Root module scope for this script (propagated to child scopes).
     def moduleRoot@(optional):EvalContext
     
-    Constructor () {
-        def v:[string]
-        variables = v
-        def vl:[EvalValue]
-        values = vl
-    }
-    
     fn define:void (name:string value:EvalValue) {
-        ; Check if already defined
-        def i:int 0
-        while (i < (array_length variables)) {
-            if ((itemAt variables i) == name) {
-                ; Update existing
-                set values i value
-                return
-            }
-            i = i + 1
-        }
-        ; Add new
-        push variables name
-        push values value
+        set bindings name value
     }
     
     fn lookup:EvalValue (name:string) {
-        def i:int 0
-        while (i < (array_length variables)) {
-            if ((itemAt variables i) == name) {
-                return (itemAt values i)
-            }
-            i = i + 1
+        if (has bindings name) {
+            return (unwrap (get bindings name))
         }
         ; Check parent scope (function locals -> outer -> … -> module root)
         if parent {
@@ -77,13 +53,9 @@ class EvalContext {
     ; Update an existing binding in the nearest enclosing scope that owns it.
     ; Returns false when the name is not declared anywhere up the parent chain.
     fn assignExisting:boolean (name:string value:EvalValue) {
-        def i:int 0
-        while (i < (array_length variables)) {
-            if ((itemAt variables i) == name) {
-                set values i value
-                return true
-            }
-            i = i + 1
+        if (has bindings name) {
+            set bindings name value
+            return true
         }
         if parent {
             def p:EvalContext (unwrap parent)
@@ -104,24 +76,16 @@ class EvalContext {
 
     ; Remove a binding from the nearest scope that owns it (parent chain walk).
     fn removeBinding:boolean (name:string) {
-        def i:int 0
-        while (i < (array_length variables)) {
-            if ((itemAt variables i) == name) {
-                def newVars:[string]
-                def newVals:[EvalValue]
-                def j:int 0
-                while (j < (array_length variables)) {
-                    if (j != i) {
-                        push newVars (itemAt variables j)
-                        push newVals (itemAt values j)
-                    }
-                    j = j + 1
+        if (has bindings name) {
+            def newBindings:[string:EvalValue]
+            def keyList:[string] (keys bindings)
+            for keyList kk:string idx {
+                if (kk != name) {
+                    set newBindings kk (unwrap (get bindings kk))
                 }
-                variables = newVars
-                values = newVals
-                return true
             }
-            i = i + 1
+            bindings = newBindings
+            return true
         }
         if parent {
             def p:EvalContext (unwrap parent)
@@ -138,12 +102,8 @@ class EvalContext {
     }
     
     fn has:boolean (name:string) {
-        def i:int 0
-        while (i < (array_length variables)) {
-            if ((itemAt variables i) == name) {
-                return true
-            }
-            i = i + 1
+        if (has bindings name) {
+            return true
         }
         if parent {
             def p:EvalContext (unwrap parent)

--- a/gallery/pdf_writer/src/jsx/EvalValue.rgr
+++ b/gallery/pdf_writer/src/jsx/EvalValue.rgr
@@ -24,8 +24,7 @@ class EvalValue {
     def stringValue:string ""
     def boolValue:boolean false
     def arrayValue:[EvalValue]
-    def objectKeys:[string]
-    def objectValues:[EvalValue]
+    def objectMap:[string:EvalValue]
     def functionName:string ""
     def functionBody:string ""  ; For parsed functions
     def functionNode@(optional):TSNode  ; For function AST nodes
@@ -76,8 +75,13 @@ class EvalValue {
     sfn object:EvalValue (keys:[string] values:[EvalValue]) {
         def v:EvalValue (new EvalValue())
         v.valueType = 5
-        v.objectKeys = keys
-        v.objectValues = values
+        def i:int 0
+        while (i < (array_length keys)) {
+            if (i < (array_length values)) {
+                set v.objectMap (itemAt keys i) (itemAt values i)
+            }
+            i = (i + 1)
+        }
         return v
     }
     
@@ -200,15 +204,15 @@ class EvalValue {
         }
         if (valueType == 5) {
             def result:string "{"
+            def keyList:[string] (keys objectMap)
             def i:int 0
-            while (i < (array_length objectKeys)) {
+            for keyList kk:string idx {
                 if (i > 0) {
                     result = result + ", "
                 }
-                def key:string (itemAt objectKeys i)
-                def val:EvalValue (itemAt objectValues i)
+                def val:EvalValue (unwrap (get objectMap kk))
                 def valStr:string (val.toString())
-                result = result + key + ": " + valStr
+                result = result + kk + ": " + valStr
                 i = i + 1
             }
             return result + "}"
@@ -260,12 +264,8 @@ class EvalValue {
     ; Object member access
     fn getMember:EvalValue (key:string) {
         if (valueType == 5) {
-            def i:int 0
-            while (i < (array_length objectKeys)) {
-                if ((itemAt objectKeys i) == key) {
-                    return (itemAt objectValues i)
-                }
-                i = i + 1
+            if (has objectMap key) {
+                return (unwrap (get objectMap key))
             }
         }
         ; Array length property
@@ -288,26 +288,7 @@ class EvalValue {
         if (valueType != 5) {
             return
         }
-        def i:int 0
-        while (i < (array_length objectKeys)) {
-            if ((itemAt objectKeys i) == key) {
-                def newVals:[EvalValue]
-                def j:int 0
-                while (j < (array_length objectValues)) {
-                    if (j == i) {
-                        push newVals value
-                    } {
-                        push newVals (itemAt objectValues j)
-                    }
-                    j = (j + 1)
-                }
-                objectValues = newVals
-                return
-            }
-            i = (i + 1)
-        }
-        push objectKeys key
-        push objectValues value
+        set objectMap key value
     }
     
     ; Set an array element by index (extends with null when needed).
@@ -318,17 +299,7 @@ class EvalValue {
         while (index >= (array_length arrayValue)) {
             push arrayValue (EvalValue.null())
         }
-        def newArr:[EvalValue]
-        def i:int 0
-        while (i < (array_length arrayValue)) {
-            if (i == index) {
-                push newArr value
-            } {
-                push newArr (itemAt arrayValue i)
-            }
-            i = (i + 1)
-        }
-        arrayValue = newArr
+        set arrayValue index value
     }
     
     ; Array index access

--- a/gallery/pdf_writer/src/tools/test_eval_value.rgr
+++ b/gallery/pdf_writer/src/tools/test_eval_value.rgr
@@ -181,6 +181,19 @@ class TestEvalValue {
         
         def missing:EvalValue (obj.getMember("unknown"))
         t.expectTrue(missing.isNull(), "unknown key returns null")
+
+        def obj2:EvalValue (EvalValue.object(keys values))
+        obj2.setMember("age" (EvalValue.number(31.0)))
+        def age2:EvalValue (obj2.getMember("age"))
+        t.expectNumEq(age2.numberValue, 31.0, "setMember updates existing key")
+        obj2.setMember("city" (EvalValue.string("Helsinki")))
+        def cityVal:EvalValue (obj2.getMember("city"))
+        t.expectStrEq(cityVal.stringValue, "Helsinki", "setMember adds new key")
+
+        def arr2:EvalValue (EvalValue.array(items))
+        arr2.setIndexAt(1 (EvalValue.number(99.0)))
+        def mid:EvalValue (arr2.getIndex(1))
+        t.expectNumEq(mid.numberValue, 99.0, "setIndexAt mutates in place")
         
         t.header("Object toString")
         def objStr:string (obj.toString())

--- a/gallery/pdf_writer/test/eval_value.test.js
+++ b/gallery/pdf_writer/test/eval_value.test.js
@@ -178,6 +178,28 @@ describe("EvalValue Arrays", () => {
     const arr = EvalValue.array(items);
     expect(arr.toString()).toBe("[1, 2, 3]");
   });
+
+  it("setIndexAt mutates array in place", () => {
+    const items = [
+      EvalValue.number(1.0),
+      EvalValue.number(2.0),
+      EvalValue.number(3.0),
+    ];
+    const arr = EvalValue.array(items);
+    arr.setIndexAt(1, EvalValue.number(99.0));
+    expect(arr.getIndex(1).numberValue).toBe(99.0);
+    expect(arr.getIndex(0).numberValue).toBe(1.0);
+    expect(arr.getIndex(2).numberValue).toBe(3.0);
+    expect(arr.getMember("length").numberValue).toBe(3.0);
+  });
+
+  it("setIndexAt extends sparse arrays with null", () => {
+    const arr = EvalValue.array([EvalValue.number(1.0)]);
+    arr.setIndexAt(2, EvalValue.number(7.0));
+    expect(arr.getMember("length").numberValue).toBe(3.0);
+    expect(arr.getIndex(1).isNull()).toBe(true);
+    expect(arr.getIndex(2).numberValue).toBe(7.0);
+  });
 });
 
 describe("EvalValue Objects", () => {
@@ -205,6 +227,23 @@ describe("EvalValue Objects", () => {
   it("getMember unknown key returns null", () => {
     const obj = EvalValue.object(["a"], [EvalValue.number(1.0)]);
     expect(obj.getMember("unknown").isNull()).toBe(true);
+  });
+
+  it("setMember updates existing property in place", () => {
+    const obj = EvalValue.object(
+      ["name", "age"],
+      [EvalValue.string("Alice"), EvalValue.number(30.0)]
+    );
+    obj.setMember("age", EvalValue.number(31.0));
+    expect(obj.getMember("age").numberValue).toBe(31.0);
+    expect(obj.getMember("name").stringValue).toBe("Alice");
+  });
+
+  it("setMember adds new property", () => {
+    const obj = EvalValue.object(["a"], [EvalValue.number(1.0)]);
+    obj.setMember("b", EvalValue.number(2.0));
+    expect(obj.getMember("a").numberValue).toBe(1.0);
+    expect(obj.getMember("b").numberValue).toBe(2.0);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Speeds up the TSX interpreter runtime by addressing three hot-path bottlenecks in `EvalValue` and `EvalContext`:

1. **Object property lookup** — `objectKeys`/`objectValues` replaced with `objectMap:[string:EvalValue]` hash map. `getMember` / `setMember` are O(1).
2. **Array index assignment** — `setIndexAt` mutates `arrayValue` in place instead of copying the whole array.
3. **Variable scope lookup** — `EvalContext` `variables`/`values` parallel arrays replaced with `bindings:[string:EvalValue]` hash map. `define`, `lookup`, `assign`, and `has` are O(1) per scope level.

## Changes

- `gallery/pdf_writer/src/jsx/EvalValue.rgr` — hash map objects + in-place array writes
- `gallery/pdf_writer/src/jsx/ComponentEngine.rgr` — hash map scope bindings
- `gallery/game_engine/scripting/game_persistence.rgr` — JSON serialization uses `objectMap`
- Tests for `setIndexAt` and `setMember`
- Rebuilt `eval_value_module.cjs` and `evg_component_tool.js`

## Impact

Especially helps game scripts that frequently resolve identifiers (`x`, `state`, loop vars) and access `state.entities[id]` with large object maps.

## Testing

- `gallery/pdf_writer` vitest — 175 tests pass
- `tsx-engine.test.ts` — pass (includes `modCount2=2` outer-scope assign regression)
- `game-scripting.test.ts` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5eb1682-8439-4250-acf1-8c94b81433b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5eb1682-8439-4250-acf1-8c94b81433b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

