### PR TITLE
game_engine: fix native text rendering (blit-to-buffer) + arrow-key UI nav

### DIFF
--- a/gallery/game_engine/framebuffer.rgr
+++ b/gallery/game_engine/framebuffer.rgr
@@ -248,11 +248,11 @@ class SoftCanvas {
         if (sh <= 0) {
             return
         }
-        def view:RasterBuffer (new RasterBuffer)
-        view.width = w
-        view.height = h
-        view.pixels = px
-        blitter.blitRect(view src sx sy sw sh ddx ddy)
+        ; Blit straight into our pixel buffer (passed by reference). Wrapping px
+        ; in a temporary RasterBuffer copies the std::vector under C++ value
+        ; semantics and silently drops the writes (text/sprites invisible on the
+        ; native build) — see rgba_fast_blit.blitRectBuf.
+        blitter.blitRectBuf(px w src sx sy sw sh ddx ddy)
     }
 
     ; Alpha-composite a source sub-rectangle onto this canvas (centered draw uses

--- a/gallery/game_engine/rgba_fast_blit.rgr
+++ b/gallery/game_engine/rgba_fast_blit.rgr
@@ -189,4 +189,46 @@ class RgbaFastBlit {
     fn blitImage:void (dest:RasterBuffer src:ImageBuffer dx:int dy:int) {
         this.blitRect(dest src 0 0 src.width src.height dx dy)
     }
+
+    ; Alpha-composite a source sub-rectangle straight into a raw destination
+    ; buffer (RGBA8888, width destW). Unlike blitRect(dest:RasterBuffer ...),
+    ; the destination is a `buffer` passed by reference, so it works when the
+    ; caller only has the raw pixel bytes (SoftCanvas.px). This is the C++-safe
+    ; path: wrapping the canvas bytes in a temporary RasterBuffer copies the
+    ; std::vector under C++ value semantics and silently drops the writes.
+    fn blitRectBuf:void (dstBuf:buffer destW:int src:ImageBuffer sx:int sy:int sw:int sh:int dx:int dy:int) {
+        def srcBuf:buffer (src.getRawBuffer())
+        def srcW:int (src.width)
+        def y 0
+        while (y < sh) {
+            def srcRowOff:int ((((sy + y) * srcW) + sx) * 4)
+            def dstRowOff:int ((((dy + y) * destW) + dx) * 4)
+            def x 0
+            while (x < sw) {
+                def sOff:int (srcRowOff + (x * 4))
+                def srcA:int (buffer_get srcBuf (sOff + 3))
+                if (srcA > 0) {
+                    def dOff:int (dstRowOff + (x * 4))
+                    if (srcA >= 255) {
+                        ; opaque: direct copy. Writing dstBuf here (buffer_set)
+                        ; also marks the parameter as mutated so it is emitted as
+                        ; a non-const C++ reference (works without the transitive
+                        ; mutable-ref compiler pass).
+                        buffer_set dstBuf dOff (buffer_get srcBuf sOff)
+                        buffer_set dstBuf (dOff + 1) (buffer_get srcBuf (sOff + 1))
+                        buffer_set dstBuf (dOff + 2) (buffer_get srcBuf (sOff + 2))
+                        buffer_set dstBuf (dOff + 3) 255
+                    } {
+                        this.blendOverBytes(dstBuf dOff
+                            (buffer_get srcBuf sOff)
+                            (buffer_get srcBuf (sOff + 1))
+                            (buffer_get srcBuf (sOff + 2))
+                            srcA)
+                    }
+                }
+                x = (x + 1)
+            }
+            y = (y + 1)
+        }
+    }
 }

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -885,8 +885,7 @@ class GameSdlRunner {
         this.syncInputEdges()
         def nav:UiNavInput (new UiNavInput)
         while (running) {
-            gfx_input_poll
-            def m:int (this.launcherNavMask())
+            def m:int (this.uiNavMask())
             nav.clear()
             nav.up = (this.upEdge((bit_and m 1) != 0))
             nav.down = (this.downEdge((bit_and m 2) != 0))
@@ -921,6 +920,15 @@ class GameSdlRunner {
         def kb:int (gfx_input_source_mask(0))
         def pad:int (gfx_input_source_mask(2))
         return (bit_or kb pad)
+    }
+
+    ; UI-menu navigation: WASD (src 0) + arrow keys (src 1) + gamepad 0 (src 2).
+    ; The launcher mask above omits src 1, so arrows wouldn't move the selection.
+    fn uiNavMask:int () {
+        def kb1:int (gfx_input_source_mask(0))
+        def kb2:int (gfx_input_source_mask(1))
+        def pad:int (gfx_input_source_mask(2))
+        return (bit_or (bit_or kb1 kb2) pad)
     }
 
     ; Return to launcher menu: Q/Esc, or gamepad Select / B.


### PR DESCRIPTION
## Summary

Two **native-only** bugs on the SDL launcher's EVG UI menu (the es6/headless path was unaffected, which is why the unit tests were green): text didn't render, and arrow keys didn't move the selection.

## 1. Text/sprites not rendering — blit into the real framebuffer

`SoftCanvas.blitImage` wrapped the canvas pixels in a temporary `RasterBuffer` (`view.pixels = px`) and blitted into that. Under C++ value semantics `buffer` is `std::vector<uint8_t>`, so **that assignment copies the canvas** — the alpha-composited glyphs land on a throwaway and the real framebuffer is never touched. (Fills/strokes work because they write the canvas field directly; that's why the borders/glow showed but the labels didn't.)

Fix: add `RgbaFastBlit.blitRectBuf`, which composites **straight into the destination buffer passed by reference**, and call it from `blitImage` (no view copy). The opaque path writes `dstBuf` directly (`buffer_set`), so the parameter is emitted as a non-const `std::vector<uint8_t>&` **without** depending on the transitive mutable-ref compiler pass — this PR is self-contained. es6 behaviour is unchanged (UI text still renders in the snapshots).

## 2. Arrow keys didn't move the selection

`runUiGame` used `launcherNavMask` = keyboard-P1 (**WASD**, source 0) | gamepad (source 2), which **omits source 1** — the arrow keys (`SDL_SCANCODE_UP/DOWN/LEFT/RIGHT` live on the P2 keyboard source in `gfx_sdl.rgr`). Add `uiNavMask` that also ORs source 1, so **WASD, arrows and the D-pad** all move the cursor.

## Verification
- Launcher + framebuffer compile (es6 + cpp).
- `blitRectBuf` emits a non-const `std::vector<uint8_t>&`; `g++ -std=c++17 -fsyntax-only` is clean (no const errors).
- `UITest` 29/29, `engine:ui:game` 4/4 — text still renders in the PNG snapshots.

> Complements #206 (native `engine=ui` load + bundled font). With #206 the guest loads; with this PR its text renders and arrows navigate. Independent of #205 (the compiler pass) — the blit fix is self-contained here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_