### PR TITLE
Update game_engine README and ROADMAP for recent engine changes

### DIFF
--- a/gallery/game_engine/README.md
+++ b/gallery/game_engine/README.md
@@ -10,31 +10,36 @@ Tarkempi suunnitelma: [`PLAN_GAME_ENGINE.md`](./PLAN_GAME_ENGINE.md). Nykytila j
 
 ```
 gallery/game_engine/
-├── games/              # Launcher-skannattavat pelit (index.tsx per kansio)
+├── games/              # Launcher-skannattavat pelit (index.tsx tai logic.wasm)
 ├── menu/               # Käynnistysvalikko (index.tsx)
 ├── scripting/          # Moottorin runtime + TSX-tyypit + vanhat *.game.tsx-demot
+├── physics/            # Cannon.js -portti (pinball, sandbox)
+├── wasm/               # Rust → WASM -moduulit (Path C) + RGW1 ABI
 ├── lpc/                # LPC-spritesheet-compositor (erillinen työkalu)
 ├── pong_*.rgr          # Käännetty Pong-viite (terminaali + SDL2)
 ├── framebuffer.rgr     # SoftCanvas (RGBA8888)
-├── gfx_sdl.rgr         # SDL2-shim (C++ polyfill)
-└── scripts/            # build-skriptit (SDL, native, Pi, LPC, …)
+├── gfx_sdl.rgr         # SDL2-shim (C++ polyfill, GLES2 GPU-present)
+└── scripts/            # build-skriptit (SDL, native, Pi, LPC, WASM, …)
 ```
 
-## Kaksi kehityspolkua
+## Kehityspolut
 
 | Polku | Milloin | Tiedostot |
 |-------|---------|-----------|
 | **TSX-skriptaus** (pääpolku) | Uudet pelit, nopea iterointi, valikko, ääni, tallennus | `games/*/index.tsx`, `scripting/game_runtime.rgr`, `scripting/game_sdl_runner.rgr` |
 | **Käännetty Ranger-ydin** | Matalan tason viite, LLVM/terminaali-Pi | `pong_core.rgr`, `pong.rgr`, `pong_sdl.rgr` |
+| **WASM (Path C)** | Logiikka Rust/C → `.wasm`, host hoitaa piirron ja fysiikan | `wasm/rust_*`, `games/*/logic.wasm`, `scripting/wasm_game_runner.rgr` |
+| **Host-fysiikka** | Ajoneuvot, törmäykset TSX:ssä tai WASM-ABI:n kautta | `scripting/game_physics.rgr`, `scripting/physics_core.rgr` |
+| **Cannon-fysiikka** | Pinball, flipperit, painovoima | `physics/src/cannon_*.rgr`, `scripting/game_cannon_physics.rgr` |
 
