### PR TITLE
Speed up autopeli with GLES2 pane GPU sprites

### DIFF
--- a/gallery/game_engine/games/autopeli_physics/index.tsx
+++ b/gallery/game_engine/games/autopeli_physics/index.tsx
@@ -66,25 +66,31 @@ const ROAD_POINTS = [
 ];
 
 function roadAt(y) {
-  let i = 0;
-  while (i < ROAD_POINTS.length - 1) {
-    const a = ROAD_POINTS[i];
-    const b = ROAD_POINTS[i + 1];
-    if (y <= a.y && y >= b.y) {
-      const span = a.y - b.y;
-      let t = 0;
-      if (span > 0) {
-        t = (a.y - y) / span;
-      }
-      return {
-        center: a.x + (b.x - a.x) * t,
-        half: a.half + (b.half - a.half) * t
-      };
-    }
-    i = i + 1;
+  const first = ROAD_POINTS[0];
+  if (y >= first.y) {
+    return { center: first.x, half: first.half };
   }
   const last = ROAD_POINTS[ROAD_POINTS.length - 1];
-  return { center: last.x, half: last.half };
+  if (y <= last.y) {
+    return { center: last.x, half: last.half };
+  }
+
+  // Points are ordered top-to-bottom at 400 world-unit intervals (the final
+  // interval is shorter). Direct indexing avoids an interpreted linear scan;
+  // traffic AI calls roadAt three times per car on every fixed update.
+  let i = ((first.y - y) / 400) | 0;
+  i = clamp(i, 0, ROAD_POINTS.length - 2);
+  const a = ROAD_POINTS[i];
+  const b = ROAD_POINTS[i + 1];
+  const span = a.y - b.y;
+  let t = 0;
+  if (span > 0) {
+    t = (a.y - y) / span;
+  }
+  return {
+    center: a.x + (b.x - a.x) * t,
+    half: a.half + (b.half - a.half) * t
+  };
 }
 
 function clamp(v, lo, hi) {

--- a/gallery/game_engine/gfx_sdl.rgr
+++ b/gallery/game_engine/gfx_sdl.rgr
@@ -614,7 +614,7 @@ static GLuint rgfx_gl_compile(GLenum type, const char* src) {
         char log[1024];
         GLsizei len = 0;
         glGetShaderInfoLog(s, (GLsizei) sizeof(log), &len, log);
-        SDL_Log("[rgfx] GL shader compile failed: %.*s", (int) len, log);
+        SDL_Log(\"[rgfx] GL shader compile failed: %.*s\", (int) len, log);
         glDeleteShader(s);
         return 0;
     }
@@ -666,7 +666,7 @@ static int rgfx_gl_init() {
         char log[1024];
         GLsizei len = 0;
         glGetProgramInfoLog(g_rgfx_gl_program, (GLsizei) sizeof(log), &len, log);
-        SDL_Log("[rgfx] GL program link failed: %.*s", (int) len, log);
+        SDL_Log(\"[rgfx] GL program link failed: %.*s\", (int) len, log);
         glDeleteProgram(g_rgfx_gl_program);
         g_rgfx_gl_program = 0;
         return 0;
@@ -818,7 +818,7 @@ static int rgfx_particles_gl_init() {
         char log[1024];
         GLsizei len = 0;
         glGetProgramInfoLog(g_rgfx_part_program, (GLsizei) sizeof(log), &len, log);
-        SDL_Log("[rgfx] particle program link failed: %.*s", (int) len, log);
+        SDL_Log(\"[rgfx] particle program link failed: %.*s\", (int) len, log);
         glDeleteProgram(g_rgfx_part_program);
         g_rgfx_part_program = 0;
         return 0;

--- a/gallery/game_engine/gfx_sdl.rgr
+++ b/gallery/game_engine/gfx_sdl.rgr
@@ -565,9 +565,13 @@ struct RgfxGpuParticle {
     float x, y, size;
     uint8_t r, g, b, a;
 };
-static std::vector<RgfxGpuParticle> g_rgfx_particles;
-static int g_rgfx_part_fb_w = 0;
-static int g_rgfx_part_fb_h = 0;
+struct RgfxGpuParticleQueue {
+    std::vector<RgfxGpuParticle> items;
+    int fbW = 0;
+    int fbH = 0;
+};
+static RgfxGpuParticleQueue g_rgfx_particle_queues[3];
+static int g_rgfx_active_particle_queue = 0;
 
 struct RgfxGpuSprite {
     int texId;
@@ -578,15 +582,14 @@ struct RgfxGpuSprite {
     float angleDeg;
     int usePivot;
 };
-static std::vector<RgfxGpuSprite> g_rgfx_sprites;
-static int g_rgfx_spr_fb_w = 0;
-static int g_rgfx_spr_fb_h = 0;
-#if defined(__arm__) || defined(__aarch64__)
-// GLES2 sprite overlay disabled on ARM until verified; CPU sheet blit only.
-static int g_rgfx_gpu_sprites_arm_safe = 0;
-#else
-static int g_rgfx_gpu_sprites_arm_safe = 1;
-#endif
+struct RgfxGpuSpriteQueue {
+    std::vector<RgfxGpuSprite> items;
+    int fbW = 0;
+    int fbH = 0;
+};
+// Queue 0 = normal/solo, queue 1 = split left, queue 2 = split right.
+static RgfxGpuSpriteQueue g_rgfx_sprite_queues[3];
+static int g_rgfx_active_sprite_queue = 0;
 static GLuint g_rgfx_part_program = 0;
 static GLint g_rgfx_part_corner_attr = 0;
 static GLint g_rgfx_part_center_attr = 0;
@@ -595,15 +598,43 @@ static GLint g_rgfx_part_color_attr = 0;
 static GLint g_rgfx_part_res_uniform = 0;
 static GLuint g_rgfx_part_vbo = 0;
 
+static int rgfx_gpu_queue_index(int pane) {
+    if (pane == 0) { return 1; }
+    if (pane == 1) { return 2; }
+    return 0;
+}
+
 static GLuint rgfx_gl_compile(GLenum type, const char* src) {
     GLuint s = glCreateShader(type);
     glShaderSource(s, 1, &src, nullptr);
     glCompileShader(s);
+    GLint ok = GL_FALSE;
+    glGetShaderiv(s, GL_COMPILE_STATUS, &ok);
+    if (ok != GL_TRUE) {
+        char log[1024];
+        GLsizei len = 0;
+        glGetShaderInfoLog(s, (GLsizei) sizeof(log), &len, log);
+        SDL_Log("[rgfx] GL shader compile failed: %.*s", (int) len, log);
+        glDeleteShader(s);
+        return 0;
+    }
     return s;
 }
 
 static int rgfx_gl_init() {
     if (g_rgfx_gl_program != 0) { return 1; }
+#if defined(__arm__) || defined(__aarch64__)
+    const char* vs =
+        \"attribute vec2 aPos;\\n\"
+        \"attribute vec2 aUv;\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"void main() { gl_Position = vec4(aPos, 0.0, 1.0); vUv = aUv; }\\n\";
+    const char* fs =
+        \"precision mediump float;\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"uniform sampler2D uTex;\\n\"
+        \"void main() { gl_FragColor = texture2D(uTex, vUv); }\\n\";
+#else
     const char* vs =
         \"#version 120\\n\"
         \"attribute vec2 aPos;\\n\"
@@ -615,14 +646,31 @@ static int rgfx_gl_init() {
         \"varying vec2 vUv;\\n\"
         \"uniform sampler2D uTex;\\n\"
         \"void main() { gl_FragColor = texture2D(uTex, vUv); }\\n\";
+#endif
     GLuint vsId = rgfx_gl_compile(GL_VERTEX_SHADER, vs);
     GLuint fsId = rgfx_gl_compile(GL_FRAGMENT_SHADER, fs);
+    if (vsId == 0 || fsId == 0) {
+        if (vsId != 0) { glDeleteShader(vsId); }
+        if (fsId != 0) { glDeleteShader(fsId); }
+        return 0;
+    }
     g_rgfx_gl_program = glCreateProgram();
     glAttachShader(g_rgfx_gl_program, vsId);
     glAttachShader(g_rgfx_gl_program, fsId);
     glLinkProgram(g_rgfx_gl_program);
+    GLint linked = GL_FALSE;
+    glGetProgramiv(g_rgfx_gl_program, GL_LINK_STATUS, &linked);
     glDeleteShader(vsId);
     glDeleteShader(fsId);
+    if (linked != GL_TRUE) {
+        char log[1024];
+        GLsizei len = 0;
+        glGetProgramInfoLog(g_rgfx_gl_program, (GLsizei) sizeof(log), &len, log);
+        SDL_Log("[rgfx] GL program link failed: %.*s", (int) len, log);
+        glDeleteProgram(g_rgfx_gl_program);
+        g_rgfx_gl_program = 0;
+        return 0;
+    }
     g_rgfx_gl_pos_attr = glGetAttribLocation(g_rgfx_gl_program, \"aPos\");
     g_rgfx_gl_uv_attr = glGetAttribLocation(g_rgfx_gl_program, \"aUv\");
     g_rgfx_gl_tex_uniform = glGetUniformLocation(g_rgfx_gl_program, \"uTex\");
@@ -636,8 +684,14 @@ static int rgfx_open_gpu(const std::string& title, int w, int h) {
     rgfx_prepare_audio_env();
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK) != 0) { return 0; }
     rgfx_scan_pads();
+#if defined(__arm__) || defined(__aarch64__)
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+#else
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+#endif
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     g_rgfx_win = SDL_CreateWindow(title.c_str(),
         SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, w, h,
@@ -649,7 +703,13 @@ static int rgfx_open_gpu(const std::string& title, int w, int h) {
     g_rgfx_gpu_mode = 1;
     g_rgfx_fb_w = w;
     g_rgfx_fb_h = h;
-    return rgfx_gl_init();
+    if (rgfx_gl_init()) { return 1; }
+    SDL_GL_DeleteContext(g_rgfx_glctx);
+    g_rgfx_glctx = nullptr;
+    SDL_DestroyWindow(g_rgfx_win);
+    g_rgfx_win = nullptr;
+    g_rgfx_gpu_mode = 0;
+    return 0;
 }
 
 static GLuint rgfx_gl_make_tex(const uint8_t* pixels, int w, int h) {
@@ -666,7 +726,7 @@ static GLuint rgfx_gl_make_tex(const uint8_t* pixels, int w, int h) {
 }
 
 static int rgfx_gpu_upload_texture(const uint8_t* pixels, int w, int h) {
-    if (!g_rgfx_gpu_mode || !g_rgfx_gpu_sprites_arm_safe || pixels == nullptr || w <= 0 || h <= 0) { return 0; }
+    if (!g_rgfx_gpu_mode || pixels == nullptr || w <= 0 || h <= 0) { return 0; }
     rgfx_gl_ensure_current();
     GLuint tex = rgfx_gl_make_tex(pixels, w, h);
     g_rgfx_gl_textures.push_back(tex);
@@ -675,6 +735,38 @@ static int rgfx_gpu_upload_texture(const uint8_t* pixels, int w, int h) {
 
 static int rgfx_particles_gl_init() {
     if (g_rgfx_part_program != 0) { return 1; }
+#if defined(__arm__) || defined(__aarch64__)
+    const char* vs =
+        \"attribute vec2 aCorner;\\n\"
+        \"attribute vec2 aCenter;\\n\"
+        \"attribute float aSize;\\n\"
+        \"attribute vec4 aColor;\\n\"
+        \"uniform vec2 uResolution;\\n\"
+        \"varying vec2 vCorner;\\n\"
+        \"varying vec4 vColor;\\n\"
+        \"void main() {\\n\"
+        \"  vec2 pix = aCenter + aCorner * aSize;\\n\"
+        \"  vec2 ndc;\\n\"
+        \"  ndc.x = (pix.x / uResolution.x) * 2.0 - 1.0;\\n\"
+        \"  ndc.y = 1.0 - (pix.y / uResolution.y) * 2.0;\\n\"
+        \"  gl_Position = vec4(ndc, 0.0, 1.0);\\n\"
+        \"  vCorner = aCorner;\\n\"
+        \"  vColor = aColor;\\n\"
+        \"}\\n\";
+    const char* fs =
+        \"precision mediump float;\\n\"
+        \"varying vec2 vCorner;\\n\"
+        \"varying vec4 vColor;\\n\"
+        \"void main() {\\n\"
+        \"  float d = dot(vCorner, vCorner);\\n\"
+        \"  if (d > 1.0) discard;\\n\"
+        \"  float soft = 1.0 - d;\\n\"
+        \"  float core = 1.0 - smoothstep(0.0, 0.22, d);\\n\"
+        \"  float alpha = vColor.a * soft * soft;\\n\"
+        \"  vec3 rgb = vColor.rgb * (1.0 + core * 0.7);\\n\"
+        \"  gl_FragColor = vec4(rgb, alpha);\\n\"
+        \"}\\n\";
+#else
     const char* vs =
         \"#version 120\\n\"
         \"attribute vec2 aCorner;\\n\"
@@ -706,14 +798,31 @@ static int rgfx_particles_gl_init() {
         \"  vec3 rgb = vColor.rgb * (1.0 + core * 0.7);\\n\"
         \"  gl_FragColor = vec4(rgb, alpha);\\n\"
         \"}\\n\";
+#endif
     GLuint vsId = rgfx_gl_compile(GL_VERTEX_SHADER, vs);
     GLuint fsId = rgfx_gl_compile(GL_FRAGMENT_SHADER, fs);
+    if (vsId == 0 || fsId == 0) {
+        if (vsId != 0) { glDeleteShader(vsId); }
+        if (fsId != 0) { glDeleteShader(fsId); }
+        return 0;
+    }
     g_rgfx_part_program = glCreateProgram();
     glAttachShader(g_rgfx_part_program, vsId);
     glAttachShader(g_rgfx_part_program, fsId);
     glLinkProgram(g_rgfx_part_program);
+    GLint linked = GL_FALSE;
+    glGetProgramiv(g_rgfx_part_program, GL_LINK_STATUS, &linked);
     glDeleteShader(vsId);
     glDeleteShader(fsId);
+    if (linked != GL_TRUE) {
+        char log[1024];
+        GLsizei len = 0;
+        glGetProgramInfoLog(g_rgfx_part_program, (GLsizei) sizeof(log), &len, log);
+        SDL_Log("[rgfx] particle program link failed: %.*s", (int) len, log);
+        glDeleteProgram(g_rgfx_part_program);
+        g_rgfx_part_program = 0;
+        return 0;
+    }
     g_rgfx_part_corner_attr = glGetAttribLocation(g_rgfx_part_program, \"aCorner\");
     g_rgfx_part_center_attr = glGetAttribLocation(g_rgfx_part_program, \"aCenter\");
     g_rgfx_part_size_attr = glGetAttribLocation(g_rgfx_part_program, \"aSize\");
@@ -723,10 +832,12 @@ static int rgfx_particles_gl_init() {
     return 1;
 }
 
-static void rgfx_particles_begin(int w, int h) {
-    g_rgfx_particles.clear();
-    g_rgfx_part_fb_w = w;
-    g_rgfx_part_fb_h = h;
+static void rgfx_particles_begin(int w, int h, int pane) {
+    g_rgfx_active_particle_queue = rgfx_gpu_queue_index(pane);
+    RgfxGpuParticleQueue& q = g_rgfx_particle_queues[g_rgfx_active_particle_queue];
+    q.items.clear();
+    q.fbW = w;
+    q.fbH = h;
 }
 
 static void rgfx_particles_push(float x, float y, float size, int r, int g, int b, int a) {
@@ -734,20 +845,22 @@ static void rgfx_particles_push(float x, float y, float size, int r, int g, int 
     RgfxGpuParticle p;
     p.x = x; p.y = y; p.size = size;
     p.r = (uint8_t) r; p.g = (uint8_t) g; p.b = (uint8_t) b; p.a = (uint8_t) a;
-    g_rgfx_particles.push_back(p);
+    g_rgfx_particle_queues[g_rgfx_active_particle_queue].items.push_back(p);
 }
 
-static void rgfx_particles_draw_overlay() {
-    if (g_rgfx_particles.empty() || g_rgfx_part_fb_w <= 0 || g_rgfx_part_fb_h <= 0) { return; }
+static void rgfx_particles_draw_queue(int queueIndex, int viewportX, int viewportW, int viewportH) {
+    RgfxGpuParticleQueue& q = g_rgfx_particle_queues[queueIndex];
+    if (q.items.empty() || q.fbW <= 0 || q.fbH <= 0 || viewportW <= 0 || viewportH <= 0) { return; }
     if (!g_rgfx_gpu_mode) { return; }
-    rgfx_particles_gl_init();
+    if (!rgfx_particles_gl_init()) { return; }
+    glViewport(viewportX, 0, viewportW, viewportH);
     static const float corners[6][2] = {
         {-1.f, -1.f}, {1.f, -1.f}, {1.f, 1.f},
         {-1.f, -1.f}, {1.f, 1.f}, {-1.f, 1.f}
     };
     std::vector<float> verts;
-    verts.reserve(g_rgfx_particles.size() * 6u * 9u);
-    for (const RgfxGpuParticle& p : g_rgfx_particles) {
+    verts.reserve(q.items.size() * 6u * 9u);
+    for (const RgfxGpuParticle& p : q.items) {
         float cr = p.r / 255.f, cg = p.g / 255.f, cb = p.b / 255.f, ca = p.a / 255.f;
         for (int i = 0; i < 6; ++i) {
             verts.push_back(corners[i][0]);
@@ -762,7 +875,7 @@ static void rgfx_particles_draw_overlay() {
         }
     }
     glUseProgram(g_rgfx_part_program);
-    glUniform2f((GLint) g_rgfx_part_res_uniform, (float) g_rgfx_part_fb_w, (float) g_rgfx_part_fb_h);
+    glUniform2f((GLint) g_rgfx_part_res_uniform, (float) q.fbW, (float) q.fbH);
     glBindBuffer(GL_ARRAY_BUFFER, g_rgfx_part_vbo);
     glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) (verts.size() * sizeof(float)), verts.data(), GL_DYNAMIC_DRAW);
     const GLsizei stride = (GLsizei) (9 * sizeof(float));
@@ -776,30 +889,36 @@ static void rgfx_particles_draw_overlay() {
     glVertexAttribPointer((GLuint) g_rgfx_part_color_attr, 4, GL_FLOAT, GL_FALSE, stride, (void*) (5 * sizeof(float)));
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE);
-    glDrawArrays(GL_TRIANGLES, 0, (GLsizei) (g_rgfx_particles.size() * 6));
-    g_rgfx_particles.clear();
+    glDrawArrays(GL_TRIANGLES, 0, (GLsizei) (q.items.size() * 6));
+    q.items.clear();
 }
 
-static void rgfx_gpu_sprites_begin(int w, int h) {
-    if (!g_rgfx_gpu_sprites_arm_safe) { return; }
-    g_rgfx_sprites.clear();
-    g_rgfx_spr_fb_w = w;
-    g_rgfx_spr_fb_h = h;
+static void rgfx_particles_draw_overlay() {
+    rgfx_particles_draw_queue(0, 0, g_rgfx_fb_w, g_rgfx_fb_h);
 }
 
-static void rgfx_px_to_ndc(float px, float py, float* nx, float* ny) {
-    *nx = (px / (float) g_rgfx_spr_fb_w) * 2.f - 1.f;
-    *ny = 1.f - (py / (float) g_rgfx_spr_fb_h) * 2.f;
+static void rgfx_gpu_sprites_begin(int w, int h, int pane) {
+    g_rgfx_active_sprite_queue = rgfx_gpu_queue_index(pane);
+    RgfxGpuSpriteQueue& q = g_rgfx_sprite_queues[g_rgfx_active_sprite_queue];
+    q.items.clear();
+    q.fbW = w;
+    q.fbH = h;
+}
+
+static void rgfx_px_to_ndc(float px, float py, int fbW, int fbH, float* nx, float* ny) {
+    *nx = (px / (float) fbW) * 2.f - 1.f;
+    *ny = 1.f - (py / (float) fbH) * 2.f;
 }
 
 static void rgfx_gpu_draw_textured_quad_corners(
     GLuint tex, float u0, float v0, float u1, float v1,
-    float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3) {
+    float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3,
+    int fbW, int fbH) {
     float nx0, ny0, nx1, ny1, nx2, ny2, nx3, ny3;
-    rgfx_px_to_ndc(x0, y0, &nx0, &ny0);
-    rgfx_px_to_ndc(x1, y1, &nx1, &ny1);
-    rgfx_px_to_ndc(x2, y2, &nx2, &ny2);
-    rgfx_px_to_ndc(x3, y3, &nx3, &ny3);
+    rgfx_px_to_ndc(x0, y0, fbW, fbH, &nx0, &ny0);
+    rgfx_px_to_ndc(x1, y1, fbW, fbH, &nx1, &ny1);
+    rgfx_px_to_ndc(x2, y2, fbW, fbH, &nx2, &ny2);
+    rgfx_px_to_ndc(x3, y3, fbW, fbH, &nx3, &ny3);
     float verts[] = {
         nx0, ny0, u0, v0,
         nx1, ny1, u1, v0,
@@ -841,16 +960,17 @@ static void rgfx_gpu_sprites_push(int texId, int atlasW, int atlasH,
     s.dh = dh;
     s.angleDeg = angleDeg;
     s.usePivot = usePivot;
-    g_rgfx_sprites.push_back(s);
+    g_rgfx_sprite_queues[g_rgfx_active_sprite_queue].items.push_back(s);
 }
 
-static void rgfx_gpu_sprites_draw_overlay() {
-    if (!g_rgfx_gpu_sprites_arm_safe) { return; }
-    if (g_rgfx_sprites.empty() || g_rgfx_spr_fb_w <= 0 || g_rgfx_spr_fb_h <= 0) { return; }
+static void rgfx_gpu_sprites_draw_queue(int queueIndex, int viewportX, int viewportW, int viewportH) {
+    RgfxGpuSpriteQueue& q = g_rgfx_sprite_queues[queueIndex];
+    if (q.items.empty() || q.fbW <= 0 || q.fbH <= 0 || viewportW <= 0 || viewportH <= 0) { return; }
     if (!g_rgfx_gpu_mode) { return; }
     rgfx_gl_ensure_current();
-    rgfx_gl_init();
-    for (const RgfxGpuSprite& s : g_rgfx_sprites) {
+    if (!rgfx_gl_init()) { return; }
+    glViewport(viewportX, 0, viewportW, viewportH);
+    for (const RgfxGpuSprite& s : q.items) {
         if (s.texId <= 0 || s.texId > (int) g_rgfx_gl_textures.size()) { continue; }
         GLuint tex = g_rgfx_gl_textures[(size_t) (s.texId - 1)];
         float u0 = (float) s.sx / (float) s.atlasW;
@@ -862,7 +982,8 @@ static void rgfx_gpu_sprites_draw_overlay() {
             float x1 = s.px + s.dw, y1 = s.py;
             float x2 = s.px + s.dw, y2 = s.py + s.dh;
             float x3 = s.px, y3 = s.py + s.dh;
-            rgfx_gpu_draw_textured_quad_corners(tex, u0, v0, u1, v1, x0, y0, x1, y1, x2, y2, x3, y3);
+            rgfx_gpu_draw_textured_quad_corners(tex, u0, v0, u1, v1,
+                x0, y0, x1, y1, x2, y2, x3, y3, q.fbW, q.fbH);
         } else {
             float rad = s.angleDeg * 3.14159265f / 180.f;
             float ca = cosf(rad), sa = sinf(rad);
@@ -875,10 +996,14 @@ static void rgfx_gpu_sprites_draw_overlay() {
                 wy[i] = s.py + (lx[i] * sa + ly[i] * ca);
             }
             rgfx_gpu_draw_textured_quad_corners(tex, u0, v0, u1, v1,
-                wx[0], wy[0], wx[1], wy[1], wx[2], wy[2], wx[3], wy[3]);
+                wx[0], wy[0], wx[1], wy[1], wx[2], wy[2], wx[3], wy[3], q.fbW, q.fbH);
         }
     }
-    g_rgfx_sprites.clear();
+    q.items.clear();
+}
+
+static void rgfx_gpu_sprites_draw_overlay() {
+    rgfx_gpu_sprites_draw_queue(0, 0, g_rgfx_fb_w, g_rgfx_fb_h);
 }
 
 static void rgfx_gpu_draw_quad_tex(GLuint tex, float x, float y, float qw, float qh) {
@@ -969,8 +1094,11 @@ static void rgfx_gpu_present_split(const uint8_t* left, const uint8_t* right, in
     glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, right);
     rgfx_gpu_draw_quad_tex(g_rgfx_base_tex_r, (float) halfW, 0.f, (float) (g_rgfx_fb_w - halfW), (float) g_rgfx_fb_h);
-    rgfx_gpu_sprites_draw_overlay();
-    rgfx_particles_draw_overlay();
+    rgfx_gpu_sprites_draw_queue(1, 0, halfW, g_rgfx_fb_h);
+    rgfx_gpu_sprites_draw_queue(2, halfW, g_rgfx_fb_w - halfW, g_rgfx_fb_h);
+    rgfx_particles_draw_queue(1, 0, halfW, g_rgfx_fb_h);
+    rgfx_particles_draw_queue(2, halfW, g_rgfx_fb_w - halfW, g_rgfx_fb_h);
+    glViewport(0, 0, g_rgfx_fb_w, g_rgfx_fb_h);
     rgfx_gpu_finish_frame();
 }
 
@@ -1003,8 +1131,10 @@ static void rgfx_gl_cleanup() {
         glDeleteProgram(g_rgfx_part_program);
         g_rgfx_part_program = 0;
     }
-    g_rgfx_particles.clear();
-    g_rgfx_sprites.clear();
+    for (int i = 0; i < 3; ++i) {
+        g_rgfx_particle_queues[i].items.clear();
+        g_rgfx_sprite_queues[i].items.clear();
+    }
     if (g_rgfx_glctx != nullptr) {
         SDL_GL_DeleteContext(g_rgfx_glctx);
         g_rgfx_glctx = nullptr;
@@ -1292,9 +1422,9 @@ static void rgfx_close() {
     }
 
     ; Begin collecting GPU particles for the next present (OpenGL path only).
-    gfx_particles_begin _:void (fbW:int fbH:int) {
+    gfx_particles_begin _:void (fbW:int fbH:int pane:int) {
         templates {
-            cpp ( "rgfx_particles_begin(" (e 1) ", " (e 2) ")" (imp "<SDL2/SDL.h>") )
+            cpp ( "rgfx_particles_begin(" (e 1) ", " (e 2) ", " (e 3) ")" (imp "<SDL2/SDL.h>") )
             es6 ( "undefined" )
         }
     }
@@ -1317,9 +1447,9 @@ static void rgfx_close() {
     }
 
     ; Begin collecting GPU sheet sprites for the next present (OpenGL path only).
-    gfx_gpu_sprites_begin _:void (fbW:int fbH:int) {
+    gfx_gpu_sprites_begin _:void (fbW:int fbH:int pane:int) {
         templates {
-            cpp ( "rgfx_gpu_sprites_begin(" (e 1) ", " (e 2) ")" (imp "<SDL2/SDL.h>") (imp "<cmath>") )
+            cpp ( "rgfx_gpu_sprites_begin(" (e 1) ", " (e 2) ", " (e 3) ")" (imp "<SDL2/SDL.h>") (imp "<cmath>") )
             es6 ( "undefined" )
         }
     }

--- a/gallery/game_engine/scripting/game_particles.rgr
+++ b/gallery/game_engine/scripting/game_particles.rgr
@@ -31,6 +31,11 @@ class GameParticleSystem {
     def pool:[GameParticle]
     def maxCount:int 96
     def seed:int 9973
+    def gpuPane:int -1
+
+    fn setGpuPane:void (pane:int) {
+        gpuPane = pane
+    }
 
     fn init:void (capacity:int) {
         if (capacity > 0) {
@@ -319,7 +324,7 @@ class GameParticleSystem {
     }
 
     fn flushGpu:void (fbW:int fbH:int) {
-        gfx_particles_begin fbW fbH
+        gfx_particles_begin fbW fbH gpuPane
         def i 0
         while (i < maxCount) {
             def p:GameParticle (itemAt pool i)

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -1263,13 +1263,27 @@ class GameRunner {
 
     fn sharedPhysicsStep:void (dtMs:int snap:GameInputSnapshot peer:GameRunner) {
         def prevScreen:string (this.currentScreenName())
+        def tScript0:int 0
+        if (profileEnabled) {
+            tScript0 = (gfx_ticks_ms)
+        }
         this.stepUpdateScript(dtMs snap)
+        def tScript1:int 0
+        if (profileEnabled) {
+            tScript1 = (gfx_ticks_ms)
+        }
         this.mergePhysicsFromPane(peer.state)
         this.mergeEventsFromPeer(peer.state)
         this.setPhysicsPassive(false)
         this.runPhysicsStep(dtMs)
         this.setPhysicsPassive(true)
         this.stepPostPhysics(dtMs prevScreen)
+        if (profileEnabled) {
+            def tSync1:int (gfx_ticks_ms)
+            profUpdateScriptMs = (profUpdateScriptMs + (tScript1 - tScript0))
+            profUpdateSyncMs = (profUpdateSyncMs + (tSync1 - tScript1))
+            profFrames = (profFrames + 1)
+        }
     }
 
     fn frameWithInput:void (dtMs:int snap:GameInputSnapshot) {

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -223,6 +223,11 @@ class GameRunner {
         spriteRenderer.setGpuSheetOverlay(false)
     }
 
+    fn setGpuPane:void (pane:int) {
+        spriteRenderer.setGpuPane(pane)
+        particles.setGpuPane(pane)
+    }
+
     fn enableGpuSheetOverlay:void () {
         if (options.gpuMode) {
             if (options.spritesGpuOverlay) {

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -742,6 +742,15 @@ class GameSdlRunner {
                 print "[game-engine] SDL software present (--software)"
             }
         }
+        ; Direct-launch games are parsed before the window/GL context opens.
+        ; Re-apply the resolved mode now so cached sheets can upload textures.
+        if (splitScreenActive) {
+            splitHost.setGpuMode(gpuModeActive)
+            splitHost.enableGpuSheetOverlay()
+        } {
+            runner.setGpuMode(gpuModeActive)
+            runner.enableGpuSheetOverlay()
+        }
         if (startFullscreen) {
             gfx_set_fullscreen(1)
         }

--- a/gallery/game_engine/scripting/game_split_screen.rgr
+++ b/gallery/game_engine/scripting/game_split_screen.rgr
@@ -64,6 +64,8 @@ class SplitScreenHost {
             left.init(paneW paneH)
             right.init(paneW paneH)
         }
+        left.setGpuPane(0)
+        right.setGpuPane(1)
     }
 
     fn setAudioSink:void (sink:GameAudioSink) {
@@ -86,8 +88,14 @@ class SplitScreenHost {
     }
 
     fn setGpuMode:void (enabled:boolean) {
-        left.setGpuMode(enabled)
-        right.setGpuMode(enabled)
+        ; Pane GPU queues are presented by gfx_present_split. Non-autoscale
+        ; split composites into one CPU canvas, so keep those runners on CPU.
+        def paneGpu:boolean enabled
+        if (false == autoscale) {
+            paneGpu = false
+        }
+        left.setGpuMode(paneGpu)
+        right.setGpuMode(paneGpu)
     }
 
     fn flushGpuParticles:void () {

--- a/gallery/game_engine/scripting/game_split_screen.rgr
+++ b/gallery/game_engine/scripting/game_split_screen.rgr
@@ -98,6 +98,11 @@ class SplitScreenHost {
         right.setGpuMode(paneGpu)
     }
 
+    fn enableGpuSheetOverlay:void () {
+        left.enableGpuSheetOverlay()
+        right.enableGpuSheetOverlay()
+    }
+
     fn flushGpuParticles:void () {
         left.flushGpuParticles()
         right.flushGpuParticles()

--- a/gallery/game_engine/scripting/game_split_screen.rgr
+++ b/gallery/game_engine/scripting/game_split_screen.rgr
@@ -179,7 +179,16 @@ class SplitScreenHost {
             def steps:int 0
             while (left.timeAccumulator >= left.fixedStepMs) {
                 def step:int left.fixedStepMs
+                def tRight0:int 0
+                if (profileEnabled) {
+                    tRight0 = (gfx_ticks_ms)
+                }
                 right.stepUpdateScript(step rightSnap)
+                if (profileEnabled) {
+                    def tRight1:int (gfx_ticks_ms)
+                    right.profUpdateScriptMs = (right.profUpdateScriptMs + (tRight1 - tRight0))
+                    right.profFrames = (right.profFrames + 1)
+                }
                 left.sharedPhysicsStep(step leftSnap right)
                 right.syncSharedWorldFrom(left)
                 left.timeAccumulator = (left.timeAccumulator - step)
@@ -192,7 +201,16 @@ class SplitScreenHost {
             }
             return
         }
+        def tRight0:int 0
+        if (profileEnabled) {
+            tRight0 = (gfx_ticks_ms)
+        }
         right.stepUpdateScript(dtMs rightSnap)
+        if (profileEnabled) {
+            def tRight1:int (gfx_ticks_ms)
+            right.profUpdateScriptMs = (right.profUpdateScriptMs + (tRight1 - tRight0))
+            right.profFrames = (right.profFrames + 1)
+        }
         left.sharedPhysicsStep(dtMs leftSnap right)
         right.syncSharedWorldFrom(left)
     }

--- a/gallery/game_engine/scripting/game_sprite.rgr
+++ b/gallery/game_engine/scripting/game_sprite.rgr
@@ -70,6 +70,7 @@ class GameEntity {
 class GameSpriteRenderer {
     def imageLoader:GameImageLoader (new GameImageLoader())
     def gpuSheetOverlay:boolean false
+    def gpuPane:int -1
     def sheetCachePaths:[string]
     def sheetCacheTpl:[GameEntity]
 
@@ -81,10 +82,14 @@ class GameSpriteRenderer {
         gpuSheetOverlay = enabled
     }
 
+    fn setGpuPane:void (pane:int) {
+        gpuPane = pane
+    }
+
     fn beginGpuSpriteFrame:void (pw:int ph:int gpuMode:boolean) {
         if (gpuMode) {
             if (gpuSheetOverlay) {
-                gfx_gpu_sprites_begin pw ph
+                gfx_gpu_sprites_begin pw ph gpuPane
             }
         }
     }

--- a/gallery/game_engine/scripting/physics_core.rgr
+++ b/gallery/game_engine/scripting/physics_core.rgr
@@ -474,6 +474,39 @@ class PhysicsCore {
         }
     }
 
+    ; Cheap conservative broad phase for segment boundaries. resolveSegment
+    ; rotates all four body corners and calculates point-to-segment distances,
+    ; so calling it for every road segment dominates dense vehicle worlds.
+    ; The reach includes the furthest corner plus resolveSegment's radius test.
+    fn segmentNearBody:boolean (b:PhysBody bd:PhysBoundary radius:double) {
+        def reach:double ((sqrt((b.hw * b.hw) + (b.hh * b.hh))) + radius)
+        def minX:double bd.x1
+        def maxX:double bd.x2
+        if (minX > maxX) {
+            minX = bd.x2
+            maxX = bd.x1
+        }
+        def minY:double bd.y1
+        def maxY:double bd.y2
+        if (minY > maxY) {
+            minY = bd.y2
+            maxY = bd.y1
+        }
+        if ((b.x + reach) < minX) {
+            return false
+        }
+        if ((b.x - reach) > maxX) {
+            return false
+        }
+        if ((b.y + reach) < minY) {
+            return false
+        }
+        if ((b.y - reach) > maxY) {
+            return false
+        }
+        return true
+    }
+
     fn resolveBoundaries:void (b:PhysBody) {
         def radius:double b.hw
         if (b.hh > radius) {
@@ -483,7 +516,9 @@ class PhysicsCore {
         while (bi < (array_length bounds)) {
             def bd:PhysBoundary (itemAt bounds bi)
             if (bd.kind == "segment") {
-                this.resolveSegment(b bd radius)
+                if (this.segmentNearBody(b bd radius)) {
+                    this.resolveSegment(b bd radius)
+                }
             }
             if (bd.kind == "rect") {
                 this.resolveRectWalls(b bd radius)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Complete autopeli/Pi performance package based on `master`. This now combines the optimization/profiling work from PR #183 with the pane-aware GLES2 GPU implementation.

## CPU/update optimizations (from #183)

- Conservative broad-phase culling before expensive rotated-corner collision checks against ~150 road-edge segments.
- Direct `ROAD_POINTS` interval indexing in autopeli traffic AI. The authority pane previously performed interpreted linear scans three times per traffic car per fixed update.
- Split/shared-world profiler accounting for left/right script, sync/physics, sprite, and HUD costs.

The old #183 commit that disabled split GPU overlays is intentionally not copied: this PR supersedes that temporary safety revert with correct pane-aware queues and viewports.

## GPU/GLES2 implementation

- Separate solo, split-left, and split-right sprite queues.
- Separate pane-aware particle queues.
- Split queues render through independent GL viewports, preserving each full-resolution pane's coordinate system while scaling it into the correct window half.
- ARM uses a GLES 2.0 context and GLES-compatible fragment precision/shaders.
- Shader compilation and program linking are validated; GL initialization falls back cleanly on error.
- ARM sheet texture uploads are enabled.
- Direct-launch games re-apply GPU mode after the GL context opens, fixing the previous no-upload path.
- Non-autoscaled split games remain on CPU pane composition because they present one already-composited framebuffer.

## Combined verification

Native desktop OpenGL, autopeli default split-screen, 600 frames:

```text
update/frame=3ms render/frame=1ms present/frame=1ms
left drawSprites=5ms total / 600 frames
right drawSprites=5ms total / 600 frames
fps=167
```

CPU/software fallback, 300 frames:

```text
update/frame=8ms render/frame=1ms
fps=62
```

Forced ARM/GLES2 compile and runtime (`-D__aarch64__`, GLESv2), 300 frames:

```text
update/frame=2ms render/frame=1ms present/frame=1ms
left/right drawSprites=3ms total each
fps=188
```

Additional checks:

- both split GPU queues populated and persistent textures uploaded (debugger verified)
- solo direct-launch GPU queue populated
- ylos2 non-autoscale split CPU fallback: 300 frames, MallocScribble enabled
- native Ranger→C++→SDL build succeeds

## Pi validation command

```bash
./tmp/game-sdl/game_sdl --profile \
  gallery/game_engine/games/autopeli_physics/index.tsx 600
```

This PR is intended to be merged as the full package; PR #183 is no longer required for code coverage once this lands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4341d177-df6d-4141-9cb1-34df2314ade6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4341d177-df6d-4141-9cb1-34df2314ade6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

