### PR TITLE
Add soundscore multi-voice music to Game Engine

### DIFF
--- a/gallery/game_engine/lib/game_helpers.tsx
+++ b/gallery/game_engine/lib/game_helpers.tsx
@@ -34,6 +34,23 @@ export function soundEvent(id) {
   return { kind: "playSound", id: id };
 }
 
+/** Start music from a registered score id (resources kind: music). */
+export function musicEvent(id, loop?) {
+  const amount = loop === false ? 0 : 1;
+  return { kind: "playMusic", id: id, amount: amount };
+}
+
+/** Start music from inline soundscore text. */
+export function musicScoreEvent(scoreText, loop?) {
+  const amount = loop === false ? 0 : 1;
+  return { kind: "playMusic", id: "inline", text: scoreText, amount: amount };
+}
+
+/** Stop the current soundscore playback. */
+export function stopMusicEvent() {
+  return { kind: "stopMusic", id: "" };
+}
+
 /** Clamp local player slots to the engine maximum (1–8). */
 export function clampPlayerSlots(n: number): number {
   if (n < 1) {

--- a/gallery/game_engine/music/demo.sscore
+++ b/gallery/game_engine/music/demo.sscore
@@ -1,0 +1,15 @@
+tempo 100
+beats 4/4
+
+@melody piano
+1:C4 1:E4 1:G4 1:C5
+1:D4 1:F4 1:A4 1:D5
+
+@harmony violin
+4:C3 4:G3
+
+@bass square
+2:C2 2:G2 2:C2 2:G2
+
+@drums drums
+1:K 1:_ 1:S 1:_ 1:K 1:K 1:S 1:_

--- a/gallery/game_engine/scripting/engine.d.ts
+++ b/gallery/game_engine/scripting/engine.d.ts
@@ -165,6 +165,15 @@ type BuiltinSoundId =
   | "lose"
   | "win";
 
+/** Score instrument voices (see game_soundscore.rgr). */
+type ScoreInstrumentId =
+  | "piano"
+  | "violin"
+  | "square"
+  | "sine"
+  | "triangle"
+  | "drums";
+
 /** Particle burst presets understood by game_particles.rgr. */
 type ParticlePresetId = "burst" | "sparkle" | "fruit";
 
@@ -175,11 +184,13 @@ interface GameEvent {
   x?: number;
   y?: number;
   amount?: number;
+  /** Inline soundscore text for playMusic events. */
+  text?: string;
 }
 
 /** Engine resource declared once in resources(). */
 interface ResourceDef {
-  kind: "image" | "sound" | "sprite" | "collision";
+  kind: "image" | "sound" | "sprite" | "collision" | "music";
   id: string;
   path?: string;
   px?: number;
@@ -192,6 +203,20 @@ interface ResourceDef {
 interface PlaySoundEvent extends GameEvent {
   kind: "playSound";
   id: BuiltinSoundId | string;
+}
+
+/** Start multi-voice music from a registered score id or inline text. */
+interface PlayMusicEvent extends GameEvent {
+  kind: "playMusic";
+  id: string;
+  text?: string;
+  /** 0 = play once, 1 (default) = loop. */
+  amount?: number;
+}
+
+/** Stop the current soundscore playback. */
+interface StopMusicEvent extends GameEvent {
+  kind: "stopMusic";
 }
 
 /** One-shot particle burst (world x/y; host subtracts cameraY). */

--- a/gallery/game_engine/scripting/game_audio.rgr
+++ b/gallery/game_engine/scripting/game_audio.rgr
@@ -9,7 +9,66 @@
 ;
 ; Built-in sound ids:
 ;   blip, brick, bounce, wall, lose, win
+;
+; Score instruments (game_soundscore.rgr):
+;   piano, violin, square, sine, triangle, drums (K/S/H hits)
 ; ==============================================================================
+
+class ScoreVoiceHit {
+    def instrument:string "piano"
+    def pitch:string ""
+}
+
+class NoteNames {
+    def midiByPitch:[string:int]
+
+    fn init:void () {
+        this.fillMap()
+    }
+
+    fn addPitch:void (pitch:string midi:int) {
+        set midiByPitch pitch midi
+    }
+
+    fn fillMap:void () {
+        def names:[string]
+        push names "C"
+        push names "C#"
+        push names "D"
+        push names "D#"
+        push names "E"
+        push names "F"
+        push names "F#"
+        push names "G"
+        push names "G#"
+        push names "A"
+        push names "A#"
+        push names "B"
+        def oct 0
+        while (oct < 9) {
+            def suf:string (to_string oct)
+            def base:int 0
+            base = (oct + 1)
+            base = (base * 12)
+            def i 0
+            while (i < 12) {
+                def nm:string (itemAt names i)
+                def key:string (nm + suf)
+                this.addPitch(key (base + i))
+                i = (i + 1)
+            }
+            oct = (oct + 1)
+        }
+    }
+
+    fn pitchToMidi:int (pitch:string) {
+        def v@(optional):int (get midiByPitch pitch)
+        if (!null? v) {
+            return (unwrap v)
+        }
+        return 60
+    }
+}
 
 ; Waveform selector for the tone generator.
 class SynthWave {
@@ -41,9 +100,102 @@ class GameAudio {
     def lastId:string ""
     def verbose:boolean false
     def sineTable:[double]
+    def midiFreq:[double]
+    def noteNames:NoteNames (new NoteNames)
 
     fn init:void () {
         sineTable = (this.buildSineTable())
+        midiFreq = (this.buildMidiFreqTable())
+        noteNames.init()
+    }
+
+    fn semitoneRatio:double (semitones:int) {
+        def ratios:[double]
+        push ratios 1.0
+        push ratios 1.059463094359
+        push ratios 1.12246204831
+        push ratios 1.189207115
+        push ratios 1.25992105
+        push ratios 1.33483985
+        push ratios 1.41421356
+        push ratios 1.49830708
+        push ratios 1.58740105
+        push ratios 1.68179283
+        push ratios 1.78179744
+        push ratios 1.88774863
+        def octaves:int (to_int (semitones / 12))
+        def rem:int (semitones - (octaves * 12))
+        if (rem < 0) {
+            rem = (rem + 12)
+            octaves = (octaves - 1)
+        }
+        def r:double (itemAt ratios rem)
+        if (octaves > 0) {
+            def i 0
+            while (i < octaves) {
+                r = (r * 2.0)
+                i = (i + 1)
+            }
+        }
+        if (octaves < 0) {
+            def i 0
+            while (i > octaves) {
+                r = (r * 0.5)
+                i = (i - 1)
+            }
+        }
+        return r
+    }
+
+    fn buildMidiFreqTable:[double] () {
+        def table:[double]
+        def m 0
+        while (m < 128) {
+            def ratio:double (this.semitoneRatio((m - 69)))
+            push table (440.0 * ratio)
+            m = (m + 1)
+        }
+        return table
+    }
+
+    fn pitchToFreq:double (pitch:string) {
+        if (pitch == "_") {
+            return 0.0
+        }
+        def midi:int (noteNames.pitchToMidi(pitch))
+        return (itemAt midiFreq midi)
+    }
+
+    fn instrumentWave:int (instrument:string) {
+        if (instrument == "square") {
+            return 1
+        }
+        if (instrument == "triangle") {
+            return 2
+        }
+        if (instrument == "violin") {
+            return 0
+        }
+        if (instrument == "drums") {
+            return 3
+        }
+        return 0
+    }
+
+    fn instrumentVolume:double (instrument:string) {
+        if (instrument == "square") {
+            return 0.22
+        }
+        if (instrument == "violin") {
+            return 0.26
+        }
+        if (instrument == "piano") {
+            return 0.30
+        }
+        if (instrument == "drums") {
+            return 0.35
+        }
+        return 0.28
     }
 
     fn buildSineTable:[double] () {
@@ -151,6 +303,236 @@ class GameAudio {
         }
         def idx:int (bit_and (to_int (phase * 64.0)) 63)
         return (itemAt sineTable idx)
+    }
+
+    fn synthMelody:buffer (instrument:string freq:double durationMs:int volume:double) {
+        def spec:SynthToneSpec (new SynthToneSpec)
+        spec.freqHz = freq
+        spec.durationMs = durationMs
+        spec.volume = volume
+        spec.wave = (this.instrumentWave(instrument))
+        def frames:int (to_int (((to_double durationMs) * (to_double sampleRate)) / 1000.0))
+        if (frames < 1) {
+            frames = 1
+        }
+        def pcm:buffer (buffer_alloc (frames * 2))
+        def phase:double 0.0
+        def vibrato:boolean false
+        if (instrument == "violin") {
+            vibrato = true
+        }
+        def i 0
+        while (i < frames) {
+            def t:double ((to_double i) / (to_double frames))
+            def env:double 1.0
+            if (instrument == "piano") {
+                if (t < 0.02) {
+                    env = (t / 0.02)
+                } {
+                    env = (1.0 - ((t - 0.02) / 0.98))
+                    if (env < 0.0) { env = 0.0 }
+                    env = (env * env)
+                }
+            } {
+                if (instrument == "violin") {
+                    env = (0.15 + (0.85 * (1.0 - t)))
+                } {
+                    if (instrument == "square") {
+                        env = (1.0 - (t * 0.35))
+                    } {
+                        env = (1.0 - t)
+                        env = (env * env)
+                    }
+                }
+            }
+            def freqNow:double freq
+            if (vibrato) {
+                def vib:double (1.0 + (0.004 * (this.sampleWave((SynthWave.sine()) ((to_double i) / 180.0) i))))
+                freqNow = (freq * vib)
+            }
+            def sample:double (this.sampleWave(spec.wave phase i))
+            def amp:double (sample * volume * env * 32767.0)
+            def iv:int (to_int amp)
+            if (iv > 32767) { iv = 32767 }
+            if (iv < -32768) { iv = -32768 }
+            def v:int iv
+            if (v < 0) {
+                v = (65536 + v)
+            }
+            def lo:int (bit_and v 255)
+            def hi:int (bit_and (to_int (v / 256)) 255)
+            def off:int (i * 2)
+            buffer_set pcm off lo
+            buffer_set pcm (off + 1) hi
+            phase = (phase + (freqNow / (to_double sampleRate)))
+            while (phase >= 1.0) {
+                phase = (phase - 1.0)
+            }
+            i = (i + 1)
+        }
+        return pcm
+    }
+
+    fn synthDrum:buffer (hit:string durationMs:int) {
+        def spec:SynthToneSpec (new SynthToneSpec)
+        spec.durationMs = durationMs
+        spec.volume = 0.35
+        spec.wave = (SynthWave.noise())
+        if (hit == "K") {
+            spec.freqHz = 80.0
+            spec.durationMs = 90
+            spec.volume = 0.42
+            spec.wave = (SynthWave.sine())
+        }
+        if (hit == "S") {
+            spec.durationMs = 70
+            spec.volume = 0.30
+        }
+        if (hit == "H") {
+            spec.durationMs = 35
+            spec.volume = 0.16
+        }
+        def frames:int (to_int (((to_double spec.durationMs) * (to_double sampleRate)) / 1000.0))
+        if (frames < 1) {
+            frames = 1
+        }
+        def pcm:buffer (buffer_alloc (frames * 2))
+        def phase:double 0.0
+        def i 0
+        while (i < frames) {
+            def t:double ((to_double i) / (to_double frames))
+            def env:double (1.0 - t)
+            env = (env * env)
+            def sample:double 0.0
+            if (hit == "K") {
+                sample = (this.sampleWave((SynthWave.sine()) phase i))
+                phase = (phase + (spec.freqHz / (to_double sampleRate)))
+                while (phase >= 1.0) {
+                    phase = (phase - 1.0)
+                }
+            } {
+                sample = (this.sampleWave((SynthWave.noise()) phase i))
+            }
+            def amp:double (sample * spec.volume * env * 32767.0)
+            def iv:int (to_int amp)
+            if (iv > 32767) { iv = 32767 }
+            if (iv < -32768) { iv = -32768 }
+            def v:int iv
+            if (v < 0) {
+                v = (65536 + v)
+            }
+            def lo:int (bit_and v 255)
+            def hi:int (bit_and (to_int (v / 256)) 255)
+            def off:int (i * 2)
+            buffer_set pcm off lo
+            buffer_set pcm (off + 1) hi
+            i = (i + 1)
+        }
+        return pcm
+    }
+
+    fn mixBuffers:buffer (a:buffer b:buffer frames:int) {
+        def bytesA:int (buffer_length a)
+        def bytesB:int (buffer_length b)
+        def framesA:int (to_int (bytesA / 2))
+        def framesB:int (to_int (bytesB / 2))
+        def useFrames:int frames
+        if (useFrames > framesA) {
+            useFrames = framesA
+        }
+        if (useFrames > framesB) {
+            useFrames = framesB
+        }
+        def pcm:buffer (buffer_alloc (frames * 2))
+        def i 0
+        while (i < frames) {
+            def off:int (i * 2)
+            def sa:int 0
+            def sb:int 0
+            if (i < useFrames) {
+                def loA:int (buffer_get a off)
+                def hiA:int (buffer_get a (off + 1))
+                sa = (loA + (hiA * 256))
+                if (sa >= 32768) { sa = (sa - 65536) }
+                def loB:int (buffer_get b off)
+                def hiB:int (buffer_get b (off + 1))
+                sb = (loB + (hiB * 256))
+                if (sb >= 32768) { sb = (sb - 65536) }
+            }
+            def mix:int (sa + sb)
+            if (mix > 32767) { mix = 32767 }
+            if (mix < -32768) { mix = -32768 }
+            def v:int mix
+            if (v < 0) {
+                v = (65536 + v)
+            }
+            def lo:int (bit_and v 255)
+            def hi:int (bit_and (to_int (v / 256)) 255)
+            buffer_set pcm off lo
+            buffer_set pcm (off + 1) hi
+            i = (i + 1)
+        }
+        return pcm
+    }
+
+    fn playScoreNote:void (instrument:string pitch:string durationMs:int) {
+        playCount = (playCount + 1)
+        lastId = ("score:" + pitch)
+        if (instrument == "drums") {
+            def pcm:buffer (this.synthDrum(pitch durationMs))
+            def frames:int (to_int (((to_double durationMs) * (to_double sampleRate)) / 1000.0))
+            sink.onSynthPlay(lastId sampleRate frames pcm)
+            return
+        }
+        def freq:double (this.pitchToFreq(pitch))
+        if (freq <= 0.0) {
+            return
+        }
+        def vol:double (this.instrumentVolume(instrument))
+        def pcm:buffer (this.synthMelody(instrument freq durationMs vol))
+        def frames:int (to_int (((to_double durationMs) * (to_double sampleRate)) / 1000.0))
+        sink.onSynthPlay(lastId sampleRate frames pcm)
+    }
+
+    fn playScoreChord:void (notes:[ScoreVoiceHit] durationMs:int) {
+        if ((array_length notes) == 0) {
+            return
+        }
+        playCount = (playCount + 1)
+        lastId = "score:chord"
+        def frames:int (to_int (((to_double durationMs) * (to_double sampleRate)) / 1000.0))
+        if (frames < 1) {
+            frames = 1
+        }
+        def mixed:buffer (buffer_alloc (frames * 2))
+        def i 0
+        while (i < frames) {
+            buffer_set mixed (i * 2) 0
+            buffer_set mixed ((i * 2) + 1) 0
+            i = (i + 1)
+        }
+        def ni 0
+        while (ni < (array_length notes)) {
+            def ev:ScoreVoiceHit (itemAt notes ni)
+            def hasPart:boolean false
+            def part:buffer (buffer_alloc (frames * 2))
+            if (ev.instrument == "drums") {
+                part = (this.synthDrum(ev.pitch durationMs))
+                hasPart = true
+            } {
+                def freq:double (this.pitchToFreq(ev.pitch))
+                if (freq > 0.0) {
+                    def vol:double (this.instrumentVolume(ev.instrument))
+                    part = (this.synthMelody(ev.instrument freq durationMs vol))
+                    hasPart = true
+                }
+            }
+            if (hasPart) {
+                mixed = (this.mixBuffers(mixed part frames))
+            }
+            ni = (ni + 1)
+        }
+        sink.onSynthPlay(lastId sampleRate frames mixed)
     }
 
     fn synthTone:buffer (spec:SynthToneSpec) {

--- a/gallery/game_engine/scripting/game_helpers.tsx
+++ b/gallery/game_engine/scripting/game_helpers.tsx
@@ -32,6 +32,23 @@ export function soundEvent(id) {
   return { kind: "playSound", id: id };
 }
 
+/** Start music from a registered score id (resources kind: music). */
+export function musicEvent(id, loop?) {
+  const amount = loop === false ? 0 : 1;
+  return { kind: "playMusic", id: id, amount: amount };
+}
+
+/** Start music from inline soundscore text. */
+export function musicScoreEvent(scoreText, loop?) {
+  const amount = loop === false ? 0 : 1;
+  return { kind: "playMusic", id: "inline", text: scoreText, amount: amount };
+}
+
+/** Stop the current soundscore playback. */
+export function stopMusicEvent() {
+  return { kind: "stopMusic", id: "" };
+}
+
 /** Built-in particle burst presets (GPU overlay or SoftCanvas circles). */
 export function particleEvent(id, x, y, amount?) {
   const n = amount == null ? 0 : amount;

--- a/gallery/game_engine/scripting/game_native_runtime.rgr
+++ b/gallery/game_engine/scripting/game_native_runtime.rgr
@@ -35,6 +35,7 @@ class NativeGameRunner {
         ph = h
         canvas.init(w h)
         host.audio = audio
+        host.wireMusic()
     }
 
     fn half:int (n:int) {
@@ -214,6 +215,7 @@ class NativeGameRunner {
     fn applyUpdate:void (patch:NativeGameState) {
         ; Drain transient events emitted this frame before merging them away.
         host.drainEvents(patch.events)
+        host.tickMusic((to_int patch.dt))
         state = (stateOps.mergeState(state patch))
         this.syncFromState()
     }

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -180,6 +180,7 @@ class GameRunner {
         options.scriptDir = dir
         engine.setBasePath(dir)
         imageLoader.setBaseDir(dir)
+        host.musicDir = dir
         engine.addAssetPath(engineLibPath)
     }
 
@@ -206,6 +207,7 @@ class GameRunner {
         if ((strlen dir) > 0) {
             engine.setBasePath(dir)
             imageLoader.setBaseDir(dir)
+            host.musicDir = dir
             engine.addAssetPath(engineLibPath)
         }
         if ((strlen file) > 0) {
@@ -532,6 +534,7 @@ class GameRunner {
 
     fn wireHostAudio:void () {
         host.audio = audio
+        host.wireMusic()
     }
 
     fn memDouble:double (obj:EvalValue key:string dflt:double) {
@@ -578,6 +581,7 @@ class GameRunner {
         e.x = (this.memDouble(d "x" 0.0))
         e.y = (this.memDouble(d "y" 0.0))
         e.amount = (this.memInt(d "amount" 0))
+        e.text = (this.memString(d "text" ""))
         return e
     }
 
@@ -757,6 +761,7 @@ class GameRunner {
             this.onScreenChanged(prevScreen nextScreen)
         }
         this.drainStateEvents()
+        host.tickMusic(dtMs)
         particles.update(dtMs)
         this.syncFromState()
         this.syncBackgroundFromState()

--- a/gallery/game_engine/scripting/game_soundscore.rgr
+++ b/gallery/game_engine/scripting/game_soundscore.rgr
@@ -1,0 +1,462 @@
+; ==============================================================================
+; game_soundscore - text-based multi-voice music scores for GameAudio.
+; ==============================================================================
+;
+; Score format (whitespace-separated tokens per line):
+;
+;   tempo 100
+;   beats 4/4
+;
+;   @melody piano
+;   1:C4 1:E4 1:G4 1:C5
+;   1:D4 1:F4 1:A4 1:D5
+;
+;   @harmony violin
+;   4:C3 4:G3
+;
+;   @bass square
+;   2:C2 2:G2 2:C2 2:G2
+;
+;   @drums drums
+;   1:K 1:_ 1:S 1:_ 1:K 1:K 1:S 1:_
+;
+; Each token is beats:note where beats is duration in quarter-note beats.
+; Notes use scientific pitch (C4, C#4, Db4). _ is a rest. Drum hits: K S H.
+; Track instrument selects the synth voice (piano, violin, square, drums, sine).
+; ==============================================================================
+
+Import "./game_audio.rgr"
+
+class ScoreNote {
+    def beats:double 1.0
+    def pitch:string ""
+}
+
+class ScoreTrack {
+    def name:string ""
+    def instrument:string "piano"
+    def notes:[ScoreNote]
+}
+
+class SoundScore {
+    def tempo:int 120
+    def beatsNum:int 4
+    def beatsDen:int 4
+    def tracks:[ScoreTrack]
+    def totalBeats:double 0.0
+}
+
+class ScheduledNote {
+    def beat:double 0.0
+    def beats:double 1.0
+    def instrument:string "piano"
+    def pitch:string ""
+    def played:boolean false
+}
+
+class SoundScoreParser {
+    fn parseIntStr:int (s:string) {
+        def out:int 0
+        def i:int 0
+        while (i < (strlen s)) {
+            def ch:int (charAt s i)
+            if (ch >= 48) {
+                if (ch <= 57) {
+                    out = ((out * 10) + (ch - 48))
+                }
+            }
+            i = (i + 1)
+        }
+        return out
+    }
+
+    fn trim:string (s:string) {
+        def start:int 0
+        def end:int (strlen s)
+        while (start < end) {
+            def ch:string (substring s start (start + 1))
+            if (ch == " ") {
+                start = (start + 1)
+            } {
+                if (ch == "\t") {
+                    start = (start + 1)
+                } {
+                    break
+                }
+            }
+        }
+        while (end > start) {
+            def ch2:string (substring s (end - 1) end)
+            if (ch2 == " ") {
+                end = (end - 1)
+            } {
+                if (ch2 == "\t") {
+                    end = (end - 1)
+                } {
+                    break
+                }
+            }
+        }
+        if (end <= start) {
+            return ""
+        }
+        return (substring s start end)
+    }
+
+    fn splitLines:[string] (s:string) {
+        def out:[string]
+        def cur:string ""
+        def i 0
+        while (i < (strlen s)) {
+            def ch:string (substring s i (i + 1))
+            if (ch == "\n") {
+                push out cur
+                cur = ""
+            } {
+                if (ch == "\r") {
+                } {
+                    cur = (cur + ch)
+                }
+            }
+            i = (i + 1)
+        }
+        push out cur
+        return out
+    }
+
+    fn splitTokens:[string] (s:string) {
+        def out:[string]
+        def cur:string ""
+        def i 0
+        while (i < (strlen s)) {
+            def ch:string (substring s i (i + 1))
+            if (ch == " ") {
+                if ((strlen cur) > 0) {
+                    push out cur
+                    cur = ""
+                }
+            } {
+                if (ch == "\t") {
+                    if ((strlen cur) > 0) {
+                        push out cur
+                        cur = ""
+                    }
+                } {
+                    cur = (cur + ch)
+                }
+            }
+            i = (i + 1)
+        }
+        if ((strlen cur) > 0) {
+            push out cur
+        }
+        return out
+    }
+
+    fn parseNoteToken:boolean (tok:string noteOut:ScoreNote) {
+        def colon:int -1
+        def i 0
+        while (i < (strlen tok)) {
+            def ch:string (substring tok i (i + 1))
+            if (ch == ":") {
+                colon = i
+                break
+            }
+            i = (i + 1)
+        }
+        if (colon < 1) {
+            return false
+        }
+        def beatsStr:string (substring tok 0 colon)
+        def pitch:string (substring tok (colon + 1) (strlen tok))
+        def beatsInt:int (this.parseIntStr(beatsStr))
+        noteOut.beats = (to_double beatsInt)
+        if (noteOut.beats <= 0.0) {
+            noteOut.beats = 1.0
+        }
+        noteOut.pitch = pitch
+        return true
+    }
+
+    fn parseTempo:boolean (line:string score:SoundScore) {
+        if ((strlen line) < 7) {
+            return false
+        }
+        def head:string (substring line 0 6)
+        if (head != "tempo ") {
+            return false
+        }
+        def valStr:string (this.trim((substring line 6 (strlen line))))
+        def val:int (this.parseIntStr(valStr))
+        if (val < 20) {
+            val = 20
+        }
+        if (val > 400) {
+            val = 400
+        }
+        score.tempo = val
+        return true
+    }
+
+    fn parseBeats:boolean (line:string score:SoundScore) {
+        if ((strlen line) < 7) {
+            return false
+        }
+        def head:string (substring line 0 6)
+        if (head != "beats ") {
+            return false
+        }
+        def sig:string (this.trim((substring line 6 (strlen line))))
+        def slash:int -1
+        def i 0
+        while (i < (strlen sig)) {
+            def ch:string (substring sig i (i + 1))
+            if (ch == "/") {
+                slash = i
+                break
+            }
+            i = (i + 1)
+        }
+        if (slash < 1) {
+            return false
+        }
+        score.beatsNum = (this.parseIntStr((substring sig 0 slash)))
+        score.beatsDen = (this.parseIntStr((substring sig (slash + 1) (strlen sig))))
+        if (score.beatsNum < 1) {
+            score.beatsNum = 4
+        }
+        if (score.beatsDen < 1) {
+            score.beatsDen = 4
+        }
+        return true
+    }
+
+    fn parseTrackHeader:boolean (line:string trackOut:ScoreTrack) {
+        if ((strlen line) < 2) {
+            return false
+        }
+        def ch0:string (substring line 0 1)
+        if (ch0 != "@") {
+            return false
+        }
+        def rest:string (this.trim((substring line 1 (strlen line))))
+        def sp:int -1
+        def i 0
+        while (i < (strlen rest)) {
+            def ch:string (substring rest i (i + 1))
+            if (ch == " ") {
+                sp = i
+                break
+            }
+            i = (i + 1)
+        }
+        if (sp < 1) {
+            return false
+        }
+        trackOut.name = (substring rest 0 sp)
+        trackOut.instrument = (this.trim((substring rest (sp + 1) (strlen rest))))
+        if ((strlen trackOut.instrument) == 0) {
+            trackOut.instrument = "piano"
+        }
+        return true
+    }
+
+    fn computeTotalBeats:double (score:SoundScore) {
+        def maxBeats:double 0.0
+        def ti 0
+        while (ti < (array_length score.tracks)) {
+            def tr:ScoreTrack (itemAt score.tracks ti)
+            def pos:double 0.0
+            def ni 0
+            while (ni < (array_length tr.notes)) {
+                def n:ScoreNote (itemAt tr.notes ni)
+                pos = (pos + n.beats)
+                ni = (ni + 1)
+            }
+            if (pos > maxBeats) {
+                maxBeats = pos
+            }
+            ti = (ti + 1)
+        }
+        return maxBeats
+    }
+
+    fn parse:SoundScore (text:string) {
+        def score:SoundScore (new SoundScore)
+        def curTrackIdx:int -1
+        def lines:[string] (this.splitLines(text))
+        def li 0
+        while (li < (array_length lines)) {
+            def line:string (this.trim((itemAt lines li)))
+            if ((strlen line) > 0) {
+                if ((substring line 0 1) != "#") {
+                    if (this.parseTempo(line score)) {
+                    } {
+                        if (this.parseBeats(line score)) {
+                        } {
+                            def hdr:ScoreTrack (new ScoreTrack)
+                            if (this.parseTrackHeader(line hdr)) {
+                                push score.tracks hdr
+                                curTrackIdx = ((array_length score.tracks) - 1)
+                            } {
+                                if (curTrackIdx >= 0) {
+                                    def tr:ScoreTrack (itemAt score.tracks curTrackIdx)
+                                    def toks:[string] (this.splitTokens(line))
+                                    def ti 0
+                                    while (ti < (array_length toks)) {
+                                        def note:ScoreNote (new ScoreNote)
+                                        if (this.parseNoteToken((itemAt toks ti) note)) {
+                                            push tr.notes note
+                                        }
+                                        ti = (ti + 1)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            li = (li + 1)
+        }
+        score.totalBeats = (this.computeTotalBeats(score))
+        return score
+    }
+
+    fn buildSchedule:[ScheduledNote] (score:SoundScore) {
+        def out:[ScheduledNote]
+        def ti 0
+        while (ti < (array_length score.tracks)) {
+            def tr:ScoreTrack (itemAt score.tracks ti)
+            def beat:double 0.0
+            def ni 0
+            while (ni < (array_length tr.notes)) {
+                def n:ScoreNote (itemAt tr.notes ni)
+                if (n.pitch != "_") {
+                    def ev:ScheduledNote (new ScheduledNote)
+                    ev.beat = beat
+                    ev.beats = n.beats
+                    ev.instrument = tr.instrument
+                    ev.pitch = n.pitch
+                    push out ev
+                }
+                beat = (beat + n.beats)
+                ni = (ni + 1)
+            }
+            ti = (ti + 1)
+        }
+        return out
+    }
+}
+
+class SoundScorePlayer {
+    def audio:GameAudio
+    def parser:SoundScoreParser (new SoundScoreParser)
+    def score:SoundScore (new SoundScore)
+    def schedule:[ScheduledNote]
+    def nextIdx:int 0
+    def beatPos:double 0.0
+    def msPerBeat:double 500.0
+    def playing:boolean false
+    def loop:boolean true
+    def noteStarts:int 0
+
+    fn load:void (text:string) {
+        score = (parser.parse(text))
+        schedule = (parser.buildSchedule(score))
+        msPerBeat = (60000.0 / (to_double score.tempo))
+        nextIdx = 0
+        beatPos = 0.0
+        noteStarts = 0
+    }
+
+    fn play:void (loopScore:boolean) {
+        loop = loopScore
+        playing = true
+        nextIdx = 0
+        beatPos = 0.0
+        def i 0
+        while (i < (array_length schedule)) {
+            def ev:ScheduledNote (itemAt schedule i)
+            ev.played = false
+            i = (i + 1)
+        }
+    }
+
+    fn stop:void () {
+        playing = false
+        nextIdx = 0
+        beatPos = 0.0
+    }
+
+    fn isPlaying:boolean () {
+        return playing
+    }
+
+    fn flushPending:void (pending:[ScheduledNote]) {
+        def n:int (array_length pending)
+        if (n <= 0) {
+            return
+        }
+        if (n == 1) {
+            def one:ScheduledNote (itemAt pending 0)
+            def durMs:int (to_int (one.beats * msPerBeat))
+            audio.playScoreNote(one.instrument one.pitch durMs)
+            noteStarts = (noteStarts + 1)
+            return
+        }
+        def hits:[ScoreVoiceHit]
+        def i 0
+        while (i < n) {
+            def src:ScheduledNote (itemAt pending i)
+            def hit:ScoreVoiceHit (new ScoreVoiceHit)
+            hit.instrument = src.instrument
+            hit.pitch = src.pitch
+            push hits hit
+            i = (i + 1)
+        }
+        def head:ScheduledNote (itemAt pending 0)
+        def durMs:int (to_int (head.beats * msPerBeat))
+        audio.playScoreChord(hits durMs)
+        noteStarts = (noteStarts + n)
+    }
+
+    fn tick:void (dtMs:int) {
+        if (false == playing) {
+            return
+        }
+        if ((array_length schedule) == 0) {
+            playing = false
+            return
+        }
+        def prevBeat:double beatPos
+        beatPos = (beatPos + ((to_double dtMs) / msPerBeat))
+        def pending:[ScheduledNote]
+        def i 0
+        while (i < (array_length schedule)) {
+            def ev:ScheduledNote (itemAt schedule i)
+            if (ev.played == false) {
+                if (ev.beat <= beatPos) {
+                    if (ev.beat >= prevBeat) {
+                        push pending ev
+                        ev.played = true
+                    }
+                }
+            }
+            i = (i + 1)
+        }
+        this.flushPending(pending)
+        if (beatPos >= score.totalBeats) {
+            if (loop) {
+                beatPos = 0.0
+                def ri 0
+                while (ri < (array_length schedule)) {
+                    def rev:ScheduledNote (itemAt schedule ri)
+                    rev.played = false
+                    ri = (ri + 1)
+                }
+            } {
+                playing = false
+            }
+        }
+    }
+}

--- a/gallery/game_engine/scripting/soundscore_runner_demo.rgr
+++ b/gallery/game_engine/scripting/soundscore_runner_demo.rgr
@@ -1,0 +1,64 @@
+; ==============================================================================
+; soundscore_runner_demo - multi-voice soundscore playback.
+; ==============================================================================
+
+Import "./game_runtime.rgr"
+Import "./game_soundscore.rgr"
+
+class SoundscoreRunnerDemo {
+    sfn m@(main):void () {
+        def runner:GameRunner (new GameRunner)
+        runner.init(320 240)
+
+        def score:string ""
+        score = (score + "tempo 100\n")
+        score = (score + "beats 4/4\n")
+        score = (score + "\n")
+        score = (score + "@melody piano\n")
+        score = (score + "1:C4 1:E4 1:G4 1:C5\n")
+        score = (score + "1:D4 1:F4 1:A4 1:D5\n")
+        score = (score + "\n")
+        score = (score + "@harmony violin\n")
+        score = (score + "4:C3 4:G3\n")
+        score = (score + "\n")
+        score = (score + "@bass square\n")
+        score = (score + "2:C2 2:G2 2:C2 2:G2\n")
+        score = (score + "\n")
+        score = (score + "@drums drums\n")
+        score = (score + "1:K 1:_ 1:S 1:_ 1:K 1:K 1:S 1:_\n")
+
+        def parser:SoundScoreParser (new SoundScoreParser)
+        def parsed:SoundScore (parser.parse(score))
+        print (("tracks=" + (array_length parsed.tracks)))
+        print (("totalBeats=" + parsed.totalBeats))
+
+        def src:string ""
+        src = (src + "function initState() { return { entities: { dot: { x: 10, y: 10 } } }; }\n")
+        src = (src + "function sprites() { return [{ id: \"dot\", kind: \"circle\", rad: 4, r: 255, g: 200, b: 80 }]; }\n")
+        src = (src + "function update(props) {\n")
+        src = (src + "  return { entities: { dot: { x: 11, y: 10 } } };\n")
+        src = (src + "}\n")
+
+        runner.loadScript(src)
+        runner.setupScene()
+
+        def host:GameHost (runner.hostRef())
+        host.startMusic(score false)
+
+        def i 0
+        while (i < 120) {
+            runner.frame(16 false false false false false false)
+            i = (i + 1)
+        }
+
+        def audio:GameAudio (runner.audioRef())
+        def playing:int 0
+        if (host.music.isPlaying()) {
+            playing = 1
+        }
+        print (("musicPlaying=" + (to_string playing)))
+        print (("noteStarts=" + host.music.noteStarts))
+        print (("audioPlays=" + audio.playCount))
+        print "soundscore-runner done"
+    }
+}

--- a/gallery/ts_to_ranger/game_host.rgr
+++ b/gallery/ts_to_ranger/game_host.rgr
@@ -20,10 +20,11 @@
 ; ==============================================================================
 
 Import "../game_engine/scripting/game_audio.rgr"
+Import "../game_engine/scripting/game_soundscore.rgr"
 
 ; A declared engine resource. `kind` selects the registry.
 class ResourceDefNative {
-    def kind:string ""        ; "image" | "sound" | "sprite" | "collision"
+    def kind:string ""        ; "image" | "sound" | "sprite" | "collision" | "music"
     def id:string ""
     def path:string ""
     def px:int 0              ; sprite pixel scale
@@ -34,11 +35,12 @@ class ResourceDefNative {
 
 ; A transient event emitted by update() and drained by the host each frame.
 class GameEventNative {
-    def kind:string ""        ; "playSound" | "spawn" | "destroy" | custom
+    def kind:string ""        ; "playSound" | "playMusic" | "stopMusic" | "spawn" | "destroy" | custom
     def id:string ""
     def x:double 0.0
     def y:double 0.0
     def amount:int 0
+    def text:string ""        ; inline soundscore text for playMusic
 }
 
 ; Engine-side registry + event sink. Both runners own one GameHost.
@@ -53,6 +55,79 @@ class GameHost {
     def eventCount:int 0
     def verbose:boolean false
     def audio@(optional):GameAudio
+    def music:SoundScorePlayer (new SoundScorePlayer)
+    def musicPaths:[string:string]
+    def musicTexts:[string:string]
+    def musicDir:string ""
+
+    fn wireMusic:void () {
+        if audio {
+            music.audio = (unwrap audio)
+        }
+    }
+
+    fn joinPath:string (dir:string file:string) {
+        if ((strlen dir) == 0) {
+            return file
+        }
+        def last:int (strlen dir)
+        last = (last - 1)
+        def tail:string (substring dir last (last + 1))
+        if (tail == "/") {
+            return (dir + file)
+        }
+        return (dir + "/" + file)
+    }
+
+    fn resolveMusicScore:string (id:string) {
+        def cached@(optional):string (get musicTexts id)
+        if (!null? cached) {
+            return (unwrap cached)
+        }
+        def path@(optional):string (get musicPaths id)
+        if (null? path) {
+            return ""
+        }
+        def full:string (this.joinPath(musicDir (unwrap path)))
+        def slash:int -1
+        def i 0
+        while (i < (strlen full)) {
+            def ch:string (substring full i (i + 1))
+            if (ch == "/") {
+                slash = i
+            }
+            i = (i + 1)
+        }
+        if (slash < 0) {
+            return ""
+        }
+        def dir:string (substring full 0 slash)
+        def file:string (substring full (slash + 1) (strlen full))
+        def buf:buffer (buffer_read_file dir file)
+        def txt:string (buffer_to_string buf)
+        set musicTexts id txt
+        return txt
+    }
+
+    fn startMusic:void (scoreText:string loopScore:boolean) {
+        if (null? audio) {
+            return
+        }
+        this.wireMusic()
+        music.load(scoreText)
+        music.play(loopScore)
+    }
+
+    fn stopMusic:void () {
+        music.stop()
+    }
+
+    fn tickMusic:void (dtMs:int) {
+        if audio {
+            this.wireMusic()
+            music.tick(dtMs)
+        }
+    }
 
     fn registerResource:void (r:ResourceDefNative) {
         if (r.kind == "image") {
@@ -73,6 +148,11 @@ class GameHost {
         if (r.kind == "collision") {
             set collisions r.id true
             if verbose { print ("[host] collision " + r.id) }
+            return
+        }
+        if (r.kind == "music") {
+            set musicPaths r.id r.path
+            if verbose { print ("[host] music " + r.id) }
             return
         }
     }
@@ -98,6 +178,28 @@ class GameHost {
                 }
             }
             if verbose { print ("[host] playSound " + e.id) }
+            return
+        }
+        if (e.kind == "playMusic") {
+            def scoreText:string e.text
+            if ((strlen scoreText) == 0) {
+                scoreText = (this.resolveMusicScore(e.id))
+            }
+            if ((strlen scoreText) > 0) {
+                def loopScore:boolean true
+                if (e.amount == 0) {
+                    loopScore = false
+                }
+                this.startMusic(scoreText loopScore)
+            } {
+                if verbose { print ("[host] playMusic (missing score) " + e.id) }
+            }
+            if verbose { print ("[host] playMusic " + e.id) }
+            return
+        }
+        if (e.kind == "stopMusic") {
+            this.stopMusic()
+            if verbose { print "[host] stopMusic" }
             return
         }
         if (e.kind == "spawn") {

--- a/tests/game-runner.test.ts
+++ b/tests/game-runner.test.ts
@@ -115,6 +115,31 @@ describe("Game runner - scripted Pong", () => {
     expect(out).toContain("lastSound=win");
   });
 
+  it("plays multi-voice soundscores with piano, violin, bass and drums", () => {
+    const { compile, run } = compileAndRun(
+      "gallery/game_engine/scripting/soundscore_runner_demo.rgr"
+    );
+
+    expect(
+      compile.success,
+      `Compile failed: ${compile.error || compile.output}`
+    ).toBe(true);
+    expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+
+    const out = run?.output || "";
+    expect(out).toContain("soundscore-runner done");
+    expect(out).toContain("tracks=4");
+    expect(out).toContain("musicPlaying=1");
+
+    const noteStarts = out.match(/noteStarts=(\d+)/);
+    expect(noteStarts, `no noteStarts in output: ${out}`).toBeTruthy();
+    expect(parseInt(noteStarts![1], 10)).toBeGreaterThan(4);
+
+    const audioPlays = out.match(/audioPlays=(\d+)/);
+    expect(audioPlays, `no audioPlays in output: ${out}`).toBeTruthy();
+    expect(parseInt(audioPlays![1], 10)).toBeGreaterThan(0);
+  });
+
   it("does not replay sticky state.events on later frames", () => {
     const { compile, run } = compileAndRun(
       "gallery/game_engine/scripting/event_drain_runner_demo.rgr"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a text-based **soundscore** format for multi-voice procedural music in the Game Engine, plus new synthetic instruments and host integration.

### Soundscore format

```
tempo 100
beats 4/4

@melody piano
1:C4 1:E4 1:G4 1:C5

@harmony violin
4:C3 4:G3

@bass square
2:C2 2:G2 2:C2 2:G2

@drums drums
1:K 1:_ 1:S 1:_ 1:K 1:K 1:S 1:_
```

- `beats:note` tokens — duration in quarter-note beats, then pitch (e.g. `C4`, `C#4`) or `_` for rest
- Drum hits: `K` (kick), `S` (snare), `H` (hi-hat)
- Instruments: `piano`, `violin`, `square`, `sine`, `triangle`, `drums`

### API (from game scripts)

```ts
import { musicEvent, musicScoreEvent, stopMusicEvent } from "./game_helpers";

// From a registered resource (kind: "music")
events.push(musicEvent("theme"));

// Inline score text
events.push(musicScoreEvent(scoreText));

events.push(stopMusicEvent());
```

`amount: 0` plays once; default loops.

### Key files

- `gallery/game_engine/scripting/game_soundscore.rgr` — parser + scheduler/player
- `gallery/game_engine/scripting/game_audio.rgr` — instrument synth + mixing
- `gallery/ts_to_ranger/game_host.rgr` — `playMusic` / `stopMusic` events, music resources
- `gallery/game_engine/music/demo.sscore` — example score

### Testing

- New `soundscore_runner_demo.rgr` + vitest case in `tests/game-runner.test.ts`
- 11/12 game-runner tests pass (breakout audio assertion was already failing on master)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a01fc66-3d7e-4a78-8ba2-258914849f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a01fc66-3d7e-4a78-8ba2-258914849f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

