### PR TITLE
Speed up autopeli split-screen update path

### DIFF
--- a/gallery/game_engine/games/autopeli_physics/index.tsx
+++ b/gallery/game_engine/games/autopeli_physics/index.tsx
@@ -66,25 +66,31 @@ const ROAD_POINTS = [
 ];
 
 function roadAt(y) {
-  let i = 0;
-  while (i < ROAD_POINTS.length - 1) {
-    const a = ROAD_POINTS[i];
-    const b = ROAD_POINTS[i + 1];
-    if (y <= a.y && y >= b.y) {
-      const span = a.y - b.y;
-      let t = 0;
-      if (span > 0) {
-        t = (a.y - y) / span;
-      }
-      return {
-        center: a.x + (b.x - a.x) * t,
-        half: a.half + (b.half - a.half) * t
-      };
-    }
-    i = i + 1;
+  const first = ROAD_POINTS[0];
+  if (y >= first.y) {
+    return { center: first.x, half: first.half };
   }
   const last = ROAD_POINTS[ROAD_POINTS.length - 1];
-  return { center: last.x, half: last.half };
+  if (y <= last.y) {
+    return { center: last.x, half: last.half };
+  }
+
+  // Points are ordered top-to-bottom at 400 world-unit intervals (the final
+  // interval is shorter). Direct indexing avoids an interpreted linear scan;
+  // traffic AI calls roadAt three times per car on every fixed update.
+  let i = ((first.y - y) / 400) | 0;
+  i = clamp(i, 0, ROAD_POINTS.length - 2);
+  const a = ROAD_POINTS[i];
+  const b = ROAD_POINTS[i + 1];
+  const span = a.y - b.y;
+  let t = 0;
+  if (span > 0) {
+    t = (a.y - y) / span;
+  }
+  return {
+    center: a.x + (b.x - a.x) * t,
+    half: a.half + (b.half - a.half) * t
+  };
 }
 
 function clamp(v, lo, hi) {

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -1258,13 +1258,27 @@ class GameRunner {
 
     fn sharedPhysicsStep:void (dtMs:int snap:GameInputSnapshot peer:GameRunner) {
         def prevScreen:string (this.currentScreenName())
+        def tScript0:int 0
+        if (profileEnabled) {
+            tScript0 = (gfx_ticks_ms)
+        }
         this.stepUpdateScript(dtMs snap)
+        def tScript1:int 0
+        if (profileEnabled) {
+            tScript1 = (gfx_ticks_ms)
+        }
         this.mergePhysicsFromPane(peer.state)
         this.mergeEventsFromPeer(peer.state)
         this.setPhysicsPassive(false)
         this.runPhysicsStep(dtMs)
         this.setPhysicsPassive(true)
         this.stepPostPhysics(dtMs prevScreen)
+        if (profileEnabled) {
+            def tSync1:int (gfx_ticks_ms)
+            profUpdateScriptMs = (profUpdateScriptMs + (tScript1 - tScript0))
+            profUpdateSyncMs = (profUpdateSyncMs + (tSync1 - tScript1))
+            profFrames = (profFrames + 1)
+        }
     }
 
     fn frameWithInput:void (dtMs:int snap:GameInputSnapshot) {

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -344,7 +344,6 @@ class GameSdlRunner {
         def splitRate:int (gfx_audio_sample_rate)
         splitHost.setAudioSampleRate(splitRate)
         splitHost.setSdlHost()
-        splitHost.setGpuMode(gpuModeActive)
         splitHost.loadPanes(panePath panePath)
         def enableHotReload:boolean hotReloadWanted
         if (maxFrames > 0) {
@@ -448,7 +447,6 @@ class GameSdlRunner {
         if (splitScreenActive) {
             def r0:int (gfx_ticks_ms)
             splitHost.draw()
-            splitHost.flushGpuParticles()
             def r1:int (gfx_ticks_ms)
             if (splitHost.isAutoscale()) {
                 gfx_present_split (splitHost.leftRaw()) (splitHost.rightRaw()) pw ph

--- a/gallery/game_engine/scripting/game_split_screen.rgr
+++ b/gallery/game_engine/scripting/game_split_screen.rgr
@@ -166,7 +166,16 @@ class SplitScreenHost {
             def steps:int 0
             while (left.timeAccumulator >= left.fixedStepMs) {
                 def step:int left.fixedStepMs
+                def tRight0:int 0
+                if (profileEnabled) {
+                    tRight0 = (gfx_ticks_ms)
+                }
                 right.stepUpdateScript(step rightSnap)
+                if (profileEnabled) {
+                    def tRight1:int (gfx_ticks_ms)
+                    right.profUpdateScriptMs = (right.profUpdateScriptMs + (tRight1 - tRight0))
+                    right.profFrames = (right.profFrames + 1)
+                }
                 left.sharedPhysicsStep(step leftSnap right)
                 right.syncSharedWorldFrom(left)
                 left.timeAccumulator = (left.timeAccumulator - step)
@@ -179,7 +188,16 @@ class SplitScreenHost {
             }
             return
         }
+        def tRight0:int 0
+        if (profileEnabled) {
+            tRight0 = (gfx_ticks_ms)
+        }
         right.stepUpdateScript(dtMs rightSnap)
+        if (profileEnabled) {
+            def tRight1:int (gfx_ticks_ms)
+            right.profUpdateScriptMs = (right.profUpdateScriptMs + (tRight1 - tRight0))
+            right.profFrames = (right.profFrames + 1)
+        }
         left.sharedPhysicsStep(dtMs leftSnap right)
         right.syncSharedWorldFrom(left)
     }

--- a/gallery/game_engine/scripting/game_split_screen.rgr
+++ b/gallery/game_engine/scripting/game_split_screen.rgr
@@ -85,16 +85,6 @@ class SplitScreenHost {
         right.wireHostAudio()
     }
 
-    fn setGpuMode:void (enabled:boolean) {
-        left.setGpuMode(enabled)
-        right.setGpuMode(enabled)
-    }
-
-    fn flushGpuParticles:void () {
-        left.flushGpuParticles()
-        right.flushGpuParticles()
-    }
-
     fn setFpsShown:void (fps:int) {
         fpsShown = fps
         left.setFpsShown(fps)
@@ -123,7 +113,6 @@ class SplitScreenHost {
         runner.loadScript(src)
         runner.registerSplitPane(pane)
         runner.setupScene()
-        runner.enableGpuSheetOverlay()
         runner.trackScriptFile(tsxPath)
     }
 

--- a/gallery/game_engine/scripting/physics_core.rgr
+++ b/gallery/game_engine/scripting/physics_core.rgr
@@ -474,6 +474,39 @@ class PhysicsCore {
         }
     }
 
+    ; Cheap conservative broad phase for segment boundaries. resolveSegment
+    ; rotates all four body corners and calculates point-to-segment distances,
+    ; so calling it for every road segment dominates dense vehicle worlds.
+    ; The reach includes the furthest corner plus resolveSegment's radius test.
+    fn segmentNearBody:boolean (b:PhysBody bd:PhysBoundary radius:double) {
+        def reach:double ((sqrt((b.hw * b.hw) + (b.hh * b.hh))) + radius)
+        def minX:double bd.x1
+        def maxX:double bd.x2
+        if (minX > maxX) {
+            minX = bd.x2
+            maxX = bd.x1
+        }
+        def minY:double bd.y1
+        def maxY:double bd.y2
+        if (minY > maxY) {
+            minY = bd.y2
+            maxY = bd.y1
+        }
+        if ((b.x + reach) < minX) {
+            return false
+        }
+        if ((b.x - reach) > maxX) {
+            return false
+        }
+        if ((b.y + reach) < minY) {
+            return false
+        }
+        if ((b.y - reach) > maxY) {
+            return false
+        }
+        return true
+    }
+
     fn resolveBoundaries:void (b:PhysBody) {
         def radius:double b.hw
         if (b.hh > radius) {
@@ -483,7 +516,9 @@ class PhysicsCore {
         while (bi < (array_length bounds)) {
             def bd:PhysBoundary (itemAt bounds bi)
             if (bd.kind == "segment") {
-                this.resolveSegment(b bd radius)
+                if (this.segmentNearBody(b bd radius)) {
+                    this.resolveSegment(b bd radius)
+                }
             }
             if (bd.kind == "rect") {
                 this.resolveRectWalls(b bd radius)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Autopeli's Pi slowdown is primarily in interpreted update/physics work, not PNG sprite blitting after the load-time bake fix.

This PR:

- adds a conservative segment-boundary broad phase before expensive rotated-corner collision math
- replaces autopeli traffic AI's interpreted linear `ROAD_POINTS` scan with direct interval indexing
- fixes split/shared-world profiling so per-runner script, sync/physics, sprite, and HUD costs are reported
- keeps sprites/particles composited into each split pane's framebuffer until a pane-aware GPU overlay exists (the shared global overlay queue cannot correctly preserve and transform both panes)

## Evidence

Autopeli defaults to `splitScreen=auto`, so all tests use the two-runner shared-world path.

Before, desktop CPU fallback (`--software --profile`):

- total update: ~30–34 ms/frame
- both panes' rendering: ~2–3 ms/frame
- ~26 FPS

After direct road indexing + boundary broad phase:

```text
[profile] update/frame=3ms render/frame=1ms present/frame=1ms
[profile:left] updateScript=6ms/frame drawSprites≈0.1ms/fixed-frame
[profile:right] updateScript=1ms/frame drawSprites≈0.1ms/fixed-frame
game-sdl done ... fps=175
```

The interpreted hotspot was `roadAt()`: authority-pane traffic AI calls it three times for each of 15 cars per fixed update. Each call previously scanned up to 15 road points. Direct indexing preserves the same piecewise-linear interpolation.

The physics narrow phase previously did trig plus four point-to-segment calculations for every moving body against all ~150 road edges. A conservative AABB check now sends only nearby segments to `resolveSegment`.

## Verification

- autopeli default split-screen, CPU fallback + profile: 300 frames OK, ~62 FPS in test environment
- autopeli default split-screen, OpenGL present + CPU pane composition: 300–600 frames OK, ~169–175 FPS
- ylos2 split-screen regression with `MallocScribble=1`: 300 frames OK
- native SDL build succeeds
- JS test suite unavailable because checkout dependencies are absent (`cross-env: not found`)

## Pi follow-up

```bash
./tmp/game-sdl/game_sdl --profile \
  gallery/game_engine/games/autopeli_physics/index.tsx 600
```

The new `[profile:left/right]` lines separate interpreter/update, physics sync, sprite draw, and HUD. ARM GPU sheet overlay remains disabled pending a GLES-validated, pane-aware implementation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4341d177-df6d-4141-9cb1-34df2314ade6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4341d177-df6d-4141-9cb1-34df2314ade6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

