### PR TITLE
compiler: propagate mutable-reference need through calls (fixes C++ const-ref build error)

### DIFF
--- a/bin/output.js
+++ b/bin/output.js
@@ -38488,6 +38488,45 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         this.analyzeTransitiveWeak(cl.constructor_fn);
       }
     };
+    propagateArgMutRef (calledParam, arg, fnCtx, changedParams) {
+      const calleeMut = calledParam.rust_borrow_type == 2;
+      const calleeCppRef = calledParam.needs_cpp_reference;
+      if ( calleeMut == false ) {
+        if ( calleeCppRef == false ) {
+          return;
+        }
+      }
+      const argVarName = arg.vref;
+      if ( (argVarName.length) == 0 ) {
+        return;
+      }
+      const argParam = fnCtx.getVariableDef(argVarName);
+      if ( (argParam.name.length) == 0 ) {
+        return;
+      }
+      if ( argParam.varType == 4 ) {
+        let didChange = false;
+        if ( calleeMut ) {
+          if ( argParam.rust_borrow_type != 2 ) {
+            argParam.rust_borrow_type = 2;
+            argParam.needs_cpp_reference = true;
+            didChange = true;
+          }
+        }
+        if ( calleeCppRef ) {
+          if ( argParam.needs_cpp_reference == false ) {
+            argParam.needs_cpp_reference = true;
+            didChange = true;
+          }
+        }
+        if ( didChange ) {
+          changedParams.push(argParam.name);
+          if ( this.debug ) {
+            console.log(((("StaticAnalysis: " + argParam.name) + " upgraded to mutable ref (passed to a param ") + calledParam.name) + " that requires it)");
+          }
+        }
+      }
+    };
     walkForTransitiveMutBorrow (node, fnCtx, fn, changedParams) {
       if ( node.hasFnCall ) {
         if ( (node.children.length) >= 2 ) {
@@ -38500,24 +38539,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
               var arg = callParams.children[i];
               if ( i < paramCnt ) {
                 const calledParam = calledFn.params[i];
-                if ( calledParam.rust_borrow_type == 2 ) {
-                  const argVarName = arg.vref;
-                  if ( (argVarName.length) > 0 ) {
-                    const argParam = fnCtx.getVariableDef(argVarName);
-                    if ( (argParam.name.length) > 0 ) {
-                      if ( argParam.varType == 4 ) {
-                        if ( argParam.rust_borrow_type != 2 ) {
-                          argParam.rust_borrow_type = 2;
-                          argParam.needs_cpp_reference = true;
-                          changedParams.push(argParam.name);
-                          if ( this.debug ) {
-                            console.log(((((("StaticAnalysis: " + argParam.name) + " upgraded to &mut (passed to ") + calledFn.name) + " param ") + calledParam.name) + " which requires &mut)");
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
+                this.propagateArgMutRef(calledParam, arg, fnCtx, changedParams);
               }
             };
           }
@@ -38533,24 +38555,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
               var arg_1 = argsNode.children[i_1];
               if ( i_1 < paramCnt_1 ) {
                 const calledParam_1 = calledFn_1.params[i_1];
-                if ( calledParam_1.rust_borrow_type == 2 ) {
-                  const argVarName_1 = arg_1.vref;
-                  if ( (argVarName_1.length) > 0 ) {
-                    const argParam_1 = fnCtx.getVariableDef(argVarName_1);
-                    if ( (argParam_1.name.length) > 0 ) {
-                      if ( argParam_1.varType == 4 ) {
-                        if ( argParam_1.rust_borrow_type != 2 ) {
-                          argParam_1.rust_borrow_type = 2;
-                          argParam_1.needs_cpp_reference = true;
-                          changedParams.push(argParam_1.name);
-                          if ( this.debug ) {
-                            console.log(((((("StaticAnalysis: " + argParam_1.name) + " upgraded to &mut (passed to ") + calledFn_1.name) + " param ") + calledParam_1.name) + " which requires &mut)");
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
+                this.propagateArgMutRef(calledParam_1, arg_1, fnCtx, changedParams);
               }
             };
           }

--- a/compiler/ng_StaticAnalysis.rgr
+++ b/compiler/ng_StaticAnalysis.rgr
@@ -1000,6 +1000,56 @@ class StaticAnalyzer {
   ;   fn transformWrapper(input, output) { transform(input, output) }
   ;   ; output here ALSO needs &mut because it's passed to transform's &mut param
   
+  ; Propagate a mutable-reference requirement from a callee parameter to the
+  ; argument we pass into it. A callee can require a mutable reference two ways:
+  ;   * rust_borrow_type == 2  — Rust &mut (objects whose fields are mutated)
+  ;   * needs_cpp_reference     — C++ non-const T& (arrays/buffers/maps mutated
+  ;                               in place, which markVarAsMutated flags WITHOUT
+  ;                               setting rust_borrow_type)
+  ; If our own parameter is the argument, it must carry the same requirement, or
+  ; the generated C++ passes it as `const T&` and then fails to bind it to the
+  ; callee's `T&` ("drops const"). Each marker propagates independently so this
+  ; does not change Rust borrow inference for the C++-only (array) case.
+  fn propagateArgMutRef:void (calledParam:RangerAppParamDesc arg:CodeNode fnCtx:RangerAppWriterContext changedParams:[string]) {
+    def calleeMut:boolean (calledParam.rust_borrow_type == 2)
+    def calleeCppRef:boolean calledParam.needs_cpp_reference
+    if (calleeMut == false) {
+      if (calleeCppRef == false) {
+        return
+      }
+    }
+    def argVarName:string arg.vref
+    if ((strlen argVarName) == 0) {
+      return
+    }
+    def argParam:RangerAppParamDesc (fnCtx.getVariableDef(argVarName))
+    if ((strlen argParam.name) == 0) {
+      return
+    }
+    if (argParam.varType == RangerContextVarType.FunctionParameter) {
+      def didChange:boolean false
+      if calleeMut {
+        if (argParam.rust_borrow_type != 2) {
+          argParam.rust_borrow_type = 2
+          argParam.needs_cpp_reference = true
+          didChange = true
+        }
+      }
+      if calleeCppRef {
+        if (argParam.needs_cpp_reference == false) {
+          argParam.needs_cpp_reference = true
+          didChange = true
+        }
+      }
+      if didChange {
+        push changedParams argParam.name
+        if debug {
+          print ("StaticAnalysis: " + argParam.name + " upgraded to mutable ref (passed to a param " + calledParam.name + " that requires it)")
+        }
+      }
+    }
+  }
+
   ; Walk function body to find calls where our parameters are passed to &mut params
   fn walkForTransitiveMutBorrow:void (node:CodeNode fnCtx:RangerAppWriterContext fn:RangerAppFunctionDesc changedParams:[string]) {
     ; Check for function/method calls
@@ -1020,31 +1070,9 @@ class StaticAnalyzer {
               ; Get the called function's parameter at this position
               def calledParam:RangerAppParamDesc (itemAt calledFn.params i)
               
-              ; Check if the called param requires &mut (borrow_type == 2)
-              if (calledParam.rust_borrow_type == 2) {
-                ; The called function wants &mut for this parameter
-                ; Check if our argument is one of our function's parameters
-                def argVarName:string arg.vref
-                if ((strlen argVarName) > 0) {
-                  ; Look up the argument in our function context
-                  def argParam:RangerAppParamDesc (fnCtx.getVariableDef(argVarName))
-                  if ((strlen argParam.name) > 0) {
-                    if (argParam.varType == RangerContextVarType.FunctionParameter) {
-                      ; Our parameter is passed to a &mut param
-                      ; Check if it's currently marked as immutable borrow or owned
-                      if (argParam.rust_borrow_type != 2) {
-                        ; Upgrade to &mut
-                        argParam.rust_borrow_type = 2
-                        argParam.needs_cpp_reference = true
-                        push changedParams argParam.name
-                        if debug {
-                          print ("StaticAnalysis: " + argParam.name + " upgraded to &mut (passed to " + calledFn.name + " param " + calledParam.name + " which requires &mut)")
-                        }
-                      }
-                    }
-                  }
-                }
-              }
+              ; Propagate a mutable-reference requirement (Rust &mut OR C++ non-const
+              ; T&) from the callee parameter to our argument.
+              this.propagateArgMutRef(calledParam arg fnCtx changedParams)
             }
           }
         }
@@ -1063,25 +1091,7 @@ class StaticAnalyzer {
           for argsNode.children arg:CodeNode i {
             if (i < paramCnt) {
               def calledParam:RangerAppParamDesc (itemAt calledFn.params i)
-              
-              if (calledParam.rust_borrow_type == 2) {
-                def argVarName:string arg.vref
-                if ((strlen argVarName) > 0) {
-                  def argParam:RangerAppParamDesc (fnCtx.getVariableDef(argVarName))
-                  if ((strlen argParam.name) > 0) {
-                    if (argParam.varType == RangerContextVarType.FunctionParameter) {
-                      if (argParam.rust_borrow_type != 2) {
-                        argParam.rust_borrow_type = 2
-                        argParam.needs_cpp_reference = true
-                        push changedParams argParam.name
-                        if debug {
-                          print ("StaticAnalysis: " + argParam.name + " upgraded to &mut (passed to " + calledFn.name + " param " + calledParam.name + " which requires &mut)")
-                        }
-                      }
-                    }
-                  }
-                }
-              }
+              this.propagateArgMutRef(calledParam arg fnCtx changedParams)
             }
           }
         }

--- a/tests/codegen-cpp.test.ts
+++ b/tests/codegen-cpp.test.ts
@@ -178,4 +178,21 @@ describe("C++ Code Generation", () => {
       expect(result.code).toContain("<vector>");
     });
   });
+
+  describe("Transitive mutable reference", () => {
+    // A parameter passed to a callee that mutates it (but not mutated directly
+    // in the caller) must still be a non-const reference, or g++ fails with
+    // "binding reference ... drops const". Regression for the RasterText
+    // flattenContour -> addEdge build break.
+    it("should not emit a const reference for a param forwarded to a mutating callee", () => {
+      const result = getGeneratedCppCode(
+        `${FIXTURES_DIR}/transitive_mut_ref.rgr`
+      );
+      expect(result.success, `Failed: ${result.error}`).toBe(true);
+      // both the direct mutator and the forwarding wrapper take non-const T&
+      expect(result.code).toContain("M::addItem( std::vector<int>& arr");
+      expect(result.code).toContain("M::wrap( std::vector<int>& arr");
+      expect(result.code).not.toContain("const std::vector<int>& arr");
+    });
+  });
 });

--- a/tests/fixtures/transitive_mut_ref.rgr
+++ b/tests/fixtures/transitive_mut_ref.rgr
@@ -1,0 +1,18 @@
+; Regression: a parameter passed to a callee that mutates it (without being
+; mutated directly in the caller) must still be emitted as a non-const C++
+; reference. Otherwise g++ fails with "binding reference ... drops const".
+class M {
+    fn addItem:void (arr:[int] v:int) {
+        push arr v
+    }
+    fn wrap:void (arr:[int]) {
+        this.addItem(arr 1)
+        this.addItem(arr 2)
+    }
+    sfn m@(main):void () {
+        def a:[int]
+        def obj (new M)
+        obj.wrap(a)
+        print (to_string (array_length a))
+    }
+}


### PR DESCRIPTION
## Summary

The C++/Rust static analysis only marked a parameter as needing a **non-const reference** (`needs_cpp_reference`) when the function mutated it **directly** (`push`/`set`). A function that merely **forwards** the parameter to a callee that mutates it stayed a `const` reference, so the generated C++ failed to bind it to the callee's `T&`:

```
error: binding reference of type 'vector<...>' to value of type 'const vector<...>' drops 'const' qualifier
        this->addEdge(edges, currX, currY, nx, ny);
```

This surfaced when the EVG UI layer pulled `RasterText` into the native `game-sdl` C++ build for the first time: `flattenContour` / `flattenQuadBezier` forward `edges` to `addEdge` (which `push`-mutates it), and g++ rejected the code.

## Root cause

The transitive pass (`walkForTransitiveMutBorrow`, Pass 5) already handled this — but only for **Rust `&mut`**, triggering on `rust_borrow_type == 2` (objects). Mutated **arrays / buffers / maps** are flagged via `needs_cpp_reference` **without** `rust_borrow_type`, so array-mutation never propagated to the C++ backend.

## Fix

`ng_StaticAnalysis.rgr`: factor the propagation into `propagateArgMutRef`, which propagates **both markers independently**:
- `rust_borrow_type` — Rust `&mut` (objects), unchanged
- `needs_cpp_reference` — C++/Rust non-const `T&` (arrays/buffers/maps), **new**

Resolved to a fixed point across the whole program, so a parameter forwarded to *any* mutating callee carries the same requirement. The frontend now emits correct references instead of failing at g++.

## Scope & safety

- `needs_cpp_reference` is read **only** by the C++ and Rust writers; JS and all other backends ignore it, and the change adds **no errors** (pure codegen propagation) — the JS self-host is unaffected.
- **Swift** is intentionally left unchanged: it uses a separate manual `@(mutates)` nameNode flag, and auto-`inout` would need to distinguish value-vs-reference types and lvalue call sites (a larger, separately-testable change).

## Changes
- `compiler/ng_StaticAnalysis.rgr` — the fix
- `bin/output.js` — rebuilt self-hosted compiler
- `tests/fixtures/transitive_mut_ref.rgr` + `tests/codegen-cpp.test.ts` — regression test

## Verification
- Rebuilt compiler self-hosts.
- Full suite green: codegen **cpp / rust / swift / kotlin / go**, compiler self-host, conformance, game-engine-render. `codegen-cpp` **23/23** incl. the new regression.
- `RasterText` now compiles under C++ **unchanged** (`g++ -fsyntax-only`: no const errors), unblocking the native `game-sdl` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_