### PR TITLE
game_engine: autoscale the WASM UI menu to fit the canvas (no more clipped Quit button)

### DIFF
--- a/gallery/game_engine/scripting/game_ui_runner.rgr
+++ b/gallery/game_engine/scripting/game_ui_runner.rgr
@@ -96,7 +96,42 @@ class GameUiRunner {
         def builder:WasmUiEvgBuilder (new WasmUiEvgBuilder)
         root = (builder.build(doc))
         ctrl.renderer.layoutTree(ctx root w h)
+        ; Autoscale-to-fit: the guest authors fixed px sizes; if the laid-out
+        ; menu is taller/wider than this canvas the bottom items would clip.
+        ; Rebuild once at a uniform scale so every element AND its font shrink
+        ; together to fit (never scales up).
+        def s:double (this.fitScale())
+        if (s < 1.0) {
+            def b2:WasmUiEvgBuilder (new WasmUiEvgBuilder)
+            b2.scale = s
+            root = (b2.build(doc))
+            ctrl.renderer.layoutTree(ctx root w h)
+        }
         ctrl.rebuild(doc root)
+    }
+
+    ; Uniform scale (<= 1) that makes the laid-out content fit the canvas, with
+    ; a small margin so nothing touches the edges. 1.0 when it already fits.
+    fn fitScale:double () {
+        def s:double 1.0
+        def fh:double (to_double h)
+        def fw:double (to_double w)
+        def needH:double (ctrl.renderer.contentBottom(root))
+        if (needH > 0.0) {
+            if (needH > fh) {
+                def sy:double ((fh * 0.96) / needH)
+                if (sy < s) { s = sy }
+            }
+        }
+        def needW:double (ctrl.renderer.contentRight(root))
+        if (needW > 0.0) {
+            if (needW > fw) {
+                def sx:double ((fw * 0.98) / needW)
+                if (sx < s) { s = sx }
+            }
+        }
+        if (s < 0.2) { s = 0.2 }
+        return s
     }
 
     ; --- per-frame --------------------------------------------------------------

--- a/gallery/game_engine/scripting/wasm_ui_io.rgr
+++ b/gallery/game_engine/scripting/wasm_ui_io.rgr
@@ -276,8 +276,16 @@ class WasmUiDoc {
 ; ==============================================================================
 class WasmUiEvgBuilder {
 
+    ; Uniform scale applied to every guest-declared px value (sizes, padding,
+    ; margins, border, radius AND font size). 1.0 = author's exact pixels; the
+    ; host lowers it to autoscale a too-large menu down to the canvas (see
+    ; GameUiRunner.rebuildTree). All px funnels through pxUnit, so this one
+    ; multiply scales the whole tree proportionally.
+    def scale:double 1.0
+
     fn pxUnit:EVGUnit (v:int) {
         def dv (to_double v)
+        dv = (dv * scale)
         def u (EVGUnit.px(dv))
         u.pixels = dv
         return u

--- a/gallery/game_engine/ui/WasmUiSelect.rgr
+++ b/gallery/game_engine/ui/WasmUiSelect.rgr
@@ -83,6 +83,59 @@ class WasmUiRenderer {
         layout.layoutElement(root 0.0 0.0 fw fh)
     }
 
+    ; Deepest laid-out bottom edge (calculatedY + calculatedHeight) among the
+    ; root's descendants, excluding the full-page root itself. This is the true
+    ; content height used to decide autoscale-to-fit.
+    fn contentBottom:double (root:EVGElement) {
+        def m:double 0.0
+        def i 0
+        def n (array_length root.children)
+        while (i < n) {
+            def c:EVGElement (itemAt root.children i)
+            def b:double (this.maxBottom(c))
+            if (b > m) { m = b }
+            i = (i + 1)
+        }
+        return m
+    }
+    fn maxBottom:double (el:EVGElement) {
+        def b:double (el.calculatedY + el.calculatedHeight)
+        def i 0
+        def n (array_length el.children)
+        while (i < n) {
+            def c:EVGElement (itemAt el.children i)
+            def cb:double (this.maxBottom(c))
+            if (cb > b) { b = cb }
+            i = (i + 1)
+        }
+        return b
+    }
+    ; Right-most laid-out edge among the root's descendants (content width).
+    fn contentRight:double (root:EVGElement) {
+        def m:double 0.0
+        def i 0
+        def n (array_length root.children)
+        while (i < n) {
+            def c:EVGElement (itemAt root.children i)
+            def b:double (this.maxRight(c))
+            if (b > m) { m = b }
+            i = (i + 1)
+        }
+        return m
+    }
+    fn maxRight:double (el:EVGElement) {
+        def b:double (el.calculatedX + el.calculatedWidth)
+        def i 0
+        def n (array_length el.children)
+        while (i < n) {
+            def c:EVGElement (itemAt el.children i)
+            def cb:double (this.maxRight(c))
+            if (cb > b) { b = cb }
+            i = (i + 1)
+        }
+        return b
+    }
+
     ; Resolved border radius (px) declared on the element by the guest, or 0.
     fn radiusOf:int (el:EVGElement) {
         if el.box.borderRadius.isSet {


### PR DESCRIPTION
## Problem

The `engine=ui` menu is authored by the guest in fixed pixels. On the native 480×270 launcher canvas the card lays out **~390px tall**, so the bottom button (Quit) and the status line clip off-screen.

## Why not just space-between?

`space-between`/`center`/`justify` only distribute **free** space. Here the content *exceeds* the container (free space is negative), so items still clip — those helpers are the right tool only once the content already fits. (Vertical `space-between` is additionally a no-op on a content-sized box; it needs a fixed-height container.) So a fit guarantee has to come from scaling.

## Fix — host-side autoscale-to-fit

- **`WasmUiEvgBuilder.scale`** (default `1.0`) applied in `pxUnit`, the single funnel every guest px passes through — sizes, padding, margins, border, radius **and font size**. One multiply scales the whole EVG tree uniformly.
- **`WasmUiRenderer.contentBottom` / `contentRight`** measure the deepest laid-out edge among the root's descendants (true content extent, excluding the full-page root).
- **`GameUiRunner.rebuildTree`** lays out once at 1.0; if content overflows it rebuilds **once** at `fitScale()` — the *largest* scale that still fits (`0.96·h/need`, `0.98·w/need`). It only ever shrinks, and only as much as needed; a menu that already fits is untouched (`s == 1.0`, zero extra work).

For the current menu this picks **s ≈ 0.66** (390 → 259px, fits). The selection highlight follows automatically because `rebuild()` re-collects rects from the scaled tree.

## Cost

The extra build+layout runs only on load/rebuild (not per frame) and only when overflowing. The recursion is O(nodes).

## Verification

- `engine:ui:game` **4/4** — unchanged (its 360×400 canvas fits at 1.0, so no scaling).
- Launcher compiles to C++.
- Headless fit check: natural `contentBottom=390`, `fitScale=0.66`, scaled `contentBottom=259 → fits=true`.

## Trade-off / follow-up

0.66 is noticeable shrinkage because the menu is designed larger than a 270px canvas — autoscale picks the largest size that fits, so it's as big as it can be. To make it *larger*, the guest side can drop the ~80px of per-item margins and switch to `space-between` inside a fixed-height card (content → ~310px → scale ~0.85). That needs an AS wasm rebuild (`as_ui_menu/build.sh`) and can be a follow-up. Autoscale then remains the pure safety net.

> Builds on #211 (the `frame()` dead-store fix) — without it the native nav loop is elided regardless of layout. Once #211 merges, this PR narrows to just the layout changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_