### PR TITLE
Benchmark autopeli ARM cost + GPU present / spiral fixes

### DIFF
--- a/gallery/game_engine/gfx_sdl.rgr
+++ b/gallery/game_engine/gfx_sdl.rgr
@@ -557,9 +557,63 @@ static GLint g_rgfx_gl_tex_uniform = 0;
 static GLuint g_rgfx_gl_vbo = 0;
 static GLuint g_rgfx_base_tex = 0;
 static GLuint g_rgfx_base_tex_r = 0;
+static int g_rgfx_base_tex_w = 0;
+static int g_rgfx_base_tex_h = 0;
+static int g_rgfx_base_tex_r_w = 0;
+static int g_rgfx_base_tex_r_h = 0;
 static int g_rgfx_fb_w = 0;
 static int g_rgfx_fb_h = 0;
 static std::vector<GLuint> g_rgfx_gl_textures;
+
+// GPU-side phase profiler (enable with RANGER_GFX_PROFILE=1). Splits the present
+// path into base-texture upload, sprite overlay, particle overlay, and buffer
+// swap (vsync/GPU wait) so ARM bottlenecks can be told apart from CPU update.
+static int g_rgfx_prof_enabled = -1;
+static Uint64 g_rgfx_prof_freq = 0;
+static double g_rgfx_prof_upload_ms = 0.0;
+static double g_rgfx_prof_sprite_ms = 0.0;
+static double g_rgfx_prof_particle_ms = 0.0;
+static double g_rgfx_prof_swap_ms = 0.0;
+static int g_rgfx_prof_frames = 0;
+
+static bool rgfx_prof_on() {
+    if (g_rgfx_prof_enabled < 0) {
+        const char* e = getenv(\"RANGER_GFX_PROFILE\");
+        g_rgfx_prof_enabled = (e != nullptr && e[0] != '\\0' && e[0] != '0') ? 1 : 0;
+        g_rgfx_prof_freq = SDL_GetPerformanceFrequency();
+    }
+    return g_rgfx_prof_enabled == 1;
+}
+
+static Uint64 rgfx_prof_now() {
+    return rgfx_prof_on() ? SDL_GetPerformanceCounter() : 0;
+}
+
+static double rgfx_prof_ms(Uint64 a, Uint64 b) {
+    if (g_rgfx_prof_freq == 0) { return 0.0; }
+    return (double) (b - a) * 1000.0 / (double) g_rgfx_prof_freq;
+}
+
+// Upload a full-frame RGBA image into a reused texture. Uses glTexSubImage2D once
+// the storage is allocated (avoids a per-frame realloc) and always sets
+// CLAMP_TO_EDGE, which GLES2 requires for NPOT textures like 480x270 panes
+// (default GL_REPEAT leaves the texture incomplete → black on the Pi).
+static void rgfx_upload_frame_tex(GLuint tex, int* allocW, int* allocH,
+    const uint8_t* pixels, int w, int h, GLint filter) {
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    if (*allocW == w && *allocH == h) {
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    } else {
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+        *allocW = w;
+        *allocH = h;
+    }
+}
 
 struct RgfxGpuParticle {
     float x, y, size;
@@ -1052,12 +1106,11 @@ static void rgfx_gpu_blit_base(const uint8_t* pixels, int w, int h) {
     if (!g_rgfx_gpu_mode || pixels == nullptr || w <= 0 || h <= 0) { return; }
     if (g_rgfx_base_tex == 0) {
         glGenTextures(1, &g_rgfx_base_tex);
+        g_rgfx_base_tex_w = 0;
+        g_rgfx_base_tex_h = 0;
     }
-    glBindTexture(GL_TEXTURE_2D, g_rgfx_base_tex);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    rgfx_upload_frame_tex(g_rgfx_base_tex, &g_rgfx_base_tex_w, &g_rgfx_base_tex_h,
+        pixels, w, h, GL_NEAREST);
     rgfx_gpu_draw_quad_tex(g_rgfx_base_tex, 0.f, 0.f, (float) g_rgfx_fb_w, (float) g_rgfx_fb_h);
 }
 
@@ -1068,9 +1121,30 @@ static void rgfx_gpu_draw_texture(int texId, int x, int y, int tw, int th) {
     rgfx_gpu_draw_quad_tex(tex, (float) x, (float) y, (float) tw, (float) th);
 }
 
+static void rgfx_gpu_prof_report() {
+    if (!rgfx_prof_on()) { return; }
+    g_rgfx_prof_frames++;
+    if (g_rgfx_prof_frames < 180) { return; }
+    double f = (double) g_rgfx_prof_frames;
+    SDL_Log(\"[rgfx-prof] frames=%d | upload=%.2fms sprites=%.2fms particles=%.2fms swap=%.2fms /frame\",
+        g_rgfx_prof_frames,
+        g_rgfx_prof_upload_ms / f,
+        g_rgfx_prof_sprite_ms / f,
+        g_rgfx_prof_particle_ms / f,
+        g_rgfx_prof_swap_ms / f);
+    g_rgfx_prof_upload_ms = 0.0;
+    g_rgfx_prof_sprite_ms = 0.0;
+    g_rgfx_prof_particle_ms = 0.0;
+    g_rgfx_prof_swap_ms = 0.0;
+    g_rgfx_prof_frames = 0;
+}
+
 static void rgfx_gpu_finish_frame() {
     if (!g_rgfx_gpu_mode || g_rgfx_win == nullptr) { return; }
+    Uint64 t0 = rgfx_prof_now();
     SDL_GL_SwapWindow(g_rgfx_win);
+    if (rgfx_prof_on()) { g_rgfx_prof_swap_ms += rgfx_prof_ms(t0, SDL_GetPerformanceCounter()); }
+    rgfx_gpu_prof_report();
 }
 
 // GPU split present: upload each full-res pane to its own texture and scale it
@@ -1080,24 +1154,22 @@ static void rgfx_gpu_present_split(const uint8_t* left, const uint8_t* right, in
     if (!g_rgfx_gpu_mode || left == nullptr || right == nullptr || w <= 0 || h <= 0) { return; }
     rgfx_gpu_start_frame(w, h);
     const int halfW = g_rgfx_fb_w / 2;
-    if (g_rgfx_base_tex == 0) { glGenTextures(1, &g_rgfx_base_tex); }
-    glBindTexture(GL_TEXTURE_2D, g_rgfx_base_tex);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, left);
+    Uint64 tUp0 = rgfx_prof_now();
+    if (g_rgfx_base_tex == 0) { glGenTextures(1, &g_rgfx_base_tex); g_rgfx_base_tex_w = 0; g_rgfx_base_tex_h = 0; }
+    rgfx_upload_frame_tex(g_rgfx_base_tex, &g_rgfx_base_tex_w, &g_rgfx_base_tex_h, left, w, h, GL_LINEAR);
     rgfx_gpu_draw_quad_tex(g_rgfx_base_tex, 0.f, 0.f, (float) halfW, (float) g_rgfx_fb_h);
-    if (g_rgfx_base_tex_r == 0) { glGenTextures(1, &g_rgfx_base_tex_r); }
-    glBindTexture(GL_TEXTURE_2D, g_rgfx_base_tex_r);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, right);
+    if (g_rgfx_base_tex_r == 0) { glGenTextures(1, &g_rgfx_base_tex_r); g_rgfx_base_tex_r_w = 0; g_rgfx_base_tex_r_h = 0; }
+    rgfx_upload_frame_tex(g_rgfx_base_tex_r, &g_rgfx_base_tex_r_w, &g_rgfx_base_tex_r_h, right, w, h, GL_LINEAR);
     rgfx_gpu_draw_quad_tex(g_rgfx_base_tex_r, (float) halfW, 0.f, (float) (g_rgfx_fb_w - halfW), (float) g_rgfx_fb_h);
+    if (rgfx_prof_on()) { g_rgfx_prof_upload_ms += rgfx_prof_ms(tUp0, SDL_GetPerformanceCounter()); }
+    Uint64 tSpr0 = rgfx_prof_now();
     rgfx_gpu_sprites_draw_queue(1, 0, halfW, g_rgfx_fb_h);
     rgfx_gpu_sprites_draw_queue(2, halfW, g_rgfx_fb_w - halfW, g_rgfx_fb_h);
+    if (rgfx_prof_on()) { g_rgfx_prof_sprite_ms += rgfx_prof_ms(tSpr0, SDL_GetPerformanceCounter()); }
+    Uint64 tPart0 = rgfx_prof_now();
     rgfx_particles_draw_queue(1, 0, halfW, g_rgfx_fb_h);
     rgfx_particles_draw_queue(2, halfW, g_rgfx_fb_w - halfW, g_rgfx_fb_h);
+    if (rgfx_prof_on()) { g_rgfx_prof_particle_ms += rgfx_prof_ms(tPart0, SDL_GetPerformanceCounter()); }
     glViewport(0, 0, g_rgfx_fb_w, g_rgfx_fb_h);
     rgfx_gpu_finish_frame();
 }
