### PR TITLE
Fix Apple Silicon startup regression (no GLES on macOS)

### DIFF
--- a/gallery/game_engine/gfx_sdl.rgr
+++ b/gallery/game_engine/gfx_sdl.rgr
@@ -623,7 +623,7 @@ static GLuint rgfx_gl_compile(GLenum type, const char* src) {
 
 static int rgfx_gl_init() {
     if (g_rgfx_gl_program != 0) { return 1; }
-#if defined(__arm__) || defined(__aarch64__)
+#if (defined(__arm__) || defined(__aarch64__)) && !defined(__APPLE__)
     const char* vs =
         \"attribute vec2 aPos;\\n\"
         \"attribute vec2 aUv;\\n\"
@@ -684,7 +684,7 @@ static int rgfx_open_gpu(const std::string& title, int w, int h) {
     rgfx_prepare_audio_env();
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK) != 0) { return 0; }
     rgfx_scan_pads();
-#if defined(__arm__) || defined(__aarch64__)
+#if (defined(__arm__) || defined(__aarch64__)) && !defined(__APPLE__)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
@@ -696,9 +696,21 @@ static int rgfx_open_gpu(const std::string& title, int w, int h) {
     g_rgfx_win = SDL_CreateWindow(title.c_str(),
         SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, w, h,
         SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
-    if (g_rgfx_win == nullptr) { return 0; }
+    if (g_rgfx_win == nullptr) {
+        // Leave the GL request state clean so the software fallback can open a
+        // plain window + SDL_Renderer instead.
+        SDL_GL_ResetAttributes();
+        return 0;
+    }
     g_rgfx_glctx = SDL_GL_CreateContext(g_rgfx_win);
-    if (g_rgfx_glctx == nullptr) { return 0; }
+    if (g_rgfx_glctx == nullptr) {
+        // Destroy the OpenGL window before falling back; otherwise it lingers as
+        // an unfocusable ghost while the software path opens a second window.
+        SDL_DestroyWindow(g_rgfx_win);
+        g_rgfx_win = nullptr;
+        SDL_GL_ResetAttributes();
+        return 0;
+    }
     SDL_GL_SetSwapInterval(1);
     g_rgfx_gpu_mode = 1;
     g_rgfx_fb_w = w;
@@ -709,6 +721,7 @@ static int rgfx_open_gpu(const std::string& title, int w, int h) {
     SDL_DestroyWindow(g_rgfx_win);
     g_rgfx_win = nullptr;
     g_rgfx_gpu_mode = 0;
+    SDL_GL_ResetAttributes();
     return 0;
 }
 
@@ -735,7 +748,7 @@ static int rgfx_gpu_upload_texture(const uint8_t* pixels, int w, int h) {
 
 static int rgfx_particles_gl_init() {
     if (g_rgfx_part_program != 0) { return 1; }
-#if defined(__arm__) || defined(__aarch64__)
+#if (defined(__arm__) || defined(__aarch64__)) && !defined(__APPLE__)
     const char* vs =
         \"attribute vec2 aCorner;\\n\"
         \"attribute vec2 aCenter;\\n\"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a startup regression introduced by the GLES2 GPU sprite work (#184). On Apple Silicon Macs the game window opened but was unfocusable/unresponsive, with:

```
gfx_open failed (no display?) - still rendering into the RGBA buffer
```

## Root cause

Apple Silicon compilers define `__aarch64__`. The GLES2 code paths were gated only on `defined(__arm__) || defined(__aarch64__)`, so an M-series Mac took the Raspberry Pi path:

- `rgfx_open_gpu` requested an OpenGL **ES 2.0** context (`SDL_GL_CONTEXT_PROFILE_ES`)
- `rgfx_gl_init` / particle init used GLES shaders (`precision mediump float`, no `#version`)

macOS has no OpenGL ES driver, so `SDL_GL_CreateContext` failed and `gfx_open_gpu` returned 0. The partially-created `SDL_WINDOW_OPENGL` window was **not destroyed**, so it lingered as an unfocusable ghost while the software fallback tried (and failed) to open a second window.

The include block was already correct (`#if defined(__APPLE__)` is checked before the ARM branch), so only the context/shader selection and failure cleanup were wrong.

## Fix

- Gate the GLES2 shader and ES-context paths on `(defined(__arm__) || defined(__aarch64__)) && !defined(__APPLE__)`. Apple Silicon now uses the desktop OpenGL 2.1 + GLSL `#version 120` path, identical to Intel Macs and to pre-#184 behavior.
- On every `rgfx_open_gpu` failure, destroy the partially-created window and call `SDL_GL_ResetAttributes()` so the software fallback (`gfx_open`) can open a clean window + renderer instead of colliding with a leaked GL window.

## Verification

- Native desktop build succeeds.
- Generated C++ guards confirmed: include selects `OpenGL/gl3.h` on `__APPLE__`; shader/context selection is `(arm||aarch64) && !__APPLE__`.
- Forced Raspberry Pi path (`-D__aarch64__`, GLESv2) still compiles, so real Pi keeps GLES2.
- Headless functional runs (menu, autopeli split, ylos2 split) all complete without hangs or crashes (`MallocScribble=1`).

Real Apple Silicon hardware validation is still recommended, but the platform routing now matches the known-good desktop OpenGL path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4341d177-df6d-4141-9cb1-34df2314ade6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4341d177-df6d-4141-9cb1-34df2314ade6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

