### PR TITLE
game_engine: probe navigate() to resolve the native UI-menu nav paradox

### DIFF
--- a/gallery/game_engine/ui/WasmUiSelect.rgr
+++ b/gallery/game_engine/ui/WasmUiSelect.rgr
@@ -316,6 +316,7 @@ class UiSelectController {
     ; to the next/previous by list order.
     fn navigate:void (dir:int) {
         def n (array_length ids)
+        print (((("[nav-dbg] navigate dir=" + (to_string dir)) + (" n=" + (to_string n))) + (" curIdx=" + (to_string selIndex))) + (" curSel=" + (to_string selectedId)))
         if (n <= 1) { return }
         def curIdx selIndex
         def ccx (this.cx(curIdx))
@@ -367,6 +368,7 @@ class UiSelectController {
         if (best >= 0) {
             selIndex = best
             selectedId = (itemAt ids best)
+            print (("[nav-dbg]   -> spatial best=" + (to_string best)) + (" newSel=" + (to_string selectedId)))
             return
         }
         ; no candidate in that direction -> wrap by order along the axis
@@ -378,6 +380,7 @@ class UiSelectController {
         while (ni >= n) { ni = (ni - n) }
         selIndex = ni
         selectedId = (itemAt ids ni)
+        print (("[nav-dbg]   -> wrap ni=" + (to_string ni)) + (" newSel=" + (to_string selectedId)))
     }
 
     ; Consume one frame of nav input. Returns the activated node id, or -1.


### PR DESCRIPTION
## Context

Builds on the runUiGame diagnostics (#208). A native run produced a logically impossible trace:

```
[ui-dbg] loaded selectable=4 sel=20
[ui-dbg] mask=2 sel=20
[ui-dbg] edge mask=2 ->sel=20 idx=0 count=4      # DOWN edge fires, 4 nodes, cursor never moves
```

`nav.down=true` reaches `frame()` → `ctrl->update()` → `navigate(1)`, with `count=4`. But `navigate()`'s **wrap path unconditionally reassigns `selIndex`** whenever `n>1` (`ni = 0+1 = 1`), and the spatial path does too — the generated C++ is correct (`shared_ptr` controller, plain `std::vector<int> ids`, plain `int selIndex`; verified). So the cursor staying at `idx=0` is only possible if `navigate` early-returns at `n <= 1`, i.e. `ids.size()` **inside** `navigate` disagrees with `count()`'s `ids.size()` **right after** — in the same frame, on what should be the same object.

## What this adds

Prints inside `UiSelectController.navigate` to capture the runtime truth (temporary, gated by the same debug pass, removed once fixed):

- **on entry** — `dir`, `n = array_length ids`, `curIdx`, `curSel`
- **on each cursor-moving exit** — the spatial `best` / `wrap` target + resulting `newSel`

## What the next run tells us

| Observation | Conclusion |
|---|---|
| `navigate n=1` while runUiGame prints `count=4` (same frame) | two reads see different state — aliasing / a second controller instance; the real fix is in how `ctrl` is shared |
| `navigate n=4` **and** a `-> wrap/spatial newSel=…` line appears, but the outer print still shows unchanged | the write is reverted downstream (a per-frame rebuild/refresh) |
| `navigate` never prints on a DOWN edge | `update` isn't dispatching to it — the `nav` bits differ between `frame` and the diagnostic read |

Compiles clean to C++ (`bin/output.js -l=cpp`); purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_