### PR TITLE
Add interactive EVG UI layer with widgets, text input, and gamepad selection

### DIFF
--- a/gallery/game_engine/RENDERING_EVG.md
+++ b/gallery/game_engine/RENDERING_EVG.md
@@ -191,5 +191,11 @@ pre-existing content bugs unrelated to the renderer.
    (SDL2) and `es6` canvas backend. Terminal downsample fallback.
 3. **Phase 2 — declarative UI.** HUD/menu/pause components via `l`/JSX +
    `EVGLayout`; custom TTF fonts; golden-frame tests (Mac↔Pi identical).
+   * **Interactive UI layer (done, pure Ranger).** An on-top-of-EVG widget layer
+     — buttons, text inputs, draggable boxes, an on-screen software keyboard,
+     selection highlight, and TTF text with correct wrapping + a glyph/line cache
+     for accelerated rendering. See [`ui/UI_LAYER.md`](./ui/UI_LAYER.md). It reads
+     an abstract `UIInput` (pointer + keys), so the only platform work left is a
+     `gfx_mouse_*` operator + `SDL_TEXTINPUT` channel (documented there).
 4. **Phase 3 — GPU.** `EVGGLRenderer` on GLES2 (Pi) / WebGL (web); gradient +
    blur shaders; texture atlas for glyphs/sprites; batching.

--- a/gallery/game_engine/ROADMAP.md
+++ b/gallery/game_engine/ROADMAP.md
@@ -294,6 +294,7 @@ Taaksepäin yhteensopiva vanhan `state.entities`-polun kanssa.
 | 3.3 | `world()` JSX — staattiset taustaelementit EVG:llä | skriptaus-API | 🟡 Keskitaso |
 | 3.4 | Täysi `render({ state })` → koko frame EVG:llä | `game_runtime.rgr` | 🟡 Keskitaso |
 | 3.5 | Asset loading: kuvat/fontit `resources()`-rekisteristä | `game_host.rgr` | 🟡 Keskitaso |
+| 3.6 | **Interaktiivinen UI-kerros** (napit, tekstikentät, raahattavat laatikot, software-näppäimistö, valinnan korostus, TTF-tekstin rivitys + glyph-cache) | [`ui/UI_LAYER.md`](./ui/UI_LAYER.md) | ✅ Valmis (portable; jäljellä `gfx_mouse_*`-operaattori) |
 
 **Vaiheittainen polku** (ks. [`RENDERING_EVG.md`](./RENDERING_EVG.md)):
 

--- a/gallery/game_engine/scripting/wasm_ui_io.rgr
+++ b/gallery/game_engine/scripting/wasm_ui_io.rgr
@@ -361,6 +361,14 @@ class WasmUiEvgBuilder {
         return el
     }
 
+    ; RgUiAlign enum (0 start,1 center,2 end,3 space-between) -> EVG string.
+    fn alignName:string (v:int) {
+        if (v == 1) { return "center" }
+        if (v == 2) { return "flex-end" }
+        if (v == 3) { return "space-between" }
+        return "flex-start"
+    }
+
     ; Apply the node's contiguous property run to a plain View/Text/Spacer.
     fn applyProps:void (doc:WasmUiDoc i:int el:EVGElement) {
         def fp (doc.nodeFirstProp(i))
@@ -389,10 +397,16 @@ class WasmUiEvgBuilder {
             }
             if (key == 12) {                ; PADDING (all sides)
                 def pad (this.pxUnit((doc.propValueA(idx))))
+                ; EVGLayout reads the BOX model (box.padding*), not the top-level
+                ; el.padding* fields - set both so padding actually insets.
                 el.paddingTop = pad
                 el.paddingRight = pad
                 el.paddingBottom = pad
                 el.paddingLeft = pad
+                el.box.setPadding((this.pxUnit((doc.propValueA(idx)))))
+            }
+            if (key == 14) {                ; BORDER_RADIUS (px)
+                el.box.borderRadius = (this.pxUnit((doc.propValueA(idx))))
             }
             if (key == 20) {                ; FLEX
                 el.flex = (to_double (doc.propValueA(idx)))
@@ -403,6 +417,12 @@ class WasmUiEvgBuilder {
                 } {
                     el.flexDirection = "column"
                 }
+            }
+            if (key == 22) {                ; ALIGN_ITEMS (cross axis)
+                el.alignItems = (this.alignName((doc.propValueA(idx))))
+            }
+            if (key == 23) {                ; JUSTIFY_CONTENT (main axis)
+                el.justifyContent = (this.alignName((doc.propValueA(idx))))
             }
             p = (p + 1)
         }

--- a/gallery/game_engine/scripting/wasm_ui_io.rgr
+++ b/gallery/game_engine/scripting/wasm_ui_io.rgr
@@ -369,6 +369,12 @@ class WasmUiEvgBuilder {
         return "flex-start"
     }
 
