### PR TITLE
game_engine: run interpreted .as UI menus on the native launcher

### DIFF
--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -923,7 +923,23 @@ class GameSdlRunner {
     ; button to the guest, and return to the launcher on Back/Quit.
     fn runUiGame:void (wasmPath:string) {
         uiRunner.init(pw ph "gallery/game_engine/assets/fonts" "OpenSans-Regular.ttf" "Open Sans")
-        if ((uiRunner.loadWasm(wasmPath)) == false) {
+        ; engine=ui games come in two flavours: a compiled logic.wasm guest, or an
+        ; interpreted .as source (runtime=as). Pick the backend by module suffix —
+        ; loading a .as through wasm_load fails with "malformed Wasm binary".
+        def ok:boolean false
+        def n:int (strlen wasmPath)
+        def isAs:boolean false
+        if (n > 3) {
+            if ((substring wasmPath (n - 3) n) == ".as") {
+                isAs = true
+            }
+        }
+        if isAs {
+            ok = (uiRunner.loadAs((this.dirOf(wasmPath))))
+        } {
+            ok = (uiRunner.loadWasm(wasmPath))
+        }
+        if (ok == false) {
             print ("[game-engine] ui game load failed: " + wasmPath)
             return
         }

--- a/gallery/game_engine/scripting/game_ui_runner.rgr
+++ b/gallery/game_engine/scripting/game_ui_runner.rgr
@@ -17,6 +17,7 @@
 
 Import "../framebuffer.rgr"
 Import "../ui/WasmUiSelect.rgr"
+Import "./as_source_runner.rgr"
 
 class GameUiRunner {
     def canvas:SoftCanvas (new SoftCanvas)
@@ -30,6 +31,17 @@ class GameUiRunner {
     def h:int 0
     def rev:int 0
     def loaded:boolean false
+
+    ; --- interpreted .as backend (engine=ui, runtime=as) ---
+    ; When useAs is set the guest is an interpreted .as source (no wasm): it reads
+    ; the input edge-mask from the shared ABI and drives its own selection, so the
+    ; host renders + highlights the node the guest reports (no UiSelectController
+    ; navigation). See games/ui_menu_as/game.as.
+    def asRunner:AsSourceRunner (new AsSourceRunner)
+    def useAs:boolean false
+    def asSelId:int 0
+    def OFF_INPUT:int 20      ; host -> guest edge mask: UP1 DOWN2 LEFT4 RIGHT8 ACT16
+    def OFF_SEL:int 52        ; guest -> host selected node id (highlight)
 
     ; page background behind the menu card
     def bgR:int 16
@@ -77,6 +89,38 @@ class GameUiRunner {
         }
         this.rebuildTree()
         rev = (wasm_call_i32 handle "rg_ui_revision" 0 0 0 0 0 0)
+        loaded = true
+        return true
+    }
+
+    ; --- interpreted .as path: bind + init the guest, pull its first document ----
+    fn loadAs:boolean (dir:string) {
+        useAs = true
+        if ((asRunner.bindDir(dir)) == false) {
+            return false
+        }
+        asRunner.callInit()
+        if ((this.refreshFromAs()) == false) {
+            return false
+        }
+        rev = (asRunner.uiRevision())
+        asSelId = (asRunner.abiRead(OFF_SEL))
+        return true
+    }
+
+    ; Copy the guest's RGU1 block out of the bridge and rebuild the EVG tree.
+    fn refreshFromAs:boolean () {
+        def bytes:[int]
+        def i 0
+        while (i < 8192) {
+            push bytes (asRunner.uiByte(i))
+            i = (i + 1)
+        }
+        doc.loadBytes(bytes 8192)
+        if (doc.valid == false) {
+            return false
+        }
+        this.rebuildTree()
         loaded = true
         return true
     }
@@ -140,6 +184,25 @@ class GameUiRunner {
         if (loaded == false) {
             return -1
         }
+        if useAs {
+            ; forward the input edges to the interpreted guest via the shared ABI;
+            ; it navigates itself and reports the selected id back for highlight.
+            def mask:int 0
+            if nav.up { mask = (mask + 1) }
+            if nav.down { mask = (mask + 2) }
+            if nav.left { mask = (mask + 4) }
+            if nav.right { mask = (mask + 8) }
+            if nav.action { mask = (mask + 16) }
+            asRunner.abiWrite(OFF_INPUT mask)
+            asRunner.callUpdate()
+            def newRev:int (asRunner.uiRevision())
+            if (newRev != rev) {
+                this.refreshFromAs()
+                rev = newRev
+            }
+            asSelId = (asRunner.abiRead(OFF_SEL))
+            return asSelId
+        }
         def act:int (ctrl.update(nav))
         if ctrl.didActivate {
             if (handle > 0) {
@@ -164,7 +227,18 @@ class GameUiRunner {
     fn render:void () {
         canvas.clear(bgR bgG bgB)
         ctrl.renderer.draw(ctx root)
-        ctrl.renderHighlight(ctx)
+        if useAs {
+            ; highlight the node the interpreted guest reports selected
+            if (asSelId > 0) {
+                def hit:RectHit (ctrl.renderer.findRect(root (to_string asSelId)))
+                if hit.found {
+                    def pad:int ctrl.highlightPad
+                    ctx.glowRoundRect((hit.x - pad) (hit.y - pad) (hit.w + (pad * 2)) (hit.h + (pad * 2)) (hit.rad + pad) ctrl.glowR ctrl.glowG ctrl.glowB ctrl.glowSpread ctrl.glowAlpha)
+                }
+            }
+        } {
+            ctrl.renderHighlight(ctx)
+        }
     }
 
     fn raw:buffer () {


### PR DESCRIPTION
## Problem

The interpreted `.as` EVG menu (#213, `games/ui_menu_as`, `engine=ui` + `runtime=as`) rendered fine headless but failed to load on the SDL launcher:

```
[wasm] parse failed: .../ui_menu_as/game.as (malformed Wasm binary)
[game-engine] ui game load failed: .../ui_menu_as/game.as
```

`runUiGame` always fed the module through `wasm_load`, but a `.as` guest is **interpreted source**, not wasm. (The `engine=as` game path already interprets `.as` — this teaches the `engine=ui` path the same trick.)

## Fix

Give the UI runner an interpreted backend and pick it by module suffix.

**`GameUiRunner`**
- `loadAs(dir)` / `refreshFromAs()` — bind + init the `.as` guest via the existing `AsSourceRunner` (`ComponentEngine` + `AsAbiBridge`), copy its RGU1 block out of the bridge, and build / lay out / autoscale the tree exactly like the wasm path.
- `frame()` — when `useAs`, forward the input edge-mask to the guest through the shared ABI (`abiWrite OFF_INPUT`) and call `update()`; the guest navigates itself and reports the selected node id back (`abiRead OFF_SEL`). Refresh only when its revision bumps.
- `render()` — when `useAs`, draw the glow highlight around the guest-reported node (no `UiSelectController` navigation). **The wasm path is unchanged.**

**`GameSdlRunner.runUiGame`** — branch on a `.as` module suffix: `loadAs(dirOf(path))` for interpreted guests, `loadWasm(path)` otherwise.

## Verification

- Native launcher compiles to C++.
- `npm run engine:ui:as` **14/14** and `engine:ui:game` (wasm path) **4/4** both still pass.
- A headless `GameUiRunner.loadAs` drive confirms the integrated path: `loadAs=true`, down×2 → Demo(22), action → demo screen(40).

> Builds on #213 (the `.as` guest + `uiPropColorRgba` bridge helper). With this, selecting **AS UI Menu (.as demo)** in the launcher runs the interpreted menu, and the "Demo" button opens the EVG technique showcase (←/→ to switch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_