### PR TITLE
game_engine: instrument engine=ui input/selection to localise native arrow-key nav

### DIFF
--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -98,6 +98,8 @@ class GameSdlRunner {
     def prevActionHeld:boolean false
     def uiRunner:GameUiRunner (new GameUiRunner)
     def uiDirectPath:string ""
+    def uiDbg:boolean true          ; print input/selection diagnostics for engine=ui
+    def uiDbgLastMask:int -1
     def gpuModeWanted:boolean true
     def gpuModeActive:boolean false
     def gameInputSnap:GameInputSnapshot (new GameInputSnapshot)
@@ -928,12 +930,16 @@ class GameSdlRunner {
             return
         }
         print ("[game-engine] ui game: " + wasmPath)
+        if uiDbg {
+            print (("[ui-dbg] loaded selectable=" + (to_string (uiRunner.selCount()))) + (" sel=" + (to_string (uiRunner.selId()))))
+        }
         currentScriptPath = wasmPath
         currentGamePath = wasmPath
         inMenu = false
         inGame = true
         gfx_clear_should_close
         this.syncInputEdges()
+        uiDbgLastMask = -1
         def nav:UiNavInput (new UiNavInput)
         while (running) {
             def m:int (this.uiNavMask())
@@ -943,7 +949,28 @@ class GameSdlRunner {
             nav.left = (this.leftEdge((bit_and m 16) != 0))
             nav.right = (this.rightEdge((bit_and m 32) != 0))
             nav.action = (this.actionEdge((bit_and m 4) != 0))
+            ; input diagnostics: log the raw nav mask only when it changes, so we
+            ; can see whether keyboard/gamepad bits ever reach this loop natively.
+            if uiDbg {
+                if (m != uiDbgLastMask) {
+                    print (("[ui-dbg] mask=" + (to_string m)) + (" sel=" + (to_string (uiRunner.selId()))))
+                    uiDbgLastMask = m
+                }
+            }
             def _a:int (uiRunner.frame(nav))
+            ; report the resulting selection whenever a nav/action edge fired, so a
+            ; moving mask that doesn't move the cursor is immediately visible.
+            if uiDbg {
+                def fired:boolean false
+                if nav.up { fired = true }
+                if nav.down { fired = true }
+                if nav.left { fired = true }
+                if nav.right { fired = true }
+                if nav.action { fired = true }
+                if fired {
+                    print (((("[ui-dbg] edge mask=" + (to_string m)) + (" ->sel=" + (to_string (uiRunner.selId())))) + (" idx=" + (to_string (uiRunner.selIndex())))) + (" count=" + (to_string (uiRunner.selCount()))))
+                }
+            }
             uiRunner.render()
             gfx_present (uiRunner.raw()) pw ph
 

--- a/gallery/game_engine/scripting/game_ui_runner.rgr
+++ b/gallery/game_engine/scripting/game_ui_runner.rgr
@@ -132,6 +132,17 @@ class GameUiRunner {
         ctrl.renderHighlight(ctx)
     }
 
+    ; --- diagnostics (used by the SDL runner to localise native input issues) ---
+    fn selCount:int () {
+        return (ctrl.count())
+    }
+    fn selId:int () {
+        return ctrl.selectedId
+    }
+    fn selIndex:int () {
+        return ctrl.selIndex
+    }
+
     fn raw:buffer () {
         return (canvas.raw())
     }


### PR DESCRIPTION
## Summary

After #207 the native SDL launcher renders the WASM UI menu (text + selection glow) but the **arrow keys still don't move the selection** — and it only reproduces in the SDL/C++ build. The headless es6 demo navigates correctly (`wasm_ui_select_demo`: `Down×2 → Options/13`, `Up×2 → New Game/11`), so the unit tests stay green and there's nothing to catch the native-only failure.

I traced the whole path statically and every host-side piece checks out:

- **Input masks** (`gfx_sdl.rgr`): `rgfx_input_source_mask` self-polls; src0 = WASD, src1 = arrows, src2 = pad, all mapping to `RGFX_UP=1/DOWN=2/ACT=4/LEFT=16/RIGHT=32`. `uiNavMask()` ORs all three (arrows included).
- **Edge detection + `runUiGame` wiring**: correct.
- **AS bytes vs host reader**: byte-identical (`N_FLAGS`@10, `N_EVENT_MASK`@20, node stride 32); `.onActivate()` sets SELECTABLE on all four buttons (guarded by the parity test).
- **Controller**: generated C++ makes `UiSelectController` a `shared_ptr` class, so `ctrl->update()` mutates the real `selIndex`/`ids` — not a value-semantics bug like the #207 blit issue.

Since SDL2 isn't in this environment I can't reproduce it, so rather than guess this PR **instruments `GameSdlRunner.runUiGame`** so a single native run pinpoints the fault.

## What it prints (gated behind `uiDbg`, engine=ui only, throttled)

- **on load**: `selectable=N sel=…` — `N==4` ⇒ doc/reader fine, fault is pure input; `N<4` ⇒ reader/AS-bytes problem.
- **per frame**: the raw `uiNavMask()` value, only when it changes — shows whether keyboard/gamepad bits ever reach the loop.
- **on any nav/action edge**: the resulting selection id + index — a moving mask that fails to move the cursor is immediately visible.

`selCount()`/`selId()`/`selIndex()` accessors added to `GameUiRunner` to expose controller state without widening its surface.

## Verification

- `game_sdl_runner.rgr` compiles clean to C++ (`bin/output.js -l=cpp`).
- Diagnostics are purely additive; no behavioural change to the render/nav path.

Once the native path is confirmed the diagnostics come back out (or flip `uiDbg` default to false).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_