### PR TITLE
cpp: never dead-eliminate a local whose initializer is a call (fixes native UI-menu nav)

### DIFF
--- a/bin/output.js
+++ b/bin/output.js
@@ -19107,7 +19107,21 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       if ( node.hasParamDesc ) {
         const nn = node.children[1];
         const p = nn.paramDesc;
-        if ( (p.ref_cnt == 0) && (p.is_class_variable == false) ) {
+        let initHasSideEffect = false;
+        if ( (node.children.length) > 2 ) {
+          const initChk = node.getThird();
+          if ( initChk.hasFnCall ) {
+            initHasSideEffect = true;
+          }
+          if ( initChk.has_call ) {
+            initHasSideEffect = true;
+          }
+          if ( initChk.hasNewOper ) {
+            initHasSideEffect = true;
+          }
+        }
+        const elideUnused = ((p.ref_cnt == 0) && (p.is_class_variable == false)) && (initHasSideEffect == false);
+        if ( elideUnused ) {
           wr.out("/** unused:  ", false);
         }
         if ( (p.set_cnt > 0) || p.is_class_variable ) {
@@ -19151,7 +19165,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         if ( (p.ref_cnt == 0) && (p.is_class_variable == true) ) {
           wr.out("     /** note: unused */", false);
         }
-        if ( (p.ref_cnt == 0) && (p.is_class_variable == false) ) {
+        if ( elideUnused ) {
           wr.out("   **/ ;", true);
         } else {
           wr.out(";", false);

--- a/compiler/ng_RangerCppClassWriter.rgr
+++ b/compiler/ng_RangerCppClassWriter.rgr
@@ -420,7 +420,26 @@ class RangerCppClassWriter {
     if node.hasParamDesc {
       def nn:CodeNode (itemAt node.children 1)
       def p:RangerAppParamDesc nn.paramDesc
-      if ((p.ref_cnt == 0) && (p.is_class_variable == false)) {
+      ; A local whose initializer contains a call (or object construction) may
+      ; have side effects, so it must never be dead-eliminated even when its
+      ; result is unused: commenting the statement out silently drops the call
+      ; and changes behaviour (e.g. `def _a (runner.frame(nav))`, where frame()
+      ; advances state). Only side-effect-free initializers are safe to elide.
+      def initHasSideEffect:boolean false
+      if ((array_length node.children) > 2) {
+        def initChk:CodeNode (node.getThird())
+        if initChk.hasFnCall {
+          initHasSideEffect = true
+        }
+        if initChk.has_call {
+          initHasSideEffect = true
+        }
+        if initChk.hasNewOper {
+          initHasSideEffect = true
+        }
+      }
+      def elideUnused:boolean (((p.ref_cnt == 0) && (p.is_class_variable == false)) && (initHasSideEffect == false))
+      if elideUnused {
         wr.out("/** unused:  " false)
       }
       if ((p.set_cnt > 0) || p.is_class_variable) {
@@ -476,7 +495,7 @@ class RangerCppClassWriter {
       if ((p.ref_cnt == 0) && (p.is_class_variable == true)) {
         wr.out("     /** note: unused */" false)
       }
-      if ((p.ref_cnt == 0) && (p.is_class_variable == false)) {
+      if elideUnused {
         wr.out("   **/ ;" true)
       } {
         wr.out(";" false)

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -98,8 +98,6 @@ class GameSdlRunner {
     def prevActionHeld:boolean false
     def uiRunner:GameUiRunner (new GameUiRunner)
     def uiDirectPath:string ""
-    def uiDbg:boolean true          ; print input/selection diagnostics for engine=ui
-    def uiDbgLastMask:int -1
     def gpuModeWanted:boolean true
     def gpuModeActive:boolean false
     def gameInputSnap:GameInputSnapshot (new GameInputSnapshot)
@@ -930,16 +928,12 @@ class GameSdlRunner {
             return
         }
         print ("[game-engine] ui game: " + wasmPath)
-        if uiDbg {
-            print (("[ui-dbg] loaded selectable=" + (to_string (uiRunner.selCount()))) + (" sel=" + (to_string (uiRunner.selId()))))
-        }
         currentScriptPath = wasmPath
         currentGamePath = wasmPath
         inMenu = false
         inGame = true
         gfx_clear_should_close
         this.syncInputEdges()
-        uiDbgLastMask = -1
         def nav:UiNavInput (new UiNavInput)
         while (running) {
             def m:int (this.uiNavMask())
@@ -949,28 +943,7 @@ class GameSdlRunner {
             nav.left = (this.leftEdge((bit_and m 16) != 0))
             nav.right = (this.rightEdge((bit_and m 32) != 0))
             nav.action = (this.actionEdge((bit_and m 4) != 0))
-            ; input diagnostics: log the raw nav mask only when it changes, so we
-            ; can see whether keyboard/gamepad bits ever reach this loop natively.
-            if uiDbg {
-                if (m != uiDbgLastMask) {
-                    print (("[ui-dbg] mask=" + (to_string m)) + (" sel=" + (to_string (uiRunner.selId()))))
-                    uiDbgLastMask = m
-                }
-            }
             def _a:int (uiRunner.frame(nav))
-            ; report the resulting selection whenever a nav/action edge fired, so a
-            ; moving mask that doesn't move the cursor is immediately visible.
-            if uiDbg {
-                def fired:boolean false
-                if nav.up { fired = true }
-                if nav.down { fired = true }
-                if nav.left { fired = true }
-                if nav.right { fired = true }
-                if nav.action { fired = true }
-                if fired {
-                    print (((("[ui-dbg] edge mask=" + (to_string m)) + (" ->sel=" + (to_string (uiRunner.selId())))) + (" idx=" + (to_string (uiRunner.selIndex())))) + (" count=" + (to_string (uiRunner.selCount()))))
-                }
-            }
             uiRunner.render()
             gfx_present (uiRunner.raw()) pw ph
 

--- a/gallery/game_engine/scripting/game_ui_runner.rgr
+++ b/gallery/game_engine/scripting/game_ui_runner.rgr
@@ -132,17 +132,6 @@ class GameUiRunner {
         ctrl.renderHighlight(ctx)
     }
 
-    ; --- diagnostics (used by the SDL runner to localise native input issues) ---
-    fn selCount:int () {
-        return (ctrl.count())
-    }
-    fn selId:int () {
-        return ctrl.selectedId
-    }
-    fn selIndex:int () {
-        return ctrl.selIndex
-    }
-
     fn raw:buffer () {
         return (canvas.raw())
     }

--- a/gallery/game_engine/ui/WasmUiSelect.rgr
+++ b/gallery/game_engine/ui/WasmUiSelect.rgr
@@ -316,7 +316,6 @@ class UiSelectController {
     ; to the next/previous by list order.
     fn navigate:void (dir:int) {
         def n (array_length ids)
-        print (((("[nav-dbg] navigate dir=" + (to_string dir)) + (" n=" + (to_string n))) + (" curIdx=" + (to_string selIndex))) + (" curSel=" + (to_string selectedId)))
         if (n <= 1) { return }
         def curIdx selIndex
         def ccx (this.cx(curIdx))
@@ -368,7 +367,6 @@ class UiSelectController {
         if (best >= 0) {
             selIndex = best
             selectedId = (itemAt ids best)
-            print (("[nav-dbg]   -> spatial best=" + (to_string best)) + (" newSel=" + (to_string selectedId)))
             return
         }
         ; no candidate in that direction -> wrap by order along the axis
@@ -380,7 +378,6 @@ class UiSelectController {
         while (ni >= n) { ni = (ni - n) }
         selIndex = ni
         selectedId = (itemAt ids ni)
-        print (("[nav-dbg]   -> wrap ni=" + (to_string ni)) + (" newSel=" + (to_string selectedId)))
     }
 
     ; Consume one frame of nav input. Returns the activated node id, or -1.

--- a/tests/codegen-cpp.test.ts
+++ b/tests/codegen-cpp.test.ts
@@ -71,6 +71,27 @@ describe("C++ Code Generation", () => {
     });
   });
 
+  describe("Dead-store elimination", () => {
+    it("should NOT eliminate an unused local whose initializer is a call (side effects)", () => {
+      const result = getGeneratedCppCode(
+        `${FIXTURES_DIR}/unused_call_result.rgr`
+      );
+      expect(result.success, `Failed: ${result.error}`).toBe(true);
+      // the call must be emitted as a live statement, not commented out
+      expect(result.code).toContain("->bump()");
+      expect(result.code).not.toMatch(/\/\*\* unused:[^\n]*bump\(\)/);
+    });
+
+    it("should still elide a genuinely unused pure-expression local", () => {
+      const result = getGeneratedCppCode(
+        `${FIXTURES_DIR}/unused_call_result.rgr`
+      );
+      expect(result.success, `Failed: ${result.error}`).toBe(true);
+      // deadPure = 2 + 3 has no side effects -> safe to comment out
+      expect(result.code).toMatch(/\/\*\* unused:[^\n]*2 \+ 3/);
+    });
+  });
+
   describe("Memory Management", () => {
     it("should use smart pointers for objects", () => {
       const result = getGeneratedCppCode(`${FIXTURES_DIR}/two_classes.rgr`);

--- a/tests/fixtures/unused_call_result.rgr
+++ b/tests/fixtures/unused_call_result.rgr
@@ -1,0 +1,20 @@
+; Regression: a local whose initializer is a CALL must never be dead-eliminated
+; by the C++ writer, even when its result is unused — the call has side effects.
+; A pure-expression unused local is still safe to elide.
+class UnusedCallResult {
+    def counter:int 0
+
+    fn bump:int () {
+        counter = (counter + 1)
+        return counter
+    }
+
+    sfn m@(main):void () {
+        def obj:UnusedCallResult (new UnusedCallResult)
+        ; result unused, but the call MUST survive (mutates counter)
+        def ignored:int (obj.bump())
+        ; pure unused local — safe to eliminate
+        def deadPure:int (2 + 3)
+        print (to_string obj.counter)
+    }
+}


### PR DESCRIPTION
## Root cause

This is the real cause of the native SDL UI-menu not responding to arrow keys — a **compiler miscompilation**, not a game bug.

The C++ writer's dead-store pass (`RangerCppClassWriter.writeVarDef`) comments out any local whose result is never read (`ref_cnt == 0`) — **including its initializer**. When that initializer is a *call*, the call has side effects, and dropping it silently changes behaviour.

The launcher's `engine=ui` loop does:

```
def _a:int (uiRunner.frame(nav))   ; advances the selection + forwards activation
```

`_a` is unused, so the whole statement was emitted as:

```cpp
/** unused:  int _a = uiRunner->frame(nav)   **/ ;
```

→ `frame()` was **never called** natively. The menu still rendered (`render()` is a separate `void` call) and the default item stayed highlighted (set at load), but arrow keys never moved the cursor because `update()`/`navigate()` never ran. The es6/JS writers gate the same removal behind the `remove-unused-class-vars` flag (off by default), which is why the headless tests and the `wasm_ui_select_demo` were unaffected and never caught it.

Diagnosis trail: `[ui-dbg]` showed the DOWN edge reaching the loop with `count=4`, but `[nav-dbg]` inside `navigate()` never printed — because `frame()` (its only caller) had been elided. The generated C++ confirmed it: the `frame(nav)` line was inside a `/** unused **/` comment.

## Fix

In `writeVarDef`, only elide an unused local when its initializer is **side-effect-free**. If the init node is `hasFnCall` / `has_call` / `hasNewOper`, keep the statement live:

```cpp
int _a = uiRunner->frame(nav);   // call now executes
```

Pure-expression unused locals (`def a (2 + 3)`) are still commented out exactly as before. C++-only — matches the earlier guidance to apply this class of analysis to C++/Swift, not JS.

## Changes

- **`compiler/ng_RangerCppClassWriter.rgr`** — side-effect guard (`initHasSideEffect` → `elideUnused`) on the dead-store pass.
- **`bin/output.js`** — rebuilt self-hosted compiler (`npm run compile`).
- **`tests/fixtures/unused_call_result.rgr` + `tests/codegen-cpp.test.ts`** — regression: an unused *call result* stays live (`->bump()` emitted), an unused *pure expr* is still elided (`/** unused: … 2 + 3 */`).
- **`gallery/game_engine/*`** — removed the temporary `[ui-dbg]`/`[nav-dbg]` instrumentation used to localise this; the game code is back to the plain `def _a (uiRunner.frame(nav))` form, which now compiles correctly.

## Verification

`getGeneratedCppCode` confirms `int _a = uiRunner->frame(nav);` is now a live statement. Test suites green: **C++ 25/25** (incl. 2 new), **es6 19/19**, **rust 9/9**, **go 15/15**, **python 15/15**.

After merge, rebuild the native launcher (`npm run engine:game-sdl:launcher`) — the UI menu will navigate with WASD, arrows, and the D-pad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_