-Useimmat demot ja uudet pelit käyttävät TSX-polkuja. Käännetty Pong on edelleen hyvä esimerkki siitä, miten pelilogiikka erotetaan alustasta (katso [Käännetty Pong-viite](#käännetty-pong-viite) alempana).
+Useimmat demot ja uudet pelit käyttävät TSX-polkuja. Käännetty Pong on edelleen hyvä esimerkki siitä, miten pelilogiikka erotetaan alustasta (katso [Käännetty Pong-viite](#käännetty-pong-viite) alempana). WASM-polku (`engine=wasm` `game.info`:ssa) on uudempi portability-vaihtoehto: logiikka wasm3-tulkissa, host renderöi spritet ja hoitaa fysiikan tarvittaessa.
 
 ## Arkkitehtuuri
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  Platform-backend                                            │
-│  game_sdl_runner.rgr (SDL2 + launcher)  |  pong_sdl.rgr     │
+│  game_sdl_runner.rgr (SDL2 + launcher + WASM)  |  pong_sdl  │
 │  pong.rgr (terminaali)                                       │
 └───────────────────────────┬─────────────────────────────────┘
                             │ input, timing, present
@@ -42,19 +47,25 @@ Useimmat demot ja uudet pelit käyttävät TSX-polkuja. Käännetty Pong on edel
 │  Pelilogiikka — pure, portable                               │
 │  TSX: initState / update / sprites / hud                     │
 │  Ranger: pong_core.rgr — Pong.step(Buttons)                  │
+│  WASM: logic.wasm — init / update (RGW1 linear ABI)          │
 └───────────────────────────┬─────────────────────────────────┘
-                            │ tila
+                            │ tila (+ physics ABI / contacts)
 ┌───────────────────────────▼─────────────────────────────────┐
-│  Piirtokerros — portable                                     │
-│  game_sprite.rgr, game_hud.rgr  |  pong_render.rgr           │
+│  Fysiikka (opt-in)                                           │
+│  game_physics.rgr (2D top-down)  |  game_cannon_physics.rgr  │
 └───────────────────────────┬─────────────────────────────────┘
-                            │ RGBA8888
+                            │ worldEntities, contacts
+┌───────────────────────────▼─────────────────────────────────┐
+│  Piirtokerros — portable (+ GPU sheet overlay)               │
+│  game_sprite.rgr, game_hud.rgr, game_particles.rgr           │
+└───────────────────────────┬─────────────────────────────────┘
+                            │ RGBA8888 (+ GPU textured quads)
 ┌───────────────────────────▼─────────────────────────────────┐
 │  framebuffer.rgr — SoftCanvas                                │
 └───────────────────────────┬─────────────────────────────────┘
                             │ (SDL-polku)
 ┌───────────────────────────▼─────────────────────────────────┐
-│  gfx_sdl.rgr — SDL2-ikkuna, gamepad, ääni                    │
+│  gfx_sdl.rgr — SDL2-ikkuna, gamepad, ääni, GLES2 present     │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -77,18 +88,26 @@ npm run engine:game-sdl:run:pong
 npm run engine:game-sdl:run:breakout
 npm run engine:game-sdl:run:pacman
 npm run engine:game-sdl:run:invaders
+npm run engine:game-sdl:run:ylos2
+npm run engine:game-sdl:run:physics_sandbox
+
+# WASM-pelit (Rust → logic.wasm)
+npm run engine:game-sdl:run:rust-pong
+npm run engine:game-sdl:run:rust-autopeli
 
 # Kehitys: hot reload (TSX-muutokset latautuvat lennossa)
 npm run engine:game:watch:pong
 npm run engine:game:watch:breakout
 ```
 
-Yleiset näppäimet SDL-hostissa: **W/S** tai nuolinäppäimet, **F11** fullscreen, **Q/Esc** poistu (pelistä takaisin valikkoon, valikosta sulkee sovelluksen). Gamepad-tuki on käytössä (`scripting/game_input.rgr`).
+Yleiset näppäimet SDL-hostissa: **W/S** tai nuolinäppäimet, **F11** fullscreen, **Q/Esc** poistu (pelistä takaisin valikkoon, valikosta sulkee sovelluksen). Gamepad-tuki on käytössä (`scripting/game_input.rgr`): SDL GameController, split-tilassa gamepad 0 vasemmalle ja gamepad 1 oikealle ruudulle.
 
 Headless / CI: binääri hyväksyy valinnaisen frameluvun ja `SDL_VIDEODRIVER=dummy`:
 
 ```bash
-npm run engine:game-sdl:smoke:pong    # 300 framea dummy-ajossa
+npm run engine:game-sdl:smoke:pong           # 300 framea dummy-ajossa
+npm run engine:game-sdl:smoke:rust-pong      # WASM Pong
+npm run engine:game-sdl:smoke:rust-autopeli  # WASM autopeli + fysiikka
 ```
 
 Käännetty terminaali-Pong (Node):
@@ -97,6 +116,21 @@ Käännetty terminaali-Pong (Node):
 npm run engine:compile && npm run engine:run
 # W/S liiku, D debug-HUD, Q lopeta
 ```
+
+## Demo-pelit (`games/`)
+
+| Peli | Polku | Huomio |
+|------|-------|--------|
+| Pong | TSX | Minimal-malli, suositeltu pohja |
+| Breakout | TSX | Multi-screen, JSX HUD, split screen |
+| Pac-Man | TSX | Split screen + autoscale |
+| Invaders | TSX | Stressitesti (paljon rect-spritejä) |
+| Pomppija (ylos2) | TSX | Platformer, LPC-sheet-spritet, musiikki |
+| Flipperitorni (pinpall) | TSX + Cannon | Pystypinball, split screen |
+| Physics Sandbox | TSX + Cannon | Flipperit, pegs, sheet-animaatiot |
+| Autopeli Physics | TSX + host physics | Top-down racer, jaettu fysiikkamaailma |
+| Rust Pong | WASM | Path C PoC, getter-ABI |
+| Rust Autopeli | WASM + physics | RGW1 linear ABI, host rendering |
 
 ## Pelivalikko ja `games/`-hakemisto
 
@@ -117,13 +151,28 @@ Pelin voi ajaa myös suoraan ilman valikkoa:
 
 Katalogi päivittyy ajon aikana (oletus ~10 s välein); uusi `games/mygame/index.tsx` ilmestyy listaan ilman uudelleenkäännöstä.
 
+### `game.info`-kentät
+
+```ini
+name=My Game
+icon=icon.png
+splitScreen=auto          # auto | always | never
+autoscale=true            # host skaalaa 480×270 → paneeliin
+soloScript=index.tsx      # split-tilan yksinpeliskripti
+engine=wasm               # tsx (oletus) | wasm
+module=logic.wasm         # WASM-moduulin tiedosto
+abi=linear                # getter (oletus) | linear (RGW1 shared memory)
+physics=true              # host GamePhysics + WASM/TSX I/O
+assets=assets             # resurssikansio (WASM)
+```
+
 ## Uuden pelin lisääminen
 
 ### 1. Luo kansio
 
 ```
 gallery/game_engine/games/mygame/
-├── index.tsx       # pakollinen — pelin pääskripti
+├── index.tsx       # pakollinen — pelin pääskripti (tai logic.wasm WASM-pelille)
 ├── game.info
 ├── gamedata.json       # luodaan saveGameData-kutsulla
 ├── level2.tsx          # valinnainen — erillinen ruututiedosto (pushGame)
@@ -153,12 +202,14 @@ Pakolliset / tyypilliset funktiot (`GameRunner`):
 
 | Funktio | Kutsutaan | Tehtävä |
 |---------|-----------|---------|
-| `sprites()` tai `sprites({ screen })` | kerran per ruutu | retained-objektit (`rect`, `circle`, `bitmap`, …) |
+| `sprites()` tai `sprites({ screen })` | kerran per ruutu | retained-objektit (`rect`, `circle`, `bitmap`, `sheet`, …) |
 | `initState()` | käynnistyksessä | alkutila |
 | `update(props)` | jokainen frame | palauttaa **uuden** tilan (`props.dt`, `props.input`, näppäimet) |
 | `hud(props)` | jokainen frame (valinnainen) | JSX-overlay (`View`, `Label`) |
 | `resources()` | kerran (valinnainen) | taustakuvat, äänet |
 | `screens()` | dokumentaatio (valinnainen) | multi-screen-pelien ruutunimet |
+| `config()` | kerran (valinnainen) | `physics`, `world`, kamera |
+| `physicsBounds()` | kerran (valinnainen) | seinät/segmentit host-fysiikalle tai Cannonille |
 
 Perussilmukka:
 
@@ -196,13 +247,17 @@ Valikosta peli näkyy automaattisesti, kun `index.tsx` on paikallaan.
 
 | Ominaisuus | Miten |
 |------------|-------|
-| **Ääni** | `import { soundEvent } from "../../scripting/game_helpers"` → `events: [soundEvent("bounce")]` `update()`-palautuksessa |
+| **Ääni** | `import { soundEvent } from "../../scripting/game_helpers"` → `events: [soundEvent("bounce")]` `update()`-palautuksessa; synth-äänet `game_audio.rgr`, musiikki `game_soundscore.rgr` |
+| **Partikkelit** | `events: [{ kind: "particles", id: "sparkle", x, y }]` — CPU- tai GPU-overlay |
 | **Taustakuva** | `resources()` + `backgroundImage()` — katso [`scripting/background_demo.game.tsx`](./scripting/background_demo.game.tsx) |
 | **Tallennus** | `loadGameData()` / `saveGameData(obj)` → `gamedata.json` pelikansiossa |
 | **Ruututiedostot** | `loadGame` / `pushGame` / `popGame` — erilliset `.tsx`-ruudut samassa pelikansiossa |
 | **Multi-screen (yksi tiedosto)** | `state.screen` + `state.screens[name]`; apurit `getScreen`, `isActiveScreen` — katso Breakout |
 | **Useampi pelaaja** | `state.playerSlots` + `props.input.players[]` |
 | **Split screen (kaksi lasta)** | `game.info`: `splitScreen=auto` — katso alla |
+| **Host-fysiikka** | `config().physics.enabled`, `state.physics` + `state.physicsContacts` — katso autopeli_physics |
+| **Cannon-fysiikka** | `config().physics.cannon`, entity `physics: { radius, mass, … }` — katso pinpall / physics_sandbox |
+| **Sheet-spritet** | `kind: "sheet"` + PNG-polku; GPU-overlay latausajassa (`game_sprite.rgr`) |
 
 ### Split screen (kaksi itsenäistä pelitilaa)
 
@@ -217,7 +272,7 @@ Kun `game.info`:ssa on `splitScreen=auto` tai `always`, SDL-host käynnistää *
 | `autoscale=false` | Paneeli = 240×270; peli skaalaa itse (`bgWidth`) |
 | `soloScript=index.tsx` | Valinnainen eri skripti split-ruuduille |
 
-**Autoscale (bitmap):** peli piirtää normaalisti täysleveään framebufferiin (`bgWidth=480`). Host kopioi valmiin RGBA-bitmappin puolikkaaseen leveyteen `copyRectScaledFrom`-blitillä. Toimii kaikilla piirtotavoilla: spritet, `createStaticBg`, HUD, suora canvas.
+**Autoscale (bitmap):** peli piirtää normaalisti täysleveään framebufferiin (`bgWidth=480`). Host kopioi valmiin RGBA-bitmappin puolikkaaseen leveyteen `copyRectScaledFrom`-blitillä tai GPU-split-presentillä. Toimii kaikilla piirtotavoilla: spritet, `createStaticBg`, HUD, suora canvas.
 
 **Ilman autoscalea:** peli saa `bgWidth=240` ja vastaa itse layoutista (esim. Ylos).
 
@@ -225,7 +280,7 @@ Kun `game.info`:ssa on `splitScreen=auto` tai `always`, SDL-host käynnistää *
 
 **Dual-player -tila:** molemmat painavat **Start** samalla framella → jaettu ruutu (esim. Ylos kahdella pelaajalla).
 
-Esimerkit: Pac-Man (`splitScreen=auto`, autoscale oletuksena päällä), Ylos (`autoscale=false`).
+Esimerkit: Pac-Man, Breakout, Invaders, Flipperitorni (`splitScreen=auto`); Pomppija (`autoscale=false`).
 
 Tiedostopohjaiset ruudut (`level2.tsx`, `win.tsx`), taustakuvat ja `gamedata.json`: **[`scripting/GAME_SCREENS_AND_STORAGE.md`](./scripting/GAME_SCREENS_AND_STORAGE.md)**.
 
@@ -233,6 +288,51 @@ Täydet tyypit: [`scripting/engine.d.ts`](./scripting/engine.d.ts). TS-tarkistus
 
 ```bash
 cd gallery/game_engine/scripting && npx tsc --noEmit
+```
+
+## WASM-pelit (Path C)
+
+WASM-pelit ladataan wasm3-tulkilla SDL-hostiin. Katalogi tunnistaa `engine=wasm` + `module=logic.wasm` `game.info`:sta.
+
+| ABI | Kuvaus | Esimerkki |
+|-----|--------|-----------|
+| **getter** | WASM exportit `ball_x()`, `update(dt, …)` | Rust Pong |
+| **linear (RGW1)** | Jaettu muistilohko (2560 B): input, kontaktit, eventit | Rust Autopeli |
+
+Rust-lähdekoodi: [`wasm/rust_pong/`](./wasm/rust_pong/), [`wasm/rust_autopeli/`](./wasm/rust_autopeli/). ABI-määrittely: [`wasm/wasm_game_abi.h`](./wasm/wasm_game_abi.h).
+
+```bash
+# Rakenna WASM-moduulit
+npm run engine:wasm:build:rust-pong
+npm run engine:wasm:build:rust-autopeli
+npm run engine:wasm:assets:autopeli   # kopioi PNG-resurssit
+
+# Headless-integraatiotestit
+npm run engine:wasm:demo:pong
+npm run engine:wasm:demo:autopeli
+
+# SDL-ajot
+npm run engine:game-sdl:run:rust-pong
+npm run engine:game-sdl:run:rust-autopeli
+```
+
+Linear-ABI-pelissä host hoitaa fysiikan (`GamePhysics`), piirron (procedural road + PNG-spritet) ja event-drainin (ääni, partikkelit, rumble). Moduuli voi rekisteröidä resurssit host-importeilla (`rg_host_register_sheet`).
+
+Lisätietoa Rust Pong -PoC:sta: [`games/rust_pong/README.md`](./games/rust_pong/README.md).
+
+## Fysiikka
+
+Kaksi opt-in-fysiikkakerrosta:
+
+| Kerros | Käyttö | API |
+|--------|--------|-----|
+| **Host physics** (`game_physics.rgr`) | Top-down racer, ajoneuvot, segmenttiseinät | `config().physics`, `state.physics`, `physicsContacts` |
+| **Cannon** (`game_cannon_physics.rgr`) | Pinball, painovoima, flipperit | `config().physics.cannon`, entity `physics: { … }` |
+
+Cannon.js -portti: [`physics/src/`](./physics/src/). Headless-testit:
+
+```bash
+npm run engine:physics:test
 ```
 
 ## Käännetty Pong-viite
@@ -275,7 +375,7 @@ npm run build:raspberry
 # → dist/raspberry-pi5/ (pong + games/menu/scripting + lib + compiler + DEPLOY.md)
 ```
 
-Kopioi `pong` Pi:lle ja aja HDMI-konsolissa. SDL-pelit (`engine:game-sdl`) vaativat Pi:llä `libsdl2-dev` ja käännöksen laitteella tai vastaavan cross-buildin.
+Kopioi `pong` Pi:lle ja aja HDMI-konsolissa. SDL-pelit (`engine:game-sdl`) vaativat Pi:llä `libsdl2-dev` ja käännöksen laitteella tai vastaavan cross-buildin. GPU-present (GLES2) on oletus SDL-hostissa; sheet-spritet voidaan renderöidä GPU-overlayna.
 
 ## LPC-spritesheet-compositor
 
@@ -291,8 +391,9 @@ npm run engine:lpc:run
 | Testi | Mitä kattaa |
 |-------|-------------|
 | [`tests/game-engine-render.test.ts`](../../tests/game-engine-render.test.ts) | SoftCanvas / Pong-renderöinti |
-| [`tests/game-runner.test.ts`](../../tests/game-runner.test.ts) | GameRunner + TSX |
+| [`tests/game-runner.test.ts`](../../tests/game-runner.test.ts) | GameRunner + TSX, ääni, fysiikka, Ylos |
 | [`tests/game-scripting.test.ts`](../../tests/game-scripting.test.ts) | ComponentEngine-skriptaus |
+| [`tests/physics-cannon.test.ts`](../../tests/physics-cannon.test.ts) | Cannon.js -portti |
 
 ## Dokumentaatio ja tiedostot
 
@@ -306,11 +407,14 @@ npm run engine:lpc:run
 | [`scripting/GAME_ENGINE_DESIGN.md`](./scripting/GAME_ENGINE_DESIGN.md) | Retained mode + JSX HUD -malli |
 | [`scripting/TSX_ENGINE_ISSUES.md`](./scripting/TSX_ENGINE_ISSUES.md) | Tunnetut evaluator-rajoitukset |
 | [`LLVM_BUGS.md`](./LLVM_BUGS.md) | LLVM-backendin bugit |
-| `scripting/game_runtime.rgr` | GameRunner (sprites, update, hud, ääni, tausta) |
-| `scripting/game_sdl_runner.rgr` | SDL2-host + launcher + hot reload |
+| [`games/rust_pong/README.md`](./games/rust_pong/README.md) | WASM Path C PoC |
+| `scripting/game_runtime.rgr` | GameRunner (sprites, update, hud, ääni, fysiikka) |
+| `scripting/game_sdl_runner.rgr` | SDL2-host + launcher + hot reload + WASM |
+| `scripting/wasm_game_runner.rgr` | WASM getter-ABI (Pong) |
+| `scripting/wasm_physics_runner.rgr` | WASM linear ABI + host physics (Autopeli) |
 | `scripting/game_catalog.rgr` | `games/`-hakemiston skannaus |
 | `scripting/game_persistence.rgr` | `gamedata.json` tallennus |
-| `scripts/build-game-sdl.sh` | TSX-pelien SDL-binääri |
+| `scripts/build-game-sdl.sh` | TSX- ja WASM-pelien SDL-binääri |
 | `scripts/build-sdl.sh` | Käännetty Pong SDL |
 | `scripts/build-native.sh` | LLVM Pong |
 | `scripts/build-raspberry.sh` | Pi 5 aarch64 -paketti (pong + runtime-assetit) |

--- a/gallery/game_engine/ROADMAP.md
+++ b/gallery/game_engine/ROADMAP.md
@@ -1,6 +1,6 @@
 # Ranger Game Engine — roadmap
 
-> **Päivitetty:** heinäkuu 2026  
+> **Päivitetty:** heinäkuu 2026 (WASM Path C, host/Cannon-fysiikka, GPU sheet-spritet)  
 > **Tarkoitus:** yhteenveto nykytilasta, puutteista ja jatkokehityksen prioriteeteista.  
 > **Liittyvät dokumentit:** [`README.md`](./README.md), [`PLAN_GAME_ENGINE.md`](./PLAN_GAME_ENGINE.md), [`RENDERING_EVG.md`](./RENDERING_EVG.md), [`scripting/GAME_ENGINE_DESIGN.md`](./scripting/GAME_ENGINE_DESIGN.md), [`LLVM_BUGS.md`](./LLVM_BUGS.md)
 
@@ -12,11 +12,13 @@ Ranger Game Engine on **ohut, portable 2D-pelimoottorin pohja** Ranger-kääntä
 `gallery/game_engine/`-hakemistossa. Se ei ole erillinen kaupallinen moottori (Unity/Godot),
 vaan **portability-demonstraatio ja kehitysalusta** tavoitteella:
 
-> Kirjoita pelilogiikka kerran → iteroi Macilla (Node / TSX) → aja sama logiikka
+> Kirjoita pelilogiikka kerran → iteroi Macilla (Node / TSX / WASM) → aja sama logiikka
 > natiivina binäärinä Raspberry Pi:llä HDMI-televisioon.
 
-**Nykyinen kypsyys:** PoC valmis ja laajentunut TSX-skriptauskerroksella. Tuotantopeli
-(esim. Koodisampo Pi:llä) vaatii vielä suorituskyky-, ääni-, gamepad- ja EVG-integraatiota.
+**Nykyinen kypsyys:** PoC laajentunut merkittävästi — TSX-skriptaus, host-fysiikka, Cannon-pinball,
+WASM Path C (Rust Pong + Autopeli), synth-äänet, gamepad, sheet-spritet ja GLES2 GPU-overlay.
+Tuotantopeli (esim. Koodisampo Pi:llä) vaatii vielä EVG-integraatiota, täyttä GPU-pinoa ja
+Pi-deployment-kovennusta.
 
 ---
 
@@ -26,59 +28,75 @@ vaan **portability-demonstraatio ja kehitysalusta** tavoitteella:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│  Platform-backend (valitse yksi)                             │
+│  Platform-backend (valitse yksi tai yhdistelmä)              │
 │  pong.rgr (terminaali)  |  pong_sdl.rgr (SDL2)               │
-│  game_sdl_runner.rgr + *.game.tsx (skriptattu peli)          │
+│  game_sdl_runner.rgr (TSX + WASM + launcher + GLES2)         │
 └───────────────────────────┬─────────────────────────────────┘
-                            │ Buttons-snapshot, step/draw
+                            │ Buttons-snapshot, dt, present
 ┌───────────────────────────▼─────────────────────────────────┐
 │  Pelilogiikka — pure, portable                               │
 │  pong_core.rgr  |  initState/update/sprites (TSX)            │
+│  logic.wasm (getter tai RGW1 linear ABI)                     │
 └───────────────────────────┬─────────────────────────────────┘
-                            │ tila (kokonaisluvut, booleanit)
+                            │ tila (+ physics I/O)
 ┌───────────────────────────▼─────────────────────────────────┐
-│  Piirtokerros — portable                                     │
-│  pong_render.rgr  |  game_sprite.rgr  |  game_hud.rgr      │
+│  Fysiikka (opt-in)                                           │
+│  game_physics.rgr  |  game_cannon_physics.rgr                │
 └───────────────────────────┬─────────────────────────────────┘
-                            │ RGBA8888-pikselit
+                            │ worldEntities, contacts
+┌───────────────────────────▼─────────────────────────────────┐
+│  Piirtokerros — portable (+ GPU sheet overlay)               │
+│  game_sprite.rgr  |  game_hud.rgr  |  game_particles.rgr     │
+└───────────────────────────┬─────────────────────────────────┘
+                            │ RGBA8888 + GPU textured quads
 ┌───────────────────────────▼─────────────────────────────────┐
 │  framebuffer.rgr — SoftCanvas                                │
 └───────────────────────────┬─────────────────────────────────┘
                             │ (SDL-polku)
 ┌───────────────────────────▼─────────────────────────────────┐
-│  gfx_sdl.rgr — SDL2-shim (C++ polyfill)                      │
+│  gfx_sdl.rgr — SDL2-shim (C++ polyfill, GLES2 present)      │
 └─────────────────────────────────────────────────────────────┘
 ```
 
 **Kova raja:** jos tiedosto kutsuu `write`, `poll_keypress` tai `gfx_present`, se on
 backend. Kaikki muu on portable.
 
-### Kolme kehityspolkua
+### Kehityspolut
 
 | Polku | Tiedostot | Tila |
 |-------|-----------|------|
 | **Käännetty Ranger-ydin** | `pong_core.rgr`, `pong.rgr`, `pong_sdl.rgr` | ✅ PoC valmis |
-| **SDL2-native ikkuna** | `framebuffer.rgr`, `gfx_sdl.rgr`, `pong_sdl.rgr` | ✅ PoC valmis |
-| **TSX-skriptaus** | `scripting/*.game.tsx`, `game_runtime.rgr` | ✅ Merkittävä |
+| **SDL2-native ikkuna** | `framebuffer.rgr`, `gfx_sdl.rgr`, `pong_sdl.rgr` | ✅ PoC valmis + GLES2 |
+| **TSX-skriptaus** | `games/*/index.tsx`, `game_runtime.rgr` | ✅ Tuotantokelpoinen demoihin |
+| **WASM Path C** | `wasm/rust_*`, `wasm_game_runner.rgr`, `wasm_physics_runner.rgr` | ✅ PoC (Pong + Autopeli) |
+| **Host-fysiikka** | `game_physics.rgr`, `physics_core.rgr` | ✅ Phase 1 |
+| **Cannon-fysiikka** | `physics/src/cannon_*.rgr`, `game_cannon_physics.rgr` | ✅ Pinball + sandbox |
 
-### Demo-pelit (TSX)
+### Demo-pelit
 
-| Peli | Entityjä | FPS (dummy SDL) | Huomio |
-|------|----------|-----------------|--------|
-| Pong | 3 | ~250 | Minimal-malli, suositeltu pohja |
-| Breakout | 52 | ~150+ | JSX `hud()`, multi-screen |
-| Pacman | — | — | Skriptattu demo |
-| Invaders | ~487 | ~8 | **Stressitesti** — ei tuotantomalli |
+| Peli | Polku | Huomio |
+|------|-------|--------|
+| Pong | TSX | Minimal-malli, ~250 FPS dummy SDL |
+| Breakout | TSX | Multi-screen, JSX HUD, split screen |
+| Pac-Man | TSX | Split screen + autoscale |
+| Invaders | TSX | Stressitesti (~487 entityä, rect-moodi) |
+| Pomppija (ylos2) | TSX | Platformer, LPC-sheet, soundscore-musiikki |
+| Flipperitorni (pinpall) | TSX + Cannon | Pystypinball, split screen |
+| Physics Sandbox | TSX + Cannon | Flipperit, pegs, sheet-animaatiot |
+| Autopeli Physics | TSX + host physics | Top-down racer, jaettu maailma |
+| Rust Pong | WASM (getter ABI) | Path C PoC |
+| Rust Autopeli | WASM (linear ABI) | Fysiikka + host rendering + eventit |
 
 ### Build-targetit (Pong-viite)
 
 | Target | Pi-native? | Binäärikoko | Huomio |
 |--------|:----------:|-------------|--------|
 | ES6 / Node | ✅ (tarvitsee Node) | — | Nopein dev-iterointi |
-| LLVM + C runtime | ✅ | ~22 KB | **Suositus Pi:lle** |
+| LLVM + C runtime | ✅ | ~22 KB | **Suositus Pi:lle** (terminaali) |
 | C++ | ✅ | ~137 KB | Luonnollinen SDL2-polku |
 | Rust | ✅ | ~4.1 MB | Toimii, iso binääri |
 | Go | ❌ | — | Keyboard-polyfill vain Windows |
+| WASM (wasm3) | ✅ (SDL-host) | moduuli ~KB–MB | Path C, ei erillistä VM:ää selaimessa |
 
 ---
 
@@ -87,34 +105,44 @@ backend. Kaikki muu on portable.
 | Moduuli | Sijainti | Tila |
 |---------|----------|------|
 | Pure game logic | `pong_core.rgr` | ✅ PoC-taso |
-| Input-abstraktio (`Buttons`) | `pong_core.rgr` | ✅ Valmis |
+| Input-abstraktio (`Buttons`) | `pong_core.rgr`, `game_input.rgr` | ✅ Valmis |
+| Gamepad (SDL GameController) | `game_input.rgr`, `gfx_sdl.rgr` | ✅ 1–8 pelaajaa, split-tuki |
 | SoftCanvas (RGBA8888) | `framebuffer.rgr` | ✅ Valmis + golden-frame testit |
-| Portable renderer | `pong_render.rgr`, `game_sprite.rgr` | ✅ rect/circle/wedge |
+| Portable renderer | `pong_render.rgr`, `game_sprite.rgr` | ✅ rect/circle/wedge/bitmap/sheet |
+| GPU sheet overlay (GLES2) | `gfx_sdl.rgr`, `game_sprite.rgr` | ⚠️ PoC — load-time bake, split-pane |
 | Terminaali-backend + debug HUD | `pong.rgr` | ✅ Valmis |
-| SDL2-backend | `pong_sdl.rgr`, `gfx_sdl.rgr` | ✅ PoC valmis |
+| SDL2-backend | `pong_sdl.rgr`, `gfx_sdl.rgr` | ✅ PoC + GPU present |
+| Delta-time SDL-loopissa | `game_sdl_runner.rgr` | ✅ `gfx_ticks_ms()` clampattu |
 | LLVM-native build | `scripts/build-native.sh` | ✅ Toimii |
-| TSX GameRunner | `game_runtime.rgr` | ✅ Retained sprites, reducer |
-| Multi-screen flow | `breakout.game.tsx` | ✅ Valmis |
+| TSX GameRunner | `game_runtime.rgr` | ✅ Retained sprites, reducer, fysiikka |
+| Multi-screen flow | Breakout, Invaders | ✅ Valmis |
+| Split screen (2 pane) | `game_split_screen.rgr` | ✅ auto/always/never, GPU split present |
 | JSX HUD (kevyt) | `game_hud.rgr` | ⚠️ View/Label, ei täyttä EVG:ä |
-| Host bridge (resources/events) | `gallery/ts_to_ranger/game_host.rgr` | ⚠️ Data-kerros, ei toistoa |
+| Host bridge (resources/events) | `game_host.rgr` | ⚠️ Data-kerros, ääni/partikkelit toimii |
 | TS→Ranger staattinen käännös | `game_native_runtime.rgr` | ⚠️ Kokeellinen |
+| Host physics (2D top-down) | `game_physics.rgr` | ✅ Ajoneuvot, kontaktit, shared world |
+| Cannon physics | `game_cannon_physics.rgr` | ✅ Pinball, sandbox |
+| WASM Path C | `wasm_game_runner.rgr`, `wasm_physics_runner.rgr` | ✅ Getter + RGW1 linear ABI |
+| Partikkelit | `game_particles.rgr` | ✅ CPU + GPU overlay |
+| Ääni (synth) | `game_audio.rgr` | ✅ Built-in id:t + soundscore |
+| Ääni (samplet) | — | ❌ Ei tiedostopohjaista |
 | EVG full-frame natiivissa | `RENDERING_EVG.md` | ❌ Suunniteltu |
-| Ääni | `GameHost.playSound` | ❌ Stub (event only) |
-| Gamepad | `PLAN_GAME_ENGINE.md` §6 | ❌ Suunniteltu |
-| GPU (WebGL/GLES2) | `RENDERING_EVG.md` | ❌ Tulevaisuus |
+| GPU (täysi EVG-pino) | `RENDERING_EVG.md` | ❌ Sheet-overlay PoC valmis |
 
 ---
 
 ## Vahvuudet (mitä hyödyntää)
 
-1. **Todellinen write-once-portability** — sama logiikka Node:ssa, LLVM-natiivissa ja SDL2:ssa.
-2. **Deterministinen simulaatio** — kokonaisluvut, golden-frame-testit, input-replay mahdollinen.
-3. **Nopea desktop-iterointi** — TSX-skriptit ilman Ranger-uudelleenkääntöä.
+1. **Todellinen write-once-portability** — sama logiikka Node:ssa, LLVM-natiivissa, SDL2:ssa ja WASM:ssa.
+2. **Deterministinen simulaatio** — kokonaisluvut (Pong), golden-frame-testit, input-replay mahdollinen.
+3. **Nopea desktop-iterointi** — TSX-skriptit ilman Ranger-uudelleenkääntöä; WASM Rust-build erillisellä komennolla.
 4. **Retained-mode + reducer** — `sprites()` kerran, `update()` palauttaa uuden tilan.
-5. **EVG-ekosysteemi valmiina** — vektorit, TTF, flexbox, JSX (`gallery/pdf_writer`).
-6. **Kaksisuuntainen skriptaus** — tulkattu (ComponentEngine) ja staattinen (ts_to_ranger).
-7. **Testipohja** — Vitest: render, runner, native parity, headless SDL smoke.
-8. **Selkeä Pi-polku** — LLVM ~22 KB tai C++ + SDL2 HDMI:lle.
+5. **Fysiikka opt-in** — host top-down (Autopeli) tai Cannon (pinball); WASM linear ABI jakaa kontaktit.
+6. **GPU sheet-spritet** — load-time atlas bake + GLES2 textured quads split-tilassa.
+7. **Synth-äänet + soundscore** — ei ulkoisia asset-paketteja perusdemoon.
+8. **Gamepad + split screen** — SDL GameController, kaksi paneelia, dual-player Start-yhdistelmä.
+9. **EVG-ekosysteemi valmiina** — vektorit, TTF, flexbox, JSX (`gallery/pdf_writer`).
+10. **Testipohja** — Vitest: render, runner, Cannon, ääni, fysiikka, headless SDL smoke.
 
 ---
 
@@ -123,8 +151,8 @@ backend. Kaikki muu on portable.
 ### Tarkoitukselliset non-goals (base)
 
 - Scene graph
-- Fysiikkamoottori
-- Asset pipeline (kuvat, äänet, kartat) — LPC bake suunniteltu: [`LPC_HEADLESS_SPRITESHEET.md`](./LPC_HEADLESS_SPRITESHEET.md)
+- Täysi asset pipeline (kuvat, äänipankit, kartat) — LPC bake osittain: [`LPC_HEADLESS_SPRITESHEET.md`](./LPC_HEADLESS_SPRITESHEET.md)
+- Yksi universaali fysiikkamoottori — kaksi erillistä kerrosta (host + Cannon) tarkoituksella
 
 Nämä ovat tulevia kerroksia tai pelikohtaisia ratkaisuja, ei base-moottorin osia.
 
@@ -132,16 +160,17 @@ Nämä ovat tulevia kerroksia tai pelikohtaisia ratkaisuja, ei base-moottorin os
 
 | Puute | Vaikutus |
 |-------|----------|
-| Ohjelmistorasterointi (`SoftCanvas.fillRect`) | Invaders ~8 FPS (480 rectiä) |
-| Kiinteä `dt = 16` ms SDL-hostissa | Simulaatio sidottu framerateen |
-| EVG ei natiivissa | Rich UI vain ES6-polulla |
-| Ääni stub | `playSound`-eventit, ei toistoa |
-| Gamepad puuttuu | `Buttons` valmis, backend ei |
-| Sprite atlas / blit | Ei bitmap-spritejä |
+| Invaders suorituskyky rect-moodissa | Stressitesti — sheet/GPU auttaa, refaktorointi avoin |
+| SoftCanvas span-fill optimointi | Suuri rect-määrä hidastaa CPU-polku |
+| EVG ei natiivissa | Rich UI vain ES6/TSX-polulla |
+| Sample-pohjainen ääni | Vain synth-id:t ja soundscore |
+| Täysi GPU-renderöinti (EVG → texture) | Vain sheet/base blit + partikkelit |
+| WASM tuotantovalmius | PoC — ei hot reload, rajoitettu debug |
 | LLVM workarounds | `to_int`, field-less struct |
 | Go Pi-target | POSIX keyboard puuttuu |
 | Record/replay-työkalu | Suunniteltu, ei paketoitu |
 | systemd kiosk-resepti | Dokumentoitu, ei toimitettu |
+| Dirty rectangle -seuranta | Backend-optimointi avoin |
 
 ---
 
@@ -154,17 +183,28 @@ Nämä ovat tulevia kerroksia tai pelikohtaisia ratkaisuja, ei base-moottorin os
 - [x] LLVM-native polku (~22 KB) + boolean-field bugi korjattu
 - [x] SoftCanvas + golden-frame render-testit
 - [x] TSX GameRunner: retained `sprites()`, reducer `update()`, `syncFromState`
-- [x] Geneerinen sprite-protokolla (`game_sprite.rgr`: rect/circle/wedge)
+- [x] Geneerinen sprite-protokolla (`game_sprite.rgr`: rect/circle/wedge/bitmap/sheet)
 - [x] Off-screen / `visible` culling
 - [x] Kevyt JSX `hud()` (`game_hud.rgr`)
 - [x] Multi-screen (Breakout: play → gameOver)
-- [x] Demo-pelit: Pong, Invaders, Breakout, Pacman, menu, spawner
+- [x] Demo-pelit: Pong, Invaders, Breakout, Pacman, Ylos2, Pinpall, Physics Sandbox
 - [x] TS→Ranger native runner (kokeellinen)
 - [x] Host bridge: resources + events (data-kerros)
+- [x] Delta-time SDL-loopissa (`gfx_ticks_ms`, clamp)
+- [x] Bitmap + sheet-spritet (PNG blit, load-time bake)
+- [x] Synth-äänet (`game_audio.rgr`) + soundscore (`game_soundscore.rgr`)
+- [x] Gamepad (SDL GameController, split-pane mapping)
+- [x] Split screen (auto/always/never, autoscale, soloScript)
+- [x] GPU present (GLES2) + sheet overlay + split-pane present
+- [x] Partikkelit (CPU + GPU overlay)
+- [x] Host physics Phase 1 (`game_physics.rgr`, Autopeli Physics)
+- [x] Cannon physics (`game_cannon_physics.rgr`, Pinpall, Sandbox)
+- [x] WASM Path C PoC (Rust Pong getter ABI)
+- [x] WASM linear ABI RGW1 (Rust Autopeli: contacts, events, host rendering)
 
 ---
 
-### Vaihe 1b — Entity-kerros ja kamera (heinäkuu 2026, osittain)
+### Vaihe 1b — Entity-kerros ja kamera (heinäkuu 2026)
 
 **Tavoite:** yhtenäinen world-entity store; kamera engineen; fixed timestep.
 Taaksepäin yhteensopiva vanhan `state.entities`-polun kanssa.
@@ -175,54 +215,71 @@ Taaksepäin yhteensopiva vanhan `state.entities`-polun kanssa.
 | 1b.2 | Engine-kamera (`camera()`, follow, smoothing, bounds) | ✅ |
 | 1b.3 | Automaattinen world→screen + culling | ✅ |
 | 1b.4 | `config().physics.fixedStep` fixed timestep | ✅ |
-| 1b.5 | body/collider/trigger-komponentit | ❌ Vaihe 2 |
+| 1b.5 | body/collider/trigger-komponentit (geneerinen) | ⚠️ Cannon + host physics erikseen |
 | 1b.6 | Valmiit controllerit (platformer, top-down, …) | ❌ Vaihe 3 |
 
 ---
 
 ### Vaihe 1 — Suorituskyky ja oikeellisuus (lyhyt aikaväli)
 
-**Tavoite:** skriptatut pelit skaalautuvat 60 FPS:iin; simulaatio riippumaton frameratesta.
+**Tavoite:** skriptatut pelit skaalautuvat 60 FPS:iin; CPU-polku optimoitu.
 
-| # | Tehtävä | Tiedostot | Prioriteetti |
-|---|---------|-----------|:------------:|
-| 1.1 | Todellinen delta-time SDL-loopissa | `game_sdl_runner.rgr` — `gfx_ticks_ms()` | 🔴 Korkea |
-| 1.2 | Sprite atlas + bitmap blit | `framebuffer.rgr`, `game_sprite.rgr` | 🔴 Korkea |
-| 1.3 | SoftCanvas optimointi: span-fill / rivikohtainen täyttö | `framebuffer.rgr` | 🟡 Keskitaso |
-| 1.4 | Invaders-refaktorointi: 1 sprite/alien (ei pixel-per-rect) | `invaders.game.tsx` | 🟡 Keskitaso |
-| 1.5 | Dirty rectangle -seuranta (backend-optimointi) | `framebuffer.rgr`, backends | 🟢 Matala |
-| 1.6 | LPC headless spritesheet bake + `kind: "sheet"` | [`lpc/`](./lpc/), `game_sprite.rgr`, [`LPC_HEADLESS_SPRITESHEET.md`](./LPC_HEADLESS_SPRITESHEET.md) | 🟡 Keskitaso |
+| # | Tehtävä | Tiedostot | Prioriteetti | Tila |
+|---|---------|-----------|:------------:|:----:|
+| 1.1 | Todellinen delta-time SDL-loopissa | `game_sdl_runner.rgr` | 🔴 Korkea | ✅ |
+| 1.2 | Sprite atlas + bitmap/sheet blit | `framebuffer.rgr`, `game_sprite.rgr` | 🔴 Korkea | ✅ |
+| 1.3 | SoftCanvas optimointi: span-fill / rivikohtainen täyttö | `framebuffer.rgr` | 🟡 Keskitaso | ❌ |
+| 1.4 | Invaders-refaktorointi: 1 sprite/alien (ei pixel-per-rect) | `invaders.game.tsx` | 🟡 Keskitaso | ❌ |
+| 1.5 | Dirty rectangle -seuranta (backend-optimointi) | `framebuffer.rgr`, backends | 🟢 Matala | ❌ |
+| 1.6 | LPC headless spritesheet bake + `kind: "sheet"` | [`lpc/`](./lpc/), `game_sprite.rgr` | 🟡 Keskitaso | ⚠️ sheet toimii, LPC bake osittain |
+| 1.7 | GPU sheet overlay laajennus (kaikki pelit, ARM-tuning) | `gfx_sdl.rgr`, `game_sprite.rgr` | 🟡 Keskitaso | ⚠️ PoC |
 
 **Onnistumiskriteerit:**
 
-- Invaders ≥ 60 FPS dummy SDL:llä (tai ≥ 30 FPS 480 entityllä rect-moodissa)
-- `update({ dt })` saa mitatun `dt`:n, ei kiinteää 16 ms
-- Uusi peli voi käyttää `kind: "bitmap"` ilman satoja rect-spritejä
+- Invaders ≥ 30 FPS 480 entityllä (sheet/GPU-polulla) tai refaktoroitu sprite-malli
+- `update({ dt })` saa mitatun `dt`:n ✅
+- Uusi peli voi käyttää `kind: "bitmap"` / `kind: "sheet"` ✅
+
+---
+
+### Vaihe 1c — WASM Path C laajennus (rinnakkainen)
+
+**Tavoite:** WASM tuotantokelpoisemmaksi portability-polkuksi.
+
+| # | Tehtävä | Tila |
+|---|---------|------|
+| 1c.1 | Getter ABI (Rust Pong) | ✅ |
+| 1c.2 | RGW1 linear ABI (input, contacts, events) | ✅ |
+| 1c.3 | Host resource imports (`rg_host_register_*`) | ✅ |
+| 1c.4 | Host rendering bridge (Autopeli road + sprites) | ✅ |
+| 1c.5 | WASM hot reload / dev loop | ❌ |
+| 1c.6 | Toinen kieli (C/C++ → wasm32) | ❌ |
+| 1c.7 | WASM CI-smoke kaikille wasm-peleille | ⚠️ demo-skriptit, ei Vitest |
 
 ---
 
 ### Vaihe 2 — Platform-API ja Pi-deployment (keskipitkä aikaväli)
 
-**Tavoite:** keskitetty gfx/pad-API, gamepad-tuki, natiivi Pi-kokemus.
+**Tavoite:** keskitetty gfx/pad-API, täysi ääni, natiivi Pi-kokemus.
 
-| # | Tehtävä | Tiedostot | Prioriteetti |
-|---|---------|-----------|:------------:|
-| 2.1 | `gfx_*` / `pad_*` operaattorit `Lang.rgr`:ään | `compiler/Lang.rgr` | 🔴 Korkea |
-| 2.2 | `runtime/ranger_gfx.c` (SDL2 shim) | `runtime/` | 🔴 Korkea |
-| 2.3 | SDL GameController → `Buttons`-mapping | `pong_sdl.rgr`, uusi pad-backend | 🔴 Korkea |
-| 2.4 | Äänimoottori: `playSound` → SDL_mixer / miniaudio | `game_host.rgr`, SDL runner | 🔴 Korkea |
-| 2.5 | LLVM: `to_int`-template | `compiler/ng_LowIR*.rgr` | 🟡 Keskitaso |
-| 2.6 | LLVM: field-less class struct -emissio | `compiler/` | 🟡 Keskitaso |
-| 2.7 | Go POSIX keyboard polyfill | `lib/stdops.rgr` / polyfill | 🟡 Keskitaso |
-| 2.8 | TV safe-area + integer scale backendissa | SDL backend | 🟡 Keskitaso |
-| 2.9 | Input record/replay -työkalu | uusi `tools/` tai `scripting/` | 🟢 Matala |
-| 2.10 | systemd autostart -resepti Pi kioskille | `scripts/`, docs | 🟢 Matala |
+| # | Tehtävä | Tiedostot | Prioriteetti | Tila |
+|---|---------|-----------|:------------:|:----:|
+| 2.1 | `gfx_*` / `pad_*` operaattorit `Lang.rgr`:ään | `compiler/Lang.rgr` | 🔴 Korkea | ❌ |
+| 2.2 | `runtime/ranger_gfx.c` (SDL2 shim) | `runtime/` | 🔴 Korkea | ❌ |
+| 2.3 | SDL GameController → `Buttons`-mapping | `game_input.rgr` | 🔴 Korkea | ✅ |
+| 2.4 | Sample-ääni: WAV/OGG `resources()`-rekisteristä | `game_audio.rgr` | 🔴 Korkea | ❌ |
+| 2.5 | LLVM: `to_int`-template | `compiler/ng_LowIR*.rgr` | 🟡 Keskitaso | ❌ |
+| 2.6 | LLVM: field-less class struct -emissio | `compiler/` | 🟡 Keskitaso | ❌ |
+| 2.7 | Go POSIX keyboard polyfill | `lib/stdops.rgr` / polyfill | 🟡 Keskitaso | ❌ |
+| 2.8 | TV safe-area + integer scale backendissa | SDL backend | 🟡 Keskitaso | ❌ |
+| 2.9 | Input record/replay -työkalu | uusi `tools/` tai `scripting/` | 🟢 Matala | ❌ |
+| 2.10 | systemd autostart -resepti Pi kioskille | `scripts/`, docs | 🟢 Matala | ❌ |
 
 **Onnistumiskriteerit:**
 
-- USB/Bluetooth gamepad toimii Pi:llä ilman pelilogiikan muutosta
-- `playSound("blip")` kuuluu SDL-ikkunassa
-- Yksi `npm run`-komento tuottaa Pi-valmiin binäärin
+- USB/Bluetooth gamepad toimii Pi:llä ilman pelilogiikan muutosta ✅ (SDL-polku)
+- `playSound("blip")` kuuluu SDL-ikkunassa ✅ (synth)
+- Yksi `npm run`-komento tuottaa Pi-valmiin SDL-binäärin ❌
 
 ---
 
@@ -241,9 +298,10 @@ Taaksepäin yhteensopiva vanhan `state.entities`-polun kanssa.
 **Vaiheittainen polku** (ks. [`RENDERING_EVG.md`](./RENDERING_EVG.md)):
 
 1. ✅ `hud()` kevyellä EVGLayout-blitterillä
-2. `world()` JSX + retained spritet päälle
-3. Täysi EVG-frame GameRunnerissa
-4. GPU-backend (vaihe 4)
+2. ⚠️ GPU sheet/base blit (PoC, ei täyttä EVG:ä)
+3. `world()` JSX + retained spritet päälle
+4. Täysi EVG-frame GameRunnerissa
+5. GPU-backend (vaihe 4)
 
 ---
 
@@ -251,14 +309,16 @@ Taaksepäin yhteensopiva vanhan `state.entities`-polun kanssa.
 
 **Tavoite:** 720p@60fps Pi:llä; ensimmäinen oikea tuotantopeli.
 
-| # | Tehtävä | Kuvaus |
-|---|---------|--------|
-| 4.1 | WebGL/GLES2 backend Pi:lle | EVG → GPU texture upload |
-| 4.2 | Asset pipeline | Sprite sheetit, äänipankit, collision mapit |
-| 4.3 | Collision-työkalut | Pelikohtaiset tai kevyt tile-map -kerros |
-| 4.3a | Host physics engine (Phase 1) | `game_physics.rgr` — opt-in `config().physics`, bodies, bounds, collision events |
-| 4.4 | Tuotantopeli: Koodisampo Pi:llä | README:n mainitsema seuraava oikea peli |
-| 4.5 | `<canvas>` ES6 dev-backend | Selain-kiosk debug |
+| # | Tehtävä | Kuvaus | Tila |
+|---|---------|--------|:----:|
+| 4.1 | WebGL/GLES2 backend Pi:lle | EVG → GPU texture upload | ⚠️ sheet/base PoC |
+| 4.2 | Asset pipeline | Sprite sheetit, äänipankit, collision mapit | ❌ |
+| 4.3 | Collision-työkalut | Pelikohtaiset tai kevyt tile-map -kerros | ❌ |
+| 4.3a | Host physics engine (Phase 1) | `game_physics.rgr` — bodies, bounds, contacts | ✅ |
+| 4.3b | Cannon physics | Pinball, flipperit, sandbox | ✅ |
+| 4.4 | Tuotantopeli: Koodisampo Pi:llä | README:n mainitsema seuraava oikea peli | ❌ |
+| 4.5 | `<canvas>` ES6 dev-backend | Selain-kiosk debug | ❌ |
+| 4.6 | WASM Path C tuotantopeli | Rust/C logiikka + host render | ⚠️ Autopeli PoC |
 
 ---
 
@@ -288,6 +348,8 @@ Noudatettava malli ([`scripting/GAME_ENGINE_DESIGN.md`](./scripting/GAME_ENGINE_
 4. **Yksi sprite per objekti** — ei yhtä rectiä per pikseli (Invaders on vain stressitesti).
 5. **Kuolleet objektit: `visible: 0`** — runner ohittaa piirron.
 6. **Multi-screen: `state.screen` + `state.screens[name]`** — Breakout-malli.
+7. **Fysiikka opt-in** — `config().physics` + `state.physics` / Cannon entity-kentät.
+8. **Sheet-spritet suurelle määrälle animaatiota** — `kind: "sheet"` GPU-overlayn kanssa.
 
 > **Yhteenveto:** Sprites kerran alussa, sijainnit reducerilla joka framella, JSX vain HUD:iin.
 
@@ -300,19 +362,23 @@ Noudatettava malli ([`scripting/GAME_ENGINE_DESIGN.md`](./scripting/GAME_ENGINE_
 | Testi | Mitä testaa |
 |-------|-------------|
 | `tests/game-engine-render.test.ts` | SoftCanvas pikselit, SDL headless |
-| `tests/game-runner.test.ts` | Pong, Invaders, Breakout, Pacman frame-count |
+| `tests/game-runner.test.ts` | Pong, Invaders, Breakout, Pacman, ääni, fysiikka, Ylos |
 | `tests/game-scripting.test.ts` | Global injection, reducer dispatch |
+| `tests/physics-cannon.test.ts` | Cannon.js -portti |
 | `tests/tsx-engine.test.ts` | ComponentEngine korjaukset |
 | `tests/ts-to-ranger-native.test.ts` | Staattinen TS→Ranger parity |
 | `tests/ts-to-ranger-host.test.ts` | Resource/event bridge |
+| `engine:wasm:demo:*` | WASM Pong + Autopeli headless (skriptit) |
+| `engine:game-sdl:smoke:*` | SDL dummy-driver smoke (TSX + WASM) |
 
 ### Roadmap-testit (lisättävät)
 
-- [ ] Delta-time regressio (`dt`-riippuvainen liike)
-- [ ] Bitmap blit golden-frame
-- [ ] Äänitapahtuman mock-toisto
+- [x] Delta-time regressio (`dt`-riippuvainen liike) — SDL-loop mittaa dt:n
+- [x] Bitmap/sheet blit — demo-pelit + runner-testit
+- [x] Äänitapahtuman mock-toisto — `audio_runner_demo`, Vitest
 - [ ] Gamepad input mapping (simuloitu)
 - [ ] Cross-target determinismi (ES6 vs native hash)
+- [ ] WASM Vitest-integraatio (nyt erilliset demo-skriptit)
 
 ---
 
@@ -326,21 +392,34 @@ npm run engine:run
 npm run engine:sdl:run
 
 # TSX-pelit
+npm run engine:game-sdl:launcher
 npm run engine:game-sdl:run:breakout
+npm run engine:game-sdl:run:ylos2
+npm run engine:game-sdl:run:physics_sandbox
 npm run engine:game-sdl:smoke:invaders
+
+# WASM-pelit
+npm run engine:wasm:demo:pong
+npm run engine:wasm:demo:autopeli
+npm run engine:game-sdl:run:rust-pong
+npm run engine:game-sdl:run:rust-autopeli
+
+# Fysiikka
+npm run engine:physics:test
 
 # LLVM-native (~22 KB)
 npm run engine:build:native
 
 # Testit
-npm test -- game-engine game-runner game-scripting
+npm test -- game-engine game-runner game-scripting physics-cannon
 ```
 
 | Dokumentti | Sisältö |
 |------------|---------|
-| [`README.md`](./README.md) | Quick start, layer stack, build-targetit |
+| [`README.md`](./README.md) | Quick start, layer stack, build-targetit, WASM, fysiikka |
 | [`PLAN_GAME_ENGINE.md`](./PLAN_GAME_ENGINE.md) | Arkkitehtuuri, HDMI/gamepad, debuggaus |
 | [`RENDERING_EVG.md`](./RENDERING_EVG.md) | EVG renderer, GPU-polku |
 | [`scripting/GAME_SCRIPTING.md`](./scripting/GAME_SCRIPTING.md) | TSX-skriptaus-API |
 | [`scripting/GAME_ENGINE_DESIGN.md`](./scripting/GAME_ENGINE_DESIGN.md) | Retained-mode, ongelmat, prioriteetit |
+| [`games/rust_pong/README.md`](./games/rust_pong/README.md) | WASM Path C PoC |
 | [`LLVM_BUGS.md`](./LLVM_BUGS.md) | Native build -bugit ja workaroundit |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `gallery/game_engine/README.md` and `gallery/game_engine/ROADMAP.md` to reflect the current state of the engine after recent work on WASM Path C, physics, GPU rendering, and expanded demo games.

## Changes

### README
- Expanded directory structure (`wasm/`, `physics/`, GLES2 present)
- Documented five development paths (TSX, Ranger, WASM, host physics, Cannon)
- Updated architecture diagram with physics and GPU overlay layers
- Added demo games table (ylos2, pinpall, physics sandbox, autopeli, rust_pong, rust_autopeli)
- Documented `game.info` fields (`engine=wasm`, `abi=linear`, `physics=true`, etc.)
- Added WASM Path C section (getter vs RGW1 linear ABI, build/run commands)
- Added physics section (host vs Cannon)
- Updated npm commands, optional features, split-screen examples, and test coverage

### ROADMAP
- Updated maturity summary and architecture diagram
- Marked completed items: delta-time, bitmap/sheet sprites, synth audio, gamepad, GPU sheet PoC, host/Cannon physics, WASM Path C
- Added demo games table and WASM build target
- Refreshed maturity matrix and deficiencies (removed obsolete stubs)
- Added Phase 1c (WASM Path C extension) and updated phase statuses
- Updated test coverage and command reference

## Testing

Documentation-only change; no code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5712-1ee6-7dc8-b7ac-e562c4f56723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5712-1ee6-7dc8-b7ac-e562c4f56723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

