### PR TITLE
Skip full CI checks when only gallery files change.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,39 @@ on:
     branches: [main, master]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      gallery_only: ${{ steps.gallery_only.outputs.result }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            gallery:
+              - 'gallery/**'
+            non_gallery:
+              - '**'
+              - '!gallery/**'
+
+      - name: Set gallery-only flag
+        id: gallery_only
+        run: |
+          if [ "${{ steps.filter.outputs.gallery }}" = "true" ] && [ "${{ steps.filter.outputs.non_gallery }}" != "true" ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+            echo "Gallery-only change detected — skipping full compiler checks"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+            echo "Non-gallery changes detected — running full compiler checks"
+          fi
+
   test-es6:
+    needs: changes
+    if: needs.changes.outputs.gallery_only != 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -31,6 +63,8 @@ jobs:
         run: npm run test:es6
 
   test-go:
+    needs: changes
+    if: needs.changes.outputs.gallery_only != 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -57,6 +91,8 @@ jobs:
         run: npm run test:go
 
   test-python:
+    needs: changes
+    if: needs.changes.outputs.gallery_only != 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -82,16 +118,47 @@ jobs:
       - name: Run Python unit tests
         run: npm run test:python
 
+  gallery-smoke:
+    name: gallery-smoke
+    needs: changes
+    if: needs.changes.outputs.gallery_only == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run gallery smoke test
+        run: npm run engine:pong:runner
+
   # Stable required check name for branch protection.
   # Prefer this over matrix-specific job names like test-es6 (20.x).
   test-gate:
     name: test-gate
     runs-on: ubuntu-latest
-    needs: [test-es6, test-go, test-python]
+    needs: [changes, test-es6, test-go, test-python, gallery-smoke]
     if: always()
     steps:
       - name: Check test results
         run: |
+          if [ "${{ needs.changes.outputs.gallery_only }}" = "true" ]; then
+            if [ "${{ needs.gallery-smoke.result }}" != "success" ]; then
+              echo "Gallery smoke test failed or was cancelled"
+              exit 1
+            fi
+            echo "Gallery-only change: smoke test passed (full checks skipped)"
+            exit 0
+          fi
+
           if [ "${{ needs.test-es6.result }}" != "success" ]; then
             echo "ES6 tests failed or were cancelled"
             exit 1

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -3,6 +3,8 @@ name: Deploy playground to GitHub Pages
 on:
   push:
     branches: [main, master]
+    paths-ignore:
+      - 'gallery/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,39 @@ on:
     branches: [main, master]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      gallery_only: ${{ steps.gallery_only.outputs.result }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            gallery:
+              - 'gallery/**'
+            non_gallery:
+              - '**'
+              - '!gallery/**'
+
+      - name: Set gallery-only flag
+        id: gallery_only
+        run: |
+          if [ "${{ steps.filter.outputs.gallery }}" = "true" ] && [ "${{ steps.filter.outputs.non_gallery }}" != "true" ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+            echo "Gallery-only change detected — skipping full ES6 matrix"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+            echo "Non-gallery changes detected — running full ES6 matrix"
+          fi
+
   test:
+    needs: changes
+    if: needs.changes.outputs.gallery_only != 'true'
     runs-on: ubuntu-latest
 
     strategy:
@@ -35,16 +67,49 @@ jobs:
       - name: Run ES6 tests
         run: npm run test:es6
 
+  gallery-smoke:
+    name: gallery-smoke
+    needs: changes
+    if: needs.changes.outputs.gallery_only == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "npm"
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run gallery smoke test
+        run: npm run engine:pong:runner
+
   # Stable required check name for branch protection.
   # Prefer this over matrix-specific job names like test (20.x).
   test-gate:
     name: test-gate
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [changes, test, gallery-smoke]
     if: always()
     steps:
       - name: Check matrix result
         run: |
+          if [ "${{ needs.changes.outputs.gallery_only }}" = "true" ]; then
+            if [ "${{ needs.gallery-smoke.result }}" != "success" ]; then
+              echo "Gallery smoke test failed or was cancelled"
+              exit 1
+            fi
+            echo "Gallery-only change: smoke test passed (full checks skipped)"
+            exit 0
+          fi
+
           if [ "${{ needs.test.result }}" != "success" ]; then
             echo "ES6 test matrix failed or was cancelled"
             exit 1

--- a/gallery/ts_to_ranger/generated/invaders_generated.rgr
+++ b/gallery/ts_to_ranger/generated/invaders_generated.rgr
@@ -307,7 +307,7 @@ class GeneratedGameScript {
             def tmp13:EntityPoseNative (new EntityPoseNative)
             tmp13.x = (to_double (waveX + (col * 40)))
             tmp13.y = (to_double (waveY + (row * 30)))
-            tmp13.p0 = (anim % 2)
+            tmp13.p0 = anim
             tmp13.visible = 1
             set entities id tmp13
         }
@@ -376,21 +376,27 @@ class GeneratedGameScript {
         if ((px > 456.0)) {
             px = 456.0
         }
-        anim = (anim + 1.0)
-        if ((anim > 18.0)) {
-            anim = 0.0
-        }
         waveTick = (waveTick + 1.0)
         if ((waveTick > 14.0)) {
             waveTick = 0.0
+            if ((anim == 0.0)) {
+                anim = 1.0
+            } {
+                anim = 0.0
+            }
             waveX = (waveX + (waveDir * 6.0))
+            if ((anim == 0.0)) {
+                push events ((this.soundEvent("wall")))
+            } {
+                push events ((this.soundEvent("bounce")))
+            }
             if ((waveX > 300.0)) {
                 waveDir = (to_double (0.0 - 1.0))
-                waveY = (waveY + 8.0)
+                waveY = (waveY + 12.0)
             }
             if ((waveX < 40.0)) {
                 waveDir = 1.0
-                waveY = (waveY + 8.0)
+                waveY = (waveY + 12.0)
             }
             if ((waveY > 190.0)) {
                 score2 = (score2 - 1)
@@ -416,6 +422,7 @@ class GeneratedGameScript {
                 shotX = px
                 shotY = (py - 16.0)
                 fireCd = 22.0
+                push events ((this.soundEvent("blip")))
             }
         }
         if ((shotActive == 1.0)) {
@@ -441,7 +448,7 @@ class GeneratedGameScript {
             }
         }
         if (((this.countAlive(alive)) == 0)) {
-            push events ((this.soundEvent("bounce")))
+            push events ((this.soundEvent("win")))
             def reset:resetWaveRetNative ((this.resetWave(alive)))
             waveX = (to_double reset.waveX)
             waveY = (to_double reset.waveY)

--- a/gallery/ts_to_ranger/generated/pong_generated.rgr
+++ b/gallery/ts_to_ranger/generated/pong_generated.rgr
@@ -3,6 +3,25 @@
 
 Import "../game_script_types.rgr"
 
+class tryLeftPaddleBounceRetNative {
+    def bx:int 0
+    def vx:int 0
+    def vy:int 0
+    def hit:boolean false
+}
+
+class tryRightPaddleBounceRetNative {
+    def bx:int 0
+    def vx:int 0
+    def vy:int 0
+    def hit:boolean false
+}
+
+class deflectFromPaddleRetNative {
+    def vx:int 0
+    def vy:double 0.0
+}
+
 class GeneratedGameScript {
 
     fn sprites:[SpriteDefNative] () {
@@ -39,6 +58,7 @@ class GeneratedGameScript {
     fn initState:NativeGameState () {
         def s:NativeGameState (new NativeGameState)
         s.showNet = 1
+        set s.numbers "playerSlots" 1.0
         def pose_ball:EntityPoseNative (new EntityPoseNative)
         pose_ball.x = 240.0
         pose_ball.y = 135.0
@@ -60,14 +80,177 @@ class GeneratedGameScript {
         return s
     }
 
+    fn tryLeftPaddleBounce:tryLeftPaddleBounceRetNative (prevBx:int bx:int by:int p1y:int p1vy:int vx:int vy:int) {
+        def paddleL:int (18)
+        def paddleR:int (28)
+        def half:int (34)
+        if ((vx >= 0)) {
+            def tmp0:tryLeftPaddleBounceRetNative (new tryLeftPaddleBounceRetNative)
+            tmp0.bx = bx
+            tmp0.vx = vx
+            tmp0.vy = vy
+            tmp0.hit = false
+            return tmp0
+        }
+        if ((by <= (p1y - half))) {
+            def tmp1:tryLeftPaddleBounceRetNative (new tryLeftPaddleBounceRetNative)
+            tmp1.bx = bx
+            tmp1.vx = vx
+            tmp1.vy = vy
+            tmp1.hit = false
+            return tmp1
+        }
+        if ((by >= (p1y + half))) {
+            def tmp2:tryLeftPaddleBounceRetNative (new tryLeftPaddleBounceRetNative)
+            tmp2.bx = bx
+            tmp2.vx = vx
+            tmp2.vy = vy
+            tmp2.hit = false
+            return tmp2
+        }
+        def hit:boolean (false)
+        if ((prevBx > paddleR)) {
+            if ((bx <= paddleR)) {
+                hit = true
+            }
+        }
+        if ((false == hit)) {
+            if ((bx <= paddleR)) {
+                if ((bx >= paddleL)) {
+                    if ((prevBx >= bx)) {
+                        hit = true
+                    }
+                }
+            }
+        }
+        if ((false == hit)) {
+            def tmp3:tryLeftPaddleBounceRetNative (new tryLeftPaddleBounceRetNative)
+            tmp3.bx = bx
+            tmp3.vx = vx
+            tmp3.vy = vy
+            tmp3.hit = false
+            return tmp3
+        }
+        def deflected:deflectFromPaddleRetNative ((this.deflectFromPaddle(vx vy by p1y p1vy half true)))
+        def tmp4:tryLeftPaddleBounceRetNative (new tryLeftPaddleBounceRetNative)
+        tmp4.bx = paddleR
+        tmp4.vx = deflected.vx
+        tmp4.vy = deflected.vy
+        tmp4.hit = true
+        return tmp4
+    }
+
+    fn tryRightPaddleBounce:tryRightPaddleBounceRetNative (prevBx:int bx:int by:int p2y:int p2vy:int vx:int vy:int) {
+        def paddleL:int (462)
+        def paddleR:int (472)
+        def half:int (34)
+        if ((vx <= 0)) {
+            def tmp5:tryRightPaddleBounceRetNative (new tryRightPaddleBounceRetNative)
+            tmp5.bx = bx
+            tmp5.vx = vx
+            tmp5.vy = vy
+            tmp5.hit = false
+            return tmp5
+        }
+        if ((by <= (p2y - half))) {
+            def tmp6:tryRightPaddleBounceRetNative (new tryRightPaddleBounceRetNative)
+            tmp6.bx = bx
+            tmp6.vx = vx
+            tmp6.vy = vy
+            tmp6.hit = false
+            return tmp6
+        }
+        if ((by >= (p2y + half))) {
+            def tmp7:tryRightPaddleBounceRetNative (new tryRightPaddleBounceRetNative)
+            tmp7.bx = bx
+            tmp7.vx = vx
+            tmp7.vy = vy
+            tmp7.hit = false
+            return tmp7
+        }
+        def hit:boolean (false)
+        if ((prevBx < paddleL)) {
+            if ((bx >= paddleL)) {
+                hit = true
+            }
+        }
+        if ((false == hit)) {
+            if ((bx >= paddleL)) {
+                if ((bx <= paddleR)) {
+                    if ((prevBx <= bx)) {
+                        hit = true
+                    }
+                }
+            }
+        }
+        if ((false == hit)) {
+            def tmp8:tryRightPaddleBounceRetNative (new tryRightPaddleBounceRetNative)
+            tmp8.bx = bx
+            tmp8.vx = vx
+            tmp8.vy = vy
+            tmp8.hit = false
+            return tmp8
+        }
+        def deflected:deflectFromPaddleRetNative ((this.deflectFromPaddle(vx vy by p2y p2vy half false)))
+        def tmp9:tryRightPaddleBounceRetNative (new tryRightPaddleBounceRetNative)
+        tmp9.bx = paddleL
+        tmp9.vx = deflected.vx
+        tmp9.vy = deflected.vy
+        tmp9.hit = true
+        return tmp9
+    }
+
+    fn deflectFromPaddle:deflectFromPaddleRetNative (vx:int vy:int by:int paddleY:int paddleVy:int half:int leftSide:int) {
+        def offset:int ((to_int ((by - paddleY) / half)))
+        def newVx:int ((0 - vx))
+        if (leftSide) {
+            if ((newVx < 0)) {
+                newVx = (0 - newVx)
+            }
+        } {
+            if ((newVx > 0)) {
+                newVx = (0 - newVx)
+            }
+        }
+        def newVy:double ((((to_double vy) + ((to_double offset) * 0.07)) + ((to_double paddleVy) * 0.9)))
+        def maxVy:double (0.26)
+        if ((newVy > maxVy)) {
+            newVy = maxVy
+        }
+        if ((newVy < (0.0 - maxVy))) {
+            newVy = (0.0 - maxVy)
+        }
+        def tmp10:deflectFromPaddleRetNative (new deflectFromPaddleRetNative)
+        tmp10.vx = newVx
+        tmp10.vy = newVy
+        return tmp10
+    }
+
     fn update:NativeGameState (props:UpdatePropsNative) {
         def s:NativeGameState (props.state)
         def in_ball:EntityPoseNative (unwrap (get s.entities "ball"))
         def in_p1:EntityPoseNative (unwrap (get s.entities "p1"))
         def in_p2:EntityPoseNative (unwrap (get s.entities "p2"))
         def dt:double (props.dt)
+        def events:int
+        def input:int (props.input)
+        def p1up:boolean (props.up)
+        def p1down:boolean (props.down)
+        def p2up:boolean (false)
+        def p2down:boolean (false)
+        if (input) {
+            if ((itemAt input.players 0)) {
+                p1up = (itemAt input.players 0).up
+                p1down = (itemAt input.players 0).down
+            }
+            if ((itemAt input.players 1)) {
+                p2up = (itemAt input.players 1).up
+                p2down = (itemAt input.players 1).down
+            }
+        }
         def bx:double ((in_ball.x + (s.vx * dt)))
         def by:double ((in_ball.y + (s.vy * dt)))
+        def prevBx:double (in_ball.x)
         def vx:double (s.vx)
         def vy:double (s.vy)
         def s1:int (s.score1)
@@ -75,16 +258,21 @@ class GeneratedGameScript {
         if ((by < 6.0)) {
             by = 6.0
             vy = (0.0 - vy)
+            push events ((this.soundEvent("wall")))
         }
         if ((by > 264.0)) {
             by = 264.0
             vy = (0.0 - vy)
+            push events ((this.soundEvent("wall")))
         }
         def p1y:double (in_p1.y)
-        if (props.up) {
+        def p1vy:int (0)
+        if (p1up) {
+            p1vy = (to_int (0.0 - 0.30))
             p1y = (p1y - (dt * 0.30))
         }
-        if (props.down) {
+        if (p1down) {
+            p1vy = (to_int 0.30)
             p1y = (p1y + (dt * 0.30))
         }
         if ((p1y < 28.0)) {
@@ -94,11 +282,14 @@ class GeneratedGameScript {
             p1y = 242.0
         }
         def p2y:double (in_p2.y)
-        if ((p2y < by)) {
-            p2y = (p2y + (dt * 0.22))
+        def p2vy:int (0)
+        if (p2up) {
+            p2vy = (to_int (0.0 - 0.30))
+            p2y = (p2y - (dt * 0.30))
         }
-        if ((p2y > by)) {
-            p2y = (p2y - (dt * 0.22))
+        if (p2down) {
+            p2vy = (to_int 0.30)
+            p2y = (p2y + (dt * 0.30))
         }
         if ((p2y < 28.0)) {
             p2y = 28.0
@@ -106,35 +297,37 @@ class GeneratedGameScript {
         if ((p2y > 242.0)) {
             p2y = 242.0
         }
-        if ((bx < 24.0)) {
-            if ((by > (p1y - 34.0))) {
-                if ((by < (p1y + 34.0))) {
-                    bx = 24.0
-                    vx = (0.0 - vx)
-                }
-            }
+        def leftHit:tryLeftPaddleBounceRetNative ((this.tryLeftPaddleBounce((to_int prevBx) (to_int bx) (to_int by) (to_int p1y) p1vy (to_int vx) (to_int vy))))
+        bx = (to_double leftHit.bx)
+        vx = (to_double leftHit.vx)
+        vy = (to_double leftHit.vy)
+        if (leftHit.hit) {
+            push events ((this.soundEvent("bounce")))
         }
-        if ((bx > 456.0)) {
-            if ((by > (p2y - 34.0))) {
-                if ((by < (p2y + 34.0))) {
-                    bx = 456.0
-                    vx = (0.0 - vx)
-                }
-            }
+        def rightHit:tryRightPaddleBounceRetNative ((this.tryRightPaddleBounce((to_int prevBx) (to_int bx) (to_int by) (to_int p2y) p2vy (to_int vx) (to_int vy))))
+        bx = (to_double rightHit.bx)
+        vx = (to_double rightHit.vx)
+        vy = (to_double rightHit.vy)
+        if (rightHit.hit) {
+            push events ((this.soundEvent("bounce")))
         }
         if ((bx < 0.0)) {
             s2 = (s2 + 1)
             bx = 240.0
             by = 135.0
             vx = 0.16
+            push events ((this.soundEvent("lose")))
         }
         if ((bx > 480.0)) {
             s1 = (s1 + 1)
             bx = 240.0
             by = 135.0
             vx = (0.0 - 0.16)
+            push events ((this.soundEvent("lose")))
         }
         def patch:NativeGameState (new NativeGameState)
+        patch.showNet = 1
+        set patch.numbers "playerSlots" 1.0
         def pose_ball:EntityPoseNative (new EntityPoseNative)
         pose_ball.x = bx
         pose_ball.y = by
@@ -153,6 +346,8 @@ class GeneratedGameScript {
         patch.hasVy = true
         patch.score1 = s1
         patch.score2 = s2
+        def patch_events:[GameEventNative]
+        patch.events = patch_events
         return patch
     }
 


### PR DESCRIPTION
Use path filtering to run a lightweight pong smoke test instead of the ES6/Go/Python matrix, and skip playground deploy for gallery-only pushes.