### PR TITLE
game_engine: EVG linear gradients + coord-reported absolute effect nodes (Slice 2)

### DIFF
--- a/gallery/evg/EVGElement.rgr
+++ b/gallery/evg/EVGElement.rgr
@@ -48,6 +48,22 @@ class EVGElement {
     ; Visual properties
     def backgroundColor:EVGColor
     def opacity:double 1.0
+
+    ; Linear-gradient background (RGU1 GRAD_FROM/GRAD_TO/GRAD_DIR). When gradientSet
+    ; the renderer fills the (rounded) box with a 2-stop linear gradient instead of
+    ; the solid backgroundColor. gradientDir: 0 = vertical (top->bottom), 1 =
+    ; horizontal (left->right).
+    def gradientSet:boolean false
+    def gradientFrom:EVGColor
+    def gradientTo:EVGColor
+    def gradientDir:int 0
+
+    ; Absolute placement (RGU1 ABS_X/ABS_Y): when absPosSet the element is laid out
+    ; at (absX, absY) in page pixels instead of participating in flex flow — used
+    ; for coord-reported overlay effects.
+    def absPosSet:boolean false
+    def absX:double 0.0
+    def absY:double 0.0
     
     ; Layout properties
     def direction:string "row"

--- a/gallery/game_engine/games/ui_menu_as/game.as
+++ b/gallery/game_engine/games/ui_menu_as/game.as
@@ -216,23 +216,23 @@ function buildDemo(): void {
 }
 
 // Coord-reported effect: read the selected node's laid-out rect (the host wrote
-// it last frame) and drop a small absolute accent at its top-right corner. This
-// demonstrates "get an element's screen coordinates, then render an effect there"
-// — the guest never sees the layout, only the reported rect.
+// it last frame) and drop a small absolute accent at its top-right corner. The
+// guest never sees the layout, only the reported rect.
 function emitEffect(): void {
   let rw: i32 = abiRead(OFF_RECT_W);
-  if (rw <= 0) return;
-  let rx: i32 = abiRead(OFF_RECT_X);
-  let ry: i32 = abiRead(OFF_RECT_Y);
-  let ex: i32 = rx + rw - 7;
-  let ey: i32 = ry - 7;
-  uiNode(EFFECT, ROOT, K_VIEW, 999);   // high order -> drawn on top
-  uiPropI32(P_WIDTH, 14);
-  uiPropI32(P_HEIGHT, 14);
-  uiPropI32(P_RADIUS, 7);
-  uiPropColorRgba(P_BG, 255, 230, 120, 235);
-  uiPropI32(P_ABS_X, ex);
-  uiPropI32(P_ABS_Y, ey);
+  if (rw > 0) {
+    let rx: i32 = abiRead(OFF_RECT_X);
+    let ry: i32 = abiRead(OFF_RECT_Y);
+    let ex: i32 = rx + rw - 7;
+    let ey: i32 = ry - 7;
+    uiNode(EFFECT, ROOT, K_VIEW, 999);   // high order -> drawn on top
+    uiPropI32(P_WIDTH, 14);
+    uiPropI32(P_HEIGHT, 14);
+    uiPropI32(P_RADIUS, 7);
+    uiPropColorRgba(P_BG, 255, 230, 120, 235);
+    uiPropI32(P_ABS_X, ex);
+    uiPropI32(P_ABS_Y, ey);
+  }
 }
 
 function build(): void {

--- a/gallery/game_engine/games/ui_menu_as/game.as
+++ b/gallery/game_engine/games/ui_menu_as/game.as
@@ -26,6 +26,12 @@ import { abiRead, abiWrite, uiReset, uiNode, uiPropI32, uiPropEnum, uiPropStr, u
 // ---- shared ABI offsets ----
 const OFF_INPUT: i32 = 20;   // host -> guest: edge mask this frame
 const OFF_SEL: i32 = 52;     // guest -> host: selected node id (highlight)
+// host -> guest: laid-out rect (page px) of the selected node, so we can place
+// an absolute overlay effect at real screen coordinates.
+const OFF_RECT_X: i32 = 200;
+const OFF_RECT_Y: i32 = 204;
+const OFF_RECT_W: i32 = 208;
+const OFF_RECT_H: i32 = 212;
 
 // input edge bits
 const IN_UP: i32 = 1;
@@ -45,6 +51,7 @@ const P_BG: i32 = 2;
 const P_COLOR: i32 = 3;
 const P_FONT: i32 = 4;
 const P_WIDTH: i32 = 10;
+const P_HEIGHT: i32 = 11;
 const P_PAD: i32 = 12;
 const P_MARGIN: i32 = 13;
 const P_RADIUS: i32 = 14;
@@ -53,6 +60,11 @@ const P_BORDER_W: i32 = 16;
 const P_FLEXDIR: i32 = 21;
 const P_ALIGN: i32 = 22;
 const P_TEXTALIGN: i32 = 24;
+const P_GRAD_FROM: i32 = 50;   // linear-gradient start colour
+const P_GRAD_TO: i32 = 51;     // linear-gradient end colour
+const P_GRAD_DIR: i32 = 52;    // 0 vertical, 1 horizontal
+const P_ABS_X: i32 = 53;       // absolute page-x
+const P_ABS_Y: i32 = 54;       // absolute page-y
 
 // enum values
 const DIR_COLUMN: i32 = 1;
@@ -67,6 +79,7 @@ const BTN_CONT: i32 = 21;
 const BTN_DEMO: i32 = 22;
 const BTN_QUIT: i32 = 23;
 const PREVIEW: i32 = 40;
+const EFFECT: i32 = 200;   // coord-reported absolute overlay accent
 
 // screens
 const SCR_MENU: i32 = 0;
@@ -184,20 +197,42 @@ function buildDemo(): void {
     uiPropColorRgba(P_BG, 22, 26, 40, 255);
     label(122, PREVIEW, 0, "Big 42", 220, 224, 236, 42);
   } else {
-    // linear gradient (real gradient fill lands in the next slice)
+    // linear gradient: a real 2-stop vertical gradient fill in the host EVG renderer
     uiNode(PREVIEW, CARD, K_VIEW, 2);
     uiPropI32(P_WIDTH, 220);
     uiPropI32(P_PAD, 26);
     uiPropI32(P_RADIUS, 12);
     uiPropI32(P_MARGIN, 8);
-    uiPropColorRgba(P_BG, 40, 60, 120, 255);
-    label(122, PREVIEW, 0, "gradient (soon)", 200, 214, 240, 15);
+    uiPropColorRgba(P_GRAD_FROM, 90, 130, 245, 255);   // blue
+    uiPropColorRgba(P_GRAD_TO, 210, 90, 200, 255);     // magenta
+    uiPropEnum(P_GRAD_DIR, 0);                          // vertical
+    label(122, PREVIEW, 0, "linear gradient", 255, 255, 255, 15);
   }
 
   label(130, CARD, 3, "< left/right >   enter: back", 143, 176, 208, 12);
 
   // the preview is the focused element on this screen
   abiWrite(OFF_SEL, PREVIEW);
+}
+
+// Coord-reported effect: read the selected node's laid-out rect (the host wrote
+// it last frame) and drop a small absolute accent at its top-right corner. This
+// demonstrates "get an element's screen coordinates, then render an effect there"
+// — the guest never sees the layout, only the reported rect.
+function emitEffect(): void {
+  let rw: i32 = abiRead(OFF_RECT_W);
+  if (rw <= 0) return;
+  let rx: i32 = abiRead(OFF_RECT_X);
+  let ry: i32 = abiRead(OFF_RECT_Y);
+  let ex: i32 = rx + rw - 7;
+  let ey: i32 = ry - 7;
+  uiNode(EFFECT, ROOT, K_VIEW, 999);   // high order -> drawn on top
+  uiPropI32(P_WIDTH, 14);
+  uiPropI32(P_HEIGHT, 14);
+  uiPropI32(P_RADIUS, 7);
+  uiPropColorRgba(P_BG, 255, 230, 120, 235);
+  uiPropI32(P_ABS_X, ex);
+  uiPropI32(P_ABS_Y, ey);
 }
 
 function build(): void {
@@ -207,6 +242,7 @@ function build(): void {
   } else {
     buildDemo();
   }
+  emitEffect();
   uiFinish(REV);
 }
 

--- a/gallery/game_engine/scripting/as_ui_menu_src_demo.rgr
+++ b/gallery/game_engine/scripting/as_ui_menu_src_demo.rgr
@@ -35,6 +35,10 @@ class AsUiMenuSrcDemo {
     ; shared-ABI offsets (mirror games/ui_menu_as/game.as)
     def OFF_INPUT:int 20
     def OFF_SEL:int 52
+    def OFF_RECT_X:int 200
+    def OFF_RECT_Y:int 204
+    def OFF_RECT_W:int 208
+    def OFF_RECT_H:int 212
 
     def runner:AsSourceRunner (new AsSourceRunner)
     def canvas:SoftCanvas (new SoftCanvas)
@@ -84,6 +88,42 @@ class AsUiMenuSrcDemo {
         return (runner.abiRead(OFF_SEL))
     }
 
+    ; report the selected node's laid-out rect back to the guest (what the native
+    ; GameUiRunner does) so its coord-reported effect can place itself next frame.
+    fn reportRect:void () {
+        def sid (this.selId())
+        if (sid > 0) {
+            def hit:RectHit (rnd.findRect(root (to_string sid)))
+            if hit.found {
+                runner.abiWrite(OFF_RECT_X hit.x)
+                runner.abiWrite(OFF_RECT_Y hit.y)
+                runner.abiWrite(OFF_RECT_W hit.w)
+                runner.abiWrite(OFF_RECT_H hit.h)
+            }
+        }
+    }
+
+    ; true if the node with the given id carries a property with `key`
+    fn hasProp:boolean (id:int key:int) {
+        def idx (doc.indexOfId(id))
+        if (idx < 0) { return false }
+        def fp (doc.nodeFirstProp(idx))
+        def pc (doc.nodePropCount(idx))
+        def p 0
+        while (p < pc) {
+            if ((doc.propKey(fp + p)) == key) {
+                return true
+            }
+            p = (p + 1)
+        }
+        return false
+    }
+
+    ; true if a node with the given id exists in the current document
+    fn hasNode:boolean (id:int) {
+        return ((doc.indexOfId(id)) >= 0)
+    }
+
     ; text of the first TEXT prop on the node with the given id ("" if none)
     fn textOfId:string (id:int) {
         def idx (doc.indexOfId(id))
@@ -126,6 +166,7 @@ class AsUiMenuSrcDemo {
         runner.abiWrite(OFF_INPUT mask)
         runner.callUpdate()
         this.refresh()
+        this.reportRect()
     }
 
     sfn m@(main):void () {
@@ -144,6 +185,7 @@ class AsUiMenuSrcDemo {
         }
         d.runner.callInit()
         d.refresh()
+        d.reportRect()
 
         ; ---- frame 0: main menu, New Game selected ----
         c.ok("doc valid" d.doc.valid)
@@ -173,6 +215,12 @@ class AsUiMenuSrcDemo {
         d.drawFrame("as_ui_4_demo_fontsize.png")
         d.step(8)
         c.ok(("right -> Linear gradient (got '" + (d.textOfId(101)) + "')") ((indexOf (d.textOfId(101)) "Linear gradient") >= 0))
+        ; the gradient example must declare a real gradient background (GRAD_FROM)
+        c.ok("gradient example has GRAD_FROM prop" (d.hasProp(40 50)))
+        c.ok("gradient example has GRAD_TO prop" (d.hasProp(40 51)))
+        ; the coord-reported absolute effect node is present + placed (ABS_X)
+        c.ok("coord-reported effect node present" (d.hasNode(200)))
+        c.ok("effect is absolutely placed (ABS_X)" (d.hasProp(200 53)))
         d.drawFrame("as_ui_5_demo_gradient.png")
 
         ; ---- left wraps back to Font size ----

--- a/gallery/game_engine/scripting/game_ui_runner.rgr
+++ b/gallery/game_engine/scripting/game_ui_runner.rgr
@@ -42,6 +42,12 @@ class GameUiRunner {
     def asSelId:int 0
     def OFF_INPUT:int 20      ; host -> guest edge mask: UP1 DOWN2 LEFT4 RIGHT8 ACT16
     def OFF_SEL:int 52        ; guest -> host selected node id (highlight)
+    ; host -> guest: laid-out rect of the selected node (page px), so the guest
+    ; can place absolute overlay effects at real screen coordinates.
+    def OFF_RECT_X:int 200
+    def OFF_RECT_Y:int 204
+    def OFF_RECT_W:int 208
+    def OFF_RECT_H:int 212
 
     ; page background behind the menu card
     def bgR:int 16
@@ -195,12 +201,23 @@ class GameUiRunner {
             if nav.action { mask = (mask + 16) }
             asRunner.abiWrite(OFF_INPUT mask)
             asRunner.callUpdate()
-            def newRev:int (asRunner.uiRevision())
-            if (newRev != rev) {
-                this.refreshFromAs()
-                rev = newRev
-            }
+            ; rebuild every frame: the guest may re-place coord-reported overlay
+            ; effects each frame from the rect we report below, so we always pull
+            ; + re-lay-out (cheap for a menu-sized document).
+            this.refreshFromAs()
+            rev = (asRunner.uiRevision())
             asSelId = (asRunner.abiRead(OFF_SEL))
+            ; report the selected node's laid-out rect back to the guest so it can
+            ; position absolute effects at exact screen coordinates next frame.
+            if (asSelId > 0) {
+                def hit:RectHit (ctrl.renderer.findRect(root (to_string asSelId)))
+                if hit.found {
+                    asRunner.abiWrite(OFF_RECT_X hit.x)
+                    asRunner.abiWrite(OFF_RECT_Y hit.y)
+                    asRunner.abiWrite(OFF_RECT_W hit.w)
+                    asRunner.abiWrite(OFF_RECT_H hit.h)
+                }
+            }
             return asSelId
         }
         def act:int (ctrl.update(nav))

--- a/gallery/game_engine/scripting/wasm_ui_io.rgr
+++ b/gallery/game_engine/scripting/wasm_ui_io.rgr
@@ -450,6 +450,27 @@ class WasmUiEvgBuilder {
             if (key == 24) {                ; TEXT_ALIGN (0 left,1 center,2 right)
                 el.textAlign = (this.textAlignName((doc.propValueA(idx))))
             }
+            if (key == 50) {                ; GRAD_FROM (linear-gradient start color)
+                el.gradientFrom = (doc.colorAt(idx))
+                el.gradientSet = true
+            }
+            if (key == 51) {                ; GRAD_TO (linear-gradient end color)
+                el.gradientTo = (doc.colorAt(idx))
+                el.gradientSet = true
+            }
+            if (key == 52) {                ; GRAD_DIR (0 vertical, 1 horizontal)
+                el.gradientDir = (doc.propValueA(idx))
+            }
+            if (key == 53) {                ; ABS_X (page px) -> absolute placement
+                el.absX = (to_double (doc.propValueA(idx)))
+                el.absPosSet = true
+                el.isAbsolute = true
+            }
+            if (key == 54) {                ; ABS_Y (page px)
+                el.absY = (to_double (doc.propValueA(idx)))
+                el.absPosSet = true
+                el.isAbsolute = true
+            }
             p = (p + 1)
         }
     }

--- a/gallery/game_engine/ui/UIContext.rgr
+++ b/gallery/game_engine/ui/UIContext.rgr
@@ -176,6 +176,51 @@ class UIContext {
         this.fillRoundRectA(x y rw rh rad (col.red()) (col.green()) (col.blue()) a)
     }
 
+    fn lerpChan:int (a:int b:int t:double) {
+        def av:double (to_double a)
+        def bv:double (to_double b)
+        return (to_int (av + ((bv - av) * t)))
+    }
+
+    ; Fill a (rounded) rect with a 2-stop linear gradient. dir 0 = vertical
+    ; (top->bottom), 1 = horizontal (left->right). Composites per pixel so it
+    ; respects the corner radius and any alpha in the stops.
+    fn fillRoundRectGrad:void (x:int y:int rw:int rh:int rad:int dir:int r1:int g1:int b1:int a1:int r2:int g2:int b2:int a2:int) {
+        if (rw <= 0) { return }
+        if (rh <= 0) { return }
+        def denomV:int (rh - 1)
+        if (denomV < 1) { denomV = 1 }
+        def denomH:int (rw - 1)
+        if (denomH < 1) { denomH = 1 }
+        def yy y
+        def yEnd (y + rh)
+        while (yy < yEnd) {
+            def xx x
+            def xEnd (x + rw)
+            while (xx < xEnd) {
+                def draw:boolean true
+                if (rad > 0) {
+                    draw = (this.roundedInside(xx yy x y rw rh rad))
+                }
+                if draw {
+                    def t:double 0.0
+                    if (dir == 1) {
+                        t = ((to_double (xx - x)) / (to_double denomH))
+                    } {
+                        t = ((to_double (yy - y)) / (to_double denomV))
+                    }
+                    def r:int (this.lerpChan(r1 r2 t))
+                    def g:int (this.lerpChan(g1 g2 t))
+                    def b:int (this.lerpChan(b1 b2 t))
+                    def a:int (this.lerpChan(a1 a2 t))
+                    this.blendPixel(xx yy r g b a)
+                }
+                xx = (xx + 1)
+            }
+            yy = (yy + 1)
+        }
+    }
+
     ; Stroke a rounded outline of `t` px (the ring between the outer rounded rect
     ; and an inner one inset by t). Composites over existing content.
     fn strokeRoundRect:void (x:int y:int rw:int rh:int rad:int t:int col:EVGColor) {

--- a/gallery/game_engine/ui/WasmUiSelect.rgr
+++ b/gallery/game_engine/ui/WasmUiSelect.rgr
@@ -81,6 +81,31 @@ class WasmUiRenderer {
             root.height.isSet = true
         }
         layout.layoutElement(root 0.0 0.0 fw fh)
+        ; place coord-reported overlay effects: absolute elements sit at their
+        ; declared page pixel (absX,absY) instead of in flex flow.
+        this.placeAbsolute(root)
+    }
+
+    ; Position absolute (ABS_X/ABS_Y) elements at their page coordinates; the
+    ; flex layout skips them, so size them from their width/height here too.
+    fn placeAbsolute:void (el:EVGElement) {
+        def i 0
+        def n (array_length el.children)
+        while (i < n) {
+            def c:EVGElement (itemAt el.children i)
+            if c.absPosSet {
+                c.calculatedX = c.absX
+                c.calculatedY = c.absY
+                if (c.calculatedWidth <= 0.0) {
+                    if c.width.isSet { c.calculatedWidth = c.width.pixels }
+                }
+                if (c.calculatedHeight <= 0.0) {
+                    if c.height.isSet { c.calculatedHeight = c.height.pixels }
+                }
+            }
+            this.placeAbsolute(c)
+            i = (i + 1)
+        }
     }
 
     ; Deepest laid-out bottom edge (calculatedY + calculatedHeight) among the
@@ -92,20 +117,26 @@ class WasmUiRenderer {
         def n (array_length root.children)
         while (i < n) {
             def c:EVGElement (itemAt root.children i)
-            def b:double (this.maxBottom(c))
-            if (b > m) { m = b }
+            if (c.absPosSet == false) {
+                def b:double (this.maxBottom(c))
+                if (b > m) { m = b }
+            }
             i = (i + 1)
         }
         return m
     }
+    ; Absolute overlays (coord-reported effects) are excluded so they never feed
+    ; back into the autoscale fit.
     fn maxBottom:double (el:EVGElement) {
         def b:double (el.calculatedY + el.calculatedHeight)
         def i 0
         def n (array_length el.children)
         while (i < n) {
             def c:EVGElement (itemAt el.children i)
-            def cb:double (this.maxBottom(c))
-            if (cb > b) { b = cb }
+            if (c.absPosSet == false) {
+                def cb:double (this.maxBottom(c))
+                if (cb > b) { b = cb }
+            }
             i = (i + 1)
         }
         return b
@@ -117,8 +148,10 @@ class WasmUiRenderer {
         def n (array_length root.children)
         while (i < n) {
             def c:EVGElement (itemAt root.children i)
-            def b:double (this.maxRight(c))
-            if (b > m) { m = b }
+            if (c.absPosSet == false) {
+                def b:double (this.maxRight(c))
+                if (b > m) { m = b }
+            }
             i = (i + 1)
         }
         return m
@@ -129,8 +162,10 @@ class WasmUiRenderer {
         def n (array_length el.children)
         while (i < n) {
             def c:EVGElement (itemAt el.children i)
-            def cb:double (this.maxRight(c))
-            if (cb > b) { b = cb }
+            if (c.absPosSet == false) {
+                def cb:double (this.maxRight(c))
+                if (cb > b) { b = cb }
+            }
             i = (i + 1)
         }
         return b
@@ -156,11 +191,20 @@ class WasmUiRenderer {
 
         def rad (this.radiusOf(el))
 
-        if el.backgroundColor.isSet {
-            def ba:double (el.backgroundColor.alpha())
-            if (ba > 0.0) {
-                def ai:int (to_int (ba * 255.0))
-                ctx.fillRoundRectA(x y rw rh rad (el.backgroundColor.red()) (el.backgroundColor.green()) (el.backgroundColor.blue()) ai)
+        if el.gradientSet {
+            ; guest-declared 2-stop linear gradient background (real EVG fill)
+            def fa:int (to_int ((el.gradientFrom.alpha()) * 255.0))
+            def ta:int (to_int ((el.gradientTo.alpha()) * 255.0))
+            ctx.fillRoundRectGrad(x y rw rh rad el.gradientDir
+                (el.gradientFrom.red()) (el.gradientFrom.green()) (el.gradientFrom.blue()) fa
+                (el.gradientTo.red()) (el.gradientTo.green()) (el.gradientTo.blue()) ta)
+        } {
+            if el.backgroundColor.isSet {
+                def ba:double (el.backgroundColor.alpha())
+                if (ba > 0.0) {
+                    def ai:int (to_int (ba * 255.0))
+                    ctx.fillRoundRectA(x y rw rh rad (el.backgroundColor.red()) (el.backgroundColor.green()) (el.backgroundColor.blue()) ai)
+                }
             }
         }
 


### PR DESCRIPTION
## What

Slice 2 of the `.as` EVG demo — the two capabilities from your earlier answers that needed host-renderer + ABI work, wired through the interpreted guest.

### 1. Real linear gradient background
- RGU1 props `GRAD_FROM(50)` / `GRAD_TO(51)` / `GRAD_DIR(52)`; `EVGElement` carries `gradientFrom/gradientTo/gradientDir` + `gradientSet`.
- **`UIContext.fillRoundRectGrad`** — a 2-stop linear gradient fill (vertical or horizontal) that respects the corner radius and per-stop alpha.
- `WasmUiRenderer.drawElement` fills with the gradient when `gradientSet`, else the solid `backgroundColor` as before.

The **"Linear gradient"** example now renders a real blue→magenta fill (verified visually).

### 2. Coord-reported absolute effect nodes
*"get an element's coordinates, then render an effect there"*
- RGU1 props `ABS_X(53)` / `ABS_Y(54)` → `EVGElement.absPosSet/absX/absY`; the flex layout skips absolute elements and **`WasmUiRenderer.placeAbsolute`** positions them at their page pixel and sizes them from width/height. The autoscale extent (`contentBottom`/`contentRight`/…) **excludes** absolute overlays so an effect never feeds back into the fit.
- `GameUiRunner` (interpreted path) writes the selected node's laid-out rect back to the shared ABI (`OFF_RECT_X/Y/W/H`) each frame, and now rebuilds every frame so a moved effect tracks the selection.
- `games/ui_menu_as/game.as` reads the reported rect and drops a small absolute accent at the selected element's top-right corner — **the guest never sees the layout, only the reported coordinates**.

## Verification

- `npm run engine:ui:as` → **18/18** (adds gradient-prop + effect-node/`ABS_X` assertions). PNG confirms the gradient fill *and* the gold accent tracking the selection.
- No regressions: `engine:ui:game` (wasm path) **4/4**, `engine:ui:test` (UIContext) **29/29**, native launcher compiles to C++.

## Notes

- No new bridge functions were needed — the guest sets gradient/abs props via the generic `uiPropColorRgba`/`uiPropEnum`/`uiPropI32` (from #213).
- One non-fatal `Parse error: expected '}'` line prints from the interpreter during load; it doesn't affect execution (all 18 checks pass, both new features render). Flagging it for a later look.

> Stacks on #214 → #213 → #212 → #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_