### PR TITLE
Fix + harden TSX parser: reserved-word names and stuck-token loops (autopeli crash on Raspberry Pi)

### DIFF
--- a/gallery/ts_parser/ts_parser_simple.rgr
+++ b/gallery/ts_parser/ts_parser_simple.rgr
@@ -186,6 +186,16 @@ class TSParserSimple {
     if (t == "Null") {
       return true
     }
+    ; Reserved words (static, class, default, get, set, new, this, ...) and TS
+    ; keywords (type, interface, ...) are all valid object-literal property keys
+    ; in JS/TS, e.g. `{ static: true, type: "x" }`. Accepting them here prevents
+    ; the parseObjectLiteral loop from stalling on a key it cannot consume.
+    if (t == "Keyword") {
+      return true
+    }
+    if (t == "TSKeyword") {
+      return true
+    }
     return false
   }
   
@@ -4300,6 +4310,7 @@ class TSParserSimple {
     this.expectValue("{")
     
     while (((this.matchValue("}")) == false) && ((this.isAtEnd()) == false)) {
+      def loopStartPos:int this.pos
       ; Check for spread property
       if (this.matchValue("...")) {
         this.advance()
@@ -4425,6 +4436,13 @@ class TSParserSimple {
       
       if (this.matchValue(",")) {
         this.advance()
+      }
+      
+      ; Safety: if an iteration consumed no tokens (e.g. an unexpected token that
+      ; is not a valid property key, comma, or "}"), bail out instead of looping
+      ; forever and exhausting memory. expectValue("}") then reports the error.
+      if (this.pos == loopStartPos) {
+        break
       }
     }
     


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated the report that **autopeli_physics crashes on Raspberry Pi**. The crash is an **infinite loop / out-of-memory in the TSX parser** at script load, triggered by `static: true` object literals in `autopeli_physics/index.tsx` (used on the barrier and oil entities) — not by PNG loading or the physics engine.

This PR fixes the specific bug and then **hardens the parser generically** so this whole class of "unusual syntax → hang/OOM" defect can't recur so easily.

## Root cause

`TSParserSimple.isObjectPropertyKeyToken()` only accepted `Identifier`/`TSType`/`String`/`Number`/`Boolean`/`Null` tokens as property keys. Reserved words like `static` are lexed as `Keyword` (and TS words like `type`/`interface` as `TSKeyword`), so the key token was **not recognized and never consumed**. In `parseObjectLiteral()`, the outer loop then repeated on the same token forever, allocating a `Property` node each iteration until the process ran out of memory. In JS/TS reserved words *are* valid object keys (`{ static: true, type: "x" }`), so accepting them is correct.

## Changes

**1. Specific fix**
- `isObjectPropertyKeyToken()` now accepts `Keyword`/`TSKeyword` tokens.
- `parseObjectLiteral()` got a no-progress guard so a key it can't consume can never hang.

**2. Generic hardening (requested follow-up)**
- **`isNameToken()`** helper (`Identifier`/`TSType`/`Keyword`/`TSKeyword`), used for both object-literal keys and member-access names.
- **`parseMemberName()`** — reserved words are legal member names in JS/TS, so member access on keywords now parses correctly instead of emitting spurious `expected Identifier` errors: `map.delete()`, `promise.catch()`/`finally()`, `obj.default`, `x.static`, `a.new`, including optional chaining (`x?.default`).
- **`guardNoProgress()`** — panic-mode recovery that skips one token when a terminator-bounded loop makes no progress in an iteration. Applied to the program, block, namespace-body, declare-module-body, and switch-consequent loops, so any future zero-consumption token degrades to a parse error instead of an infinite loop/OOM. Also replaces the previous always-on `[debug]` no-progress print (now respects `quiet`).

## Verification

Built the parser to JS and ran a harness (29 assertions):
- Reserved-word object keys (`static`, `class`, `default`, `type`, `new`, `delete`, …) parse.
- Reserved-word member names parse (`map.delete`, `promise.catch/finally`, `obj.default`, `x.static`, `x?.default`, …).
- Regressions intact: methods, getters, setters, computed keys, spread, shorthand, normal member chains, functions/blocks/switch.
- Pathological/garbage inputs (`{ @#: 1 }`, `{ : 1 }`, `switch(x){case 1: @@@}`, `{ , , }`) now **terminate** instead of hanging.

End-to-end: the `static: true` repro and the full `autopeli_physics/index.tsx` now load; the headless `autopeli_physics_runner_demo` passes (`autopeli-physics-runner done`, physics active, car advances y 5184 → 217) within a 600 MB heap cap. One of the three pre-existing generic/JSX parse-error messages also disappeared (fewer errors, no new ones).

## Notes on the originally-suspected areas

- **PNG loader:** not the crash. Decoding all five assets is fast (~0.5 s) and doesn't OOM. It is suboptimal though — car PNGs are 471×909 RGBA (~1.7 MB decoded each) drawn at ~4% scale, and `png_decoder.rgr`'s `unfilter` uses per-row boxed `[int]` arrays. Pre-scaling the assets and/or unfiltering into the output byte buffer would cut Pi load time/memory. Left for a follow-up.
- **Physics engine:** no crash cause. Minor robustness notes for later: `normalizeAngle()` reduces angles with a `while`-subtract loop and there's no upper clamp on `angularVel`.

## Generated artifacts

Only the source (`ts_parser_simple.rgr`) is changed. The generated parser bundles (`benchmark/ts_parser_module.cjs`/`.mjs`, native ports) were left out — the committed bundles were already out of sync with source and regenerating them (especially `.mjs`) produces large unrelated compiler-formatting churn. They should be rebuilt via `npm run tsparser:module` as part of the normal build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09fabab1-ea54-42fe-9b10-6c05be219de3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09fabab1-ea54-42fe-9b10-6c05be219de3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