+    fn textAlignName:string (v:int) {
+        if (v == 1) { return "center" }
+        if (v == 2) { return "right" }
+        return "left"
+    }
+
     ; Apply the node's contiguous property run to a plain View/Text/Spacer.
     fn applyProps:void (doc:WasmUiDoc i:int el:EVGElement) {
         def fp (doc.nodeFirstProp(i))
@@ -411,6 +417,12 @@ class WasmUiEvgBuilder {
             if (key == 14) {                ; BORDER_RADIUS (px)
                 el.box.borderRadius = (this.pxUnit((doc.propValueA(idx))))
             }
+            if (key == 15) {                ; BORDER_COLOR
+                el.box.borderColor = (doc.colorAt(idx))
+            }
+            if (key == 16) {                ; BORDER_WIDTH (px)
+                el.box.borderWidth = (this.pxUnit((doc.propValueA(idx))))
+            }
             if (key == 20) {                ; FLEX
                 el.flex = (to_double (doc.propValueA(idx)))
             }
@@ -426,6 +438,9 @@ class WasmUiEvgBuilder {
             }
             if (key == 23) {                ; JUSTIFY_CONTENT (main axis)
                 el.justifyContent = (this.alignName((doc.propValueA(idx))))
+            }
+            if (key == 24) {                ; TEXT_ALIGN (0 left,1 center,2 right)
+                el.textAlign = (this.textAlignName((doc.propValueA(idx))))
             }
             p = (p + 1)
         }

--- a/gallery/game_engine/scripting/wasm_ui_io.rgr
+++ b/gallery/game_engine/scripting/wasm_ui_io.rgr
@@ -119,6 +119,26 @@ class WasmUiDoc {
     fn nodeOrder:int (i:int) {
         return (this.u16((this.nBase(i)) + 18))
     }
+    fn nodeFlags:int (i:int) {
+        return (this.u16((this.nBase(i)) + 10))
+    }
+    fn nodeEventMask:int (i:int) {
+        return (this.u32((this.nBase(i)) + 20))
+    }
+
+    ; ---- interactivity helpers (RG_UI_NODEFLAG_* / RG_UI_EVENT_*) ----------
+    fn nodeIsSelectable:boolean (i:int) {
+        return ((bit_and (this.nodeFlags(i)) 1) != 0)
+    }
+    fn nodeIsDisabled:boolean (i:int) {
+        return ((bit_and (this.nodeFlags(i)) 2) != 0)
+    }
+    fn nodeIsDefault:boolean (i:int) {
+        return ((bit_and (this.nodeFlags(i)) 4) != 0)
+    }
+    fn nodeWantsActivate:boolean (i:int) {
+        return ((bit_and (this.nodeEventMask(i)) 1) != 0)
+    }
 
     fn pBase:int (p:int) {
         return (propOffset + (p * 16))
@@ -290,6 +310,9 @@ class WasmUiEvgBuilder {
     fn buildNode:EVGElement (doc:WasmUiDoc i:int) {
         def kind (doc.nodeKind(i))
         def el:EVGElement (this.makeElement(doc i kind))
+        ; stamp the stable RGU1 node id onto the element so the host can map a
+        ; selection cursor / highlight back to it after layout.
+        el.id = (to_string (doc.nodeId(i)))
         def kids:[int] (this.childrenOf(doc i))
         def c 0
         while (c < (array_length kids)) {

--- a/gallery/game_engine/scripting/wasm_ui_io.rgr
+++ b/gallery/game_engine/scripting/wasm_ui_io.rgr
@@ -405,6 +405,9 @@ class WasmUiEvgBuilder {
                 el.paddingLeft = pad
                 el.box.setPadding((this.pxUnit((doc.propValueA(idx)))))
             }
+            if (key == 13) {                ; MARGIN (all sides) - spaces siblings
+                el.box.setMargin((this.pxUnit((doc.propValueA(idx)))))
+            }
             if (key == 14) {                ; BORDER_RADIUS (px)
                 el.box.borderRadius = (this.pxUnit((doc.propValueA(idx))))
             }

--- a/gallery/game_engine/ui/.gitignore
+++ b/gallery/game_engine/ui/.gitignore
@@ -1,0 +1,4 @@
+# Compiled ES6 output (regenerate with the engine:ui:* npm scripts).
+# The .rgr sources are the source of truth.
+*.js
+tests/*.js

--- a/gallery/game_engine/ui/RgUiWriter.rgr
+++ b/gallery/game_engine/ui/RgUiWriter.rgr
@@ -140,6 +140,19 @@ class RgUiWriter {
         this.propI32(14 v)
         return this
     }
+    fn borderColor:RgUiWriter (r:int g:int b:int a:int) {
+        this.propColorBytes(15 r g b a)
+        return this
+    }
+    fn borderWidth:RgUiWriter (v:int) {
+        this.propI32(16 v)
+        return this
+    }
+    fn border:RgUiWriter (wdt:int r:int g:int b:int a:int) {
+        this.propColorBytes(15 r g b a)
+        this.propI32(16 wdt)
+        return this
+    }
     ; RgUiAlign: 0 start, 1 center, 2 end, 3 space-between
     fn alignItems:RgUiWriter (a:int) {
         this.propEnum(22 a)
@@ -149,8 +162,16 @@ class RgUiWriter {
         this.propEnum(23 a)
         return this
     }
+    fn textAlign:RgUiWriter (a:int) {
+        this.propEnum(24 a)
+        return this
+    }
     fn center:RgUiWriter () {
         this.propEnum(22 1)
+        return this
+    }
+    fn textCenter:RgUiWriter () {
+        this.propEnum(24 1)
         return this
     }
 

--- a/gallery/game_engine/ui/RgUiWriter.rgr
+++ b/gallery/game_engine/ui/RgUiWriter.rgr
@@ -130,6 +130,23 @@ class RgUiWriter {
         this.propColorBytes(2 r g b a)
         return this
     }
+    fn radius:RgUiWriter (v:int) {
+        this.propI32(14 v)
+        return this
+    }
+    ; RgUiAlign: 0 start, 1 center, 2 end, 3 space-between
+    fn alignItems:RgUiWriter (a:int) {
+        this.propEnum(22 a)
+        return this
+    }
+    fn justify:RgUiWriter (a:int) {
+        this.propEnum(23 a)
+        return this
+    }
+    fn center:RgUiWriter () {
+        this.propEnum(22 1)
+        return this
+    }
 
     ; ---- fluent interactivity ------------------------------------------------
     fn selectable:RgUiWriter () {

--- a/gallery/game_engine/ui/RgUiWriter.rgr
+++ b/gallery/game_engine/ui/RgUiWriter.rgr
@@ -94,9 +94,11 @@ class RgUiWriter {
     }
 
     ; A TEXT node (text -> font-size -> color), matching the reader's key order.
-    fn label:void (id:int parent:int order:int s:string color:int fontSize:int) {
+    ; Returns the writer so visual attrs (margin, …) can chain like button().
+    fn label:RgUiWriter (id:int parent:int order:int s:string color:int fontSize:int) {
         this.node(id parent 2 order)
         this.addTextProps(s color fontSize)
+        return this
     }
 
     fn addTextProps:void (s:string color:int fontSize:int) {
@@ -128,6 +130,10 @@ class RgUiWriter {
     }
     fn bg:RgUiWriter (r:int g:int b:int a:int) {
         this.propColorBytes(2 r g b a)
+        return this
+    }
+    fn margin:RgUiWriter (v:int) {
+        this.propI32(13 v)
         return this
     }
     fn radius:RgUiWriter (v:int) {

--- a/gallery/game_engine/ui/RgUiWriter.rgr
+++ b/gallery/game_engine/ui/RgUiWriter.rgr
@@ -1,0 +1,294 @@
+; ==============================================================================
+; RgUiWriter - author an RGU1 UI document (bytes) on the host, in Ranger.
+; ==============================================================================
+;
+; The RGU1 bridge (wasm/wasm_ui_abi.h) is normally guest->host: an AssemblyScript
+; / Rust WASM guest builds the byte block and the host reads it. This writer
+; emits the SAME bytes from Ranger, which is useful for:
+;   * testing the whole host path (reader -> EVG tree -> selection) WITHOUT a
+;     WASM runtime (the es6 dev build has no wasm),
+;   * host-authored / fallback UI when there is no guest,
+;   * documenting the exact byte format next to the reader.
+;
+; It mirrors the AS `Ui` builder (as_autopeli/assembly/ui.ts): fluent
+; view/label/button openers + selectable()/onActivate(). `emit()` returns a
+; byte array that `WasmUiDoc.loadBytes(...)` parses.
+; ==============================================================================
+
+class RgNode {
+    def id:int 0
+    def parent:int 0
+    def kind:int 1
+    def flags:int 0
+    def firstProp:int 0
+    def propCount:int 0
+    def order:int 0
+    def eventMask:int 0
+}
+
+class RgProp {
+    def key:int 0
+    def ptype:int 1
+    ; up to 4 explicit value bytes for colors; otherwise valueA/valueB ints.
+    def valueA:int 0
+    def valueB:int 0
+    def isColor:boolean false
+    def cr:int 0
+    def cg:int 0
+    def cb:int 0
+    def ca:int 0
+}
+
+class RgUiWriter {
+    def nodes:[RgNode]
+    def props:[RgProp]
+    def strBytes:[int]
+    def rootId:int 0
+    def cur:RgNode (new RgNode)
+    def hasCur:boolean false
+
+    ; property type constants
+    def T_I32:int 1
+    def T_COLOR:int 3
+    def T_STRING:int 4
+    def T_ENUM:int 7
+
+    Constructor () {
+    }
+
+    fn reset:void () {
+        clear nodes
+        clear props
+        clear strBytes
+        rootId = 0
+        hasCur = false
+    }
+
+    ; ---- nodes ---------------------------------------------------------------
+    fn node:RgNode (id:int parent:int kind:int order:int) {
+        def n:RgNode (new RgNode)
+        n.id = id
+        n.parent = parent
+        n.kind = kind
+        n.order = order
+        n.firstProp = (array_length props)
+        n.propCount = 0
+        if ((array_length nodes) == 0) {
+            rootId = id
+        }
+        push nodes n
+        cur = n
+        hasCur = true
+        return n
+    }
+
+    fn view:RgUiWriter (id:int parent:int order:int) {
+        this.node(id parent 1 order)
+        return this
+    }
+
+    fn button:RgUiWriter (id:int parent:int order:int s:string color:int fontSize:int) {
+        this.node(id parent 5 order)
+        this.addTextProps(s color fontSize)
+        return this
+    }
+
+    ; A TEXT node (text -> font-size -> color), matching the reader's key order.
+    fn label:void (id:int parent:int order:int s:string color:int fontSize:int) {
+        this.node(id parent 2 order)
+        this.addTextProps(s color fontSize)
+    }
+
+    fn addTextProps:void (s:string color:int fontSize:int) {
+        this.propStr(1 s)          ; K_TEXT
+        this.propI32(4 fontSize)   ; K_FONT_SIZE
+        this.propColorRGBA(3 color)   ; K_COLOR (0xRRGGBBAA)
+    }
+
+    ; ---- fluent props on the current node ------------------------------------
+    fn row:RgUiWriter () {
+        this.propEnum(21 0)
+        return this
+    }
+    fn column:RgUiWriter () {
+        this.propEnum(21 1)
+        return this
+    }
+    fn padding:RgUiWriter (v:int) {
+        this.propI32(12 v)
+        return this
+    }
+    fn width:RgUiWriter (v:int) {
+        this.propI32(10 v)
+        return this
+    }
+    fn height:RgUiWriter (v:int) {
+        this.propI32(11 v)
+        return this
+    }
+    fn bg:RgUiWriter (r:int g:int b:int a:int) {
+        this.propColorBytes(2 r g b a)
+        return this
+    }
+
+    ; ---- fluent interactivity ------------------------------------------------
+    fn selectable:RgUiWriter () {
+        if hasCur { cur.flags = (bit_or cur.flags 1) }
+        return this
+    }
+    fn defaultSelected:RgUiWriter () {
+        if hasCur { cur.flags = (bit_or cur.flags 4) }
+        return this
+    }
+    fn disabled:RgUiWriter () {
+        if hasCur { cur.flags = (bit_or cur.flags 2) }
+        return this
+    }
+    fn onActivate:RgUiWriter () {
+        if hasCur {
+            cur.flags = (bit_or cur.flags 1)
+            cur.eventMask = (bit_or cur.eventMask 1)
+        }
+        return this
+    }
+
+    ; ---- low-level prop appenders --------------------------------------------
+    fn beginProp:RgProp (key:int ptype:int) {
+        def p:RgProp (new RgProp)
+        p.key = key
+        p.ptype = ptype
+        push props p
+        if hasCur {
+            cur.propCount = (cur.propCount + 1)
+        }
+        return p
+    }
+    fn propI32:void (key:int v:int) {
+        def p (this.beginProp(key T_I32))
+        p.valueA = v
+    }
+    fn propEnum:void (key:int v:int) {
+        def p (this.beginProp(key T_ENUM))
+        p.valueA = v
+    }
+    fn propColorRGBA:void (key:int rgba:int) {
+        ; rgba is 0xRRGGBBAA packed as an int; split into bytes.
+        def r (bit_and (bit_shr rgba 24) 255)
+        def g (bit_and (bit_shr rgba 16) 255)
+        def b (bit_and (bit_shr rgba 8) 255)
+        def a (bit_and rgba 255)
+        this.propColorBytes(key r g b a)
+    }
+    fn propColorBytes:void (key:int r:int g:int b:int a:int) {
+        def p (this.beginProp(key T_COLOR))
+        p.isColor = true
+        p.cr = r
+        p.cg = g
+        p.cb = b
+        p.ca = a
+    }
+    fn propStr:void (key:int s:string) {
+        def p (this.beginProp(key T_STRING))
+        def off (array_length strBytes)
+        def i 0
+        def n (strlen s)
+        while (i < n) {
+            push strBytes (charAt s i)
+            i = (i + 1)
+        }
+        p.valueA = off
+        p.valueB = n
+    }
+
+    ; ---- emit flat RGU1 bytes ------------------------------------------------
+    fn setU8:void (arr:[int] off:int v:int) {
+        set arr off (bit_and v 255)
+    }
+    fn setU16:void (arr:[int] off:int v:int) {
+        this.setU8(arr off (bit_and v 255))
+        this.setU8(arr (off + 1) (bit_and (bit_shr v 8) 255))
+    }
+    fn setU32:void (arr:[int] off:int v:int) {
+        this.setU8(arr off (bit_and v 255))
+        this.setU8(arr (off + 1) (bit_and (bit_shr v 8) 255))
+        this.setU8(arr (off + 2) (bit_and (bit_shr v 16) 255))
+        this.setU8(arr (off + 3) (bit_and (bit_shr v 24) 255))
+    }
+
+    fn emit:[int] () {
+        def nodeCount (array_length nodes)
+        def propCount (array_length props)
+        def stringSize (array_length strBytes)
+        def nodeOffset 64
+        def propOffset (nodeOffset + (nodeCount * 32))
+        def stringOffset (propOffset + (propCount * 16))
+        def total (stringOffset + stringSize)
+
+        def out:[int]
+        def z 0
+        while (z < total) {
+            push out 0
+            z = (z + 1)
+        }
+
+        ; header
+        this.setU32(out 0 827672402)      ; magic 'RGU1' (0x31554752)
+        this.setU16(out 4 1)              ; major
+        this.setU16(out 6 0)              ; minor
+        this.setU32(out 8 1)              ; revision
+        this.setU32(out 12 rootId)
+        this.setU32(out 16 nodeOffset)
+        this.setU32(out 20 nodeCount)
+        this.setU32(out 24 propOffset)
+        this.setU32(out 28 propCount)
+        this.setU32(out 32 stringOffset)
+        this.setU32(out 36 stringSize)
+        this.setU32(out 40 1)             ; FLAG_VALID
+
+        ; nodes
+        def i 0
+        while (i < nodeCount) {
+            def n:RgNode (itemAt nodes i)
+            def b (nodeOffset + (i * 32))
+            this.setU32(out b n.id)
+            this.setU32(out (b + 4) n.parent)
+            this.setU16(out (b + 8) n.kind)
+            this.setU16(out (b + 10) n.flags)
+            this.setU32(out (b + 12) n.firstProp)
+            this.setU16(out (b + 16) n.propCount)
+            this.setU16(out (b + 18) n.order)
+            this.setU32(out (b + 20) n.eventMask)
+            i = (i + 1)
+        }
+
+        ; props
+        def p 0
+        while (p < propCount) {
+            def pr:RgProp (itemAt props p)
+            def pb (propOffset + (p * 16))
+            this.setU16(out pb pr.key)
+            this.setU8(out (pb + 2) pr.ptype)
+            this.setU8(out (pb + 3) 0)
+            if pr.isColor {
+                ; value_a bytes = [A,B,G,R] (little-endian of 0xRRGGBBAA)
+                this.setU8(out (pb + 4) pr.ca)
+                this.setU8(out (pb + 5) pr.cb)
+                this.setU8(out (pb + 6) pr.cg)
+                this.setU8(out (pb + 7) pr.cr)
+            } {
+                this.setU32(out (pb + 4) pr.valueA)
+                this.setU32(out (pb + 8) pr.valueB)
+            }
+            p = (p + 1)
+        }
+
+        ; string table
+        def s 0
+        while (s < stringSize) {
+            this.setU8(out (stringOffset + s) (itemAt strBytes s))
+            s = (s + 1)
+        }
+
+        return out
+    }
+}

--- a/gallery/game_engine/ui/UIContext.rgr
+++ b/gallery/game_engine/ui/UIContext.rgr
@@ -212,6 +212,49 @@ class UIContext {
         }
     }
 
+    ; Rounded ring with explicit RGBA (the alpha-parameterised core of a glow).
+    fn strokeRoundRectA:void (x:int y:int rw:int rh:int rad:int t:int r:int g:int b:int a:int) {
+        if (rw <= 0) { return }
+        if (rh <= 0) { return }
+        if (a <= 0) { return }
+        def innerRad (rad - t)
+        if (innerRad < 0) { innerRad = 0 }
+        def ix (x + t)
+        def iy (y + t)
+        def iw (rw - (t * 2))
+        def ih (rh - (t * 2))
+        def yy y
+        def yEnd (y + rh)
+        while (yy < yEnd) {
+            def xx x
+            def xEnd (x + rw)
+            while (xx < xEnd) {
+                if (this.roundedInside(xx yy x y rw rh rad)) {
+                    if ((this.roundedInside(xx yy ix iy iw ih innerRad)) == false) {
+                        this.blendPixel(xx yy r g b a)
+                    }
+                }
+                xx = (xx + 1)
+            }
+            yy = (yy + 1)
+        }
+    }
+
+    ; Soft glow / drop-shadow-style outline: concentric 1px rounded rings growing
+    ; outward from the rect edge, alpha fading with a quadratic falloff. Reads as
+    ; a smooth halo rather than a hard border. `spread` = glow width in px.
+    fn glowRoundRect:void (x:int y:int rw:int rh:int rad:int r:int g:int b:int spread:int maxAlpha:int) {
+        if (spread <= 0) { return }
+        def i 0
+        while (i < spread) {
+            def num (spread - i)
+            ; linear falloff: brightest ring at the edge (i=0), fading outward.
+            def a (to_int ((maxAlpha * num) / spread))
+            this.strokeRoundRectA((x - i) (y - i) (rw + (i * 2)) (rh + (i * 2)) (rad + i) 1 r g b a)
+            i = (i + 1)
+        }
+    }
+
     ; --- text ------------------------------------------------------------------
     fn text:void (s:string x:int y:int size:double col:EVGColor) {
         tr.drawLine(canvas s x y size (col.red()) (col.green()) (col.blue()) (to_int ((col.alpha()) * 255.0)))

--- a/gallery/game_engine/ui/UIContext.rgr
+++ b/gallery/game_engine/ui/UIContext.rgr
@@ -117,6 +117,101 @@ class UIContext {
         this.fillRect((x + rw - t) y t rh col)          ; right
     }
 
+    ; --- rounded rectangles ----------------------------------------------------
+    fn clampi:int (v:int lo:int hi:int) {
+        if (v < lo) { return lo }
+        if (v > hi) { return hi }
+        return v
+    }
+
+    ; True if (px,py) is inside the rounded rect [x,y,w,h] with corner radius rad.
+    ; The clamp-to-inner-rect + radius test also clips to the rect bounds.
+    fn roundedInside:boolean (px:int py:int x:int y:int w:int h:int rad:int) {
+        if (w <= 0) { return false }
+        if (h <= 0) { return false }
+        def r rad
+        def hw (to_int (w / 2))
+        def hh (to_int (h / 2))
+        if (r > hw) { r = hw }
+        if (r > hh) { r = hh }
+        if (r < 0) { r = 0 }
+        if (r == 0) {
+            if (px < x) { return false }
+            if (py < y) { return false }
+            if (px >= (x + w)) { return false }
+            if (py >= (y + h)) { return false }
+            return true
+        }
+        def qx (this.clampi(px (x + r) ((x + w - 1) - r)))
+        def qy (this.clampi(py (y + r) ((y + h - 1) - r)))
+        def dx (px - qx)
+        def dy (py - qy)
+        return (((dx * dx) + (dy * dy)) <= (r * r))
+    }
+
+    fn fillRoundRectA:void (x:int y:int rw:int rh:int rad:int r:int g:int b:int a:int) {
+        if (rw <= 0) { return }
+        if (rh <= 0) { return }
+        if (rad <= 0) {
+            this.fillRectA(x y rw rh r g b a)
+            return
+        }
+        def yy y
+        def yEnd (y + rh)
+        while (yy < yEnd) {
+            def xx x
+            def xEnd (x + rw)
+            while (xx < xEnd) {
+                if (this.roundedInside(xx yy x y rw rh rad)) {
+                    this.blendPixel(xx yy r g b a)
+                }
+                xx = (xx + 1)
+            }
+            yy = (yy + 1)
+        }
+    }
+
+    fn fillRoundRect:void (x:int y:int rw:int rh:int rad:int col:EVGColor) {
+        def a:int (to_int ((col.alpha()) * 255.0))
+        this.fillRoundRectA(x y rw rh rad (col.red()) (col.green()) (col.blue()) a)
+    }
+
+    ; Stroke a rounded outline of `t` px (the ring between the outer rounded rect
+    ; and an inner one inset by t). Composites over existing content.
+    fn strokeRoundRect:void (x:int y:int rw:int rh:int rad:int t:int col:EVGColor) {
+        if (rw <= 0) { return }
+        if (rh <= 0) { return }
+        if (rad <= 0) {
+            this.strokeRect(x y rw rh t col)
+            return
+        }
+        def cr:int (col.red())
+        def cg:int (col.green())
+        def cb:int (col.blue())
+        def ca:int (to_int ((col.alpha()) * 255.0))
+        def innerRad (rad - t)
+        if (innerRad < 0) { innerRad = 0 }
+        def ix (x + t)
+        def iy (y + t)
+        def iw (rw - (t * 2))
+        def ih (rh - (t * 2))
+        def yy y
+        def yEnd (y + rh)
+        while (yy < yEnd) {
+            def xx x
+            def xEnd (x + rw)
+            while (xx < xEnd) {
+                if (this.roundedInside(xx yy x y rw rh rad)) {
+                    if ((this.roundedInside(xx yy ix iy iw ih innerRad)) == false) {
+                        this.blendPixel(xx yy cr cg cb ca)
+                    }
+                }
+                xx = (xx + 1)
+            }
+            yy = (yy + 1)
+        }
+    }
+
     ; --- text ------------------------------------------------------------------
     fn text:void (s:string x:int y:int size:double col:EVGColor) {
         tr.drawLine(canvas s x y size (col.red()) (col.green()) (col.blue()) (to_int ((col.alpha()) * 255.0)))

--- a/gallery/game_engine/ui/UIContext.rgr
+++ b/gallery/game_engine/ui/UIContext.rgr
@@ -1,0 +1,136 @@
+; ==============================================================================
+; UIContext - theme + paint helpers shared by every widget.
+; ==============================================================================
+;
+; Widgets never touch the SoftCanvas directly; they draw through a UIContext,
+; which owns the framebuffer, the text renderer and the colour theme. This keeps
+; alpha-compositing (HUD panels over the game world) and text in one place and
+; makes the widgets pure geometry + state.
+; ==============================================================================
+
+Import "../framebuffer.rgr"
+Import "UITextRenderer.rgr"
+Import "../../evg/EVGColor.rgr"
+
+; Named colour roles. Dark, translucent-panel theme by default (reads well as an
+; overlay on top of a bright game world). Swap fields for a light theme.
+class UITheme {
+    def panelBg:EVGColor    (EVGColor.rgba(20 24 38 0.85))
+    def panelBorder:EVGColor (EVGColor.rgba(90 110 150 0.9))
+    def label:EVGColor      (EVGColor.rgb(226 232 245))
+    def mutedLabel:EVGColor  (EVGColor.rgb(150 165 190))
+
+    def buttonBg:EVGColor    (EVGColor.rgba(46 54 82 0.95))
+    def buttonHover:EVGColor  (EVGColor.rgba(64 76 116 0.95))
+    def buttonPressed:EVGColor (EVGColor.rgba(30 36 58 0.95))
+    def buttonText:EVGColor  (EVGColor.rgb(232 238 250))
+    def buttonBorder:EVGColor (EVGColor.rgba(110 130 175 0.9))
+
+    def inputBg:EVGColor     (EVGColor.rgba(14 17 28 0.95))
+    def inputText:EVGColor   (EVGColor.rgb(236 240 250))
+    def inputBorder:EVGColor  (EVGColor.rgba(80 96 130 0.9))
+    def placeholder:EVGColor  (EVGColor.rgb(110 122 145))
+    def caret:EVGColor       (EVGColor.rgb(120 200 255))
+
+    def boxFill:EVGColor     (EVGColor.rgba(70 120 190 0.9))
+    def boxBorder:EVGColor    (EVGColor.rgba(120 170 230 0.95))
+
+    ; Selection / focus accent used for the "highlight selected element" outline.
+    def accent:EVGColor      (EVGColor.rgb(255 190 70))
+    def focusRing:EVGColor    (EVGColor.rgb(120 200 255))
+
+    def keyBg:EVGColor       (EVGColor.rgba(40 48 72 0.97))
+    def keyText:EVGColor     (EVGColor.rgb(230 236 248))
+
+    Constructor () {
+    }
+}
+
+class UIContext {
+    def canvas:SoftCanvas (new SoftCanvas)
+    def tr:UITextRenderer (new UITextRenderer)
+    def theme:UITheme (new UITheme)
+    def frame:int 0        ; frame counter, drives caret blink etc.
+
+    Constructor () {
+    }
+
+    fn attach:void (c:SoftCanvas) {
+        canvas = c
+    }
+
+    ; --- low-level fills -------------------------------------------------------
+    fn blendPixel:void (x:int y:int r:int g:int b:int a:int) {
+        if (a <= 0) { return }
+        def cw:int (canvas.getWidth())
+        def ch:int (canvas.getHeight())
+        if (x < 0) { return }
+        if (y < 0) { return }
+        if (x >= cw) { return }
+        if (y >= ch) { return }
+        if (a >= 255) {
+            canvas.setPixel(x y r g b)
+            return
+        }
+        def oldR:int (canvas.pixelR(x y))
+        def oldG:int (canvas.pixelG(x y))
+        def oldB:int (canvas.pixelB(x y))
+        def inv (255 - a)
+        def nr (to_int (((r * a) + (oldR * inv)) / 255))
+        def ng (to_int (((g * a) + (oldG * inv)) / 255))
+        def nb (to_int (((b * a) + (oldB * inv)) / 255))
+        canvas.setPixel(x y nr ng nb)
+    }
+
+    fn fillRectA:void (x:int y:int rw:int rh:int r:int g:int b:int a:int) {
+        if (rw <= 0) { return }
+        if (rh <= 0) { return }
+        if (a >= 255) {
+            canvas.fillRect(x y rw rh r g b)
+            return
+        }
+        def yy y
+        def yEnd (y + rh)
+        def xEnd (x + rw)
+        while (yy < yEnd) {
+            def xx x
+            while (xx < xEnd) {
+                this.blendPixel(xx yy r g b a)
+                xx = (xx + 1)
+            }
+            yy = (yy + 1)
+        }
+    }
+
+    fn fillRect:void (x:int y:int rw:int rh:int col:EVGColor) {
+        def a:int (to_int ((col.alpha()) * 255.0))
+        this.fillRectA(x y rw rh (col.red()) (col.green()) (col.blue()) a)
+    }
+
+    ; Stroke an outline of `t` px, inset inside the rect bounds.
+    fn strokeRect:void (x:int y:int rw:int rh:int t:int col:EVGColor) {
+        if (rw <= 0) { return }
+        if (rh <= 0) { return }
+        this.fillRect(x y rw t col)                     ; top
+        this.fillRect(x (y + rh - t) rw t col)          ; bottom
+        this.fillRect(x y t rh col)                     ; left
+        this.fillRect((x + rw - t) y t rh col)          ; right
+    }
+
+    ; --- text ------------------------------------------------------------------
+    fn text:void (s:string x:int y:int size:double col:EVGColor) {
+        tr.drawLine(canvas s x y size (col.red()) (col.green()) (col.blue()) (to_int ((col.alpha()) * 255.0)))
+    }
+
+    fn textWrapped:int (s:string x:int y:int size:double maxWidth:double col:EVGColor) {
+        return (tr.drawText(canvas s x y size maxWidth (col.red()) (col.green()) (col.blue()) (to_int ((col.alpha()) * 255.0))))
+    }
+
+    fn measureWidth:double (s:string size:double) {
+        return (tr.measureWidth(s size))
+    }
+
+    fn lineHeight:double (size:double) {
+        return (tr.lineHeight(size))
+    }
+}

--- a/gallery/game_engine/ui/UIInput.rgr
+++ b/gallery/game_engine/ui/UIInput.rgr
@@ -1,0 +1,136 @@
+; ==============================================================================
+; UIInput - portable pointer + keyboard input snapshot for the EVG UI layer.
+; ==============================================================================
+;
+; This is the ONE data shape the UI layer reads, mirroring how the game engine
+; abstracts a controller with `Buttons` / `PlayerButtons` (see
+; gallery/game_engine/scripting/game_input.rgr). The UI core never touches SDL,
+; a canvas, or `poll_keypress` directly: a thin platform layer fills a UIInput
+; each frame and hands it to `UILayer.update(input)`.
+;
+;   platform (SDL mouse / canvas events / keyboard queue)
+;        |  fills a UIInput each frame
+;        v
+;   UILayer.update(input)   <- pure, portable, unit-testable
+;
+; Because everything above the platform is integer/deterministic, a recorded
+; UIInput stream replays the exact same UI behaviour on every target - the same
+; record/replay debugging the engine already relies on.
+; ==============================================================================
+
+; Special (non-character) keys, tracked as per-frame edges. Kept as an int enum
+; so a platform can OR several together cheaply if it wants.
+class UIKey {
+    sfn none:int ()      { return 0 }
+    sfn backspace:int () { return 1 }
+    sfn enter:int ()     { return 2 }
+    sfn tab:int ()       { return 3 }
+    sfn escape:int ()    { return 4 }
+    sfn left:int ()      { return 5 }
+    sfn right:int ()     { return 6 }
+    sfn up:int ()        { return 7 }
+    sfn down:int ()      { return 8 }
+    sfn del:int ()       { return 9 }
+    sfn home:int ()      { return 10 }
+    sfn end:int ()       { return 11 }
+}
+
+class UIInput {
+    ; --- pointer (mouse / touch / virtual cursor) -----------------------------
+    def pointerX:int 0
+    def pointerY:int 0
+    def pointerDown:boolean false      ; current held state
+    def prevPointerDown:boolean false  ; held state at start of this frame
+    def pointerPressed:boolean false   ; edge: went down this frame
+    def pointerReleased:boolean false  ; edge: went up this frame
+    def scrollDelta:int 0              ; wheel notches this frame (+up / -down)
+
+    ; --- keyboard -------------------------------------------------------------
+    ; Printable characters typed this frame, in order (already de-modified:
+    ; shift/caps applied by the platform). A software keyboard appends here too.
+    def textInput:string ""
+    ; Special keys that fired this frame. Parallel-array queue so several can
+    ; arrive in one frame (e.g. autorepeat backspace).
+    def specialKeys:[int]
+    ; Modifier state (level, not edge) for shortcuts.
+    def shiftDown:boolean false
+    def ctrlDown:boolean false
+
+    Constructor () {
+    }
+
+    ; Call at the very start of each frame, BEFORE the platform writes new input.
+    ; Captures the previous held state and clears all per-frame (edge) data.
+    fn newFrame:void () {
+        prevPointerDown = pointerDown
+        pointerPressed = false
+        pointerReleased = false
+        scrollDelta = 0
+        textInput = ""
+        clear specialKeys
+    }
+
+    ; --- platform writers -----------------------------------------------------
+    fn setPointerPos:void (px:int py:int) {
+        pointerX = px
+        pointerY = py
+    }
+
+    ; Update the held state; derives pressed/released edges vs. this frame's start.
+    fn setPointerDown:void (down:boolean) {
+        if (down && (prevPointerDown == false)) {
+            pointerPressed = true
+        }
+        if ((down == false) && prevPointerDown) {
+            pointerReleased = true
+        }
+        pointerDown = down
+    }
+
+    fn addScroll:void (delta:int) {
+        scrollDelta = (scrollDelta + delta)
+    }
+
+    fn pushText:void (s:string) {
+        textInput = (textInput + s)
+    }
+
+    fn pushChar:void (code:int) {
+        textInput = (textInput + (strfromcode code))
+    }
+
+    fn pushKey:void (key:int) {
+        push specialKeys key
+    }
+
+    fn setModifiers:void (shift:boolean ctrl:boolean) {
+        shiftDown = shift
+        ctrlDown = ctrl
+    }
+
+    ; --- consumer helpers -----------------------------------------------------
+    fn hasText:boolean () {
+        return ((strlen textInput) > 0)
+    }
+
+    fn keyCount:int () {
+        return (array_length specialKeys)
+    }
+
+    fn keyAt:int (i:int) {
+        return (itemAt specialKeys i)
+    }
+
+    ; True if the given special key fired at least once this frame.
+    fn hasKey:boolean (key:int) {
+        def i 0
+        def n (array_length specialKeys)
+        while (i < n) {
+            if ((itemAt specialKeys i) == key) {
+                return true
+            }
+            i = (i + 1)
+        }
+        return false
+    }
+}

--- a/gallery/game_engine/ui/UILayer.rgr
+++ b/gallery/game_engine/ui/UILayer.rgr
@@ -1,0 +1,495 @@
+; ==============================================================================
+; UILayer - the interactive UI/HUD overlay that sits on top of the EVG/game world.
+; ==============================================================================
+;
+; Holds a retained set of widgets, consumes ONE UIInput per frame, and:
+;   * hit-tests the pointer (hover / press / release / click)
+;   * manages focus (text routing), selection (highlight) and dragging
+;   * routes characters from the hardware OR the on-screen software keyboard to
+;     the focused text field
+;   * maps common UI commands: Tab (focus next), Enter (submit), Esc (cancel),
+;     Backspace/Delete (edit or remove selection), arrows (caret or nudge box)
+;   * emits a queue of UIEvents the app reads each frame (retained-mode friendly,
+;     no callbacks across the compile-target boundary)
+;   * renders every widget through a UIContext, drawing the selection highlight
+;     ("highlight selected element") and the software keyboard on top.
+;
+; It never performs I/O: a thin platform layer fills the UIInput (SDL mouse /
+; canvas events / keyboard queue) and blits ctx.canvas.raw() to the display.
+; ==============================================================================
+
+Import "UIWidget.rgr"
+Import "UITextInput.rgr"
+Import "UISoftKeyboard.rgr"
+Import "UIInput.rgr"
+
+class UIEventType {
+    sfn none:int ()        { return 0 }
+    sfn click:int ()       { return 1 }
+    sfn dragStart:int ()   { return 2 }
+    sfn dragMove:int ()    { return 3 }
+    sfn dragEnd:int ()     { return 4 }
+    sfn select:int ()      { return 5 }
+    sfn deselect:int ()    { return 6 }
+    sfn textChanged:int () { return 7 }
+    sfn submit:int ()      { return 8 }
+    sfn focus:int ()       { return 9 }
+}
+
+class UIEvent {
+    def type:int 0
+    def widgetId:string ""
+    def x:int 0
+    def y:int 0
+    def text:string ""
+}
+
+class UILayer {
+    def ctx:UIContext (new UIContext)
+    def widgets:[UIWidget]
+    def events:[UIEvent]
+
+    def focusId:string ""
+    def selectedId:string ""
+    def dragId:string ""
+    def pressId:string ""
+    def hoverId:string ""
+    def dragOffX:int 0
+    def dragOffY:int 0
+    def frame:int 0
+
+    def keyboard:UISoftKeyboard (new UISoftKeyboard)
+    def keyboardVisible:boolean false
+
+    def nudgeStep:int 4
+
+    Constructor () {
+    }
+
+    fn attach:void (c:SoftCanvas) {
+        ctx.attach(c)
+    }
+
+    fn add:void (wgt:UIWidget) {
+        push widgets wgt
+    }
+
+    ; --- lookup ---------------------------------------------------------------
+    fn indexOf:int (id:string) {
+        def i:int 0
+        def n:int (array_length widgets)
+        while (i < n) {
+            def wg:UIWidget (itemAt widgets i)
+            if (wg.id == id) {
+                return i
+            }
+            i = (i + 1)
+        }
+        return (0 - 1)
+    }
+
+    fn hasWidget:boolean (id:string) {
+        return ((this.indexOf(id)) >= 0)
+    }
+
+    fn get:UIWidget (id:string) {
+        def idx:int (this.indexOf(id))
+        if (idx >= 0) {
+            return (itemAt widgets idx)
+        }
+        def dummy:UIWidget (new UIWidget)
+        return dummy
+    }
+
+    ; Topmost visible widget index at (px,py), or -1.
+    fn topWidgetAt:int (px:int py:int) {
+        def i:int ((array_length widgets) - 1)
+        while (i >= 0) {
+            def wg:UIWidget (itemAt widgets i)
+            if (wg.visible) {
+                if (wg.enabled) {
+                    if (wg.contains(px py)) {
+                        return i
+                    }
+                }
+            }
+            i = (i - 1)
+        }
+        return (0 - 1)
+    }
+
+    ; --- keyboard control -----------------------------------------------------
+    fn showKeyboard:void (kx:int ky:int kw:int kh:int) {
+        keyboard.setBounds(kx ky kw kh)
+        keyboard.fontSize = 15.0
+        keyboardVisible = true
+    }
+
+    fn hideKeyboard:void () {
+        keyboardVisible = false
+    }
+
+    ; --- focus / selection ----------------------------------------------------
+    fn setFocus:void (id:string) {
+        def i:int 0
+        def n:int (array_length widgets)
+        while (i < n) {
+            def wg:UIWidget (itemAt widgets i)
+            wg.focused = (wg.id == id)
+            i = (i + 1)
+        }
+        focusId = id
+        ; place caret at end of a freshly focused text field
+        def w2:UIWidget (this.get(id))
+        if (w2.acceptsText()) {
+            w2.moveCaret(100000)
+        }
+    }
+
+    fn clearFocus:void () {
+        def i:int 0
+        def n:int (array_length widgets)
+        while (i < n) {
+            def wg:UIWidget (itemAt widgets i)
+            wg.focused = false
+            i = (i + 1)
+        }
+        focusId = ""
+    }
+
+    fn setSelected:void (id:string) {
+        if (selectedId == id) {
+            return
+        }
+        def i:int 0
+        def n:int (array_length widgets)
+        while (i < n) {
+            def wg:UIWidget (itemAt widgets i)
+            wg.selected = (wg.id == id)
+            i = (i + 1)
+        }
+        selectedId = id
+        this.emit((UIEventType.select()) id 0 0 "")
+    }
+
+    fn clearSelection:void () {
+        if ((strlen selectedId) == 0) {
+            return
+        }
+        def old:string selectedId
+        def i:int 0
+        def n:int (array_length widgets)
+        while (i < n) {
+            def wg:UIWidget (itemAt widgets i)
+            wg.selected = false
+            i = (i + 1)
+        }
+        selectedId = ""
+        this.emit((UIEventType.deselect()) old 0 0 "")
+    }
+
+    ; Focus the next focusable+visible widget after the current focus (wraps).
+    fn focusNext:void () {
+        def n:int (array_length widgets)
+        if (n == 0) { return }
+        def start:int (this.indexOf(focusId))
+        def i:int 1
+        while (i <= n) {
+            def idx:int (start + i)
+            ; wrap
+            while (idx >= n) {
+                idx = (idx - n)
+            }
+            def wg:UIWidget (itemAt widgets idx)
+            if (wg.visible) {
+                if (wg.enabled) {
+                    if (wg.focusable) {
+                        this.setFocus(wg.id)
+                        return
+                    }
+                }
+            }
+            i = (i + 1)
+        }
+    }
+
+    fn removeSelected:void () {
+        if ((strlen selectedId) == 0) { return }
+        def idx:int (this.indexOf(selectedId))
+        if (idx < 0) { return }
+        def gone:UIWidget (array_extract widgets idx)
+        selectedId = ""
+        if (dragId == gone.id) { dragId = "" }
+        if (pressId == gone.id) { pressId = "" }
+        if (focusId == gone.id) { focusId = "" }
+    }
+
+    ; --- events ---------------------------------------------------------------
+    fn emit:void (type:int id:string ex:int ey:int etext:string) {
+        def ev:UIEvent (new UIEvent)
+        ev.type = type
+        ev.widgetId = id
+        ev.x = ex
+        ev.y = ey
+        ev.text = etext
+        push events ev
+    }
+
+    fn eventCount:int () {
+        return (array_length events)
+    }
+
+    fn eventAt:UIEvent (i:int) {
+        return (itemAt events i)
+    }
+
+    ; --- per-frame update -----------------------------------------------------
+    fn update:void (input:UIInput) {
+        frame = (frame + 1)
+        ctx.frame = frame
+        clear events
+
+        def px:int input.pointerX
+        def py:int input.pointerY
+
+        this.updateHover(px py)
+        if input.pointerPressed {
+            this.handlePress(px py)
+        }
+        if input.pointerDown {
+            this.handleDrag(px py)
+        }
+        if input.pointerReleased {
+            this.handleRelease(px py)
+        }
+
+        this.routeText(input)
+        this.handleKeys(input)
+    }
+
+    fn updateHover:void (px:int py:int) {
+        def top:int (this.topWidgetAt(px py))
+        def i:int 0
+        def n:int (array_length widgets)
+        while (i < n) {
+            def wg:UIWidget (itemAt widgets i)
+            wg.hovered = (i == top)
+            i = (i + 1)
+        }
+        if (top >= 0) {
+            def tw:UIWidget (itemAt widgets top)
+            hoverId = tw.id
+        } {
+            hoverId = ""
+        }
+        if keyboardVisible {
+            keyboard.updateHover(px py)
+        }
+    }
+
+    fn handlePress:void (px:int py:int) {
+        ; Software keyboard takes priority when visible.
+        if keyboardVisible {
+            if (keyboard.contains(px py)) {
+                def token:string (keyboard.tokenAt(px py))
+                this.applyKeyboardToken(token)
+                return
+            }
+        }
+        def idx:int (this.topWidgetAt(px py))
+        if (idx < 0) {
+            ; clicked empty space -> cancel selection & text focus
+            this.clearSelection()
+            this.clearFocus()
+            return
+        }
+        def wg:UIWidget (itemAt widgets idx)
+        pressId = wg.id
+        wg.pressed = true
+
+        if (wg.focusable) {
+            this.setFocus(wg.id)
+        } {
+            this.clearFocus()
+        }
+        if (wg.selectable) {
+            this.setSelected(wg.id)
+        } {
+            this.clearSelection()
+        }
+        if (wg.draggable) {
+            dragId = wg.id
+            dragOffX = (px - wg.x)
+            dragOffY = (py - wg.y)
+            this.emit((UIEventType.dragStart()) wg.id wg.x wg.y "")
+        }
+    }
+
+    fn handleDrag:void (px:int py:int) {
+        if ((strlen dragId) == 0) { return }
+        def idx:int (this.indexOf(dragId))
+        if (idx < 0) { return }
+        def wg:UIWidget (itemAt widgets idx)
+        wg.x = (px - dragOffX)
+        wg.y = (py - dragOffY)
+        this.emit((UIEventType.dragMove()) wg.id wg.x wg.y "")
+    }
+
+    fn handleRelease:void (px:int py:int) {
+        if ((strlen pressId) > 0) {
+            def idx:int (this.indexOf(pressId))
+            if (idx >= 0) {
+                def wg:UIWidget (itemAt widgets idx)
+                wg.pressed = false
+                if (wg.contains(px py)) {
+                    wg.onActivate()
+                    this.emit((UIEventType.click()) wg.id px py "")
+                }
+            }
+            pressId = ""
+        }
+        if ((strlen dragId) > 0) {
+            def d:UIWidget (this.get(dragId))
+            this.emit((UIEventType.dragEnd()) dragId d.x d.y "")
+            dragId = ""
+        }
+    }
+
+    fn routeText:void (input:UIInput) {
+        if (input.hasText() == false) { return }
+        if ((strlen focusId) == 0) { return }
+        def wg:UIWidget (this.get(focusId))
+        if (wg.acceptsText()) {
+            wg.insertText(input.textInput)
+            this.emit((UIEventType.textChanged()) wg.id 0 0 wg.text)
+        }
+    }
+
+    fn handleKeys:void (input:UIInput) {
+        def focusEdits:boolean false
+        def wg:UIWidget (this.get(focusId))
+        if ((strlen focusId) > 0) {
+            focusEdits = (wg.acceptsText())
+        }
+
+        if (input.hasKey((UIKey.tab()))) {
+            this.focusNext()
+        }
+        if (input.hasKey((UIKey.escape()))) {
+            this.clearSelection()
+            this.clearFocus()
+            this.hideKeyboard()
+        }
+        if (input.hasKey((UIKey.backspace()))) {
+            if focusEdits {
+                wg.backspace()
+                this.emit((UIEventType.textChanged()) wg.id 0 0 wg.text)
+            }
+        }
+        if (input.hasKey((UIKey.enter()))) {
+            if (focusEdits) {
+                this.emit((UIEventType.submit()) wg.id 0 0 wg.text)
+            }
+        }
+        if (input.hasKey((UIKey.del()))) {
+            if focusEdits {
+                wg.deleteForward()
+                this.emit((UIEventType.textChanged()) wg.id 0 0 wg.text)
+            } {
+                this.removeSelected()
+            }
+        }
+        if (input.hasKey((UIKey.left()))) {
+            if focusEdits {
+                wg.moveCaret((0 - 1))
+            } {
+                this.nudgeSelected((0 - nudgeStep) 0)
+            }
+        }
+        if (input.hasKey((UIKey.right()))) {
+            if focusEdits {
+                wg.moveCaret(1)
+            } {
+                this.nudgeSelected(nudgeStep 0)
+            }
+        }
+        if (input.hasKey((UIKey.up()))) {
+            if (focusEdits == false) {
+                this.nudgeSelected(0 (0 - nudgeStep))
+            }
+        }
+        if (input.hasKey((UIKey.down()))) {
+            if (focusEdits == false) {
+                this.nudgeSelected(0 nudgeStep)
+            }
+        }
+    }
+
+    fn nudgeSelected:void (dx:int dy:int) {
+        if ((strlen selectedId) == 0) { return }
+        def idx:int (this.indexOf(selectedId))
+        if (idx < 0) { return }
+        def wg:UIWidget (itemAt widgets idx)
+        wg.x = (wg.x + dx)
+        wg.y = (wg.y + dy)
+        this.emit((UIEventType.dragMove()) wg.id wg.x wg.y "")
+    }
+
+    ; Route an on-screen keyboard token to the focused text field.
+    fn applyKeyboardToken:void (token:string) {
+        if ((strlen token) == 0) { return }
+        if (token == "Shift") {
+            keyboard.toggleShift()
+            return
+        }
+        def wg:UIWidget (this.get(focusId))
+        def canEdit:boolean false
+        if ((strlen focusId) > 0) {
+            canEdit = (wg.acceptsText())
+        }
+        if (token == "OK") {
+            if canEdit {
+                this.emit((UIEventType.submit()) wg.id 0 0 wg.text)
+            }
+            return
+        }
+        if (token == "back") {
+            if canEdit {
+                wg.backspace()
+                this.emit((UIEventType.textChanged()) wg.id 0 0 wg.text)
+            }
+            return
+        }
+        def ch:string (keyboard.charFor(token))
+        if ((strlen ch) > 0) {
+            if canEdit {
+                wg.insertText(ch)
+                this.emit((UIEventType.textChanged()) wg.id 0 0 wg.text)
+            }
+        }
+    }
+
+    ; --- render ---------------------------------------------------------------
+    ; Draw the whole overlay onto ctx.canvas. Call AFTER the game world has been
+    ; drawn into the same framebuffer, then blit ctx.canvas.raw() to the display.
+    fn render:void () {
+        def i:int 0
+        def n:int (array_length widgets)
+        while (i < n) {
+            def wg:UIWidget (itemAt widgets i)
+            wg.draw(ctx)
+            i = (i + 1)
+        }
+        ; selection highlight ("highlight selected element")
+        if ((strlen selectedId) > 0) {
+            def idx:int (this.indexOf(selectedId))
+            if (idx >= 0) {
+                def sw:UIWidget (itemAt widgets idx)
+                ctx.strokeRect((sw.x - 2) (sw.y - 2) (sw.w + 4) (sw.h + 4) 2 ctx.theme.accent)
+            }
+        }
+        if keyboardVisible {
+            keyboard.draw(ctx)
+        }
+    }
+}

--- a/gallery/game_engine/ui/UISoftKeyboard.rgr
+++ b/gallery/game_engine/ui/UISoftKeyboard.rgr
@@ -1,0 +1,154 @@
+; ==============================================================================
+; UISoftKeyboard - on-screen keyboard for touch / gamepad / mouse text entry.
+; ==============================================================================
+;
+; A grid of keys drawn inside the widget's bounds. It carries NO reference to
+; the UILayer (avoids an import cycle): it just answers "which key token is at
+; this point?" and "what character does that token produce?". UILayer routes the
+; result into the focused text input. Control tokens: Shift, back, OK, space.
+;
+; Usable three ways, all through the same tokenAt():
+;   * pointer/touch  - click a key
+;   * mouse hover     - updateHover() highlights the key under the cursor
+;   * gamepad/keys    - a caller can move a selection cursor over the grid
+; ==============================================================================
+
+Import "UIWidget.rgr"
+
+class UISoftKeyboard {
+    Extends(UIWidget)
+
+    ; Each row is a space-separated list of key tokens.
+    def rows:[string]
+    def shift:boolean false
+    def hoverToken:string ""
+    def pad:int 3
+
+    Constructor () {
+        kind = 5
+        push rows "1 2 3 4 5 6 7 8 9 0"
+        push rows "Q W E R T Y U I O P"
+        push rows "A S D F G H J K L"
+        push rows "Z X C V B N M"
+        push rows "Shift space back OK"
+    }
+
+    fn rowCount:int () {
+        return (array_length rows)
+    }
+
+    fn tokensAt:[string] (r:int) {
+        return (strsplit (itemAt rows r) " ")
+    }
+
+    fn rowHeight:int () {
+        def rc:int (this.rowCount())
+        if (rc < 1) { rc = 1 }
+        return (to_int (h / rc))
+    }
+
+    ; Return the key token at a framebuffer point, or "" if none.
+    fn tokenAt:string (px:int py:int) {
+        if ((this.contains(px py)) == false) {
+            return ""
+        }
+        def rh:int (this.rowHeight())
+        if (rh < 1) { rh = 1 }
+        def r:int (to_int ((py - y) / rh))
+        def rc:int (this.rowCount())
+        if (r < 0) { r = 0 }
+        if (r >= rc) { r = (rc - 1) }
+        def toks:[string] (this.tokensAt(r))
+        def n:int (array_length toks)
+        if (n < 1) { return "" }
+        def c:int (to_int (((px - x) * n) / w))
+        if (c < 0) { c = 0 }
+        if (c >= n) { c = (n - 1) }
+        return (itemAt toks c)
+    }
+
+    fn isControl:boolean (token:string) {
+        if (token == "Shift") { return true }
+        if (token == "back") { return true }
+        if (token == "OK") { return true }
+        return false
+    }
+
+    ; The actual character a printable token produces (case applied), or "" for
+    ; control tokens.
+    fn charFor:string (token:string) {
+        if (token == "space") { return " " }
+        if (this.isControl(token)) { return "" }
+        ; letters/digits: tokens are stored uppercase
+        def code:int (charAt token 0)
+        if ((code >= 65) && (code <= 90)) {
+            if (shift == false) {
+                return (strfromcode (code + 32))   ; lowercase
+            }
+        }
+        return token
+    }
+
+    fn displayLabel:string (token:string) {
+        if (token == "space") { return "Space" }
+        if (token == "back") { return "<-" }
+        if (token == "OK") { return "OK" }
+        if (token == "Shift") {
+            if shift { return "SHIFT" }
+            return "shift"
+        }
+        return (this.charFor(token))
+    }
+
+    fn toggleShift:void () {
+        if shift {
+            shift = false
+        } {
+            shift = true
+        }
+    }
+
+    fn updateHover:void (px:int py:int) {
+        hoverToken = (this.tokenAt(px py))
+    }
+
+    fn draw:void (ctx:UIContext) {
+        if (visible == false) { return }
+        ctx.fillRect(x y w h ctx.theme.panelBg)
+        ctx.strokeRect(x y w h 1 ctx.theme.panelBorder)
+
+        def rh:int (this.rowHeight())
+        def r:int 0
+        def rc:int (this.rowCount())
+        while (r < rc) {
+            def toks:[string] (this.tokensAt(r))
+            def n:int (array_length toks)
+            def ry:int (y + (r * rh))
+            def c:int 0
+            while (c < n) {
+                def kx:int (x + (to_int ((c * w) / n)))
+                def kxNext:int (x + (to_int (((c + 1) * w) / n)))
+                def kw:int (kxNext - kx)
+                def token:string (itemAt toks c)
+                def bg:EVGColor ctx.theme.keyBg
+                if (token == hoverToken) {
+                    bg = ctx.theme.buttonHover
+                }
+                if ((token == "Shift") && shift) {
+                    bg = ctx.theme.accent
+                }
+                ctx.fillRect((kx + pad) (ry + pad) (kw - (pad * 2)) (rh - (pad * 2)) bg)
+                ctx.strokeRect((kx + pad) (ry + pad) (kw - (pad * 2)) (rh - (pad * 2)) 1 ctx.theme.buttonBorder)
+                ; centered label
+                def lbl:string (this.displayLabel(token))
+                def tw:int (to_int (ctx.measureWidth(lbl fontSize)))
+                def lh:int (to_int (ctx.lineHeight(fontSize)))
+                def tx:int (kx + (to_int ((kw - tw) / 2)))
+                def ty:int (ry + (to_int ((rh - lh) / 2)))
+                ctx.text(lbl tx ty fontSize ctx.theme.keyText)
+                c = (c + 1)
+            }
+            r = (r + 1)
+        }
+    }
+}

--- a/gallery/game_engine/ui/UITextInput.rgr
+++ b/gallery/game_engine/ui/UITextInput.rgr
@@ -1,0 +1,107 @@
+; ==============================================================================
+; UITextInput - an editable single-line text field with a caret.
+; ==============================================================================
+;
+; Receives characters from the keyboard OR the on-screen software keyboard (both
+; funnel through UILayer -> focused widget). `text` holds the current value;
+; `caret` is the insertion index. A focused field draws a blinking caret and a
+; focus ring.
+; ==============================================================================
+
+Import "UIWidget.rgr"
+
+class UITextInput {
+    Extends(UIWidget)
+
+    def placeholder:string ""
+    def caret:int 0
+    def padX:int 7
+
+    Constructor () {
+        kind = 4
+        focusable = true
+        selectable = true
+    }
+
+    fn setValue:void (v:string) {
+        text = v
+        caret = (strlen v)
+    }
+
+    fn acceptsText:boolean () {
+        return true
+    }
+
+    fn insertText:void (s:string) {
+        def len:int (strlen text)
+        if (caret < 0) { caret = 0 }
+        if (caret > len) { caret = len }
+        def before:string (substring text 0 caret)
+        def after:string (substring text caret len)
+        text = (before + s + after)
+        caret = (caret + (strlen s))
+    }
+
+    fn backspace:void () {
+        def len:int (strlen text)
+        if (caret <= 0) { return }
+        if (caret > len) { caret = len }
+        def before:string (substring text 0 (caret - 1))
+        def after:string (substring text caret len)
+        text = (before + after)
+        caret = (caret - 1)
+    }
+
+    fn deleteForward:void () {
+        def len:int (strlen text)
+        if (caret >= len) { return }
+        def before:string (substring text 0 caret)
+        def after:string (substring text (caret + 1) len)
+        text = (before + after)
+    }
+
+    fn moveCaret:void (dir:int) {
+        def len:int (strlen text)
+        caret = (caret + dir)
+        if (caret < 0) { caret = 0 }
+        if (caret > len) { caret = len }
+    }
+
+    fn caretToEnd:void () {
+        caret = (strlen text)
+    }
+
+    fn draw:void (ctx:UIContext) {
+        if (visible == false) { return }
+        ctx.fillRect(x y w h ctx.theme.inputBg)
+        def border:EVGColor ctx.theme.inputBorder
+        if focused {
+            border = ctx.theme.focusRing
+        }
+        ctx.strokeRect(x y w h 1 border)
+
+        def lh:int (to_int (ctx.lineHeight(fontSize)))
+        def ty:int (y + (to_int ((h - lh) / 2)))
+        def tx:int (x + padX)
+
+        if ((strlen text) > 0) {
+            ctx.text(text tx ty fontSize ctx.theme.inputText)
+        } {
+            if ((strlen placeholder) > 0) {
+                ctx.text(placeholder tx ty fontSize ctx.theme.placeholder)
+            }
+        }
+
+        ; Caret: blink ~ every 30 frames while focused.
+        if focused {
+            def phase:int (to_int (ctx.frame / 30))
+            def on:int (phase - ((to_int (phase / 2)) * 2))   ; phase % 2
+            if (on == 0) {
+                def pre:string (substring text 0 caret)
+                def cw:int (to_int (ctx.measureWidth(pre fontSize)))
+                def cx:int (tx + cw)
+                ctx.fillRect(cx (ty - 1) 2 (lh + 2) ctx.theme.caret)
+            }
+        }
+    }
+}

--- a/gallery/game_engine/ui/UITextRenderer.rgr
+++ b/gallery/game_engine/ui/UITextRenderer.rgr
@@ -1,0 +1,361 @@
+; ==============================================================================
+; UITextRenderer - accelerated, font-aware text for the EVG UI layer.
+; ==============================================================================
+;
+; Two goals from the request:
+;   1. "font loading so text wraps correctly" - real TrueType metrics via
+;      FontManager + TTFTextMeasurer.wrapText (the same stack pdf_writer uses).
+;   2. "genuinely accelerated rendering" - each distinct rendered line is
+;      rasterized ONCE (TrueType outline -> anti-aliased RGBA) and cached as an
+;      ImageBuffer; subsequent frames just alpha-blit the cached bitmap. Static
+;      labels/buttons therefore cost a memcpy-blit per frame, not a full glyph
+;      rasterization. This is the CPU analogue of a glyph atlas and the natural
+;      hand-off point for the future GPU (WebGL/GLES2) path in RENDERING_EVG.md.
+;
+; If no TTF is loaded it falls back to a compact 3x5 bitmap font (same glyphs as
+; game_hud.rgr) so the UI always renders, even with zero assets - useful for
+; headless tests and a crisp retro look.
+; ==============================================================================
+
+Import "../framebuffer.rgr"
+Import "../../pdf_writer/src/raster/RasterText.rgr"
+Import "../../pdf_writer/src/raster/RasterBuffer.rgr"
+Import "../../pdf_writer/src/fonts/FontManager.rgr"
+Import "../../pdf_writer/src/jpeg/ImageBuffer.rgr"
+Import "../../evg/EVGTextMeasurer.rgr"
+
+; One cached, pre-rasterized line of text (color baked in).
+class UICachedLine {
+    def key:string ""
+    def img:ImageBuffer (new ImageBuffer)
+    def w:int 0
+    def h:int 0
+}
+
+class UITextRenderer {
+    def fm:FontManager (new FontManager)
+    ; Base measurer gives rough estimates until a real font is loaded.
+    def measurer:EVGTextMeasurer (new EVGTextMeasurer)
+    def rt:RasterText (new RasterText)
+    def fontFamily:string "Open Sans"
+    def hasFont:boolean false
+    def defaultSize:double 14.0
+
+    ; Rasterized-line cache (LRU-ish: cleared wholesale when it grows too big).
+    def cache:[UICachedLine]
+    def maxCache:int 512
+    def cacheHits:int 0
+    def cacheMisses:int 0
+
+    Constructor () {
+    }
+
+    ; --- font management ------------------------------------------------------
+    fn addFontDir:void (path:string) {
+        fm.addFontsDirectory(path)
+    }
+
+    ; relativePath is resolved against the registered font dirs, e.g.
+    ; "Open_Sans/OpenSans-Regular.ttf". family is the name you draw with.
+    fn loadFont:boolean (family:string relativePath:string) {
+        def ok:boolean (fm.loadFont(relativePath))
+        if ok {
+            fontFamily = family
+            def ttf:TrueTypeFont (fm.getFont(family))
+            rt.setFont(ttf)
+            def tm:TTFTextMeasurer (new TTFTextMeasurer(fm))
+            measurer = tm
+            hasFont = true
+            this.clearCache()
+        }
+        return ok
+    }
+
+    fn setDefaultSize:void (sz:double) {
+        defaultSize = sz
+    }
+
+    fn clearCache:void () {
+        clear cache
+    }
+
+    ; --- measurement & wrapping ----------------------------------------------
+    fn measureWidth:double (text:string size:double) {
+        if hasFont {
+            return (measurer.measureTextWidth(text fontFamily size))
+        }
+        def step:double (to_double (this.bmCharStep(size)))
+        return ((to_double (strlen text)) * step)
+    }
+
+    fn lineHeight:double (size:double) {
+        if hasFont {
+            return (measurer.getLineHeight(fontFamily size))
+        }
+        return (to_double (this.bmLineStep(size)))
+    }
+
+    ; Greedy word-wrap into lines that fit maxWidth. Uses real TTF metrics when
+    ; a font is loaded, otherwise the bitmap step width.
+    fn wrap:[string] (text:string size:double maxWidth:double) {
+        if hasFont {
+            return (measurer.wrapText(text fontFamily size maxWidth))
+        }
+        return (this.bitmapWrap(text size maxWidth))
+    }
+
+    ; --- drawing --------------------------------------------------------------
+    ; Draw a single (already-wrapped) line, top-left anchored at (x, y).
+    fn drawLine:void (canvas:SoftCanvas text:string x:int y:int size:double r:int g:int b:int a:int) {
+        if ((strlen text) == 0) {
+            return
+        }
+        if (hasFont == false) {
+            def scale:int (this.bmScaleFor(size))
+            this.bitmapDrawLine(canvas x y scale text r g b)
+            return
+        }
+        def line:UICachedLine (this.getCachedLine(text size r g b a))
+        if (line.w > 0) {
+            canvas.blitImage(line.img x y)
+        }
+    }
+
+    ; Draw text, word-wrapped to maxWidth (<= 0 = single line, no wrapping).
+    ; Returns the total height consumed (so callers can stack content).
+    fn drawText:int (canvas:SoftCanvas text:string x:int y:int size:double maxWidth:double r:int g:int b:int a:int) {
+        def lh:int (to_int (this.lineHeight(size)))
+        if (lh < 1) {
+            lh = 1
+        }
+        def lines:[string]
+        if (maxWidth > 0.0) {
+            lines = (this.wrap(text size maxWidth))
+        } {
+            push lines text
+        }
+        def i:int 0
+        def cy:int y
+        def n:int (array_length lines)
+        while (i < n) {
+            def ln:string (itemAt lines i)
+            this.drawLine(canvas ln x cy size r g b a)
+            cy = (cy + lh)
+            i = (i + 1)
+        }
+        return (n * lh)
+    }
+
+    ; --- glyph/line cache -----------------------------------------------------
+    fn cacheKey:string (text:string size:double r:int g:int b:int a:int) {
+        return (text + "|" + (to_string (to_int size)) + "|" + (to_string r) + "," + (to_string g) + "," + (to_string b) + "," + (to_string a))
+    }
+
+    fn findCached:UICachedLine (key:string) {
+        def i:int 0
+        def n:int (array_length cache)
+        while (i < n) {
+            def c:UICachedLine (itemAt cache i)
+            if (c.key == key) {
+                return c
+            }
+            i = (i + 1)
+        }
+        def miss:UICachedLine (new UICachedLine)
+        return miss
+    }
+
+    fn getCachedLine:UICachedLine (text:string size:double r:int g:int b:int a:int) {
+        def key:string (this.cacheKey(text size r g b a))
+        def hit:UICachedLine (this.findCached(key))
+        if ((strlen hit.key) > 0) {
+            cacheHits = (cacheHits + 1)
+            return hit
+        }
+        cacheMisses = (cacheMisses + 1)
+        ; Rasterize once.
+        def wf:double (this.measureWidth(text size))
+        def hf:double (this.lineHeight(size))
+        def bw:int ((to_int (wf + 1.0)) + 2)
+        def bh:int ((to_int (hf + 1.0)) + 2)
+        if (bw < 1) { bw = 1 }
+        if (bh < 1) { bh = 1 }
+        def rb:RasterBuffer (new RasterBuffer)
+        rb.create(bw bh)
+        ; renderText places the baseline at y + ascent; y=0 => text fits [0, lineH].
+        rt.renderText(rb text 0.0 0.0 size r g b a)
+        ; Wrap the rasterized RGBA bytes as an ImageBuffer WITHOUT the white
+        ; pre-blend that RasterBuffer.toImageBuffer() would apply - the UI overlay
+        ; needs the true per-pixel alpha so only the glyph coverage composites.
+        def img:ImageBuffer (new ImageBuffer)
+        img.width = rb.width
+        img.height = rb.height
+        img.pixels = rb.pixels
+        def line:UICachedLine (new UICachedLine)
+        line.key = key
+        line.img = img
+        line.w = bw
+        line.h = bh
+        if ((array_length cache) >= maxCache) {
+            this.clearCache()
+        }
+        push cache line
+        return line
+    }
+
+    ; ==========================================================================
+    ; Bitmap fallback font (compact 3x5). Ported from game_hud.rgr so the UI
+    ; renders with no external assets.
+    ; ==========================================================================
+    fn bmScaleFor:int (fontSize:double) {
+        def scale 2
+        if (fontSize >= 14.0) {
+            scale = 3
+        }
+        return scale
+    }
+
+    fn bmCharStep:int (fontSize:double) {
+        def scale (this.bmScaleFor(fontSize))
+        return (scale * 4)
+    }
+
+    fn bmLineStep:int (fontSize:double) {
+        def scale (this.bmScaleFor(fontSize))
+        return (scale * 6)
+    }
+
+    fn bitmapWrap:[string] (text:string size:double maxWidth:double) {
+        def out:[string]
+        def step:double (to_double (this.bmCharStep(size)))
+        def words:[string] (strsplit text " ")
+        def cur:string ""
+        def i:int 0
+        def n:int (array_length words)
+        while (i < n) {
+            def word:string (itemAt words i)
+            def trial:string word
+            if ((strlen cur) > 0) {
+                trial = (cur + " " + word)
+            }
+            def wpx:double ((to_double (strlen trial)) * step)
+            if ((wpx > maxWidth) && ((strlen cur) > 0)) {
+                push out cur
+                cur = word
+            } {
+                cur = trial
+            }
+            i = (i + 1)
+        }
+        if ((strlen cur) > 0) {
+            push out cur
+        }
+        if ((array_length out) == 0) {
+            push out ""
+        }
+        return out
+    }
+
+    fn bitmapDrawLine:void (canvas:SoftCanvas x:int y:int scale:int text:string r:int g:int b:int) {
+        def step ((scale * 3) + scale)
+        def i 0
+        def len:int (strlen text)
+        def cx x
+        while (i < len) {
+            def ch:string (substring text i (i + 1))
+            this.bitmapGlyph(canvas cx y scale ch r g b)
+            cx = (cx + step)
+            i = (i + 1)
+        }
+    }
+
+    fn bitmapGlyph:void (canvas:SoftCanvas x:int y:int scale:int ch:string r:int g:int b:int) {
+        def bits:string (this.bmGlyphLookup(ch))
+        def row 0
+        while (row < 5) {
+            def col 0
+            while (col < 3) {
+                def idx ((row * 3) + col)
+                def pixel:string (substring bits idx (idx + 1))
+                if (pixel == "1") {
+                    canvas.fillRect((x + (col * scale)) (y + (row * scale)) scale scale r g b)
+                }
+                col = (col + 1)
+            }
+            row = (row + 1)
+        }
+    }
+
+    fn bmGlyphLookup:string (ch:string) {
+        if ((strlen ch) == 0) {
+            return "000000000000000"
+        }
+        def code:int (charAt ch 0)
+        if ((code >= 97) && (code <= 122)) {
+            return (this.bmGlyphBits((strfromcode (code - 32))))
+        }
+        return (this.bmGlyphBits(ch))
+    }
+
+    fn bmGlyphBits:string (ch:string) {
+        if (ch == "0") { return "111101101101111" }
+        if (ch == "1") { return "010110010010111" }
+        if (ch == "2") { return "111001111100111" }
+        if (ch == "3") { return "111001111001111" }
+        if (ch == "4") { return "101101111001001" }
+        if (ch == "5") { return "111100111001111" }
+        if (ch == "6") { return "111100111101111" }
+        if (ch == "7") { return "111001010010010" }
+        if (ch == "8") { return "111101111101111" }
+        if (ch == "9") { return "111101111001111" }
+        if (ch == "A") { return "111101101111101" }
+        if (ch == "B") { return "110101110101110" }
+        if (ch == "C") { return "111100100100111" }
+        if (ch == "D") { return "110101101101110" }
+        if (ch == "E") { return "111100111100111" }
+        if (ch == "F") { return "111100111100100" }
+        if (ch == "G") { return "111100101101111" }
+        if (ch == "H") { return "101101111101101" }
+        if (ch == "I") { return "111010010010111" }
+        if (ch == "J") { return "011110010000100" }
+        if (ch == "K") { return "101101110101101" }
+        if (ch == "L") { return "100100100100111" }
+        if (ch == "M") { return "101111111101101" }
+        if (ch == "N") { return "101110110101101" }
+        if (ch == "O") { return "111101101101111" }
+        if (ch == "P") { return "111101111100100" }
+        if (ch == "Q") { return "111101111001111" }
+        if (ch == "R") { return "111101111101101" }
+        if (ch == "S") { return "111100111001111" }
+        if (ch == "T") { return "111010010010010" }
+        if (ch == "U") { return "101101101101111" }
+        if (ch == "V") { return "101101101010010" }
+        if (ch == "W") { return "101101101101101" }
+        if (ch == "X") { return "101101010101101" }
+        if (ch == "Y") { return "101101010010010" }
+        if (ch == "Z") { return "111001010110111" }
+        if (ch == ":") { return "000010000010000" }
+        if (ch == ".") { return "000000000000010" }
+        if (ch == ",") { return "000000000010100" }
+        if (ch == "-") { return "000000111000000" }
+        if (ch == "_") { return "000000000000111" }
+        if (ch == "/") { return "001001010100100" }
+        if (ch == "!") { return "010010010000010" }
+        if (ch == "?") { return "111001011000010" }
+        if (ch == "(") { return "010100100100010" }
+        if (ch == ")") { return "010001001001010" }
+        if (ch == "[") { return "110100100100110" }
+        if (ch == "]") { return "011001001001011" }
+        if (ch == "+") { return "000010111010000" }
+        if (ch == "=") { return "000111000111000" }
+        if (ch == "<") { return "001010100010001" }
+        if (ch == ">") { return "100010001010100" }
+        if (ch == "*") { return "000101010101000" }
+        if (ch == "'") { return "010010000000000" }
+        if (ch == "\"") { return "101101000000000" }
+        if (ch == "@") { return "111101101100111" }
+        if (ch == "#") { return "101111101111101" }
+        if (ch == " ") { return "000000000000000" }
+        return "000000000000000"
+    }
+}

--- a/gallery/game_engine/ui/UIWidget.rgr
+++ b/gallery/game_engine/ui/UIWidget.rgr
@@ -1,0 +1,173 @@
+; ==============================================================================
+; UIWidget - base widget + Label / Button / Box (draggable square).
+; ==============================================================================
+;
+; Widgets are plain retained-mode objects: geometry (x,y,w,h in framebuffer
+; pixels) + interaction state (hovered/pressed/focused/selected). UILayer owns
+; hit-testing, focus, drag and dispatch; a widget only knows how to draw itself
+; through a UIContext and expose a few virtual hooks (acceptsText, onActivate).
+; This mirrors the engine's retained GameEntity model (one object per element,
+; move/restyle it, never re-parse each frame).
+; ==============================================================================
+
+Import "UIContext.rgr"
+Import "UIInput.rgr"
+
+class UIKind {
+    sfn panel:int ()     { return 0 }
+    sfn label:int ()     { return 1 }
+    sfn button:int ()    { return 2 }
+    sfn box:int ()       { return 3 }
+    sfn textInput:int () { return 4 }
+    sfn keyboard:int ()  { return 5 }
+}
+
+class UIWidget {
+    def id:string ""
+    def kind:int 0
+
+    def x:int 0
+    def y:int 0
+    def w:int 0
+    def h:int 0
+
+    def visible:boolean true
+    def enabled:boolean true
+
+    def focusable:boolean false
+    def draggable:boolean false
+    def selectable:boolean false
+
+    def hovered:boolean false
+    def pressed:boolean false
+    def focused:boolean false
+    def selected:boolean false
+
+    def text:string ""
+    def fontSize:double 14.0
+
+    Constructor () {
+    }
+
+    ; --- geometry -------------------------------------------------------------
+    fn setBounds:void (px:int py:int pw:int ph:int) {
+        x = px
+        y = py
+        w = pw
+        h = ph
+    }
+
+    fn contains:boolean (px:int py:int) {
+        if (visible == false) { return false }
+        if (px < x) { return false }
+        if (py < y) { return false }
+        if (px >= (x + w)) { return false }
+        if (py >= (y + h)) { return false }
+        return true
+    }
+
+    fn centerX:int () { return (x + (to_int (w / 2))) }
+    fn centerY:int () { return (y + (to_int (h / 2))) }
+
+    ; --- virtual interaction hooks (overridden where meaningful) ---------------
+    ; Fires when the widget is clicked (press+release inside). Return an event
+    ; type the layer should emit, or UIEventType.none() for nothing.
+    fn acceptsText:boolean () { return false }
+    fn insertText:void (s:string) { }
+    fn backspace:void () { }
+    fn deleteForward:void () { }
+    fn moveCaret:void (dir:int) { }
+    fn onActivate:void () { }
+
+    ; --- virtual draw ---------------------------------------------------------
+    ; Base widget = translucent panel with a border (a HUD container).
+    fn draw:void (ctx:UIContext) {
+        if (visible == false) { return }
+        ctx.fillRect(x y w h ctx.theme.panelBg)
+        ctx.strokeRect(x y w h 1 ctx.theme.panelBorder)
+    }
+
+    ; Helper: draw `s` centered inside this widget's box.
+    fn drawCenteredText:void (ctx:UIContext s:string size:double col:EVGColor) {
+        def tw:int (to_int (ctx.measureWidth(s size)))
+        def lh:int (to_int (ctx.lineHeight(size)))
+        def tx:int (x + (to_int ((w - tw) / 2)))
+        def ty:int (y + (to_int ((h - lh) / 2)))
+        ctx.text(s tx ty size col)
+    }
+}
+
+; --- Label: text only, no background -----------------------------------------
+class UILabel {
+    Extends(UIWidget)
+
+    Constructor () {
+        kind = 1
+        focusable = false
+    }
+
+    fn draw:void (ctx:UIContext) {
+        if (visible == false) { return }
+        def lh:int (to_int (ctx.lineHeight(fontSize)))
+        def ty:int (y + (to_int ((h - lh) / 2)))
+        if (h == 0) { ty = y }
+        ctx.text(text x ty fontSize ctx.theme.label)
+    }
+}
+
+; --- Button ------------------------------------------------------------------
+class UIButton {
+    Extends(UIWidget)
+
+    Constructor () {
+        kind = 2
+        focusable = true
+    }
+
+    fn draw:void (ctx:UIContext) {
+        if (visible == false) { return }
+        def bg:EVGColor ctx.theme.buttonBg
+        if pressed {
+            bg = ctx.theme.buttonPressed
+        } {
+            if hovered {
+                bg = ctx.theme.buttonHover
+            }
+        }
+        ctx.fillRect(x y w h bg)
+        ctx.strokeRect(x y w h 1 ctx.theme.buttonBorder)
+        this.drawCenteredText(ctx text fontSize ctx.theme.buttonText)
+    }
+}
+
+; --- Box: a draggable square, the building block for an editor canvas --------
+class UIBox {
+    Extends(UIWidget)
+
+    def fillColor:EVGColor (EVGColor.rgba(70 120 190 0.9))
+    def hasCustomFill:boolean false
+
+    Constructor () {
+        kind = 3
+        draggable = true
+        selectable = true
+    }
+
+    fn setFill:void (col:EVGColor) {
+        fillColor = col
+        hasCustomFill = true
+    }
+
+    fn draw:void (ctx:UIContext) {
+        if (visible == false) { return }
+        def fill:EVGColor ctx.theme.boxFill
+        if hasCustomFill {
+            fill = fillColor
+        }
+        ctx.fillRect(x y w h fill)
+        ctx.strokeRect(x y w h 1 ctx.theme.boxBorder)
+        if ((strlen text) > 0) {
+            this.drawCenteredText(ctx text fontSize ctx.theme.label)
+        }
+    }
+}

--- a/gallery/game_engine/ui/UI_LAYER.md
+++ b/gallery/game_engine/ui/UI_LAYER.md
@@ -189,10 +189,22 @@ and reporting the action button back to the guest. This rides the existing
 ```
 
 **ABI additions** (`wasm_ui_abi.h`): node `flags` bits `SELECTABLE` / `DISABLED`
-/ `DEFAULT`, `event_mask` bits `ACTIVATE` / `SELECT` / `DESELECT`, and the
-optional guest export `rg_ui_event(node_id, event, value)`. The AS builder
-(`../wasm/as_autopeli/assembly/ui.ts`) gains fluent `.selectable()`,
-`.onActivate()`, `.defaultSelected()`, `.disabled()` and a `button()` opener.
+/ `DEFAULT`, `event_mask` bits `ACTIVATE` / `SELECT` / `DESELECT`, the property
+key `BORDER_RADIUS`, and the optional guest export
+`rg_ui_event(node_id, event, value)`. The AS builder
+(`../wasm/as_autopeli/assembly/ui.ts`) gains a `button()` opener plus fluent
+`.selectable()`, `.onActivate()`, `.defaultSelected()`, `.disabled()`, and the
+visual setters `.width()`, `.height()`, `.background()`, `.radius()`,
+`.alignItems()`/`.center()`, `.justify()`.
+
+**All styling is guest-declared, host-resolved.** Centring, size, colours and
+corner radius are RGU1 properties the guest sets (e.g. an outer `column().center()`
+root wrapping a `width(280).background(…).radius(16)` card); the host reader maps
+them onto `EVGElement` and **EVGLayout** resolves position/size — the host
+renderer carries no per-menu styling, and the selection highlight's rounding
+follows the selected node's declared `radius`. (Reader note: padding is applied
+to the **box model** `el.box.padding*`, which is what EVGLayout reads — the
+top-level `el.padding*` fields do not affect layout.)
 
 **Host pieces** (`ui/`):
 * `WasmUiSelect.rgr` — `WasmUiRenderer` (EVG tree → SoftCanvas with cached TTF

--- a/gallery/game_engine/ui/UI_LAYER.md
+++ b/gallery/game_engine/ui/UI_LAYER.md
@@ -1,0 +1,178 @@
+# EVG UI Layer — interactive HUD widgets on top of EVG
+
+> An interactive **UI/HUD layer** for the Ranger game engine that sits **on top
+> of the EVG elements**: buttons, text-input boxes, draggable squares (the
+> building blocks of an editor), an on-screen **software keyboard**, common UI
+> commands, and a **"highlight selected element"** outline. Text is rendered
+> with a **loaded TrueType font so it wraps correctly**, through a
+> **glyph/line cache** for genuinely accelerated rendering. SVG paths and
+> clipping are noted as the next step.
+>
+> Follows the engine's core rule (see [`../PLAN_GAME_ENGINE.md`](../PLAN_GAME_ENGINE.md),
+> [`../RENDERING_EVG.md`](../RENDERING_EVG.md)): **UI logic is pure & portable**,
+> all device I/O lives in a thin platform layer.
+
+> Run `npm run engine:ui:demo` to generate the reference screenshots
+> `editor_1_start.png` / `editor_2_edit.png` / `editor_3_keyboard.png` in this
+> folder (PNGs are git-ignored as generated output). `editor_2_edit.png` shows
+> the toolbar, the `Name` field holding *"Player One"*, four boxes with one
+> dragged out and wrapped in the orange selection highlight, and a status bar.
+
+## Why a separate interactive layer
+
+`game_hud.rgr`'s `GameHudBlitter` already composites a **static** JSX/EVG tree
+(labels, panels) onto the `SoftCanvas`. What was missing is **interaction**:
+hit-testing a pointer, focus, dragging, text entry, selection. This layer adds
+exactly that, reusing the same framebuffer + font stack, so a game can build an
+editor / settings screen / level tool without leaving Ranger.
+
+## Architecture — one input shape, one framebuffer
+
+```
+   platform (SDL mouse / canvas events / key queue)   <- the ONLY I/O
+        │  fills a UIInput each frame
+        ▼
+   UILayer.update(input)     ── pure, portable, unit-tested
+        │  hit-test · focus · drag · select · route text · UI commands
+        │  emits a UIEvent queue the app reads
+        ▼
+   UILayer.render()          ── draws every widget through a UIContext
+        │  (game world drawn first, UI composited on top, keyboard on top)
+        ▼
+   ctx.canvas.raw()  →  gfx_present (SDL2) / putImageData (canvas)
+```
+
+`UIInput` is to the pointer/keyboard what `Buttons` / `PlayerButtons`
+(`../scripting/game_input.rgr`) are to the controller: the single data shape the
+logic reads. Because everything above the platform is integer/deterministic, a
+recorded `UIInput` stream **replays the exact same UI behaviour** on every
+target — the same record/replay debugging the engine already relies on.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `UIInput.rgr` | Portable pointer + keyboard snapshot. `pointerX/Y`, `pointerDown` with `pointerPressed`/`pointerReleased` **edges**, scroll, a per-frame `textInput` string, and a `specialKeys` queue (`UIKey`: enter/backspace/tab/esc/arrows/del…). |
+| `UITextRenderer.rgr` | Font loading (`FontManager`) + correct wrapping (`TTFTextMeasurer.wrapText`) + a **rasterized-line cache** for acceleration. Bitmap 3×5 fallback when no TTF is loaded. |
+| `UIContext.rgr` | `UITheme` (colour roles) + paint helpers (alpha fills, stroked rects, text) over the `SoftCanvas`. Widgets draw only through this. |
+| `UIWidget.rgr` | Base widget (geometry, state, hit-test, virtual hooks) + `UILabel`, `UIButton`, `UIBox` (draggable square). |
+| `UITextInput.rgr` | Editable single-line field: caret, insert/backspace/delete-forward, caret movement, focus ring, blinking caret. |
+| `UISoftKeyboard.rgr` | On-screen keyboard grid; answers `tokenAt(x,y)` and `charFor(token)` (case via Shift). No layer dependency (no import cycle). |
+| `UILayer.rgr` | The manager: widget list, hit-testing, focus/selection/drag, text routing, common UI commands, `UIEvent` queue, and `render()`. |
+| `ui_editor_demo.rgr` | A small **editor** built on the layer (toolbar, name field + keyboard, draggable boxes, selection highlight). Reusable `UiEditorApp` + a headless scripted `main` that writes PNG snapshots. |
+| `tests/UITest.rgr` | 29 self-checking unit tests (input edges, hit-test, focus, editing, drag, selection, tab, keyboard, wrapping). |
+
+## Widget catalog
+
+* **UILabel** — text only, no background.
+* **UIButton** — hover/pressed states, centered label, emits a `click` event.
+* **UITextInput** — focusable, editable, caret + focus ring; receives characters
+  from the hardware keyboard **or** the software keyboard.
+* **UIBox** — a draggable, selectable square (optional custom fill). The unit an
+  editor manipulates.
+* **UISoftKeyboard** — QWERTY grid + Shift / Space / ⌫ / OK, drawn on top.
+
+All widgets share the base interface (`contains`, `draw(ctx)`, and the editing
+hooks `acceptsText`/`insertText`/`backspace`/`deleteForward`/`moveCaret`), so the
+layer routes edits polymorphically with **no downcasting**.
+
+## Accelerated, font-aware text
+
+The request's two text goals:
+
+1. **Correct wrapping via a real font.** `UITextRenderer.loadFont(family, path)`
+   loads a `.ttf` through `FontManager`; `wrap()` delegates to
+   `TTFTextMeasurer.wrapText`, which uses true glyph advance widths — the same
+   metric path `pdf_writer` uses. Long text wraps on word boundaries to a max
+   width.
+2. **"Genuinely accelerated rendering."** Each **distinct rendered line**
+   (text + size + colour) is rasterized **once**: TrueType outline →
+   anti-aliased RGBA in a `RasterBuffer`, wrapped as an `ImageBuffer` **sharing
+   the same bytes** (bypassing `RasterBuffer.toImageBuffer()`, which pre-blends
+   white and would destroy the overlay's alpha). Subsequent frames only
+   alpha-blit the cached bitmap. Static labels/buttons therefore cost a
+   memcpy-blit per frame instead of a full glyph rasterization. This is the CPU
+   analogue of a glyph atlas and the natural hand-off point for the future GPU
+   (WebGL/GLES2) path in `../RENDERING_EVG.md §6`.
+
+   As part of this, the hot-path debug `print`s in `RasterText` are now gated
+   behind an off-by-default `debug` flag (they previously fired per glyph — see
+   the note the render doc already carried: *"strip the debug prints"*).
+
+If no font is loaded the renderer falls back to a compact 3×5 bitmap font (same
+glyphs as `game_hud.rgr`), so the UI always draws — handy for headless tests and
+a crisp retro look.
+
+## Common UI commands
+
+Handled in `UILayer.update`, mapped from `UIInput`:
+
+| Command | Trigger |
+|---------|---------|
+| Activate / click | pointer press+release inside a widget |
+| Focus a field | click a focusable widget |
+| Cycle focus | **Tab** |
+| Type / edit | characters, **Backspace**, **Delete**, **←/→** (caret) |
+| Submit | **Enter** (or the keyboard's **OK**) on a focused field |
+| Select element | click a selectable widget (draws the highlight) |
+| Move selection | **←/→/↑/↓** nudge the selected box |
+| Delete selection | **Delete** with no field focused |
+| Cancel | **Esc** (clears selection & focus, hides keyboard) |
+| Drag | press + move on a draggable widget |
+
+The app reads the resulting `UIEvent` queue (`click`, `dragStart/Move/End`,
+`select/deselect`, `textChanged`, `submit`) each frame — a retained-mode,
+callback-free contract that ports cleanly across every compile target.
+
+## Highlight selected element
+
+The selected widget is drawn with a 2 px accent outline (`theme.accent`) outset
+around its bounds, on top of everything except the software keyboard. Focused
+text fields additionally draw a focus ring (see `editor_2_edit.png`).
+
+## Run it
+
+```bash
+npm run engine:ui:test     # compile + run the 29 unit tests -> "ALL PASS"
+npm run engine:ui:demo     # compile + run the editor, writes editor_*.png
+```
+
+`editor_1_start.png`, `editor_2_edit.png`, `editor_3_keyboard.png` are the
+headless snapshots of the demo session (start → edit → keyboard).
+
+## Platform integration (the one real gap: pointer + text I/O)
+
+The engine today is **digital-button + gamepad only** — there is no mouse /
+pointer capture and no character-text channel on the SDL/canvas paths (the SDL
+pump reads `SDL_GetKeyboardState` + gamepads; `poll_keypress` exists but the SDL
+runner doesn't use it). This layer is deliberately built against the abstract
+`UIInput` so it works **today** with any input source (including a virtual
+cursor driven by the existing buttons), and so the platform work is small and
+isolated:
+
+1. **Add a `gfx_mouse_*` operator family** in `compiler/Lang.rgr`, mirroring the
+   `gfx_*` pattern: `gfx_mouse_x`, `gfx_mouse_y`, `gfx_mouse_down`, `gfx_wheel`.
+   * `llvm`/`cpp` → `SDL_GetMouseState` / `SDL_MOUSEWHEEL` in
+     `gfx_sdl.rgr` (extend `rgfx_pump_events`).
+   * `es6` → `mousemove`/`mousedown`/`mouseup`/`wheel` listeners on the canvas.
+2. **Add a character-text channel**: feed SDL `SDL_TEXTINPUT` (and a canvas
+   `keydown`) into a queue like the existing `poll_keypress`, drained into
+   `UIInput.pushText` / `pushKey`.
+3. **Inject a UI step** into `GameSdlRunner.runGameLoop` between `pollGameInput`
+   and `draw`: fill a `UIInput`, call `uiLayer.update(input)`, and call
+   `uiLayer.render()` after the world is drawn (before `gfx_present`).
+
+None of that touches the widget/logic code here.
+
+## Roadmap / next
+
+* **SVG paths** — `EVGElement` already carries `svgPath` and there is a
+  `gallery/evg/SVGPathParser.rgr`; a `UIPath` widget can fill/stroke vector
+  icons once the raster path-fill lands (EVG SPEC §3.4, currently unchecked).
+* **Clipping** — `EVGElement.clipPath` + `overflow: hidden` exist in the model;
+  add a scissor rect to `UIContext` (and later an SVG clip path) so scroll
+  panels and rounded containers clip their children. This pairs naturally with
+  the SVG path work.
+* **GPU** — the line cache is already an atlas-shaped hand-off to the
+  WebGL/GLES2 backend described in `../RENDERING_EVG.md §6`.
+* **More widgets** — checkbox, slider, dropdown, scroll panel (needs clipping).

--- a/gallery/game_engine/ui/UI_LAYER.md
+++ b/gallery/game_engine/ui/UI_LAYER.md
@@ -194,8 +194,11 @@ key `BORDER_RADIUS`, and the optional guest export
 `rg_ui_event(node_id, event, value)`. The AS builder
 (`../wasm/as_autopeli/assembly/ui.ts`) gains a `button()` opener plus fluent
 `.selectable()`, `.onActivate()`, `.defaultSelected()`, `.disabled()`, and the
-visual setters `.width()`, `.height()`, `.background()`, `.radius()`,
-`.alignItems()`/`.center()`, `.justify()`.
+visual setters `.width()`, `.height()`, `.margin()`, `.background()`,
+`.border()`/`.borderColor()`/`.borderWidth()`, `.radius()`,
+`.alignItems()`/`.center()`, `.justify()`, `.textAlign()`/`.textCenter()`.
+The demo menu uses these to declare uniform bordered buttons (width = 50% of the
+guest's screen, centred labels, extra vertical padding).
 
 **All styling is guest-declared, host-resolved.** Centring, size, colours and
 corner radius are RGU1 properties the guest sets (e.g. an outer `column().center()`

--- a/gallery/game_engine/ui/UI_LAYER.md
+++ b/gallery/game_engine/ui/UI_LAYER.md
@@ -201,9 +201,11 @@ visual setters `.width()`, `.height()`, `.background()`, `.radius()`,
 corner radius are RGU1 properties the guest sets (e.g. an outer `column().center()`
 root wrapping a `width(280).background(…).radius(16)` card); the host reader maps
 them onto `EVGElement` and **EVGLayout** resolves position/size — the host
-renderer carries no per-menu styling, and the selection highlight's rounding
-follows the selected node's declared `radius`. (Reader note: padding is applied
-to the **box model** `el.box.padding*`, which is what EVGLayout reads — the
+renderer carries no per-menu styling. The selection highlight is a **soft white
+glow** (feathered concentric rounded rings, `UIContext.glowRoundRect`) whose
+rounding follows the selected node's declared `radius`. Items are spaced with the
+`margin` property. (Reader note: padding/margin are applied to the **box model**
+`el.box.padding*` / `el.box.margin*`, which is what EVGLayout reads — the
 top-level `el.padding*` fields do not affect layout.)
 
 **Host pieces** (`ui/`):

--- a/gallery/game_engine/ui/UI_LAYER.md
+++ b/gallery/game_engine/ui/UI_LAYER.md
@@ -164,6 +164,68 @@ isolated:
 
 None of that touches the widget/logic code here.
 
+## WASM-driven selectable UI (gamepad / keyboard, no pointer)
+
+The widgets above are host-authored and pointer-driven. A second, complementary
+path lets a **WASM guest** (AssemblyScript / Rust) declare the UI and mark which
+elements are selectable, with the host driving **selection by gamepad/keyboard**
+and reporting the action button back to the guest. This rides the existing
+**RGU1** retained-mode bridge (`../wasm/wasm_ui_abi.h`, host reader
+`../scripting/wasm_ui_io.rgr`).
+
+```
+  WASM guest (AS/Rust)                 Host (Ranger)
+  ─────────────────────                ─────────────
+  ui.button(20,…,"New Game")           WasmUiDoc.loadFromWasm() ─┐
+    .onActivate()                      WasmUiEvgBuilder.build()  │ EVG tree
+    .defaultSelected();          ────► WasmUiRenderer (TTF)      │ (el.id = node id)
+  ui.label(90,…,"plays: 0");           UiSelectController         │
+  ui.finish(rev);                        · collect SELECTABLE nodes + rects
+                                         · D-pad moves the cursor (spatial)
+                                         · draw highlight border
+        ▲                                · action button ─────────┐
+        └── rg_ui_event(id, ACTIVATE) ◄───────────────────────────┘
+            guest reacts, bumps revision, rebuilds
+```
+
+**ABI additions** (`wasm_ui_abi.h`): node `flags` bits `SELECTABLE` / `DISABLED`
+/ `DEFAULT`, `event_mask` bits `ACTIVATE` / `SELECT` / `DESELECT`, and the
+optional guest export `rg_ui_event(node_id, event, value)`. The AS builder
+(`../wasm/as_autopeli/assembly/ui.ts`) gains fluent `.selectable()`,
+`.onActivate()`, `.defaultSelected()`, `.disabled()` and a `button()` opener.
+
+**Host pieces** (`ui/`):
+* `WasmUiSelect.rgr` — `WasmUiRenderer` (EVG tree → SoftCanvas with cached TTF
+  text) + `UiSelectController` (collect selectable nodes, D-pad navigation,
+  highlight border, activation). Driven by `UiNavInput` (up/down/left/right/
+  action edges), so it runs on the engine's existing button/gamepad input — **no
+  mouse operator needed**. Selection lives on the host, keyed by stable node id,
+  so it survives document rebuilds.
+* `RgUiWriter.rgr` — authors RGU1 bytes from Ranger (host-side authoring, and the
+  test oracle that lets the whole path run without a WASM engine in the es6 dev
+  build).
+
+**Examples & tests:**
+
+```bash
+npm run engine:ui:wasm-select   # host demo: render + navigate + activate (8 checks)
+                                # writes wasm_select_1_start / _2_nav / _3_activated.png
+npm run engine:ui:wasm-guest    # builds the AS guest .wasm, instantiates it, checks
+                                # the emitted flags + the activation round-trip (10 checks)
+```
+
+The AS guest is `../wasm/as_ui_menu/` (a selectable text menu; activating
+"New Game" bumps a counter the next document shows). `wasm_ui_select_demo.rgr`
+authors the same document on the host, navigates it with a scripted D-pad
+stream, activates the selection, and emulates the guest's `rg_ui_event` rebuild —
+proving reader → EVG tree → layout → selection → highlight → activation.
+
+> Native wiring: on the SDL/native target the host calls `rg_ui_ptr/size/
+> revision` via `wasm_call_i32` to pull the document (the es6 dev build stubs
+> these), and calls the guest's `rg_ui_event` export on activation. The D-pad
+> comes from the engine's existing `PlayerButtons`; map its up/down/left/right/
+> action edges onto `UiNavInput`.
+
 ## Roadmap / next
 
 * **SVG paths** — `EVGElement` already carries `svgPath` and there is a

--- a/gallery/game_engine/ui/WasmUiSelect.rgr
+++ b/gallery/game_engine/ui/WasmUiSelect.rgr
@@ -179,6 +179,13 @@ class UiSelectController {
     def selIndex:int 0
     def borderWidth:int 2
     def highlightPad:int 3       ; how far the border sits outside the node
+    ; soft-glow highlight (white drop-shadow style). Set glowSpread=0 for the
+    ; plain hard border.
+    def glowSpread:int 6
+    def glowAlpha:int 200
+    def glowR:int 255
+    def glowG:int 255
+    def glowB:int 255
 
     ; last activation (node id) or -1; set by update() on the action button
     def lastActivatedId:int 0
@@ -378,10 +385,14 @@ class UiSelectController {
         def bh (hgt + (pad * 2))
         ; radius follows the guest-declared radius of the selected node (+pad)
         def nodeRad (itemAt rrad selIndex)
-        if (nodeRad > 0) {
-            ctx.strokeRoundRect(bx by bw bh (nodeRad + pad) borderWidth ctx.theme.accent)
+        def rad (nodeRad + pad)
+        if (rad < 0) { rad = 0 }
+        if (glowSpread > 0) {
+            ; soft white glow (drop-shadow style): the brightest ring sits on the
+            ; node edge and fades outward into a smooth halo.
+            ctx.glowRoundRect(bx by bw bh rad glowR glowG glowB glowSpread glowAlpha)
         } {
-            ctx.strokeRect(bx by bw bh borderWidth ctx.theme.accent)
+            ctx.strokeRoundRect(bx by bw bh rad borderWidth ctx.theme.accent)
         }
     }
 }

--- a/gallery/game_engine/ui/WasmUiSelect.rgr
+++ b/gallery/game_engine/ui/WasmUiSelect.rgr
@@ -52,6 +52,7 @@ class RectHit {
     def y:int 0
     def w:int 0
     def h:int 0
+    def rad:int 0
 }
 
 ; -----------------------------------------------------------------------------
@@ -60,6 +61,9 @@ class RectHit {
 class WasmUiRenderer {
     def layout:EVGLayout (new EVGLayout)
 
+    ; All presentation (centring, radius, colours, sizes) is declared by the
+    ; guest as RGU1 properties and resolved by EVGLayout here - the host renderer
+    ; carries no per-menu styling of its own.
     fn layoutTree:void (ctx:UIContext root:EVGElement w:int h:int) {
         def fw:double (to_double w)
         def fh:double (to_double h)
@@ -72,7 +76,19 @@ class WasmUiRenderer {
             root.width = (EVGUnit.px(fw))
             root.width.isSet = true
         }
+        if (root.height.isSet == false) {
+            root.height = (EVGUnit.px(fh))
+            root.height.isSet = true
+        }
         layout.layoutElement(root 0.0 0.0 fw fh)
+    }
+
+    ; Resolved border radius (px) declared on the element by the guest, or 0.
+    fn radiusOf:int (el:EVGElement) {
+        if el.box.borderRadius.isSet {
+            return (to_int el.box.borderRadius.pixels)
+        }
+        return 0
     }
 
     fn draw:void (ctx:UIContext root:EVGElement) {
@@ -89,7 +105,8 @@ class WasmUiRenderer {
             def ba:double (el.backgroundColor.alpha())
             if (ba > 0.0) {
                 def ai:int (to_int (ba * 255.0))
-                ctx.fillRectA(x y rw rh (el.backgroundColor.red()) (el.backgroundColor.green()) (el.backgroundColor.blue()) ai)
+                def rad (this.radiusOf(el))
+                ctx.fillRoundRectA(x y rw rh rad (el.backgroundColor.red()) (el.backgroundColor.green()) (el.backgroundColor.blue()) ai)
             }
         }
 
@@ -130,6 +147,7 @@ class WasmUiRenderer {
             hit.y = (to_int el.calculatedY)
             hit.w = (to_int el.calculatedWidth)
             hit.h = (to_int el.calculatedHeight)
+            hit.rad = (this.radiusOf(el))
             return
         }
         def i 0
@@ -155,10 +173,12 @@ class UiSelectController {
     def ry:[int]
     def rw:[int]
     def rh:[int]
+    def rrad:[int]               ; per-node border radius (guest-declared, px)
 
     def selectedId:int 0
     def selIndex:int 0
     def borderWidth:int 2
+    def highlightPad:int 3       ; how far the border sits outside the node
 
     ; last activation (node id) or -1; set by update() on the action button
     def lastActivatedId:int 0
@@ -180,6 +200,7 @@ class UiSelectController {
         clear ry
         clear rw
         clear rh
+        clear rrad
         def defaultId 0
         def i 0
         while (i < doc.nodeCount) {
@@ -195,6 +216,7 @@ class UiSelectController {
                         push ry hit.y
                         push rw hit.w
                         push rh hit.h
+                        push rrad hit.rad
                         if (doc.nodeIsDefault(i)) {
                             if (defaultId == 0) {
                                 defaultId = nid
@@ -349,7 +371,17 @@ class UiSelectController {
         def y (itemAt ry selIndex)
         def wdt (itemAt rw selIndex)
         def hgt (itemAt rh selIndex)
-        def pad 2
-        ctx.strokeRect((x - pad) (y - pad) (wdt + (pad * 2)) (hgt + (pad * 2)) borderWidth ctx.theme.accent)
+        def pad highlightPad
+        def bx (x - pad)
+        def by (y - pad)
+        def bw (wdt + (pad * 2))
+        def bh (hgt + (pad * 2))
+        ; radius follows the guest-declared radius of the selected node (+pad)
+        def nodeRad (itemAt rrad selIndex)
+        if (nodeRad > 0) {
+            ctx.strokeRoundRect(bx by bw bh (nodeRad + pad) borderWidth ctx.theme.accent)
+        } {
+            ctx.strokeRect(bx by bw bh borderWidth ctx.theme.accent)
+        }
     }
 }

--- a/gallery/game_engine/ui/WasmUiSelect.rgr
+++ b/gallery/game_engine/ui/WasmUiSelect.rgr
@@ -1,0 +1,355 @@
+; ==============================================================================
+; WasmUiSelect - render a WASM-authored EVG UI tree + gamepad/keyboard selection.
+; ==============================================================================
+;
+; This is the interactive half of the RGU1 bridge. A WASM (AssemblyScript/Rust)
+; guest builds a flat UI document; the host reads it into an EVGElement tree
+; (see ../scripting/wasm_ui_io.rgr) where each element carries its stable node
+; id. This file:
+;
+;   * WasmUiRenderer   - lays the tree out (EVGLayout + the loaded TTF measurer)
+;                        and draws backgrounds + text onto a SoftCanvas via a
+;                        UIContext (crisp, cached TrueType text).
+;   * UiSelectController- reads which nodes the guest tagged SELECTABLE, tracks a
+;                        selection cursor over them, moves it with the D-pad /
+;                        arrow keys (spatial: nearest selectable node in the
+;                        pressed direction), draws a highlight border around the
+;                        selected node, and reports the action button as an
+;                        activation the host forwards to the guest (rg_ui_event).
+;
+; Pointer-free by design: the whole thing is driven by directional + action
+; button edges (UiNavInput), so it works on a gamepad or keyboard with the
+; engine's existing input - no mouse operator required.
+; ==============================================================================
+
+Import "UIContext.rgr"
+Import "../scripting/wasm_ui_io.rgr"
+Import "../../evg/EVGLayout.rgr"
+Import "../../evg/EVGElement.rgr"
+
+; Directional + action edges for one frame (pressed-this-frame booleans). A
+; platform maps PlayerButtons / keyboard edges onto this - see UI_LAYER.md.
+class UiNavInput {
+    def up:boolean false
+    def down:boolean false
+    def left:boolean false
+    def right:boolean false
+    def action:boolean false
+
+    fn clear:void () {
+        up = false
+        down = false
+        left = false
+        right = false
+        action = false
+    }
+}
+
+; Result of locating a node's laid-out rectangle in the tree.
+class RectHit {
+    def found:boolean false
+    def x:int 0
+    def y:int 0
+    def w:int 0
+    def h:int 0
+}
+
+; -----------------------------------------------------------------------------
+; Renderer: EVGElement tree -> SoftCanvas (via UIContext / TTF).
+; -----------------------------------------------------------------------------
+class WasmUiRenderer {
+    def layout:EVGLayout (new EVGLayout)
+
+    fn layoutTree:void (ctx:UIContext root:EVGElement w:int h:int) {
+        def fw:double (to_double w)
+        def fh:double (to_double h)
+        layout.setPageSize(fw fh)
+        ; use the same TTF metrics for layout and drawing, so wrapping matches
+        layout.setMeasurer(ctx.tr.measurer)
+        root.calculatedX = 0.0
+        root.calculatedY = 0.0
+        if (root.width.isSet == false) {
+            root.width = (EVGUnit.px(fw))
+            root.width.isSet = true
+        }
+        layout.layoutElement(root 0.0 0.0 fw fh)
+    }
+
+    fn draw:void (ctx:UIContext root:EVGElement) {
+        this.drawElement(ctx root)
+    }
+
+    fn drawElement:void (ctx:UIContext el:EVGElement) {
+        def x:int (to_int el.calculatedX)
+        def y:int (to_int el.calculatedY)
+        def rw:int (to_int el.calculatedWidth)
+        def rh:int (to_int el.calculatedHeight)
+
+        if el.backgroundColor.isSet {
+            def ba:double (el.backgroundColor.alpha())
+            if (ba > 0.0) {
+                def ai:int (to_int (ba * 255.0))
+                ctx.fillRectA(x y rw rh (el.backgroundColor.red()) (el.backgroundColor.green()) (el.backgroundColor.blue()) ai)
+            }
+        }
+
+        def txt:string el.textContent
+        if ((strlen txt) > 0) {
+            def fs:double el.inheritedFontSize
+            if el.fontSize.isSet {
+                fs = el.fontSize.pixels
+            }
+            if (fs <= 0.0) {
+                fs = 14.0
+            }
+            def col:EVGColor (EVGColor.rgba((el.color.red()) (el.color.green()) (el.color.blue()) (el.color.alpha())))
+            ctx.text(txt x y fs col)
+        }
+
+        def i 0
+        def n (array_length el.children)
+        while (i < n) {
+            def child:EVGElement (itemAt el.children i)
+            this.drawElement(ctx child)
+            i = (i + 1)
+        }
+    }
+
+    ; Locate a node's laid-out rectangle by its stamped id (string of node id).
+    fn findRect:RectHit (root:EVGElement id:string) {
+        def hit:RectHit (new RectHit)
+        this.findRectInto(root id hit)
+        return hit
+    }
+
+    fn findRectInto:void (el:EVGElement id:string hit:RectHit) {
+        if hit.found { return }
+        if (el.id == id) {
+            hit.found = true
+            hit.x = (to_int el.calculatedX)
+            hit.y = (to_int el.calculatedY)
+            hit.w = (to_int el.calculatedWidth)
+            hit.h = (to_int el.calculatedHeight)
+            return
+        }
+        def i 0
+        def n (array_length el.children)
+        while (i < n) {
+            def child:EVGElement (itemAt el.children i)
+            this.findRectInto(child id hit)
+            if hit.found { return }
+            i = (i + 1)
+        }
+    }
+}
+
+; -----------------------------------------------------------------------------
+; Selection controller: which nodes are selectable, cursor navigation, highlight.
+; -----------------------------------------------------------------------------
+class UiSelectController {
+    def renderer:WasmUiRenderer (new WasmUiRenderer)
+
+    ; selectable set (parallel arrays), rebuilt from the doc + laid-out tree
+    def ids:[int]
+    def rx:[int]
+    def ry:[int]
+    def rw:[int]
+    def rh:[int]
+
+    def selectedId:int 0
+    def selIndex:int 0
+    def borderWidth:int 2
+
+    ; last activation (node id) or -1; set by update() on the action button
+    def lastActivatedId:int 0
+    def didActivate:boolean false
+
+    Constructor () {
+    }
+
+    fn count:int () {
+        return (array_length ids)
+    }
+
+    ; Rebuild the selectable set after (re)building + laying out the tree.
+    ; Keeps the current selection if that node is still selectable; otherwise
+    ; honours the guest's DEFAULT flag; otherwise selects the first one.
+    fn rebuild:void (doc:WasmUiDoc root:EVGElement) {
+        clear ids
+        clear rx
+        clear ry
+        clear rw
+        clear rh
+        def defaultId 0
+        def i 0
+        while (i < doc.nodeCount) {
+            def sel:boolean (doc.nodeIsSelectable(i))
+            def dis:boolean (doc.nodeIsDisabled(i))
+            if sel {
+                if (dis == false) {
+                    def nid (doc.nodeId(i))
+                    def hit:RectHit (renderer.findRect(root (to_string nid)))
+                    if hit.found {
+                        push ids nid
+                        push rx hit.x
+                        push ry hit.y
+                        push rw hit.w
+                        push rh hit.h
+                        if (doc.nodeIsDefault(i)) {
+                            if (defaultId == 0) {
+                                defaultId = nid
+                            }
+                        }
+                    }
+                }
+            }
+            i = (i + 1)
+        }
+        ; resolve selection
+        def keepIdx (this.indexOfId(selectedId))
+        if (keepIdx >= 0) {
+            selIndex = keepIdx
+            selectedId = (itemAt ids keepIdx)
+            return
+        }
+        if (defaultId != 0) {
+            def di (this.indexOfId(defaultId))
+            if (di >= 0) {
+                selIndex = di
+                selectedId = defaultId
+                return
+            }
+        }
+        if ((array_length ids) > 0) {
+            selIndex = 0
+            selectedId = (itemAt ids 0)
+        } {
+            selIndex = 0
+            selectedId = 0
+        }
+    }
+
+    fn indexOfId:int (id:int) {
+        def i 0
+        def n (array_length ids)
+        while (i < n) {
+            if ((itemAt ids i) == id) {
+                return i
+            }
+            i = (i + 1)
+        }
+        return -1
+    }
+
+    fn iabs:int (v:int) {
+        if (v < 0) { return (0 - v) }
+        return v
+    }
+
+    fn cx:int (i:int) {
+        return ((itemAt rx i) + (to_int ((itemAt rw i) / 2)))
+    }
+    fn cy:int (i:int) {
+        return ((itemAt ry i) + (to_int ((itemAt rh i) / 2)))
+    }
+
+    ; Move the cursor: dir 0=up 1=down 2=left 3=right. Picks the nearest
+    ; selectable node whose centre lies in the pressed direction; if none, wraps
+    ; to the next/previous by list order.
+    fn navigate:void (dir:int) {
+        def n (array_length ids)
+        if (n <= 1) { return }
+        def curIdx selIndex
+        def ccx (this.cx(curIdx))
+        def ccy (this.cy(curIdx))
+
+        def best -1
+        def bestScore 1000000000
+        def i 0
+        while (i < n) {
+            if (i != curIdx) {
+                def ox (this.cx(i))
+                def oy (this.cy(i))
+                def dx (ox - ccx)
+                def dy (oy - ccy)
+                def inDir false
+                def primary 0
+                def secondary 0
+                if (dir == 0) {
+                    if (dy < 0) { inDir = true }
+                    primary = (this.iabs(dy))
+                    secondary = (this.iabs(dx))
+                }
+                if (dir == 1) {
+                    if (dy > 0) { inDir = true }
+                    primary = (this.iabs(dy))
+                    secondary = (this.iabs(dx))
+                }
+                if (dir == 2) {
+                    if (dx < 0) { inDir = true }
+                    primary = (this.iabs(dx))
+                    secondary = (this.iabs(dy))
+                }
+                if (dir == 3) {
+                    if (dx > 0) { inDir = true }
+                    primary = (this.iabs(dx))
+                    secondary = (this.iabs(dy))
+                }
+                if inDir {
+                    def score (primary + (secondary * 3))
+                    if (score < bestScore) {
+                        bestScore = score
+                        best = i
+                    }
+                }
+            }
+            i = (i + 1)
+        }
+
+        if (best >= 0) {
+            selIndex = best
+            selectedId = (itemAt ids best)
+            return
+        }
+        ; no candidate in that direction -> wrap by order along the axis
+        def step 1
+        if (dir == 0) { step = (0 - 1) }
+        if (dir == 2) { step = (0 - 1) }
+        def ni (selIndex + step)
+        while (ni < 0) { ni = (ni + n) }
+        while (ni >= n) { ni = (ni - n) }
+        selIndex = ni
+        selectedId = (itemAt ids ni)
+    }
+
+    ; Consume one frame of nav input. Returns the activated node id, or -1.
+    fn update:int (nav:UiNavInput) {
+        didActivate = false
+        lastActivatedId = -1
+        if nav.up { this.navigate(0) }
+        if nav.down { this.navigate(1) }
+        if nav.left { this.navigate(2) }
+        if nav.right { this.navigate(3) }
+        if nav.action {
+            if ((array_length ids) > 0) {
+                didActivate = true
+                lastActivatedId = selectedId
+                return selectedId
+            }
+        }
+        return -1
+    }
+
+    ; Draw the highlight border around the selected node.
+    fn renderHighlight:void (ctx:UIContext) {
+        if ((array_length ids) == 0) { return }
+        if (selIndex < 0) { return }
+        if (selIndex >= (array_length ids)) { return }
+        def x (itemAt rx selIndex)
+        def y (itemAt ry selIndex)
+        def wdt (itemAt rw selIndex)
+        def hgt (itemAt rh selIndex)
+        def pad 2
+        ctx.strokeRect((x - pad) (y - pad) (wdt + (pad * 2)) (hgt + (pad * 2)) borderWidth ctx.theme.accent)
+    }
+}

--- a/gallery/game_engine/ui/WasmUiSelect.rgr
+++ b/gallery/game_engine/ui/WasmUiSelect.rgr
@@ -101,12 +101,21 @@ class WasmUiRenderer {
         def rw:int (to_int el.calculatedWidth)
         def rh:int (to_int el.calculatedHeight)
 
+        def rad (this.radiusOf(el))
+
         if el.backgroundColor.isSet {
             def ba:double (el.backgroundColor.alpha())
             if (ba > 0.0) {
                 def ai:int (to_int (ba * 255.0))
-                def rad (this.radiusOf(el))
                 ctx.fillRoundRectA(x y rw rh rad (el.backgroundColor.red()) (el.backgroundColor.green()) (el.backgroundColor.blue()) ai)
+            }
+        }
+
+        ; guest-declared border (colour + width), rounded to the element radius
+        def bpx:int (to_int el.box.borderWidthPx)
+        if (bpx > 0) {
+            if el.box.borderColor.isSet {
+                ctx.strokeRoundRectA(x y rw rh rad bpx (el.box.borderColor.red()) (el.box.borderColor.green()) (el.box.borderColor.blue()) (to_int ((el.box.borderColor.alpha()) * 255.0)))
             }
         }
 
@@ -120,7 +129,27 @@ class WasmUiRenderer {
                 fs = 14.0
             }
             def col:EVGColor (EVGColor.rgba((el.color.red()) (el.color.green()) (el.color.blue()) (el.color.alpha())))
-            ctx.text(txt x y fs col)
+            ; place text inside the content box (respect border + padding) and
+            ; honour textAlign so a fixed-width button centres its label.
+            def padL:int (to_int el.box.paddingLeftPx)
+            def padT:int (to_int el.box.paddingTopPx)
+            def padR:int (to_int el.box.paddingRightPx)
+            def padB:int (to_int el.box.paddingBottomPx)
+            def contentX:int (x + bpx + padL)
+            def contentY:int (y + bpx + padT)
+            def contentW:int (rw - (bpx * 2) - padL - padR)
+            def contentH:int (rh - (bpx * 2) - padT - padB)
+            def tw:int (to_int (ctx.measureWidth(txt fs)))
+            def lh:int (to_int (ctx.lineHeight(fs)))
+            def tx:int contentX
+            if (el.textAlign == "center") {
+                tx = (contentX + (to_int ((contentW - tw) / 2)))
+            }
+            if (el.textAlign == "right") {
+                tx = (contentX + (contentW - tw))
+            }
+            def ty:int (contentY + (to_int ((contentH - lh) / 2)))
+            ctx.text(txt tx ty fs col)
         }
 
         def i 0

--- a/gallery/game_engine/ui/tests/UITest.rgr
+++ b/gallery/game_engine/ui/tests/UITest.rgr
@@ -1,0 +1,208 @@
+; ==============================================================================
+; UITest - self-checking unit tests for the EVG UI layer (pure logic).
+; ==============================================================================
+; Compile to ES6 and run under Node; prints per-check PASS/FAIL and a final
+; "ALL PASS" line (grep-able for CI). Covers input edges, hit-testing, focus &
+; text routing, editing, dragging, selection/removal, tab focus, the software
+; keyboard, and TrueType wrapping vs. the bitmap fallback.
+; ==============================================================================
+
+Import "../UILayer.rgr"
+
+class Checker {
+    def passed:int 0
+    def failed:int 0
+
+    fn ok:void (name:string cond:boolean) {
+        if cond {
+            passed = (passed + 1)
+            print ("  PASS " + name)
+        } {
+            failed = (failed + 1)
+            print ("  FAIL " + name)
+        }
+    }
+
+    fn eqStr:void (name:string got:string want:string) {
+        this.ok((name + " (got '" + got + "' want '" + want + "')") (got == want))
+    }
+
+    fn eqInt:void (name:string got:int want:int) {
+        this.ok((name + " (got " + (to_string got) + " want " + (to_string want) + ")") (got == want))
+    }
+}
+
+class UITest {
+    sfn newInput:UIInput () {
+        def i:UIInput (new UIInput)
+        return i
+    }
+
+    ; press+release "click" at a point, two frames.
+    sfn click:void (layer:UILayer input:UIInput px:int py:int) {
+        input.newFrame()
+        input.setPointerPos(px py)
+        input.setPointerDown(true)
+        layer.update(input)
+        input.newFrame()
+        input.setPointerPos(px py)
+        input.setPointerDown(false)
+        layer.update(input)
+    }
+
+    sfn buildLayer:UILayer () {
+        def layer:UILayer (new UILayer)
+        def canvas:SoftCanvas (new SoftCanvas)
+        canvas.init(400 300)
+        layer.attach(canvas)
+        ; font optional for logic; load if available so wrap tests are real
+        layer.ctx.tr.addFontDir("gallery/pdf_writer/assets/fonts")
+        layer.ctx.tr.loadFont("Open Sans" "Open_Sans/OpenSans-Regular.ttf")
+
+        def btn:UIButton (new UIButton)
+        btn.id = "b"
+        btn.text = "Go"
+        btn.setBounds(10 10 80 30)
+        layer.add(btn)
+
+        def name:UITextInput (new UITextInput)
+        name.id = "name"
+        name.setBounds(10 60 300 30)
+        layer.add(name)
+
+        def box:UIBox (new UIBox)
+        box.id = "box"
+        box.setBounds(40 120 50 50)
+        layer.add(box)
+        return layer
+    }
+
+    sfn m@(main):void () {
+        def c:Checker (new Checker)
+        print "== UIInput edges =="
+        def inp:UIInput (new UIInput)
+        inp.newFrame()
+        inp.setPointerDown(true)
+        c.ok("press edge" inp.pointerPressed)
+        c.ok("not released on press" (inp.pointerReleased == false))
+        inp.newFrame()
+        inp.setPointerDown(false)
+        c.ok("release edge" inp.pointerReleased)
+        c.ok("press cleared next frame" (inp.pointerPressed == false))
+
+        print "== hit testing =="
+        def hbtn:UIButton (new UIButton)
+        hbtn.setBounds(10 10 80 30)
+        c.ok("contains inside" (hbtn.contains(20 20)))
+        c.ok("outside right" (hbtn.contains(100 20) == false))
+        c.ok("edge exclusive" (hbtn.contains(90 20) == false))
+
+        print "== focus + text routing =="
+        def layer:UILayer (UITest.buildLayer())
+        UITest.click(layer inp 30 72)
+        c.eqStr("focus is name" layer.focusId "name")
+        inp.newFrame()
+        inp.pushText("Neo")
+        layer.update(inp)
+        def nameW:UIWidget (layer.get("name"))
+        c.eqStr("typed value" nameW.text "Neo")
+
+        print "== editing: backspace + caret + delete =="
+        inp.newFrame()
+        inp.pushKey((UIKey.backspace()))
+        layer.update(inp)
+        def nameW2:UIWidget (layer.get("name"))
+        c.eqStr("after backspace" nameW2.text "Ne")
+        ; move caret home then delete-forward removes 'N'
+        inp.newFrame()
+        inp.pushKey((UIKey.left()))
+        layer.update(inp)
+        inp.newFrame()
+        inp.pushKey((UIKey.left()))
+        layer.update(inp)
+        inp.newFrame()
+        inp.pushKey((UIKey.del()))
+        layer.update(inp)
+        def nameW3:UIWidget (layer.get("name"))
+        c.eqStr("after delete-forward at home" nameW3.text "e")
+
+        print "== dragging a box =="
+        def layer2:UILayer (UITest.buildLayer())
+        ; press on the box, move, release
+        inp.newFrame()
+        inp.setPointerPos(50 130)
+        inp.setPointerDown(true)
+        layer2.update(inp)
+        inp.newFrame()
+        inp.setPointerPos(200 210)
+        inp.setPointerDown(true)
+        layer2.update(inp)
+        inp.newFrame()
+        inp.setPointerPos(200 210)
+        inp.setPointerDown(false)
+        layer2.update(inp)
+        def boxW:UIWidget (layer2.get("box"))
+        ; grabbed at offset (10,10) -> new x = 200-10, y = 210-10
+        c.eqInt("dragged x" boxW.x 190)
+        c.eqInt("dragged y" boxW.y 200)
+        c.eqStr("box selected via press" layer2.selectedId "box")
+
+        print "== selection removal =="
+        def before:int (array_length layer2.widgets)
+        layer2.removeSelected()
+        def after:int (array_length layer2.widgets)
+        c.eqInt("widget removed" after (before - 1))
+        c.eqStr("selection cleared" layer2.selectedId "")
+
+        print "== tab focus cycling =="
+        def layer3:UILayer (UITest.buildLayer())
+        layer3.setFocus("b")
+        inp.newFrame()
+        inp.pushKey((UIKey.tab()))
+        layer3.update(inp)
+        c.eqStr("tab moved focus to name" layer3.focusId "name")
+
+        print "== software keyboard =="
+        def kb:UISoftKeyboard (new UISoftKeyboard)
+        kb.setBounds(0 0 400 100)
+        c.eqStr("charFor A lower (no shift)" (kb.charFor("A")) "a")
+        kb.toggleShift()
+        c.eqStr("charFor A upper (shift)" (kb.charFor("A")) "A")
+        c.eqStr("charFor space" (kb.charFor("space")) " ")
+        c.ok("back is control" (kb.isControl("back")))
+        c.ok("A is not control" (kb.isControl("A") == false))
+        ; tokenAt: row0 is "1..0" across full width -> first cell is '1'
+        c.eqStr("tokenAt top-left" (kb.tokenAt(5 5)) "1")
+
+        print "== keyboard routed into focused field =="
+        def layer4:UILayer (UITest.buildLayer())
+        layer4.showKeyboard(0 200 400 100)
+        UITest.click(layer4 inp 30 72)        ; focus name
+        layer4.applyKeyboardToken("H")
+        layer4.applyKeyboardToken("I")
+        def nameK:UIWidget (layer4.get("name"))
+        c.eqStr("keyboard typed lowercase" nameK.text "hi")
+
+        print "== text wrapping (TrueType metrics) =="
+        def tw:double (layer.ctx.measureWidth("Hello" 16.0))
+        c.ok("measured width positive" (tw > 0.0))
+        def lines:[string] (layer.ctx.tr.wrap("the quick brown fox jumps over the lazy dog" 16.0 120.0))
+        c.ok("wrap produced multiple lines" ((array_length lines) > 1))
+
+        print "== bitmap fallback wrapping (no font) =="
+        def bare:UITextRenderer (new UITextRenderer)
+        c.ok("bitmap: no font loaded" (bare.hasFont == false))
+        def bl:[string] (bare.wrap("aaaa bbbb cccc dddd eeee" 12.0 40.0))
+        c.ok("bitmap wrap produced multiple lines" ((array_length bl) > 1))
+        def bw:double (bare.measureWidth("abc" 12.0))
+        c.ok("bitmap measured width positive" (bw > 0.0))
+
+        print "======================================"
+        print (("RESULT: " + (to_string c.passed) + " passed, ") + ((to_string c.failed) + " failed"))
+        if (c.failed == 0) {
+            print "ALL PASS"
+        } {
+            print "SOME FAILED"
+        }
+    }
+}

--- a/gallery/game_engine/ui/ui_editor_demo.rgr
+++ b/gallery/game_engine/ui/ui_editor_demo.rgr
@@ -1,0 +1,230 @@
+; ==============================================================================
+; ui_editor_demo - a tiny "editor" built on the EVG UI layer.
+; ==============================================================================
+;
+; Demonstrates the whole layer as a HUD overlay: a toolbar of buttons, a name
+; text field with an on-screen keyboard, and a canvas of draggable / selectable
+; boxes with a selection highlight. The `UiEditorApp` class is the reusable part
+; (build scene, feed it a UIInput each frame, render, hand off raw() to the
+; display); `main` drives it headless with a scripted UIInput stream and writes
+; PNG snapshots so the result is inspectable without a window.
+;
+; A real platform (SDL / canvas) would replace `main` with a loop that fills a
+; UIInput from the mouse + keyboard and blits app.raw() each frame - the app
+; code below does not change. See UI_LAYER.md.
+; ==============================================================================
+
+Import "UILayer.rgr"
+Import "../../pdf_writer/src/raster/PNGEncoder.rgr"
+
+class UiEditorApp {
+    def canvas:SoftCanvas (new SoftCanvas)
+    def layer:UILayer (new UILayer)
+    def nextBox:int 1
+    def spawnX:int 40
+    def spawnY:int 120
+    def status:string "ready"
+
+    def W:int 480
+    def H:int 320
+
+    Constructor () {
+    }
+
+    fn init:void (fontDir:string) {
+        canvas.init(W H)
+        layer.attach(canvas)
+        layer.ctx.tr.addFontDir(fontDir)
+        def ok:boolean (layer.ctx.tr.loadFont("Open Sans" "Open_Sans/OpenSans-Regular.ttf"))
+        if (ok == false) {
+            status = "no-font(bitmap fallback)"
+        }
+        this.buildScene()
+    }
+
+    fn buildScene:void () {
+        ; --- toolbar ----------------------------------------------------------
+        def title:UILabel (new UILabel)
+        title.id = "title"
+        title.text = "EVG UI Editor"
+        title.fontSize = 20.0
+        title.setBounds(16 10 300 26)
+        layer.add(title)
+
+        def addBtn:UIButton (new UIButton)
+        addBtn.id = "add"
+        addBtn.text = "Add Box"
+        addBtn.setBounds(16 44 96 30)
+        layer.add(addBtn)
+
+        def delBtn:UIButton (new UIButton)
+        delBtn.id = "del"
+        delBtn.text = "Delete"
+        delBtn.setBounds(120 44 90 30)
+        layer.add(delBtn)
+
+        def kbdBtn:UIButton (new UIButton)
+        kbdBtn.id = "kbd"
+        kbdBtn.text = "Keyboard"
+        kbdBtn.setBounds(218 44 104 30)
+        layer.add(kbdBtn)
+
+        ; --- name field -------------------------------------------------------
+        def nameLbl:UILabel (new UILabel)
+        nameLbl.id = "nameLbl"
+        nameLbl.text = "Name:"
+        nameLbl.fontSize = 14.0
+        nameLbl.setBounds(16 84 60 26)
+        layer.add(nameLbl)
+
+        def name:UITextInput (new UITextInput)
+        name.id = "name"
+        name.placeholder = "Type or tap the keyboard..."
+        name.setBounds(78 82 386 30)
+        layer.add(name)
+
+        ; --- initial boxes ----------------------------------------------------
+        this.addBox()
+        this.addBox()
+    }
+
+    fn addBox:void () {
+        def b:UIBox (new UIBox)
+        b.id = ("box" + (to_string nextBox))
+        b.text = (to_string nextBox)
+        b.fontSize = 16.0
+        b.setBounds(spawnX spawnY 58 58)
+        layer.add(b)
+        spawnX = (spawnX + 74)
+        if (spawnX > (W - 80)) {
+            spawnX = 40
+            spawnY = (spawnY + 74)
+        }
+        nextBox = (nextBox + 1)
+        status = ("added box" + (to_string (nextBox - 1)))
+    }
+
+    ; The app's own event handling - reads the layer's per-frame event queue.
+    fn handleEvents:void () {
+        def i:int 0
+        def n:int (layer.eventCount())
+        while (i < n) {
+            def ev:UIEvent (layer.eventAt(i))
+            if (ev.type == (UIEventType.click())) {
+                if (ev.widgetId == "add") {
+                    this.addBox()
+                }
+                if (ev.widgetId == "del") {
+                    layer.removeSelected()
+                    status = "deleted selection"
+                }
+                if (ev.widgetId == "kbd") {
+                    if layer.keyboardVisible {
+                        layer.hideKeyboard()
+                        status = "keyboard hidden"
+                    } {
+                        layer.showKeyboard(16 244 448 68)
+                        status = "keyboard shown"
+                    }
+                }
+            }
+            if (ev.type == (UIEventType.submit())) {
+                status = ("submitted: " + ev.text)
+            }
+            if (ev.type == (UIEventType.select())) {
+                status = ("selected " + ev.widgetId)
+            }
+            i = (i + 1)
+        }
+    }
+
+    fn update:void (input:UIInput) {
+        layer.update(input)
+        this.handleEvents()
+    }
+
+    fn render:void () {
+        canvas.clear(30 34 52)
+        ; status bar strip
+        layer.ctx.fillRectA(0 (H - 22) W 22 12 15 26 220)
+        layer.ctx.text(("status: " + status) 10 (H - 18) 13.0 layer.ctx.theme.mutedLabel)
+        layer.render()
+    }
+
+    fn raw:buffer () {
+        return (canvas.raw())
+    }
+
+    fn snapshot:void (dir:string file:string) {
+        def rb:RasterBuffer (new RasterBuffer)
+        rb.width = W
+        rb.height = H
+        rb.pixels = (canvas.raw())
+        def png:PNGEncoder (new PNGEncoder)
+        png.encode(rb dir file)
+    }
+}
+
+class UiEditorDemo {
+    ; helper: run one full press+release "click" at (x,y) as two frames
+    sfn click:void (app:UiEditorApp input:UIInput px:int py:int) {
+        input.newFrame()
+        input.setPointerPos(px py)
+        input.setPointerDown(true)
+        app.update(input)
+        input.newFrame()
+        input.setPointerPos(px py)
+        input.setPointerDown(false)
+        app.update(input)
+    }
+
+    sfn m@(main):void () {
+        def app:UiEditorApp (new UiEditorApp)
+        app.init("gallery/pdf_writer/assets/fonts")
+        def input:UIInput (new UIInput)
+
+        ; 1) starting scene
+        app.render()
+        app.snapshot("gallery/game_engine/ui" "editor_1_start.png")
+
+        ; 2) click "Add Box" twice -> 4 boxes total
+        UiEditorDemo.click(app input 64 59)
+        UiEditorDemo.click(app input 64 59)
+
+        ; 3) focus the name field and type a name
+        UiEditorDemo.click(app input 120 97)
+        input.newFrame()
+        input.pushText("Player One")
+        app.update(input)
+
+        ; 4) select a box and drag it
+        UiEditorDemo.click(app input 60 149)
+        input.newFrame()
+        input.setPointerPos(60 149)
+        input.setPointerDown(true)
+        app.update(input)
+        input.newFrame()
+        input.setPointerPos(300 190)
+        input.setPointerDown(true)
+        app.update(input)
+        input.newFrame()
+        input.setPointerPos(300 190)
+        input.setPointerDown(false)
+        app.update(input)
+
+        app.render()
+        app.snapshot("gallery/game_engine/ui" "editor_2_edit.png")
+
+        ; 5) open the software keyboard and tap a couple of keys
+        UiEditorDemo.click(app input 270 59)   ; "Keyboard" button
+        UiEditorDemo.click(app input 120 97)   ; refocus name field
+        app.render()
+        app.snapshot("gallery/game_engine/ui" "editor_3_keyboard.png")
+
+        def nameW:UIWidget (app.layer.get("name"))
+        print ("final name = " + nameW.text)
+        print ("status = " + app.status)
+        print ("widgets = " + (to_string (array_length app.layer.widgets)))
+        print "wrote editor_1_start.png editor_2_edit.png editor_3_keyboard.png"
+    }
+}

--- a/gallery/game_engine/ui/wasm_ui_select_demo.rgr
+++ b/gallery/game_engine/ui/wasm_ui_select_demo.rgr
@@ -1,0 +1,159 @@
+; ==============================================================================
+; wasm_ui_select_demo - WASM-authored selectable menu, navigated by gamepad/keys.
+; ==============================================================================
+;
+; End-to-end host demo of the RGU1 selection bridge, self-checking + PNG dumps.
+;
+; The real native path is: a WASM guest (see ../wasm/as_ui_menu) builds the RGU1
+; document, the host reads it, the player moves a highlight with the D-pad, and
+; the action button is forwarded back to the guest (rg_ui_event) which rebuilds.
+; The es6 dev build has no WASM runtime, so here we author the SAME RGU1 bytes on
+; the host with RgUiWriter (byte-for-byte the guest's format) and emulate the
+; guest's rg_ui_event by re-authoring the document after activation. This
+; exercises the whole host path — reader -> EVG tree -> layout -> selection ->
+; highlight -> activation — without a wasm engine.
+; ==============================================================================
+
+Import "WasmUiSelect.rgr"
+Import "RgUiWriter.rgr"
+Import "../../pdf_writer/src/raster/PNGEncoder.rgr"
+
+class DemoCheck {
+    def passed:int 0
+    def failed:int 0
+    fn ok:void (name:string cond:boolean) {
+        if cond {
+            passed = (passed + 1)
+            print ("  PASS " + name)
+        } {
+            failed = (failed + 1)
+            print ("  FAIL " + name)
+        }
+    }
+}
+
+class WasmUiSelectDemo {
+    ; Author the menu document for a given "plays" count and last-activated id.
+    ; This is exactly what the AS guest's rebuild() emits.
+    sfn buildMenu:[int] (plays:int lastId:int) {
+        def w:RgUiWriter (new RgUiWriter)
+        w.view(1 0 0).column().padding(12).bg(24 28 44 255)
+        w.label(10 1 0 "WASM UI - Main Menu" 4294967295 20)
+        w.button(11 1 1 "New Game" 3505978623 16).onActivate().defaultSelected()
+        w.button(12 1 2 "Continue" 3505978623 16).onActivate()
+        w.button(13 1 3 "Options" 3505978623 16).onActivate()
+        w.button(14 1 4 "Quit" 4285559039 16).onActivate()
+        def status:string ("plays: " + (to_string plays))
+        if (lastId != 0) {
+            status = (status + "   last: #" + (to_string lastId))
+        }
+        w.label(90 1 5 status 2410771663 13)
+        return (w.emit())
+    }
+
+    sfn statusOf:string (doc:WasmUiDoc) {
+        def idx (doc.indexOfId(90))
+        if (idx < 0) { return "" }
+        return (doc.propString((doc.nodeFirstProp(idx))))
+    }
+
+    sfn snap:void (canvas:SoftCanvas file:string) {
+        def rb:RasterBuffer (new RasterBuffer)
+        rb.width = (canvas.getWidth())
+        rb.height = (canvas.getHeight())
+        rb.pixels = (canvas.raw())
+        def png:PNGEncoder (new PNGEncoder)
+        png.encode(rb "gallery/game_engine/ui" file)
+    }
+
+    ; Load a fresh document into the tree + relayout, keeping the controller's
+    ; selection (by stable node id). Mirrors a per-frame host refresh.
+    sfn refresh:EVGElement (ctx:UIContext ctrl:UiSelectController doc:WasmUiDoc) {
+        def builder:WasmUiEvgBuilder (new WasmUiEvgBuilder)
+        def root:EVGElement (builder.build(doc))
+        ctrl.renderer.layoutTree(ctx root 360 280)
+        ctrl.rebuild(doc root)
+        return root
+    }
+
+    sfn drawFrame:void (ctx:UIContext ctrl:UiSelectController root:EVGElement canvas:SoftCanvas file:string) {
+        canvas.clear(24 28 44)
+        ctrl.renderer.draw(ctx root)
+        ctrl.renderHighlight(ctx)
+        WasmUiSelectDemo.snap(canvas file)
+    }
+
+    sfn m@(main):void () {
+        def c:DemoCheck (new DemoCheck)
+
+        def canvas:SoftCanvas (new SoftCanvas)
+        canvas.init(360 280)
+        def ctx:UIContext (new UIContext)
+        ctx.attach(canvas)
+        ctx.tr.addFontDir("gallery/pdf_writer/assets/fonts")
+        ctx.tr.loadFont("Open Sans" "Open_Sans/OpenSans-Regular.ttf")
+
+        def ctrl:UiSelectController (new UiSelectController)
+
+        ; ---- frame 0: initial menu (guest revision 0) ----
+        def doc:WasmUiDoc (new WasmUiDoc)
+        def bytes0:[int] (WasmUiSelectDemo.buildMenu(0 0))
+        doc.loadBytes(bytes0 (array_length bytes0))
+        def root:EVGElement (WasmUiSelectDemo.refresh(ctx ctrl doc))
+        WasmUiSelectDemo.drawFrame(ctx ctrl root canvas "wasm_select_1_start.png")
+
+        c.ok(("selectable count == 4 (got " + (to_string (ctrl.count())) + ")") ((ctrl.count()) == 4))
+        c.ok(("default selection == New Game/11 (got " + (to_string ctrl.selectedId) + ")") (ctrl.selectedId == 11))
+
+        ; ---- navigate down twice with the D-pad ----
+        def nav:UiNavInput (new UiNavInput)
+        nav.clear()
+        nav.down = true
+        ctrl.update(nav)
+        nav.clear()
+        nav.down = true
+        ctrl.update(nav)
+        c.ok(("Down x2 -> Options/13 (got " + (to_string ctrl.selectedId) + ")") (ctrl.selectedId == 13))
+        WasmUiSelectDemo.drawFrame(ctx ctrl root canvas "wasm_select_2_nav.png")
+
+        ; navigate back up to New Game and activate it
+        nav.clear()
+        nav.up = true
+        ctrl.update(nav)
+        nav.clear()
+        nav.up = true
+        ctrl.update(nav)
+        c.ok(("Up x2 -> New Game/11 (got " + (to_string ctrl.selectedId) + ")") (ctrl.selectedId == 11))
+
+        nav.clear()
+        nav.action = true
+        def activated (ctrl.update(nav))
+        c.ok(("action activates 11 (got " + (to_string activated) + ")") (activated == 11))
+
+        ; ---- emulate the guest reacting to rg_ui_event(11, ACTIVATE) ----
+        def wantsAct (doc.nodeWantsActivate((doc.indexOfId(activated))))
+        c.ok("node 11 subscribes ACTIVATE" wantsAct)
+        def plays 0
+        if wantsAct {
+            if (activated == 11) {
+                plays = 1
+            }
+        }
+        def bytes1:[int] (WasmUiSelectDemo.buildMenu(plays activated))
+        doc.loadBytes(bytes1 (array_length bytes1))
+        def root2:EVGElement (WasmUiSelectDemo.refresh(ctx ctrl doc))
+        def st (WasmUiSelectDemo.statusOf(doc))
+        c.ok(("status reflects activation (got '" + st + "')") (st == "plays: 1   last: #11"))
+        c.ok("selection preserved after guest rebuild" (ctrl.selectedId == 11))
+        WasmUiSelectDemo.drawFrame(ctx ctrl root2 canvas "wasm_select_3_activated.png")
+
+        print "======================================"
+        print (("RESULT: " + (to_string c.passed) + " passed, ") + ((to_string c.failed) + " failed"))
+        if (c.failed == 0) {
+            print "ALL PASS"
+        } {
+            print "SOME FAILED"
+        }
+        print "wrote wasm_select_1_start.png wasm_select_2_nav.png wasm_select_3_activated.png"
+    }
+}

--- a/gallery/game_engine/ui/wasm_ui_select_demo.rgr
+++ b/gallery/game_engine/ui/wasm_ui_select_demo.rgr
@@ -43,16 +43,16 @@ class WasmUiSelectDemo {
         ; its items centred too — every visual attribute declared here (in the
         ; guest), rendered by the host EVG.
         w.view(2 1 0).column().center().padding(18).width(280).bg(36 42 64 255).radius(16)
-        w.label(10 2 0 "WASM UI - Main Menu" 4294967295 20)
-        w.button(11 2 1 "New Game" 3505978623 16).onActivate().defaultSelected().radius(8)
-        w.button(12 2 2 "Continue" 3505978623 16).onActivate().radius(8)
-        w.button(13 2 3 "Options" 3505978623 16).onActivate().radius(8)
-        w.button(14 2 4 "Quit" 4285559039 16).onActivate().radius(8)
+        w.label(10 2 0 "WASM UI - Main Menu" 4294967295 20).margin(8)
+        w.button(11 2 1 "New Game" 3505978623 16).onActivate().defaultSelected().radius(8).margin(7)
+        w.button(12 2 2 "Continue" 3505978623 16).onActivate().radius(8).margin(7)
+        w.button(13 2 3 "Options" 3505978623 16).onActivate().radius(8).margin(7)
+        w.button(14 2 4 "Quit" 4285559039 16).onActivate().radius(8).margin(7)
         def status:string ("plays: " + (to_string plays))
         if (lastId != 0) {
             status = (status + "   last: #" + (to_string lastId))
         }
-        w.label(90 2 5 status 2410771663 13)
+        w.label(90 2 5 status 2410771663 13).margin(6)
         return (w.emit())
     }
 

--- a/gallery/game_engine/ui/wasm_ui_select_demo.rgr
+++ b/gallery/game_engine/ui/wasm_ui_select_demo.rgr
@@ -39,9 +39,10 @@ class WasmUiSelectDemo {
         def w:RgUiWriter (new RgUiWriter)
         ; Outer root fills the frame and centres its child horizontally.
         w.view(1 0 0).column().center().padding(22)
-        ; The menu "card": fixed width, padded, rounded, translucent panel — every
-        ; visual attribute declared here (in the guest), rendered by the host EVG.
-        w.view(2 1 0).column().padding(18).width(280).bg(36 42 64 255).radius(16)
+        ; The menu "card": fixed width, padded, rounded, translucent panel, with
+        ; its items centred too — every visual attribute declared here (in the
+        ; guest), rendered by the host EVG.
+        w.view(2 1 0).column().center().padding(18).width(280).bg(36 42 64 255).radius(16)
         w.label(10 2 0 "WASM UI - Main Menu" 4294967295 20)
         w.button(11 2 1 "New Game" 3505978623 16).onActivate().defaultSelected().radius(8)
         w.button(12 2 2 "Continue" 3505978623 16).onActivate().radius(8)

--- a/gallery/game_engine/ui/wasm_ui_select_demo.rgr
+++ b/gallery/game_engine/ui/wasm_ui_select_demo.rgr
@@ -44,15 +44,17 @@ class WasmUiSelectDemo {
         ; guest), rendered by the host EVG.
         w.view(2 1 0).column().center().padding(18).width(280).bg(36 42 64 255).radius(16)
         w.label(10 2 0 "WASM UI - Main Menu" 4294967295 20).margin(8)
-        w.button(11 2 1 "New Game" 3505978623 16).onActivate().defaultSelected().radius(8).margin(7)
-        w.button(12 2 2 "Continue" 3505978623 16).onActivate().radius(8).margin(7)
-        w.button(13 2 3 "Options" 3505978623 16).onActivate().radius(8).margin(7)
-        w.button(14 2 4 "Quit" 4285559039 16).onActivate().radius(8).margin(7)
+        ; Uniform buttons: 180px = 50% of the 360px screen, bordered, extra
+        ; vertical padding, centred label. All declared here in the guest.
+        w.button(11 2 1 "New Game" 3839943679 16).onActivate().defaultSelected().width(180).padding(10).border(2 120 150 210 255).radius(9).textCenter().margin(6)
+        w.button(12 2 2 "Continue" 3839943679 16).onActivate().width(180).padding(10).border(2 120 150 210 255).radius(9).textCenter().margin(6)
+        w.button(13 2 3 "Options" 3839943679 16).onActivate().width(180).padding(10).border(2 120 150 210 255).radius(9).textCenter().margin(6)
+        w.button(14 2 4 "Quit" 4285559039 16).onActivate().width(180).padding(10).border(2 200 110 110 255).radius(9).textCenter().margin(6)
         def status:string ("plays: " + (to_string plays))
         if (lastId != 0) {
             status = (status + "   last: #" + (to_string lastId))
         }
-        w.label(90 2 5 status 2410771663 13).margin(6)
+        w.label(90 2 5 status 2410771663 13).margin(8)
         return (w.emit())
     }
 
@@ -76,7 +78,7 @@ class WasmUiSelectDemo {
     sfn refresh:EVGElement (ctx:UIContext ctrl:UiSelectController doc:WasmUiDoc) {
         def builder:WasmUiEvgBuilder (new WasmUiEvgBuilder)
         def root:EVGElement (builder.build(doc))
-        ctrl.renderer.layoutTree(ctx root 360 280)
+        ctrl.renderer.layoutTree(ctx root 360 400)
         ctrl.rebuild(doc root)
         return root
     }
@@ -92,7 +94,7 @@ class WasmUiSelectDemo {
         def c:DemoCheck (new DemoCheck)
 
         def canvas:SoftCanvas (new SoftCanvas)
-        canvas.init(360 280)
+        canvas.init(360 400)
         def ctx:UIContext (new UIContext)
         ctx.attach(canvas)
         ctx.tr.addFontDir("gallery/pdf_writer/assets/fonts")

--- a/gallery/game_engine/ui/wasm_ui_select_demo.rgr
+++ b/gallery/game_engine/ui/wasm_ui_select_demo.rgr
@@ -37,17 +37,21 @@ class WasmUiSelectDemo {
     ; This is exactly what the AS guest's rebuild() emits.
     sfn buildMenu:[int] (plays:int lastId:int) {
         def w:RgUiWriter (new RgUiWriter)
-        w.view(1 0 0).column().padding(12).bg(24 28 44 255)
-        w.label(10 1 0 "WASM UI - Main Menu" 4294967295 20)
-        w.button(11 1 1 "New Game" 3505978623 16).onActivate().defaultSelected()
-        w.button(12 1 2 "Continue" 3505978623 16).onActivate()
-        w.button(13 1 3 "Options" 3505978623 16).onActivate()
-        w.button(14 1 4 "Quit" 4285559039 16).onActivate()
+        ; Outer root fills the frame and centres its child horizontally.
+        w.view(1 0 0).column().center().padding(22)
+        ; The menu "card": fixed width, padded, rounded, translucent panel — every
+        ; visual attribute declared here (in the guest), rendered by the host EVG.
+        w.view(2 1 0).column().padding(18).width(280).bg(36 42 64 255).radius(16)
+        w.label(10 2 0 "WASM UI - Main Menu" 4294967295 20)
+        w.button(11 2 1 "New Game" 3505978623 16).onActivate().defaultSelected().radius(8)
+        w.button(12 2 2 "Continue" 3505978623 16).onActivate().radius(8)
+        w.button(13 2 3 "Options" 3505978623 16).onActivate().radius(8)
+        w.button(14 2 4 "Quit" 4285559039 16).onActivate().radius(8)
         def status:string ("plays: " + (to_string plays))
         if (lastId != 0) {
             status = (status + "   last: #" + (to_string lastId))
         }
-        w.label(90 1 5 status 2410771663 13)
+        w.label(90 2 5 status 2410771663 13)
         return (w.emit())
     }
 
@@ -77,7 +81,7 @@ class WasmUiSelectDemo {
     }
 
     sfn drawFrame:void (ctx:UIContext ctrl:UiSelectController root:EVGElement canvas:SoftCanvas file:string) {
-        canvas.clear(24 28 44)
+        canvas.clear(16 18 30)
         ctrl.renderer.draw(ctx root)
         ctrl.renderHighlight(ctx)
         WasmUiSelectDemo.snap(canvas file)
@@ -94,6 +98,10 @@ class WasmUiSelectDemo {
         ctx.tr.loadFont("Open Sans" "Open_Sans/OpenSans-Regular.ttf")
 
         def ctrl:UiSelectController (new UiSelectController)
+        ; Host-side cursor look only (thickness + gap); the highlight's ROUNDING
+        ; follows the selected node's guest-declared border radius.
+        ctrl.borderWidth = 2
+        ctrl.highlightPad = 4
 
         ; ---- frame 0: initial menu (guest revision 0) ----
         def doc:WasmUiDoc (new WasmUiDoc)

--- a/gallery/game_engine/ui/wasm_ui_select_demo.rgr
+++ b/gallery/game_engine/ui/wasm_ui_select_demo.rgr
@@ -46,10 +46,10 @@ class WasmUiSelectDemo {
         w.label(10 2 0 "WASM UI - Main Menu" 4294967295 20).margin(8)
         ; Uniform buttons: 180px = 50% of the 360px screen, bordered, extra
         ; vertical padding, centred label. All declared here in the guest.
-        w.button(11 2 1 "New Game" 3839943679 16).onActivate().defaultSelected().width(180).padding(10).border(2 120 150 210 255).radius(9).textCenter().margin(6)
-        w.button(12 2 2 "Continue" 3839943679 16).onActivate().width(180).padding(10).border(2 120 150 210 255).radius(9).textCenter().margin(6)
-        w.button(13 2 3 "Options" 3839943679 16).onActivate().width(180).padding(10).border(2 120 150 210 255).radius(9).textCenter().margin(6)
-        w.button(14 2 4 "Quit" 4285559039 16).onActivate().width(180).padding(10).border(2 200 110 110 255).radius(9).textCenter().margin(6)
+        w.button(11 2 1 "New Game" 3839943679 16).onActivate().defaultSelected().width(180).padding(10).bg(120 165 230 46).border(2 120 150 210 255).radius(9).textCenter().margin(6)
+        w.button(12 2 2 "Continue" 3839943679 16).onActivate().width(180).padding(10).bg(120 165 230 46).border(2 120 150 210 255).radius(9).textCenter().margin(6)
+        w.button(13 2 3 "Options" 3839943679 16).onActivate().width(180).padding(10).bg(120 165 230 46).border(2 120 150 210 255).radius(9).textCenter().margin(6)
+        w.button(14 2 4 "Quit" 4285559039 16).onActivate().width(180).padding(10).bg(220 120 120 40).border(2 200 110 110 255).radius(9).textCenter().margin(6)
         def status:string ("plays: " + (to_string plays))
         if (lastId != 0) {
             status = (status + "   last: #" + (to_string lastId))

--- a/gallery/game_engine/wasm/as_autopeli/assembly/ui.ts
+++ b/gallery/game_engine/wasm/as_autopeli/assembly/ui.ts
@@ -84,6 +84,7 @@ const K_FONT_SIZE: u16 = 4;
 const K_WIDTH: u16 = 10;
 const K_HEIGHT: u16 = 11;
 const K_PADDING: u16 = 12;
+const K_MARGIN: u16 = 13;
 const K_BORDER_RADIUS: u16 = 14;
 const K_FLEX_DIRECTION: u16 = 21;
 const K_ALIGN_ITEMS: u16 = 22;
@@ -234,6 +235,7 @@ export class Ui {
   row(): Ui { this.propEnum(K_FLEX_DIRECTION, DIR_ROW); return this; }
   column(): Ui { this.propEnum(K_FLEX_DIRECTION, DIR_COLUMN); return this; }
   padding(v: i32): Ui { this.propI32(K_PADDING, v); return this; }
+  margin(v: i32): Ui { this.propI32(K_MARGIN, v); return this; }
   width(v: i32): Ui { this.propI32(K_WIDTH, v); return this; }
   height(v: i32): Ui { this.propI32(K_HEIGHT, v); return this; }
   background(rgba: u32): Ui { this.propColor(K_BACKGROUND, rgba); return this; }

--- a/gallery/game_engine/wasm/as_autopeli/assembly/ui.ts
+++ b/gallery/game_engine/wasm/as_autopeli/assembly/ui.ts
@@ -78,13 +78,25 @@ const T_ENUM: u8 = 7;
 
 // property keys
 const K_TEXT: u16 = 1;
+const K_BACKGROUND: u16 = 2;
 const K_COLOR: u16 = 3;
 const K_FONT_SIZE: u16 = 4;
+const K_WIDTH: u16 = 10;
+const K_HEIGHT: u16 = 11;
 const K_PADDING: u16 = 12;
+const K_BORDER_RADIUS: u16 = 14;
 const K_FLEX_DIRECTION: u16 = 21;
+const K_ALIGN_ITEMS: u16 = 22;
+const K_JUSTIFY: u16 = 23;
 
 export const DIR_ROW: u32 = 0;
 export const DIR_COLUMN: u32 = 1;
+
+// RgUiAlign
+export const ALIGN_START: u32 = 0;
+export const ALIGN_CENTER: u32 = 1;
+export const ALIGN_END: u32 = 2;
+export const ALIGN_SPACE_BETWEEN: u32 = 3;
 
 const FLAG_VALID: u32 = 1;
 
@@ -222,6 +234,14 @@ export class Ui {
   row(): Ui { this.propEnum(K_FLEX_DIRECTION, DIR_ROW); return this; }
   column(): Ui { this.propEnum(K_FLEX_DIRECTION, DIR_COLUMN); return this; }
   padding(v: i32): Ui { this.propI32(K_PADDING, v); return this; }
+  width(v: i32): Ui { this.propI32(K_WIDTH, v); return this; }
+  height(v: i32): Ui { this.propI32(K_HEIGHT, v); return this; }
+  background(rgba: u32): Ui { this.propColor(K_BACKGROUND, rgba); return this; }
+  radius(v: i32): Ui { this.propI32(K_BORDER_RADIUS, v); return this; }
+  alignItems(a: u32): Ui { this.propEnum(K_ALIGN_ITEMS, a); return this; }
+  justify(a: u32): Ui { this.propEnum(K_JUSTIFY, a); return this; }
+  // Horizontally centre children of a column (cross-axis center).
+  center(): Ui { this.propEnum(K_ALIGN_ITEMS, ALIGN_CENTER); return this; }
 
   // ---- interactivity (fluent, apply to the current node) ----
   // OR a bit into the current node's u16 flags field.

--- a/gallery/game_engine/wasm/as_autopeli/assembly/ui.ts
+++ b/gallery/game_engine/wasm/as_autopeli/assembly/ui.ts
@@ -86,9 +86,12 @@ const K_HEIGHT: u16 = 11;
 const K_PADDING: u16 = 12;
 const K_MARGIN: u16 = 13;
 const K_BORDER_RADIUS: u16 = 14;
+const K_BORDER_COLOR: u16 = 15;
+const K_BORDER_WIDTH: u16 = 16;
 const K_FLEX_DIRECTION: u16 = 21;
 const K_ALIGN_ITEMS: u16 = 22;
 const K_JUSTIFY: u16 = 23;
+const K_TEXT_ALIGN: u16 = 24;
 
 export const DIR_ROW: u32 = 0;
 export const DIR_COLUMN: u32 = 1;
@@ -240,10 +243,16 @@ export class Ui {
   height(v: i32): Ui { this.propI32(K_HEIGHT, v); return this; }
   background(rgba: u32): Ui { this.propColor(K_BACKGROUND, rgba); return this; }
   radius(v: i32): Ui { this.propI32(K_BORDER_RADIUS, v); return this; }
+  borderColor(rgba: u32): Ui { this.propColor(K_BORDER_COLOR, rgba); return this; }
+  borderWidth(v: i32): Ui { this.propI32(K_BORDER_WIDTH, v); return this; }
+  border(w: i32, rgba: u32): Ui { this.propColor(K_BORDER_COLOR, rgba); this.propI32(K_BORDER_WIDTH, w); return this; }
   alignItems(a: u32): Ui { this.propEnum(K_ALIGN_ITEMS, a); return this; }
   justify(a: u32): Ui { this.propEnum(K_JUSTIFY, a); return this; }
+  textAlign(a: u32): Ui { this.propEnum(K_TEXT_ALIGN, a); return this; }
   // Horizontally centre children of a column (cross-axis center).
   center(): Ui { this.propEnum(K_ALIGN_ITEMS, ALIGN_CENTER); return this; }
+  // Centre this node's own text within its (fixed) width.
+  textCenter(): Ui { this.propEnum(K_TEXT_ALIGN, ALIGN_CENTER); return this; }
 
   // ---- interactivity (fluent, apply to the current node) ----
   // OR a bit into the current node's u16 flags field.

--- a/gallery/game_engine/wasm/as_autopeli/assembly/ui.ts
+++ b/gallery/game_engine/wasm/as_autopeli/assembly/ui.ts
@@ -58,6 +58,17 @@ const P_VALUE_B: i32 = 8;
 // node kinds
 export const VIEW: u16 = 1;
 export const TEXT: u16 = 2;
+export const BUTTON: u16 = 5;
+
+// node flags (node.flags, u16) — interactivity is opt-in per node
+export const NODEFLAG_SELECTABLE: i32 = 0x0001;
+export const NODEFLAG_DISABLED: i32 = 0x0002;
+export const NODEFLAG_DEFAULT: i32 = 0x0004;
+
+// event mask (node.event_mask, u32) — host->guest callbacks
+export const EVENT_ACTIVATE: u32 = 0x0001;
+export const EVENT_SELECT: u32 = 0x0002;
+export const EVENT_DESELECT: u32 = 0x0004;
 
 // property types
 const T_I32: u8 = 1;
@@ -100,6 +111,9 @@ function wu32(off: i32, v: u32): void {
   UI[off + 1] = <u8>((v >> 8) & 0xff);
   UI[off + 2] = <u8>((v >> 16) & 0xff);
   UI[off + 3] = <u8>((v >> 24) & 0xff);
+}
+function wu32read(off: i32): u32 {
+  return (<u32>UI[off]) | (<u32>UI[off + 1] << 8) | (<u32>UI[off + 2] << 16) | (<u32>UI[off + 3] << 24);
 }
 
 // ---- Per-player HUD state (plain typed struct, like the .tsx state) ----
@@ -209,6 +223,31 @@ export class Ui {
   column(): Ui { this.propEnum(K_FLEX_DIRECTION, DIR_COLUMN); return this; }
   padding(v: i32): Ui { this.propI32(K_PADDING, v); return this; }
 
+  // ---- interactivity (fluent, apply to the current node) ----
+  // OR a bit into the current node's u16 flags field.
+  private orFlags(bit: i32): void {
+    if (this.nodeCount == 0) return;
+    const off = this.curNode + N_FLAGS;
+    const cur = <i32>UI[off] | (<i32>UI[off + 1] << 8);
+    wu16(off, cur | bit);
+  }
+  // OR a bit into the current node's u32 event_mask field.
+  private orEvent(bit: u32): void {
+    if (this.nodeCount == 0) return;
+    const off = this.curNode + N_EVENT_MASK;
+    const cur = wu32read(off);
+    wu32(off, cur | bit);
+  }
+
+  // Mark the current node selectable by the host's D-pad/keyboard cursor.
+  selectable(): Ui { this.orFlags(NODEFLAG_SELECTABLE); return this; }
+  // Mark it the initial selection (host picks it on the first frame).
+  defaultSelected(): Ui { this.orFlags(NODEFLAG_DEFAULT); return this; }
+  // Skip in navigation and render dimmed.
+  disabled(): Ui { this.orFlags(NODEFLAG_DISABLED); return this; }
+  // Subscribe to the ACTIVATE callback (action button while selected).
+  onActivate(): Ui { this.selectable(); this.orEvent(EVENT_ACTIVATE); return this; }
+
   // Emit a complete TEXT node (text -> font-size -> color, fixed order).
   // `fontSize` is a defaulted parameter: old call sites keep the RGU1 8px look,
   // new games can override without any signature break.
@@ -217,6 +256,16 @@ export class Ui {
     this.propStr(K_TEXT, s);
     this.propI32(K_FONT_SIZE, fontSize);
     this.propColor(K_COLOR, color);
+  }
+
+  // Like label(), but a BUTTON node that RETURNS the builder so interactivity
+  // chains fluently: `ui.button(...).onActivate().defaultSelected()`.
+  button(id: u32, parent: u32, order: u16, s: string, color: u32, fontSize: i32 = DEFAULT_FONT_SIZE): Ui {
+    this.node(id, parent, BUTTON, order);
+    this.propStr(K_TEXT, s);
+    this.propI32(K_FONT_SIZE, fontSize);
+    this.propColor(K_COLOR, color);
+    return this;
   }
 
   finish(revision: u32): void {

--- a/gallery/game_engine/wasm/as_ui_menu/.gitignore
+++ b/gallery/game_engine/wasm/as_ui_menu/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/gallery/game_engine/wasm/as_ui_menu/README.md
+++ b/gallery/game_engine/wasm/as_ui_menu/README.md
@@ -1,0 +1,56 @@
+# as_ui_menu — AssemblyScript selectable-menu WASM guest
+
+A minimal **WASM text example** for the RGU1 UI bridge: an AssemblyScript guest
+that builds a **selectable menu** the host navigates with the **gamepad /
+keyboard** (no pointer) and highlights, and that reacts to the **action button**.
+
+It reuses the shared RGU1 builder in
+[`../as_autopeli/assembly/ui.ts`](../as_autopeli/assembly/ui.ts) — including the
+interactivity helpers added for this feature:
+
+```ts
+ui.reset();
+ui.view(1, 0, 0).column().padding(12);
+ui.label(10, 1, 0, "WASM UI - Main Menu", 0xffffffff, 20);
+ui.button(20, 1, 1, "New Game", C_ITEM, 16).onActivate().defaultSelected();
+ui.button(21, 1, 2, "Continue", C_ITEM, 16).onActivate();
+ui.label(90, 1, 5, "plays: " + PLAYS.toString(), C_STATUS, 13); // not selectable
+ui.finish(revision);
+```
+
+* `.selectable()` — the host's D-pad/keyboard cursor may land here.
+* `.onActivate()` — selectable **and** subscribes to the ACTIVATE callback.
+* `.defaultSelected()` — the host highlights this node first.
+
+## Selection & activation (host ↔ guest)
+
+The document is guest→host. Selection and "button recognition" flow back via an
+optional export the host calls:
+
+```ts
+export function rg_ui_event(nodeId: u32, event: u32, value: u32): void { … }
+```
+
+Each frame: the host reads the doc, tracks a selection cursor over the selectable
+nodes, moves it with the D-pad (nearest selectable node in the pressed
+direction), and on the action button calls `rg_ui_event(selectedId, ACTIVATE, 0)`.
+This guest bumps a counter and rebuilds, so the next document shows `plays: N`.
+See the ABI contract in [`../wasm_ui_abi.h`](../wasm_ui_abi.h) and the host side
+in [`../../ui/WasmUiSelect.rgr`](../../ui/WasmUiSelect.rgr).
+
+## Build & verify
+
+```bash
+bash gallery/game_engine/wasm/as_ui_menu/build.sh     # -> build/logic.wasm
+node gallery/game_engine/wasm/as_ui_menu/tools/parity.cjs   # instantiates it, checks the bytes
+# or, from the repo root:
+npm run engine:ui:wasm-guest
+```
+
+`parity.cjs` instantiates the real `.wasm`, reads the RGU1 block out of linear
+memory, asserts the selectable/default/activate flags, then calls
+`rg_ui_event(20, ACTIVATE, 0)` and checks the guest reacted (`plays()` → 1,
+`rg_ui_revision()` bumped).
+
+The **host** counterpart (Ranger, renders + navigates + highlights) is
+`gallery/game_engine/ui/wasm_ui_select_demo.rgr` — run `npm run engine:ui:wasm-select`.

--- a/gallery/game_engine/wasm/as_ui_menu/assembly/index.ts
+++ b/gallery/game_engine/wasm/as_ui_menu/assembly/index.ts
@@ -43,6 +43,8 @@ const C_QUIT: u32 = 0xff6a6aff;
 const C_CARD: u32 = 0x242a40ff;      // 36,42,64
 const C_BORDER: u32 = 0x7896d2ff;    // 120,150,210
 const C_BORDER_QUIT: u32 = 0xc86e6eff; // 200,110,110
+const C_BTN_BG: u32 = 0x78a5e62e;    // light blue, ~18% alpha
+const C_BTN_BG_QUIT: u32 = 0xdc787828; // light red, ~16% alpha
 
 // The guest picks its target screen width; buttons are 50% of it (uniform).
 const SCREEN_W: i32 = 360;
@@ -76,13 +78,13 @@ function rebuild(): void {
   // Uniform buttons: width = 50% screen, bordered, extra vertical padding,
   // centred label — every attribute declared here in the guest.
   ui.button(BTN_NEW, CARD, 1, "New Game", C_ITEM, 16)
-    .onActivate().defaultSelected().width(BTN_W).padding(10).border(2, C_BORDER).radius(9).textCenter().margin(6);
+    .onActivate().defaultSelected().width(BTN_W).padding(10).background(C_BTN_BG).border(2, C_BORDER).radius(9).textCenter().margin(6);
   ui.button(BTN_CONT, CARD, 2, "Continue", C_ITEM, 16)
-    .onActivate().width(BTN_W).padding(10).border(2, C_BORDER).radius(9).textCenter().margin(6);
+    .onActivate().width(BTN_W).padding(10).background(C_BTN_BG).border(2, C_BORDER).radius(9).textCenter().margin(6);
   ui.button(BTN_OPTS, CARD, 3, "Options", C_ITEM, 16)
-    .onActivate().width(BTN_W).padding(10).border(2, C_BORDER).radius(9).textCenter().margin(6);
+    .onActivate().width(BTN_W).padding(10).background(C_BTN_BG).border(2, C_BORDER).radius(9).textCenter().margin(6);
   ui.button(BTN_QUIT, CARD, 4, "Quit", C_QUIT, 16)
-    .onActivate().width(BTN_W).padding(10).border(2, C_BORDER_QUIT).radius(9).textCenter().margin(6);
+    .onActivate().width(BTN_W).padding(10).background(C_BTN_BG_QUIT).border(2, C_BORDER_QUIT).radius(9).textCenter().margin(6);
 
   // Non-selectable status line — proves selectable is opt-in per node.
   ui.label(STATUS, CARD, 5, statusText(), C_STATUS, 13);

--- a/gallery/game_engine/wasm/as_ui_menu/assembly/index.ts
+++ b/gallery/game_engine/wasm/as_ui_menu/assembly/index.ts
@@ -40,7 +40,13 @@ const C_TITLE: u32 = 0xffffffff;
 const C_ITEM: u32 = 0xd0dcf0ff;
 const C_STATUS: u32 = 0x8fb0d0ff;
 const C_QUIT: u32 = 0xff6a6aff;
-const C_CARD: u32 = 0x242a40ff;   // 36,42,64
+const C_CARD: u32 = 0x242a40ff;      // 36,42,64
+const C_BORDER: u32 = 0x7896d2ff;    // 120,150,210
+const C_BORDER_QUIT: u32 = 0xc86e6eff; // 200,110,110
+
+// The guest picks its target screen width; buttons are 50% of it (uniform).
+const SCREEN_W: i32 = 360;
+const BTN_W: i32 = SCREEN_W / 2;     // 180 = 50% screen
 
 let UI_REV: u32 = 0;
 let PLAYS: i32 = 0;     // times "New Game" was activated
@@ -67,10 +73,16 @@ function rebuild(): void {
   // Selectable menu items. onActivate() marks them selectable AND subscribes to
   // the ACTIVATE callback; defaultSelected() picks the first host highlight;
   // radius() rounds the host's selection border to match.
-  ui.button(BTN_NEW, CARD, 1, "New Game", C_ITEM, 16).onActivate().defaultSelected().radius(8).margin(7);
-  ui.button(BTN_CONT, CARD, 2, "Continue", C_ITEM, 16).onActivate().radius(8).margin(7);
-  ui.button(BTN_OPTS, CARD, 3, "Options", C_ITEM, 16).onActivate().radius(8).margin(7);
-  ui.button(BTN_QUIT, CARD, 4, "Quit", C_QUIT, 16).onActivate().radius(8).margin(7);
+  // Uniform buttons: width = 50% screen, bordered, extra vertical padding,
+  // centred label — every attribute declared here in the guest.
+  ui.button(BTN_NEW, CARD, 1, "New Game", C_ITEM, 16)
+    .onActivate().defaultSelected().width(BTN_W).padding(10).border(2, C_BORDER).radius(9).textCenter().margin(6);
+  ui.button(BTN_CONT, CARD, 2, "Continue", C_ITEM, 16)
+    .onActivate().width(BTN_W).padding(10).border(2, C_BORDER).radius(9).textCenter().margin(6);
+  ui.button(BTN_OPTS, CARD, 3, "Options", C_ITEM, 16)
+    .onActivate().width(BTN_W).padding(10).border(2, C_BORDER).radius(9).textCenter().margin(6);
+  ui.button(BTN_QUIT, CARD, 4, "Quit", C_QUIT, 16)
+    .onActivate().width(BTN_W).padding(10).border(2, C_BORDER_QUIT).radius(9).textCenter().margin(6);
 
   // Non-selectable status line — proves selectable is opt-in per node.
   ui.label(STATUS, CARD, 5, statusText(), C_STATUS, 13);

--- a/gallery/game_engine/wasm/as_ui_menu/assembly/index.ts
+++ b/gallery/game_engine/wasm/as_ui_menu/assembly/index.ts
@@ -1,0 +1,96 @@
+// ============================================================================
+// as_ui_menu — an AssemblyScript "WASM text example" with a SELECTABLE menu.
+// ============================================================================
+//
+// A minimal WASM guest that builds a text menu the host can navigate with the
+// gamepad/keyboard D-pad (no pointer) and highlight, and that reacts to the
+// action button. It reuses the shared RGU1 builder from as_autopeli/assembly/
+// ui.ts — including the interactivity helpers added there:
+//
+//     ui.button(id, parent, order, "New Game", color, size)
+//       .onActivate()        // selectable + subscribes to the ACTIVATE event
+//       .defaultSelected();  // host highlights this one first
+//
+// Host flow (see gallery/game_engine/ui/WasmUiSelect.rgr):
+//   1. host reads this document, lays it out, tracks a selection cursor over the
+//      nodes tagged selectable, and draws a highlight border on the selected one
+//   2. D-pad up/down moves the cursor (spatially nearest selectable node)
+//   3. action button -> host calls rg_ui_event(selectedId, EVENT_ACTIVATE, 0)
+//   4. we react (bump a counter), bump the revision, and rebuild — the next
+//      frame's document reflects the change ("plays: N").
+//
+// Build:  bash gallery/game_engine/wasm/as_ui_menu/build.sh
+// (produces build/logic.wasm; the host loads it via wasm_call_i32 on native).
+// ============================================================================
+
+import { ui, UI_SIZE, uiPtr, EVENT_ACTIVATE } from "../../as_autopeli/assembly/ui";
+
+// node ids
+const ROOT: u32 = 1;
+const TITLE: u32 = 10;
+const BTN_NEW: u32 = 20;
+const BTN_CONT: u32 = 21;
+const BTN_OPTS: u32 = 22;
+const BTN_QUIT: u32 = 23;
+const STATUS: u32 = 90;
+
+// colors 0xRRGGBBAA
+const C_TITLE: u32 = 0xffffffff;
+const C_ITEM: u32 = 0xd0dcf0ff;
+const C_STATUS: u32 = 0x8fb0d0ff;
+const C_QUIT: u32 = 0xff6a6aff;
+
+let UI_REV: u32 = 0;
+let PLAYS: i32 = 0;     // times "New Game" was activated
+let LAST_ID: u32 = 0;   // last activated node id
+
+function statusText(): string {
+  if (LAST_ID == 0) return "plays: " + PLAYS.toString();
+  return "plays: " + PLAYS.toString() + "   last: #" + LAST_ID.toString();
+}
+
+function rebuild(): void {
+  ui.reset();
+  ui.view(ROOT, 0, 0).column().padding(12);
+
+  ui.label(TITLE, ROOT, 0, "WASM UI - Main Menu", C_TITLE, 20);
+
+  // Selectable menu items. onActivate() marks them selectable AND subscribes to
+  // the ACTIVATE callback; defaultSelected() picks the first host highlight.
+  ui.button(BTN_NEW, ROOT, 1, "New Game", C_ITEM, 16).onActivate().defaultSelected();
+  ui.button(BTN_CONT, ROOT, 2, "Continue", C_ITEM, 16).onActivate();
+  ui.button(BTN_OPTS, ROOT, 3, "Options", C_ITEM, 16).onActivate();
+  ui.button(BTN_QUIT, ROOT, 4, "Quit", C_QUIT, 16).onActivate();
+
+  // Non-selectable status line — proves selectable is opt-in per node.
+  ui.label(STATUS, ROOT, 5, statusText(), C_STATUS, 13);
+
+  ui.finish(UI_REV);
+}
+
+// ---- exports the host calls ------------------------------------------------
+export function init(): void {
+  PLAYS = 0;
+  LAST_ID = 0;
+  UI_REV = 0;
+  rebuild();
+}
+
+// "Button recognition": the host forwards the action button here for whichever
+// node the selection cursor is on (and that subscribed to ACTIVATE).
+export function rg_ui_event(nodeId: u32, event: u32, value: u32): void {
+  if (event == EVENT_ACTIVATE) {
+    LAST_ID = nodeId;
+    if (nodeId == BTN_NEW) PLAYS += 1;
+    // Continue / Options / Quit would branch here in a real game.
+    UI_REV += 1;
+    rebuild();
+  }
+}
+
+export function rg_ui_ptr(): i32 { return <i32>uiPtr(); }
+export function rg_ui_size(): i32 { return UI_SIZE; }
+export function rg_ui_revision(): i32 { return <i32>UI_REV; }
+
+// Convenience for host tests: how many times New Game fired.
+export function plays(): i32 { return PLAYS; }

--- a/gallery/game_engine/wasm/as_ui_menu/assembly/index.ts
+++ b/gallery/game_engine/wasm/as_ui_menu/assembly/index.ts
@@ -27,6 +27,7 @@ import { ui, UI_SIZE, uiPtr, EVENT_ACTIVATE } from "../../as_autopeli/assembly/u
 
 // node ids
 const ROOT: u32 = 1;
+const CARD: u32 = 2;
 const TITLE: u32 = 10;
 const BTN_NEW: u32 = 20;
 const BTN_CONT: u32 = 21;
@@ -39,6 +40,7 @@ const C_TITLE: u32 = 0xffffffff;
 const C_ITEM: u32 = 0xd0dcf0ff;
 const C_STATUS: u32 = 0x8fb0d0ff;
 const C_QUIT: u32 = 0xff6a6aff;
+const C_CARD: u32 = 0x242a40ff;   // 36,42,64
 
 let UI_REV: u32 = 0;
 let PLAYS: i32 = 0;     // times "New Game" was activated
@@ -51,19 +53,26 @@ function statusText(): string {
 
 function rebuild(): void {
   ui.reset();
-  ui.view(ROOT, 0, 0).column().padding(12);
+  // Outer root fills the frame and centres its child horizontally. All visual
+  // attributes (layout, size, colour, radius) are declared HERE in the guest;
+  // the host EVG layout/renderer just resolves them.
+  ui.view(ROOT, 0, 0).column().center().padding(22);
 
-  ui.label(TITLE, ROOT, 0, "WASM UI - Main Menu", C_TITLE, 20);
+  // The menu "card": fixed width, padded, rounded, translucent panel.
+  ui.view(CARD, ROOT, 0).column().padding(18).width(280).background(C_CARD).radius(16);
+
+  ui.label(TITLE, CARD, 0, "WASM UI - Main Menu", C_TITLE, 20);
 
   // Selectable menu items. onActivate() marks them selectable AND subscribes to
-  // the ACTIVATE callback; defaultSelected() picks the first host highlight.
-  ui.button(BTN_NEW, ROOT, 1, "New Game", C_ITEM, 16).onActivate().defaultSelected();
-  ui.button(BTN_CONT, ROOT, 2, "Continue", C_ITEM, 16).onActivate();
-  ui.button(BTN_OPTS, ROOT, 3, "Options", C_ITEM, 16).onActivate();
-  ui.button(BTN_QUIT, ROOT, 4, "Quit", C_QUIT, 16).onActivate();
+  // the ACTIVATE callback; defaultSelected() picks the first host highlight;
+  // radius() rounds the host's selection border to match.
+  ui.button(BTN_NEW, CARD, 1, "New Game", C_ITEM, 16).onActivate().defaultSelected().radius(8);
+  ui.button(BTN_CONT, CARD, 2, "Continue", C_ITEM, 16).onActivate().radius(8);
+  ui.button(BTN_OPTS, CARD, 3, "Options", C_ITEM, 16).onActivate().radius(8);
+  ui.button(BTN_QUIT, CARD, 4, "Quit", C_QUIT, 16).onActivate().radius(8);
 
   // Non-selectable status line — proves selectable is opt-in per node.
-  ui.label(STATUS, ROOT, 5, statusText(), C_STATUS, 13);
+  ui.label(STATUS, CARD, 5, statusText(), C_STATUS, 13);
 
   ui.finish(UI_REV);
 }

--- a/gallery/game_engine/wasm/as_ui_menu/assembly/index.ts
+++ b/gallery/game_engine/wasm/as_ui_menu/assembly/index.ts
@@ -67,10 +67,10 @@ function rebuild(): void {
   // Selectable menu items. onActivate() marks them selectable AND subscribes to
   // the ACTIVATE callback; defaultSelected() picks the first host highlight;
   // radius() rounds the host's selection border to match.
-  ui.button(BTN_NEW, CARD, 1, "New Game", C_ITEM, 16).onActivate().defaultSelected().radius(8);
-  ui.button(BTN_CONT, CARD, 2, "Continue", C_ITEM, 16).onActivate().radius(8);
-  ui.button(BTN_OPTS, CARD, 3, "Options", C_ITEM, 16).onActivate().radius(8);
-  ui.button(BTN_QUIT, CARD, 4, "Quit", C_QUIT, 16).onActivate().radius(8);
+  ui.button(BTN_NEW, CARD, 1, "New Game", C_ITEM, 16).onActivate().defaultSelected().radius(8).margin(7);
+  ui.button(BTN_CONT, CARD, 2, "Continue", C_ITEM, 16).onActivate().radius(8).margin(7);
+  ui.button(BTN_OPTS, CARD, 3, "Options", C_ITEM, 16).onActivate().radius(8).margin(7);
+  ui.button(BTN_QUIT, CARD, 4, "Quit", C_QUIT, 16).onActivate().radius(8).margin(7);
 
   // Non-selectable status line — proves selectable is opt-in per node.
   ui.label(STATUS, CARD, 5, statusText(), C_STATUS, 13);

--- a/gallery/game_engine/wasm/as_ui_menu/assembly/index.ts
+++ b/gallery/game_engine/wasm/as_ui_menu/assembly/index.ts
@@ -58,8 +58,9 @@ function rebuild(): void {
   // the host EVG layout/renderer just resolves them.
   ui.view(ROOT, 0, 0).column().center().padding(22);
 
-  // The menu "card": fixed width, padded, rounded, translucent panel.
-  ui.view(CARD, ROOT, 0).column().padding(18).width(280).background(C_CARD).radius(16);
+  // The menu "card": fixed width, padded, rounded, translucent panel, with its
+  // items centred (cross-axis center on the column).
+  ui.view(CARD, ROOT, 0).column().center().padding(18).width(280).background(C_CARD).radius(16);
 
   ui.label(TITLE, CARD, 0, "WASM UI - Main Menu", C_TITLE, 20);
 

--- a/gallery/game_engine/wasm/as_ui_menu/build.sh
+++ b/gallery/game_engine/wasm/as_ui_menu/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Build the AssemblyScript selectable-menu guest to build/logic.wasm.
+#
+# Usage:  bash gallery/game_engine/wasm/as_ui_menu/build.sh
+#
+# Reuses the shared RGU1 builder in ../as_autopeli/assembly/ui.ts, so its
+# node_modules (assemblyscript) satisfy the import too. If asc is not present in
+# this project, we fall back to the sibling as_autopeli install.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+CRATE="$ROOT/gallery/game_engine/wasm/as_ui_menu"
+SIB="$ROOT/gallery/game_engine/wasm/as_autopeli"
+
+cd "$CRATE"
+mkdir -p build
+
+ASC=""
+if [[ -x node_modules/.bin/asc ]]; then
+  ASC="node_modules/.bin/asc"
+elif [[ -x "$SIB/node_modules/.bin/asc" ]]; then
+  ASC="$SIB/node_modules/.bin/asc"
+else
+  echo "==> npm install (assemblyscript)"
+  npm install --no-audit --no-fund
+  ASC="node_modules/.bin/asc"
+fi
+
+echo "==> asc build (optimize, minimal runtime)"
+"$ASC" assembly/index.ts \
+  --outFile build/logic.wasm --runtime minimal --use abort= --optimize
+
+echo "==> wrote $CRATE/build/logic.wasm ($(wc -c < build/logic.wasm) bytes)"

--- a/gallery/game_engine/wasm/as_ui_menu/package.json
+++ b/gallery/game_engine/wasm/as_ui_menu/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "as_ui_menu",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "asbuild": "asc assembly/index.ts --outFile build/logic.wasm --optimize --runtime minimal --exportRuntime false"
+  },
+  "devDependencies": {
+    "assemblyscript": "^0.27.0"
+  }
+}

--- a/gallery/game_engine/wasm/as_ui_menu/tools/parity.cjs
+++ b/gallery/game_engine/wasm/as_ui_menu/tools/parity.cjs
@@ -1,0 +1,63 @@
+// Instantiate the AS guest and verify the RGU1 selectable-menu bytes + the
+// activation round-trip. Run: node gallery/game_engine/wasm/as_ui_menu/tools/parity.cjs
+const fs = require('fs');
+const path = require('path');
+const wasmPath = path.join(__dirname, '..', 'build', 'logic.wasm');
+const bytes = fs.readFileSync(wasmPath);
+const mod = new WebAssembly.Module(bytes);
+const inst = new WebAssembly.Instance(mod, {});
+const e = inst.exports;
+const mem = new Uint8Array(e.memory.buffer);
+const dv = () => new DataView(e.memory.buffer);
+
+function readDoc() {
+  const base = e.rg_ui_ptr();
+  const size = e.rg_ui_size();
+  const d = dv();
+  const magic = d.getUint32(base + 0, true);
+  const nodeOff = d.getUint32(base + 16, true);
+  const nodeCount = d.getUint32(base + 20, true);
+  return { base, size, magic, nodeOff, nodeCount, d };
+}
+function nodeById(doc, id) {
+  for (let i = 0; i < doc.nodeCount; i++) {
+    const nb = doc.base + doc.nodeOff + i * 32;
+    if (doc.d.getUint32(nb, true) === id) {
+      return {
+        id,
+        flags: doc.d.getUint16(nb + 10, true),
+        eventMask: doc.d.getUint32(nb + 20, true),
+        kind: doc.d.getUint16(nb + 8, true),
+      };
+    }
+  }
+  return null;
+}
+
+let pass = 0, fail = 0;
+function ok(name, cond) { if (cond) { pass++; console.log('  PASS ' + name); } else { fail++; console.log('  FAIL ' + name); } }
+
+e.init();
+let doc = readDoc();
+ok('magic RGU1', doc.magic === 0x31554752);
+ok('has nodes', doc.nodeCount >= 6);
+
+const newGame = nodeById(doc, 20);
+ok('New Game is BUTTON kind', newGame && newGame.kind === 5);
+ok('New Game selectable flag', newGame && (newGame.flags & 0x0001) !== 0);
+ok('New Game default flag', newGame && (newGame.flags & 0x0004) !== 0);
+ok('New Game subscribes ACTIVATE', newGame && (newGame.eventMask & 0x0001) !== 0);
+
+const status = nodeById(doc, 90);
+ok('status line NOT selectable', status && (status.flags & 0x0001) === 0);
+
+const rev0 = e.rg_ui_revision();
+ok('plays starts 0', e.plays() === 0);
+// host recognizes the action button on the selected node -> forwards to guest
+e.rg_ui_event(20, 0x0001, 0);
+ok('plays incremented after activate', e.plays() === 1);
+ok('revision bumped', e.rg_ui_revision() === rev0 + 1);
+
+console.log('RESULT: ' + pass + ' passed, ' + fail + ' failed');
+console.log(fail === 0 ? 'ALL PASS' : 'SOME FAILED');
+process.exit(fail === 0 ? 0 : 1);

--- a/gallery/game_engine/wasm/wasm_ui_abi.h
+++ b/gallery/game_engine/wasm/wasm_ui_abi.h
@@ -111,10 +111,52 @@ enum RgUiNodeKind {
     RG_UI_TEXT         = 2,
     RG_UI_IMAGE        = 3,
     RG_UI_PROGRESS_BAR = 4,
-    RG_UI_BUTTON       = 5,  /* reserved for Phase 3 (interactive)            */
+    RG_UI_BUTTON       = 5,  /* interactive: focusable + activatable (Phase 3) */
     RG_UI_SPACER       = 6,
     RG_UI_CUSTOM       = 100
 };
+
+/* ---- Node flags (node.flags, u16) -------------------------------------- */
+/* Interactivity is opt-in per node: the guest tags which nodes the host may
+ * select, and the host drives selection with the gamepad/keyboard D-pad (no
+ * pointer required). See "Selection & activation" below. */
+#define RG_UI_NODEFLAG_SELECTABLE  0x0001u  /* host may move the cursor here   */
+#define RG_UI_NODEFLAG_DISABLED    0x0002u  /* skip in navigation, dim it      */
+#define RG_UI_NODEFLAG_DEFAULT     0x0004u  /* initial selection on first frame*/
+
+/* ---- Event mask (node.event_mask, u32) --------------------------------- */
+/* Which host->guest events a node wants. The host only calls back for nodes
+ * that subscribe, so a plain label costs nothing. */
+#define RG_UI_EVENT_ACTIVATE  0x0001u  /* action button pressed while selected */
+#define RG_UI_EVENT_SELECT    0x0002u  /* selection cursor moved onto the node */
+#define RG_UI_EVENT_DESELECT  0x0004u  /* selection cursor left the node       */
+
+/* ---- Selection & activation (host -> guest) ----------------------------
+ * The RGU1 document is guest->host (the guest builds it, the host renders it).
+ * Selection navigation and "button recognition" flow back the other way via an
+ * OPTIONAL guest export the host calls when something happens:
+ *
+ *     void rg_ui_event(uint32_t node_id, uint32_t event, uint32_t value);
+ *
+ *   event  = one of RG_UI_EVENT_* (ACTIVATE / SELECT / DESELECT)
+ *   value  = event-specific payload (0 for ACTIVATE; reserved otherwise)
+ *
+ * Flow each frame:
+ *   1. Guest builds the document, tagging selectable nodes with
+ *      RG_UI_NODEFLAG_SELECTABLE and (optionally) RG_UI_NODEFLAG_DEFAULT, and
+ *      subscribing to RG_UI_EVENT_ACTIVATE on the ones that react to a press.
+ *   2. Host reads the doc, lays it out, and tracks a selection cursor over the
+ *      selectable nodes. The D-pad / arrow keys move it (spatially: nearest
+ *      selectable node in the pressed direction); the host draws a highlight
+ *      border around the selected node.
+ *   3. On the action button, if the selected node subscribed to ACTIVATE, the
+ *      host calls rg_ui_event(selected_id, RG_UI_EVENT_ACTIVATE, 0). The guest
+ *      reacts (e.g. changes state) and the next document reflects it.
+ *
+ * If the guest does not export rg_ui_event, the host still navigates and
+ * highlights; activation is simply not delivered. Selection state lives on the
+ * HOST (keyed by stable node id) so it survives document rebuilds.
+ */
 
 /* ---- Property (16 bytes) ----------------------------------------------- */
 #define RG_UI_PROP_OFF_KEY      0   /* u16 RgUiPropertyKey                    */

--- a/gallery/game_engine/wasm/wasm_ui_abi.h
+++ b/gallery/game_engine/wasm/wasm_ui_abi.h
@@ -199,11 +199,14 @@ enum RgUiPropertyKey {
     RG_UI_KEY_PADDING        = 12,  /* i32 px (all sides)                     */
     RG_UI_KEY_MARGIN         = 13,  /* i32 px (all sides)                     */
     RG_UI_KEY_BORDER_RADIUS  = 14,  /* i32 px (rounded corners)               */
+    RG_UI_KEY_BORDER_COLOR   = 15,  /* color                                  */
+    RG_UI_KEY_BORDER_WIDTH   = 16,  /* i32 px                                 */
 
     RG_UI_KEY_FLEX           = 20,  /* i32 (flex-grow)                        */
     RG_UI_KEY_FLEX_DIRECTION = 21,  /* enum RgUiFlexDirection                 */
     RG_UI_KEY_ALIGN_ITEMS    = 22,  /* enum RgUiAlign                         */
     RG_UI_KEY_JUSTIFY        = 23,  /* enum RgUiAlign                         */
+    RG_UI_KEY_TEXT_ALIGN     = 24,  /* enum RgUiAlign (0 left,1 center,2 end) */
 
     RG_UI_KEY_IMAGE_RESOURCE = 30,  /* string (host resource id)              */
 

--- a/gallery/game_engine/wasm/wasm_ui_abi.h
+++ b/gallery/game_engine/wasm/wasm_ui_abi.h
@@ -198,6 +198,7 @@ enum RgUiPropertyKey {
     RG_UI_KEY_HEIGHT         = 11,  /* i32 px                                 */
     RG_UI_KEY_PADDING        = 12,  /* i32 px (all sides)                     */
     RG_UI_KEY_MARGIN         = 13,  /* i32 px (all sides)                     */
+    RG_UI_KEY_BORDER_RADIUS  = 14,  /* i32 px (rounded corners)               */
 
     RG_UI_KEY_FLEX           = 20,  /* i32 (flex-grow)                        */
     RG_UI_KEY_FLEX_DIRECTION = 21,  /* enum RgUiFlexDirection                 */

--- a/gallery/pdf_writer/src/raster/RasterText.rgr
+++ b/gallery/pdf_writer/src/raster/RasterText.rgr
@@ -121,7 +121,13 @@ class GlyphEdge {
 class RasterText {
     def font:TrueTypeFont
     def compositor:RasterCompositor (new RasterCompositor())
-    
+
+    ; Per-glyph diagnostic logging. OFF by default: the debug prints below sit in
+    ; the hot glyph path and flood stdout / kill throughput for real-time (UI /
+    ; game) rendering. Set true only when debugging the rasterizer itself.
+    ; (See gallery/game_engine/RENDERING_EVG.md: "strip the debug prints".)
+    def debug:boolean false
+
     ; Edges buffer for glyph rendering (reused to avoid slice issues in Go)
     def currentEdges:[GlyphEdge]
     
@@ -234,7 +240,7 @@ class RasterText {
         
         ; Safety check - limit points to prevent infinite loops
         if (numPoints > 10000) {
-            print ("Warning: Too many points in glyph: " + (to_string numPoints))
+            if debug { print ("Warning: Too many points in glyph: " + (to_string numPoints)) }
             return outline
         }
         
@@ -360,12 +366,12 @@ class RasterText {
         currentEdges = newEdges
         
         def numContours:int (array_length outline.contours)
-        print ("  renderGlyph: numContours=" + (to_string numContours) + " pos=(" + (to_string x) + "," + (to_string y) + ")")
+        if debug { print ("  renderGlyph: numContours=" + (to_string numContours) + " pos=(" + (to_string x) + "," + (to_string y) + ")") }
         def cIdx:int 0
         while (cIdx < numContours) {
             def contour:GlyphContour (itemAt outline.contours cIdx)
             def numPts:int (contour.numPoints())
-            print ("    contour " + (to_string cIdx) + ": numPoints=" + (to_string numPts))
+            if debug { print ("    contour " + (to_string cIdx) + ": numPoints=" + (to_string numPts)) }
             
             if (numPts >= 2) {
                 ; Flatten curves and create edges - uses currentEdges field
@@ -374,7 +380,7 @@ class RasterText {
             cIdx = cIdx + 1
         }
         
-        print ("    total edges after flatten: " + (to_string (array_length currentEdges)))
+        if debug { print ("    total edges after flatten: " + (to_string (array_length currentEdges))) }
         
         ; Anti-aliased scanline fill using edges
         this.scanlineFillAA(buf currentEdges r g b a)
@@ -745,7 +751,7 @@ class RasterText {
     fn scanlineFillAA:void (buf:RasterBuffer edges:[GlyphEdge] r:int g:int b:int a:int) {
         def numEdges:int (array_length edges)
         if (numEdges == 0) {
-            print ("    scanlineFillAA: no edges, returning early!")
+            if debug { print ("    scanlineFillAA: no edges, returning early!") }
             return
         }
         
@@ -778,7 +784,7 @@ class RasterText {
             i = i + 1
         }
         
-        print ("    scanlineFillAA: " + (to_string numEdges) + " edges, bbox=(" + (to_string minX) + "," + (to_string minY) + ")-(" + (to_string maxX) + "," + (to_string maxY) + ")")
+        if debug { print ("    scanlineFillAA: " + (to_string numEdges) + " edges, bbox=(" + (to_string minX) + "," + (to_string minY) + ")-(" + (to_string maxX) + "," + (to_string maxY) + ")") }
         
         ; Clamp to buffer with 1 pixel margin
         def startY:int ((to_int minY) - 1)
@@ -798,7 +804,7 @@ class RasterText {
             endX = buf.width - 1
         }
         
-        print ("    scanlineFillAA: clamped range X=" + (to_string startX) + "-" + (to_string endX) + " Y=" + (to_string startY) + "-" + (to_string endY))
+        if debug { print ("    scanlineFillAA: clamped range X=" + (to_string startX) + "-" + (to_string endX) + " Y=" + (to_string startY) + "-" + (to_string endY)) }
         
         ; Subpixel offsets for 4x4 grid
         def subStep:double 0.25
@@ -918,7 +924,7 @@ class RasterText {
         
         ; Debug: check if font is loaded
         if (font.unitsPerEm <= 0) {
-            print ("ERROR: Font not loaded in RasterText! unitsPerEm=" + (to_string font.unitsPerEm))
+            if debug { print ("ERROR: Font not loaded in RasterText! unitsPerEm=" + (to_string font.unitsPerEm)) }
             return
         }
         
@@ -926,8 +932,8 @@ class RasterText {
         def baseline:double (font.getAscender(fontSize))
         def renderY:double (y + baseline)
         
-        print ("RasterText.renderText: text='" + text + "' pos=(" + (to_string x) + "," + (to_string y) + ") fontSize=" + (to_string fontSize) + " baseline=" + (to_string baseline) + " renderY=" + (to_string renderY))
-        print ("RasterText.renderText: color=RGB(" + (to_string r) + "," + (to_string g) + "," + (to_string b) + ") alpha=" + (to_string a) + " bufSize=" + (to_string buf.width) + "x" + (to_string buf.height))
+        if debug { print ("RasterText.renderText: text='" + text + "' pos=(" + (to_string x) + "," + (to_string y) + ") fontSize=" + (to_string fontSize) + " baseline=" + (to_string baseline) + " renderY=" + (to_string renderY)) }
+        if debug { print ("RasterText.renderText: color=RGB(" + (to_string r) + "," + (to_string g) + "," + (to_string b) + ") alpha=" + (to_string a) + " bufSize=" + (to_string buf.width) + "x" + (to_string buf.height)) }
         
         while (i < len) {
             def ch:int (charAt text i)
@@ -937,7 +943,7 @@ class RasterText {
             
             ; Debug first character
             if (i == 0) {
-                print ("  First char: code=" + (to_string ch) + " glyphIdx=" + (to_string glyphIdx) + " numContours=" + (to_string (array_length outline.contours)) + " advanceWidth=" + (to_string outline.advanceWidth))
+                if debug { print ("  First char: code=" + (to_string ch) + " glyphIdx=" + (to_string glyphIdx) + " numContours=" + (to_string (array_length outline.contours)) + " advanceWidth=" + (to_string outline.advanceWidth)) }
             }
             
             this.renderGlyph(buf outline currX renderY r g b a)

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
     "build:raspberry": "bash gallery/game_engine/scripts/build-raspberry.sh",
     "deploy:pi": "bash gallery/game_engine/scripts/deploy-pi.sh",
     "engine:run": "node ./gallery/game_engine/pong.js",
+    "engine:ui:demo": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/ui/ui_editor_demo.rgr -d=./gallery/game_engine/ui -o=ui_editor_demo.js -nodecli && node ./gallery/game_engine/ui/ui_editor_demo.js",
+    "engine:ui:test": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/ui/tests/UITest.rgr -d=./gallery/game_engine/ui/tests -o=UITest.js -nodecli && node ./gallery/game_engine/ui/tests/UITest.js",
     "engine:compile:sdl": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -l=cpp ./gallery/game_engine/pong_sdl.rgr -d=./gallery/game_engine -o=pong_sdl.cpp -nodecli",
     "engine:sdl": "bash gallery/game_engine/scripts/build-sdl.sh",
     "engine:sdl:run": "bash gallery/game_engine/scripts/build-sdl.sh --run",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     "engine:run": "node ./gallery/game_engine/pong.js",
     "engine:ui:demo": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/ui/ui_editor_demo.rgr -d=./gallery/game_engine/ui -o=ui_editor_demo.js -nodecli && node ./gallery/game_engine/ui/ui_editor_demo.js",
     "engine:ui:test": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/ui/tests/UITest.rgr -d=./gallery/game_engine/ui/tests -o=UITest.js -nodecli && node ./gallery/game_engine/ui/tests/UITest.js",
+    "engine:ui:wasm-select": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/ui/wasm_ui_select_demo.rgr -d=./gallery/game_engine/ui -o=wasm_ui_select_demo.js -nodecli && node ./gallery/game_engine/ui/wasm_ui_select_demo.js",
+    "engine:ui:wasm-guest": "bash gallery/game_engine/wasm/as_ui_menu/build.sh && node gallery/game_engine/wasm/as_ui_menu/tools/parity.cjs",
     "engine:compile:sdl": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -l=cpp ./gallery/game_engine/pong_sdl.rgr -d=./gallery/game_engine -o=pong_sdl.cpp -nodecli",
     "engine:sdl": "bash gallery/game_engine/scripts/build-sdl.sh",
     "engine:sdl:run": "bash gallery/game_engine/scripts/build-sdl.sh --run",


### PR DESCRIPTION
## Summary

This PR introduces a complete **interactive UI/HUD layer** for the Ranger game engine that sits on top of EVG elements. It provides buttons, text-input boxes, draggable widgets, an on-screen software keyboard, and a "highlight selected element" outline. The layer is designed as pure, portable logic with all device I/O delegated to a thin platform layer.

## Key Changes

### Core UI Layer (`UILayer.rgr`)
- Retained-mode widget system with hit-testing, focus management, and drag handling
- Processes a single `UIInput` per frame (pointer + keyboard snapshot)
- Emits a queue of `UIEvent`s for the application to consume
- Manages focus routing, text input, and common UI commands (Tab, Enter, Esc, arrows)
- Renders all widgets through a `UIContext` with selection highlight and software keyboard overlay

### Widget System
- **`UIWidget.rgr`**: Base widget class with geometry, interaction state, and virtual hooks
- **`UITextInput.rgr`**: Single-line editable text field with caret and focus ring
- **`UISoftKeyboard.rgr`**: On-screen keyboard grid for touch/gamepad/mouse text entry
- **`UIBox.rgr`**: Draggable square widget for editor-like interactions

### Text Rendering (`UITextRenderer.rgr`)
- Font-aware text wrapping using real TrueType metrics (`FontManager` + `TTFTextMeasurer`)
- **Rasterized-line cache** for acceleration: each distinct rendered line is cached as an `ImageBuffer` and reused across frames
- Bitmap 3×5 fallback font when no TTF is loaded, ensuring UI always renders
- Proper text measurement and wrapping that matches layout

### Presentation (`UIContext.rgr`)
- Centralized `UITheme` with named color roles (dark, translucent-panel theme by default)
- Paint helpers for alpha-blended fills, stroked rectangles, and text rendering
- Shared framebuffer and text renderer across all widgets

### WASM UI Bridge (`WasmUiSelect.rgr`)
- **`WasmUiRenderer`**: Lays out an EVGElement tree and draws it via `UIContext`
- **`UiSelectController`**: Tracks selection cursor over WASM-declared selectable nodes
- Spatial D-pad navigation (finds nearest selectable node in pressed direction)
- Gamepad/keyboard-driven (pointer-free by design)
- Highlights selected node with a border and reports activation back to guest

### WASM Guest Example (`as_ui_menu/`)
- Minimal AssemblyScript selectable-menu guest demonstrating the RGU1 bridge
- Reuses shared RGU1 builder from `as_autopeli/assembly/ui.ts`
- Interactivity helpers: `.onActivate()`, `.defaultSelected()`, node flags for selectability
- Reacts to action button by rebuilding the document

### Host-Side RGU1 Writer (`RgUiWriter.rgr`)
- Emits RGU1 UI document bytes from Ranger (same format as WASM guest)
- Useful for testing the host path without a WASM runtime
- Fluent builder API: `view()`, `button()`, `label()` with chainable property setters

### Input Abstraction (`UIInput.rgr`)
- Single portable data shape for pointer + keyboard input
- Pointer position, press/release edges, scroll, per-frame text input, special keys queue
- Enables record/replay of UI behavior across all targets

### Testing & Demo
- **`UITest.rgr`**: Unit tests for pure UI logic (hit-testing, focus, text routing, dragging, selection, wrapping)
- **`ui_editor_demo.rgr`**: Tiny editor demo with toolbar, text field, draggable boxes, and selection highlight
- **`wasm_ui_select_demo.rgr`**: End-to-end demo of WASM-authored selectable menu with gamepad navigation

### Documentation
- **`UI_LAYER.md`**: Architecture overview, file guide, platform integration instructions, and design

https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91