@@ -1110,10 +1182,14 @@ static void rgfx_gl_cleanup() {
     if (g_rgfx_base_tex != 0) {
         glDeleteTextures(1, &g_rgfx_base_tex);
         g_rgfx_base_tex = 0;
+        g_rgfx_base_tex_w = 0;
+        g_rgfx_base_tex_h = 0;
     }
     if (g_rgfx_base_tex_r != 0) {
         glDeleteTextures(1, &g_rgfx_base_tex_r);
         g_rgfx_base_tex_r = 0;
+        g_rgfx_base_tex_r_w = 0;
+        g_rgfx_base_tex_r_h = 0;
     }
     if (g_rgfx_gl_vbo != 0) {
         glDeleteBuffers(1, &g_rgfx_gl_vbo);
@@ -1161,9 +1237,15 @@ static int rgfx_open(const std::string& title, int w, int h) {
 static void rgfx_present(const uint8_t* pixels, int w, int h) {
     if (g_rgfx_gpu_mode) {
         rgfx_gpu_start_frame(w, h);
+        Uint64 tUp0 = rgfx_prof_now();
         rgfx_gpu_blit_base(pixels, w, h);
+        if (rgfx_prof_on()) { g_rgfx_prof_upload_ms += rgfx_prof_ms(tUp0, SDL_GetPerformanceCounter()); }
+        Uint64 tSpr0 = rgfx_prof_now();
         rgfx_gpu_sprites_draw_overlay();
+        if (rgfx_prof_on()) { g_rgfx_prof_sprite_ms += rgfx_prof_ms(tSpr0, SDL_GetPerformanceCounter()); }
+        Uint64 tPart0 = rgfx_prof_now();
         rgfx_particles_draw_overlay();
+        if (rgfx_prof_on()) { g_rgfx_prof_particle_ms += rgfx_prof_ms(tPart0, SDL_GetPerformanceCounter()); }
         rgfx_gpu_finish_frame();
         return;
     }

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -97,6 +97,8 @@ class GameRunner {
     def cannonRestitution:double 0.75
     def fixedStepMs:int 0
     def timeAccumulator:int 0
+    ; Max fixed-update steps per rendered frame (spiral-of-death guard).
+    def maxFixedSteps:int 3
     def worldHeight:int 0
     def physicsPassive:boolean false
     def physicsSharedWorld:boolean false
@@ -1291,6 +1293,13 @@ class GameRunner {
             timeAccumulator = (timeAccumulator + dtMs)
             def steps:int 0
             while (timeAccumulator >= fixedStepMs) {
+                if (steps >= maxFixedSteps) {
+                    ; Spiral-of-death guard: on a slow device (e.g. Pi) a heavy
+                    ; frame would otherwise run many fixed steps, multiplying the
+                    ; interpreter/physics cost per rendered frame and locking fps
+                    ; low. Drop the backlog so the sim runs slightly slow instead.
+                    timeAccumulator = 0
+                }
                 this.stepUpdate(fixedStepMs snap)
                 timeAccumulator = (timeAccumulator - fixedStepMs)
                 steps = (steps + 1)

--- a/gallery/game_engine/scripting/game_split_screen.rgr
+++ b/gallery/game_engine/scripting/game_split_screen.rgr
@@ -178,6 +178,11 @@ class SplitScreenHost {
             left.timeAccumulator = (left.timeAccumulator + dtMs)
             def steps:int 0
             while (left.timeAccumulator >= left.fixedStepMs) {
+                if (steps >= left.maxFixedSteps) {
+                    ; Spiral-of-death guard (see GameRunner.frameWithInput): keep
+                    ; both panes in lockstep by draining the shared backlog.
+                    left.timeAccumulator = 0
+                }
                 def step:int left.fixedStepMs
                 def tRight0:int 0
                 if (profileEnabled) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds benchmarking instrumentation to locate the Raspberry Pi autopeli bottleneck, plus ARM-focused fixes. Desktop profiling shows the cost is the **TSX interpreter (update + hud)**, not CPU sprite scaling/rotation.

## New benchmarking

`RANGER_GFX_PROFILE=1` prints a per-phase GPU present breakdown every 180 frames:

```
[rgfx-prof] frames=180 | upload=..ms sprites=..ms particles=..ms swap=..ms /frame
```

Combined with the existing `--profile` (interpreter/physics/draw), this separates GPU-side cost from CPU-side cost. Run on the Pi:

```bash
RANGER_GFX_PROFILE=1 ./tmp/game-sdl/game_sdl --profile \
  gallery/game_engine/games/autopeli_physics/index.tsx 600
```

## What the numbers show (desktop reference)

```
[profile:left]  updateScript=6ms/frame  drawSprites=~0ms  drawHud(interp)=2ms/frame
[profile:right] updateScript=1ms/frame  drawSprites=~0ms  drawHud(interp)=1ms/frame
[rgfx-prof] upload=0.1ms sprites=0.03ms swap=0.6ms /frame
```

- **Dominant cost: `updateScript` (interpreted `update()` physics + AI) and `drawHud` (interpreted JSX per pane).**
- Sprite scaling/rotation is negligible: sheets are baked at load, and rotation runs on the GPU. `drawSprites` is ~0ms and the GPU sprite overlay is 0.03ms.
- GPU upload/swap are tiny.

On the Pi the CPU is ~15–20× slower, so the interpreter phases scale to tens of ms each while the GPU phases stay small. That is the 8fps wall — not element scaling/rotation.

## ARM fixes included

- **NPOT texture correctness (GLES2):** pane/base textures are 480×270 (non‑power‑of‑two). The split path set `GL_LINEAR` but left wrap at the default `GL_REPEAT`, which makes NPOT textures incomplete on GLES2 (can render black on the Pi). Now always `GL_CLAMP_TO_EDGE`.
- **Per-frame realloc removed:** reuse textures with `glTexSubImage2D` instead of `glTexImage2D` each frame (less memory-bandwidth churn on the Pi).
- **Spiral-of-death guard:** `dtMs` is clamped to 100ms and `fixedStep` is 16ms, so a heavy frame could run ~6 sim steps per rendered frame, multiplying the (expensive) interpreter cost and pinning fps low. Fixed-update steps per rendered frame are now capped; under overload the sim runs slightly slow instead of collapsing.

## Verification

- Native desktop build succeeds; autopeli split 400 frames, ~198 fps.
- Forced Raspberry Pi path (`-D__aarch64__` + GLESv2) compiles and runs the profiler.
- Regression: ylos2 split and pacman solo run clean with `MallocScribble=1`.

## Suggested next steps for the Pi FPS (interpreter-bound)

Because the bottleneck is interpreter time, the highest-leverage follow-ups are: reduce per-frame `update()` work (e.g. cap AI/physics update rate, skip `hud()` re-render when unchanged), or move hot game logic out of the interpreter. Please run the Pi command above and share the `[profile:*]` + `[rgfx-prof]` lines to confirm the split there.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4341d177-df6d-4141-9cb1-34df2314ade6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4341d177-df6d-4141-9cb1-34df2314ade6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

