### PR TITLE
Fix bakeSheetScale segfault (SoftCanvas::raw() C++ copy UB)

### DIFF
--- a/gallery/game_engine/framebuffer.rgr
+++ b/gallery/game_engine/framebuffer.rgr
@@ -54,6 +54,14 @@ class SoftCanvas {
         return px
     }
 
+    ; Copy px into dst.pixels (w*h*4 bytes). Use this instead of buffer_copy on
+    ; raw(): the C++ backend returns raw() by value, so buffer ops on raw() touch
+    ; temporaries and can crash (iterator pair from different vectors).
+    fn copyPixelsToImage:void (dst:ImageBuffer) {
+        def len:int (w * h * 4)
+        buffer_copy dst.pixels 0 px 0 len
+    }
+
     ; Fill `count` consecutive opaque RGBA pixels starting at byte offset `off`.
     ;
     ; Small spans are written directly byte-by-byte: at low optimization levels

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -344,6 +344,7 @@ class GameSdlRunner {
         def splitRate:int (gfx_audio_sample_rate)
         splitHost.setAudioSampleRate(splitRate)
         splitHost.setSdlHost()
+        splitHost.setGpuMode(gpuModeActive)
         splitHost.loadPanes(panePath panePath)
         def enableHotReload:boolean hotReloadWanted
         if (maxFrames > 0) {
@@ -447,6 +448,7 @@ class GameSdlRunner {
         if (splitScreenActive) {
             def r0:int (gfx_ticks_ms)
             splitHost.draw()
+            splitHost.flushGpuParticles()
             def r1:int (gfx_ticks_ms)
             if (splitHost.isAutoscale()) {
                 gfx_present_split (splitHost.leftRaw()) (splitHost.rightRaw()) pw ph

--- a/gallery/game_engine/scripting/game_split_screen.rgr
+++ b/gallery/game_engine/scripting/game_split_screen.rgr
@@ -85,6 +85,16 @@ class SplitScreenHost {
         right.wireHostAudio()
     }
 
+    fn setGpuMode:void (enabled:boolean) {
+        left.setGpuMode(enabled)
+        right.setGpuMode(enabled)
+    }
+
+    fn flushGpuParticles:void () {
+        left.flushGpuParticles()
+        right.flushGpuParticles()
+    }
+
     fn setFpsShown:void (fps:int) {
         fpsShown = fps
         left.setFpsShown(fps)
@@ -113,6 +123,7 @@ class SplitScreenHost {
         runner.loadScript(src)
         runner.registerSplitPane(pane)
         runner.setupScene()
+        runner.enableGpuSheetOverlay()
         runner.trackScriptFile(tsxPath)
     }
 

--- a/gallery/game_engine/scripting/game_sprite.rgr
+++ b/gallery/game_engine/scripting/game_sprite.rgr
@@ -274,11 +274,10 @@ class GameSpriteRenderer {
         def atlasH:int (this.scaledDim(src.height scale))
         def scratch:SoftCanvas (new SoftCanvas)
         scratch.init(atlasW atlasH)
-        buffer_fill (scratch.raw()) 0 0 (atlasW * atlasH * 4)
         scratch.blitImageRectScaled(src 0 0 src.width src.height 0 0 atlasW atlasH)
         def baked:ImageBuffer (new ImageBuffer)
         baked.initClear(atlasW atlasH)
-        buffer_copy baked.pixels 0 (scratch.raw()) 0 (atlasW * atlasH * 4)
+        scratch.copyPixelsToImage(baked)
         e.shImg = baked
         e.shFrameW = (this.scaledDim(e.shFrameW scale))
         e.shFrameH = (this.scaledDim(e.shFrameH scale))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the loading-time segfault/bus error on `perf/gpu-sheet-sprites` when launching sheet-sprite games (e.g. Pomppija / `ylos2`, split-screen path).

Also wires GPU mode + sheet overlay into the **split-screen host** so autopeli (`splitScreen=auto`, default two-player) uses the same GPU path as solo games.

## Root cause (bisect)

| Variant | ylos2 result |
|---------|--------------|
| HEAD baseline | **CRASH** in `bakeSheetScale` |
| Remove runtime GPU hooks (`beginGpuSpriteFrame`, overlay, cache, etc.) | still crashes |
| Remove only `this.bakeSheetScale(e)` call | **OK** |

GDB: `buffer_fill(scratch->raw()...)` → SIGSEGV. C++ `SoftCanvas::raw()` returns `px` **by value**, so `std::fill` got iterators from different temporaries.

## Fix

1. `SoftCanvas.copyPixelsToImage()` — copies owned `px` directly
2. `bakeSheetScale` — use it instead of `buffer_fill`/`buffer_copy` on `raw()`
3. **Split-screen GPU wiring** (`game_split_screen.rgr`, `game_sdl_runner.rgr`):
   - `splitHost.setGpuMode(gpuModeActive)` before `loadPanes`
   - `runner.enableGpuSheetOverlay()` after `setupScene` in each pane
   - `splitHost.flushGpuParticles()` before `gfx_present_split`

## Verified

- **Autopeli split (default)**: `loadGame` → `loadSplitGame`, OpenGL + MallocScribble, 200–300 frames — OK
- ylos2 split-screen — OK
- menu launcher — OK

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4341d177-df6d-4141-9cb1-34df2314ade6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4341d177-df6d-4141-9cb1-34df2314ade6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

