### PR TITLE
Harden TSX parser: reserved-word member names and stuck-token loop recovery

### DIFF
--- a/gallery/ts_parser/ts_parser_simple.rgr
+++ b/gallery/ts_parser/ts_parser_simple.rgr
@@ -165,8 +165,13 @@ class TSParserSimple {
     return (v == value)
   }
 
-  ; Object literal keys may use reserved/type words: { any: 1, string: "x" }.
-  fn isObjectPropertyKeyToken:boolean () {
+  ; A token that can stand in for a name. In JS/TS reserved words (static,
+  ; class, default, get, set, new, delete, catch, finally, ...) and TS keywords
+  ; (type, interface, ...) are valid as object-literal property keys and as
+  ; member-access property names, e.g. `{ static: 1 }`, `map.delete()`,
+  ; `promise.finally()`. Treating them as names here keeps such code parsing and
+  ; stops key/name loops from stalling on a token they cannot otherwise consume.
+  fn isNameToken:boolean () {
     def t (this.peekType())
     if (t == "Identifier") {
       return true
@@ -174,6 +179,21 @@ class TSParserSimple {
     if (t == "TSType") {
       return true
     }
+    if (t == "Keyword") {
+      return true
+    }
+    if (t == "TSKeyword") {
+      return true
+    }
+    return false
+  }
+
+  ; Object literal keys may use reserved/type words: { any: 1, string: "x" }.
+  fn isObjectPropertyKeyToken:boolean () {
+    if (this.isNameToken()) {
+      return true
+    }
+    def t (this.peekType())
     if (t == "String") {
       return true
     }
@@ -186,17 +206,37 @@ class TSParserSimple {
     if (t == "Null") {
       return true
     }
-    ; Reserved words (static, class, default, get, set, new, this, ...) and TS
-    ; keywords (type, interface, ...) are all valid object-literal property keys
-    ; in JS/TS, e.g. `{ static: true, type: "x" }`. Accepting them here prevents
-    ; the parseObjectLiteral loop from stalling on a key it cannot consume.
-    if (t == "Keyword") {
-      return true
-    }
-    if (t == "TSKeyword") {
-      return true
-    }
     return false
+  }
+
+  ; Consume a member/property name after '.' or '?.'. Reserved words are legal
+  ; here (obj.default, map.delete, promise.catch/finally), so accept any name
+  ; token without an error; fall back to expect() for genuinely invalid syntax
+  ; (which still advances, so callers keep making progress).
+  fn parseMemberName:Token () {
+    if (this.isNameToken()) {
+      def tok (this.peek())
+      this.advance()
+      return tok
+    }
+    return (this.expect("Identifier"))
+  }
+
+  ; Panic-mode recovery for terminator-bounded loops. If an iteration consumed
+  ; no tokens (this.pos unchanged), the current token is one the loop body does
+  ; not know how to handle. Skip it so parsing always terminates instead of
+  ; spinning forever and exhausting memory on unexpected/invalid syntax.
+  fn guardNoProgress:void (prevPos:int) {
+    if (this.pos != prevPos) {
+      return
+    }
+    if (this.quiet == false) {
+      def tok (this.peek())
+      print ("Parser recovery: skipping unexpected token '" + tok.value + "' (type " + tok.tokenType + ")")
+    }
+    if ((this.isAtEnd()) == false) {
+      this.advance()
+    }
   }
   
   ; === Parse Program ===
@@ -207,14 +247,9 @@ class TSParserSimple {
     
     while ((this.isAtEnd()) == false) {
       def beforePos:int this.pos
-      def beforeVal:string (this.peekValue())
-      def beforeType:string (this.peekType())
       def stmt (this.parseStatement())
       push prog.children stmt
-      if (this.pos == beforePos) {
-        print ("[debug] TSParserSimple.parseProgram made no progress at token '" + beforeVal + "' type=" + beforeType)
-        this.advance()
-      }
+      this.guardNoProgress(beforePos)
     }
     
     return prog
@@ -1381,8 +1416,10 @@ class TSParserSimple {
     body.nodeType = "TSModuleBlock"
     
     while (((this.matchValue("}")) == false) && ((this.isAtEnd()) == false)) {
+      def beforePos:int this.pos
       def stmt (this.parseStatement())
       push body.children stmt
+      this.guardNoProgress(beforePos)
     }
     
     this.expectValue("}")
@@ -1425,8 +1462,10 @@ class TSParserSimple {
       body.nodeType = "TSModuleBlock"
       
       while (((this.matchValue("}")) == false) && ((this.isAtEnd()) == false)) {
+        def beforePos:int this.pos
         def stmt (this.parseStatement())
         push body.children stmt
+        this.guardNoProgress(beforePos)
       }
       
       this.expectValue("}")
@@ -1707,6 +1746,7 @@ class TSParserSimple {
       
       ; Parse consequent statements
       while (((this.matchValue("case")) == false) && ((this.matchValue("default")) == false) && ((this.matchValue("}")) == false) && ((this.isAtEnd()) == false)) {
+        def beforePos:int this.pos
         if (this.matchValue("break")) {
           def breakNode (new TSNode())
           breakNode.nodeType = "BreakStatement"
@@ -1719,6 +1759,7 @@ class TSParserSimple {
           def stmt (this.parseStatement())
           push caseNode.children stmt
         }
+        this.guardNoProgress(beforePos)
       }
       
       push node.children caseNode
@@ -2128,8 +2169,10 @@ class TSParserSimple {
     this.expectValue("{")
     
     while (((this.matchValue("}")) == false) && ((this.isAtEnd()) == false)) {
+      def beforePos:int this.pos
       def stmt (this.parseStatement())
       push block.children stmt
+      this.guardNoProgress(beforePos)
     }
     
     this.expectValue("}")
@@ -3862,7 +3905,7 @@ class TSParserSimple {
       ; Member access .property
       if (tokVal == ".") {
         this.advance()
-        def propTok (this.expect("Identifier"))
+        def propTok (this.parseMemberName())
         def member (new TSNode())
         member.nodeType = "MemberExpression"
         member.left = expr
@@ -3917,8 +3960,8 @@ class TSParserSimple {
         }
         
         ; Optional member access ?.property
-        if (this.matchType("Identifier")) {
-          def propTok (this.expect("Identifier"))
+        if (this.isNameToken()) {
+          def propTok (this.parseMemberName())
           def optMember (new TSNode())
           optMember.nodeType = "OptionalMemberExpression"
           optMember.optional = true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #178 (already merged), which fixed the immediate **autopeli_physics crash on Raspberry Pi** caused by `{ static: true }` object literals hanging the TSX parser in an infinite loop / OOM.

This PR adds **generic parser hardening** so the same class of defect — reserved words used as names, or unexpected tokens in terminator-bounded loops — cannot easily recur.

## What #178 fixed (already on master)

- `isObjectPropertyKeyToken()` accepts `Keyword`/`TSKeyword` tokens.
- `parseObjectLiteral()` has a no-progress guard for object keys.

## What this PR adds

**1. Shared name handling**
- **`isNameToken()`** — single definition of "token usable as a name" (`Identifier`/`TSType`/`Keyword`/`TSKeyword`). Object-literal keys route through it.
- **`parseMemberName()`** — reserved words are legal member names in JS/TS. Member access on keywords now parses correctly instead of emitting spurious `expected Identifier` errors:
  - `map.delete(k)`
  - `promise.catch(f)` / `promise.finally(f)`
  - `obj.default`, `x.static`, `a.new`, `a.class`
  - optional chaining: `x?.default`

**2. Panic-mode loop recovery**
- **`guardNoProgress()`** — if a terminator-bounded loop makes no progress in an iteration, skip one token so parsing always terminates instead of spinning forever / OOMing.
- Applied to: program, block, namespace body, declare-module body, and switch-consequent loops.
- Replaces the previous always-on `[debug]` no-progress print (now respects `quiet`).

## Why this matters

The `static: true` bug was one instance of a broader pattern: **loops that inline token consumption** can stall when they encounter a token type they don't recognize. Most parser loops delegate to `parseStatement()` / `parseExpr()` / `expect*()` which always advance, but object-literal keys were an exception. This PR:

1. Fixes the same keyword-as-name pitfall for **member access** (not just object keys).
2. Adds a **safety net** on statement-list loops so any future zero-consumption token degrades to a parse error instead of hanging.

## Verification

Parser harness (29 assertions):
- Reserved-word object keys and member names parse.
- Optional chaining with reserved words works.
- Regressions intact: methods, getters, setters, computed keys, spread, shorthand, normal member chains, functions/blocks/switch.
- Pathological garbage (`{ @#: 1 }`, `{ : 1 }`, `switch(x){case 1: @@@}`, `{ , , }`) **terminates** instead of hanging.

End-to-end: `autopeli_physics` integration test still passes after this change.

## Generated artifacts

Only `gallery/ts_parser/ts_parser_simple.rgr` is changed. Generated parser bundles (`benchmark/ts_parser_module.cjs`/`.mjs`) should be rebuilt via `npm run tsparser:module` as part of the normal build step.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09fabab1-ea54-42fe-9b10-6c05be219de3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09fabab1-ea54-42fe-9b10-6c05be219de3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

