### PR TITLE
Fix particle 360° spread and improve GPU glow shader

### DIFF
--- a/gallery/game_engine/gfx_sdl.rgr
+++ b/gallery/game_engine/gfx_sdl.rgr
@@ -672,8 +672,11 @@ static int rgfx_particles_gl_init() {
         \"void main() {\\n\"
         \"  float d = dot(vCorner, vCorner);\\n\"
         \"  if (d > 1.0) discard;\\n\"
-        \"  float alpha = vColor.a * (1.0 - d);\\n\"
-        \"  gl_FragColor = vec4(vColor.rgb, alpha);\\n\"
+        \"  float soft = 1.0 - d;\\n\"
+        \"  float core = 1.0 - smoothstep(0.0, 0.22, d);\\n\"
+        \"  float alpha = vColor.a * soft * soft;\\n\"
+        \"  vec3 rgb = vColor.rgb * (1.0 + core * 0.7);\\n\"
+        \"  gl_FragColor = vec4(rgb, alpha);\\n\"
         \"}\\n\";
     GLuint vsId = rgfx_gl_compile(GL_VERTEX_SHADER, vs);
     GLuint fsId = rgfx_gl_compile(GL_FRAGMENT_SHADER, fs);
@@ -744,7 +747,7 @@ static void rgfx_particles_draw_overlay() {
     glEnableVertexAttribArray((GLuint) g_rgfx_part_color_attr);
     glVertexAttribPointer((GLuint) g_rgfx_part_color_attr, 4, GL_FLOAT, GL_FALSE, stride, (void*) (5 * sizeof(float)));
     glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE);
     glDrawArrays(GL_TRIANGLES, 0, (GLsizei) (g_rgfx_particles.size() * 6));
     g_rgfx_particles.clear();
 }

--- a/gallery/game_engine/scripting/game_particles.rgr
+++ b/gallery/game_engine/scripting/game_particles.rgr
@@ -121,9 +121,9 @@ class GameParticleSystem {
         def i 0
         while (i < count) {
             def slot:int (this.allocSlot())
-            def ang:double ((to_double i) / (to_double count))
-            ang = (ang * 6.28318)
-            def spd:double (this.randRange(0.08 0.22))
+            ; Full 360° radial burst — random angle + speed per particle.
+            def ang:double (this.randRange(0.0 6.283185307))
+            def spd:double (this.randRange(0.10 0.26))
             def vx:double (cos(ang) * spd)
             def vy:double (sin(ang) * spd)
             def life:int (to_int (this.randRange(220.0 420.0)))
@@ -145,11 +145,10 @@ class GameParticleSystem {
         def i 0
         while (i < count) {
             def slot:int (this.allocSlot())
-            def ang:double (this.randRange(0.0 6.28318))
-            def spd:double (this.randRange(0.05 0.20))
+            def ang:double (this.randRange(0.0 6.283185307))
+            def spd:double (this.randRange(0.06 0.22))
             def vx:double (cos(ang) * spd)
             def vy:double (sin(ang) * spd)
-            vy = (vy + (this.randRange(-0.18 -0.04)))
             def life:int (to_int (this.randRange(200.0 420.0)))
             def size:double (this.randRange(1.5 4.0))
             def pick:int (to_int (this.randRange(0.0 3.0)))
@@ -187,19 +186,11 @@ class GameParticleSystem {
         def i 0
         while (i < count) {
             def slot:int (this.allocSlot())
-            def vx:double 0.0
-            def vy:double 0.0
-            def mode:int (to_int (this.randRange(0.0 10.0)))
-            if (mode < 6) {
-                ; confetti fountain — mostly up and outward
-                vx = (this.randRange(-0.26 0.26))
-                vy = (this.randRange(-0.36 -0.10))
-            } {
-                def ang:double (this.randRange(0.0 6.28318))
-                def spd:double (this.randRange(0.06 0.22))
-                vx = (cos(ang) * spd)
-                vy = (sin(ang) * spd)
-            }
+            ; Omnidirectional confetti — full 360° with varied speed.
+            def ang:double (this.randRange(0.0 6.283185307))
+            def spd:double (this.randRange(0.08 0.28))
+            def vx:double (cos(ang) * spd)
+            def vy:double (sin(ang) * spd)
             def life:int (to_int (this.randRange(420.0 980.0)))
             def size:double (this.randRange(2.0 6.5))
             def pick:int (to_int (this.randRange(0.0 5.0)))
@@ -247,11 +238,10 @@ class GameParticleSystem {
         def i 0
         while (i < count) {
             def slot:int (this.allocSlot())
-            def ang:double (this.randRange(0.0 6.28318))
-            def spd:double (this.randRange(0.04 0.16))
+            def ang:double (this.randRange(0.0 6.283185307))
+            def spd:double (this.randRange(0.06 0.20))
             def vx:double (cos(ang) * spd)
-            def vy:double (this.randRange(-0.22 -0.04))
-            vy = (vy + (sin(ang) * spd * 0.35))
+            def vy:double (sin(ang) * spd)
             def life:int (to_int (this.randRange(350.0 700.0)))
             def size:double (this.randRange(2.0 5.0))
             def pick:int (to_int (this.randRange(0.0 3.0)))
@@ -278,7 +268,7 @@ class GameParticleSystem {
             return
         }
         def dt:double (to_double dtMs)
-        def grav:double 0.00028
+        def grav:double 0.00018
         def i 0
         while (i < maxCount) {
             def p:GameParticle (itemAt pool i)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Particle bursts were visually constrained because several presets overrode velocity with upward or fountain-style biases instead of using full polar coordinates. This change makes all presets emit in true 360° radial patterns and improves the WebGL particle overlay shader.

## Changes

### `game_particles.rgr`
- **burst**: random angle per particle (0–2π) instead of evenly spaced wedge
- **sparkle**: removed upward `vy` bias that pulled particles into a narrow arc
- **celebrate**: removed 60% upward fountain mode; all confetti uses omnidirectional polar velocity
- **fruit**: replaced forced upward `vy` with `sin(angle) * speed` for full radial spread
- Slightly reduced gravity (0.00028 → 0.00018) so radial motion stays visible longer before particles fade

### `gfx_sdl.rgr`
- Particle fragment shader: soft quadratic falloff + bright core via `smoothstep`
- Additive blending (`GL_SRC_ALPHA, GL_ONE`) for a glow/sparkle look closer to shader-based engines

## Testing

- Ranger → C++ compilation of `game_sdl_runner.rgr` succeeds
- SDL2 runtime build not available in cloud agent environment (no `libsdl2-dev`)

## Visual expectation

Particles should now spray in all directions (up, down, left, right) from spawn points instead of clustering in a down-right quadrant or upward fountain.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e21a7e72-d507-4685-882d-020062e405cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e21a7e72-d507-4685-882d-020062e405cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

