### PR TITLE
Pose deploy/build fixes: preserve the ~1h TFLite build, real camera check, cpp header

### DIFF
--- a/bin/variant.hpp
+++ b/bin/variant.hpp
@@ -1,0 +1,22 @@
+// Variant header - maps mpark::variant to std::variant for C++17
+#ifndef VARIANT_HPP
+#define VARIANT_HPP
+
+#include <variant>
+
+namespace mpark {
+    template<typename... Types>
+    using variant = std::variant<Types...>;
+    
+    template<typename T, typename... Types>
+    constexpr T& get(variant<Types...>& v) {
+        return std::get<T>(v);
+    }
+    
+    template<typename T, typename... Types>
+    constexpr const T& get(const variant<Types...>& v) {
+        return std::get<T>(v);
+    }
+}
+
+#endif // VARIANT_HPP

--- a/gallery/game_engine/pose/build-pose-native-pi.sh
+++ b/gallery/game_engine/pose/build-pose-native-pi.sh
@@ -43,16 +43,27 @@ fi
 
 echo "==> [4/4] build + run native_bench (threads=$THREADS)"
 BENCH="$HERE/native_bench"
-# Build OUT OF TREE (not $BENCH/build) so it survives: deploy-pi.sh rsyncs the
-# repo with --delete, which would wipe an in-repo build/ (it's gitignored, so not
-# in the source) and force a full TFLite rebuild every deploy. This cache is
-# incremental: the first run compiles all of TFLite/XNNPACK/kleidiai (~slow, once);
-# after that only pose_bench.cc relinks (seconds). rm -rf "$BUILD_DIR" to force a
-# clean rebuild.
-BUILD_DIR="${POSE_BUILD_DIR:-$HOME/.cache/ranger-pose-bench}"
+# REUSE an existing build wherever it already is — a full TFLite/XNNPACK/kleidiai
+# compile is ~1h, and we never want to repeat it. Never move a CMake build dir
+# (it bakes absolute paths and would reconfigure); build in place. Precedence:
+#   POSE_BUILD_DIR  ->  existing in-repo build/  ->  existing ~/.cache build  ->  in-repo (fresh)
+# The in-repo build/ is kept across deploys by deploy-pi.sh's rsync exclude, so
+# it survives --delete. Incremental after the first build: only pose_bench.cc
+# relinks (seconds). rm -rf the dir to force a clean rebuild.
+if [ -n "${POSE_BUILD_DIR:-}" ]; then
+  BUILD_DIR="$POSE_BUILD_DIR"
+elif [ -f "$BENCH/build/pose_bench" ]; then
+  BUILD_DIR="$BENCH/build"
+elif [ -f "$HOME/.cache/ranger-pose-bench/pose_bench" ]; then
+  BUILD_DIR="$HOME/.cache/ranger-pose-bench"
+else
+  BUILD_DIR="$BENCH/build"
+fi
 mkdir -p "$BUILD_DIR"
 if [ -f "$BUILD_DIR/pose_bench" ]; then
-  echo "    (incremental — reusing cached TFLite build in $BUILD_DIR)"
+  echo "    (incremental — reusing existing build in $BUILD_DIR; no TFLite rebuild)"
+else
+  echo "    (first build — compiles TFLite once, ~slow; cached in $BUILD_DIR after)"
 fi
 cmake -S "$BENCH" -B "$BUILD_DIR" -DTENSORFLOW_SOURCE_DIR="$TF" -DCMAKE_BUILD_TYPE=Release
 cmake --build "$BUILD_DIR" -j"$(nproc)"

--- a/gallery/game_engine/pose/build-pose-native-pi.sh
+++ b/gallery/game_engine/pose/build-pose-native-pi.sh
@@ -43,18 +43,30 @@ fi
 
 echo "==> [4/4] build + run native_bench (threads=$THREADS)"
 BENCH="$HERE/native_bench"
-cmake -S "$BENCH" -B "$BENCH/build" -DTENSORFLOW_SOURCE_DIR="$TF" -DCMAKE_BUILD_TYPE=Release
-cmake --build "$BENCH/build" -j"$(nproc)"
+# Build OUT OF TREE (not $BENCH/build) so it survives: deploy-pi.sh rsyncs the
+# repo with --delete, which would wipe an in-repo build/ (it's gitignored, so not
+# in the source) and force a full TFLite rebuild every deploy. This cache is
+# incremental: the first run compiles all of TFLite/XNNPACK/kleidiai (~slow, once);
+# after that only pose_bench.cc relinks (seconds). rm -rf "$BUILD_DIR" to force a
+# clean rebuild.
+BUILD_DIR="${POSE_BUILD_DIR:-$HOME/.cache/ranger-pose-bench}"
+mkdir -p "$BUILD_DIR"
+if [ -f "$BUILD_DIR/pose_bench" ]; then
+  echo "    (incremental — reusing cached TFLite build in $BUILD_DIR)"
+fi
+cmake -S "$BENCH" -B "$BUILD_DIR" -DTENSORFLOW_SOURCE_DIR="$TF" -DCMAKE_BUILD_TYPE=Release
+cmake --build "$BUILD_DIR" -j"$(nproc)"
 
+BIN="$BUILD_DIR/pose_bench"
 DET="$MODELS/tflite/pose_detector.tflite"
 LM="$MODELS/tflite/pose_landmarks_detector.tflite"
 echo ""
 echo "--- perf + landmarks (human) ---"
-"$BENCH/build/pose_bench" "$DET" "$LM" "$BENCH/pose.ppm" --threads "$THREADS"
+"$BIN" "$DET" "$LM" "$BENCH/pose.ppm" --threads "$THREADS"
 echo ""
 echo "--- accuracy vs browser reference (compare.mjs) ---"
-"$BENCH/build/pose_bench" "$DET" "$LM" "$BENCH/pose.ppm" --threads "$THREADS" --json \
+"$BIN" "$DET" "$LM" "$BENCH/pose.ppm" --threads "$THREADS" --json \
   | node "$BENCH/compare.mjs" "$HERE/mediapipe_poc/reference/landmarks.json" -
 echo ""
 echo "Thread sweep for the game budget (see NATIVE_EMBED.md): re-run with"
-echo "  POSE_THREADS=1|2|3|4 bash $(basename "$0")"
+echo "  POSE_THREADS=1|2|3|4 bash $(basename "$0")   (fast — build is cached in $BUILD_DIR)"

--- a/gallery/game_engine/scripts/deploy-pi.sh
+++ b/gallery/game_engine/scripts/deploy-pi.sh
@@ -172,6 +172,8 @@ rsync -az --delete \
   --exclude tmp \
   --exclude dist \
   --exclude .git/objects \
+  --exclude 'gallery/game_engine/pose/native_bench/build' \
+  --exclude 'gallery/game_engine/pose/mediapipe_poc/assets/models' \
   "$ROOT/" "$TARGET:~/$REMOTE_DIR/"
 
 echo "==> 5/$TOTAL_STEPS Build game launcher on Pi (CXX_OPT=$CXX_OPT, wasm3 embedded)"

--- a/gallery/game_engine/scripts/deploy-pi.sh
+++ b/gallery/game_engine/scripts/deploy-pi.sh
@@ -94,39 +94,48 @@ verify_wasm_artifacts() {
   fi
 }
 
-# Verify a capture-capable USB camera on the Pi (over SSH). Returns non-zero if
-# no /dev/video* node reports a Video Capture capability. Needs v4l-utils (apt).
+# Verify a REAL camera on the Pi (over SSH). A Pi 5 exposes many /dev/video*
+# nodes for hardware codecs and the ISP (rpi-hevc-dec, pispbe, bcm2835-codec,
+# rpivid, unicam, ...) that all report "Video Capture" capability but are NOT
+# cameras. So capability alone is a false positive — key on the bus/driver: a
+# USB webcam is uvcvideo / bus_info usb-*. Needs v4l-utils (apt). Returns non-zero
+# if no such device is present.
 check_usb_camera() {
   ssh "$TARGET" 'bash -s' <<'CAMEOF'
 set -uo pipefail
-have_v4l2=0; command -v v4l2-ctl >/dev/null 2>&1 && have_v4l2=1
+if ! command -v v4l2-ctl >/dev/null 2>&1; then
+  echo "    v4l-utils missing — cannot verify a camera"; exit 5
+fi
 vids=$(ls /dev/video* 2>/dev/null || true)
 if [[ -z "$vids" ]]; then
   echo "    no /dev/video* devices — is the USB camera plugged in?"
   echo "    try: lsusb ; dmesg | grep -i -E 'camera|uvc|video' | tail"
   exit 3
 fi
-echo "    video nodes: $(echo $vids | tr '\n' ' ')"
-lsusb 2>/dev/null | grep -iE 'cam|webcam|video|uvc' | sed 's/^/      usb: /' || true
-found=0
+lsusb 2>/dev/null | grep -iE 'cam|webcam|uvc' | sed 's/^/      usb: /' || true
+found=0; skipped=""
 for dev in $vids; do
-  if [[ "$have_v4l2" == "1" ]]; then
-    all=$(v4l2-ctl -d "$dev" --all 2>/dev/null || true)
-    if echo "$all" | grep -qi 'Video Capture'; then
-      found=1
-      name=$(echo "$all" | grep -m1 -i 'Card type' | sed 's/.*: *//')
-      echo "    capture: $dev  ${name:-camera}"
-      v4l2-ctl -d "$dev" --list-formats-ext 2>/dev/null \
-        | grep -E 'Pixel Format|Size: Discrete' | head -4 | sed 's/^[[:space:]]*/        /' || true
-    fi
+  all=$(v4l2-ctl -d "$dev" --all 2>/dev/null || true)
+  echo "$all" | grep -qi 'Video Capture' || continue          # capture-capable only
+  driver=$(echo "$all" | grep -m1 -i 'Driver name' | sed 's/.*: *//')
+  bus=$(echo "$all"    | grep -m1 -i 'Bus info'    | sed 's/.*: *//')
+  card=$(echo "$all"   | grep -m1 -i 'Card type'   | sed 's/.*: *//')
+  # a real camera: UVC webcam (usb) — not a platform codec/ISP block
+  is_cam=0
+  [[ "$driver" == uvcvideo ]] && is_cam=1
+  [[ "$bus" == usb* || "$bus" == *usb* ]] && is_cam=1
+  if [[ "$is_cam" == "1" ]]; then
+    found=1
+    echo "    camera: $dev  ${card:-?}  [driver=$driver bus=$bus]"
+    v4l2-ctl -d "$dev" --list-formats-ext 2>/dev/null \
+      | grep -E 'Pixel Format|Size: Discrete' | head -4 | sed 's/^[[:space:]]*/        /' || true
+  else
+    skipped="$skipped $dev($driver)"
   fi
 done
 if [[ "$found" == "0" ]]; then
-  if [[ "$have_v4l2" == "1" ]]; then
-    echo "    video nodes exist but none report Video Capture capability"
-  else
-    echo "    v4l-utils missing — cannot confirm capture capability"
-  fi
+  echo "    no camera found — only platform codec/ISP capture nodes:${skipped:- none}"
+  echo "    plug in a USB webcam (shows as driver=uvcvideo, bus=usb-*)."
   exit 4
 fi
 exit 0


### PR DESCRIPTION
Follow-up fixes to the pose native pipeline (PR #218 merged at an earlier commit, so these four land on `master` here). All are deploy/build only — no change to the pose runtime.

## Preserve the native_bench TFLite build (the headline fix)
The TFLite/XNNPACK/kleidiai compile is **~1 hour** on the Pi. Two things made it repeat:
- `deploy-pi.sh` rsyncs with `--delete`, which wiped the in-repo `native_bench/build/` (gitignored → "extraneous"). Now excluded from the sync (also excludes the downloaded `assets/models/`), so an existing build survives a deploy.
- `build-pose-native-pi.sh` now **reuses an existing build wherever it is** (`POSE_BUILD_DIR` → in-repo `build/` → `~/.cache/ranger-pose-bench` → fresh in-repo) and never moves a CMake dir (absolute paths). Incremental after the first build — later runs (incl. the `POSE_THREADS` sweep) relink `pose_bench` in seconds.

## Camera check no longer false-positives
A Pi 5 exposes many `/dev/video*` nodes for hardware codecs / the ISP (`rpi-hevc-dec`, `pispbe`) that all advertise "Video Capture", so keying on capability alone reported "camera OK" with no camera attached. Now keys on driver/bus (`uvcvideo` / `usb-*`) — correctly reports "no camera found — only platform codec/ISP nodes" until a USB webcam is present (deploy with `RANGER_SKIP_CAMERA_CHECK=1` meanwhile).

## Silence the cpp `variant.hpp` warning
The cpp backend's `installFile("variant.hpp")` looked in the repo `bin/` and, not finding it, printed `did not find installed file .../binvariant.hpp` (also missing a path separator). Harmless — `build-game-sdl.sh` copies the header next to the generated `.cpp` — but alarming. Added `bin/variant.hpp` (the C++17 `std::variant` shim every other sub-project ships) so `installFile` self-serves.

## Context: it works on the Pi
The native pipeline was validated on a Pi 5: `native_provider` unit tests pass on ARM (200k-frame no-tearing), and `native_bench` matches the browser MediaPipe reference to **mean 0.0073 normalized error** (`compare.mjs` → `[OK]`) at **~28 fps** (2 threads, full detect+landmark; ~50 fps steady-state with tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWZEHVpM8SHaMxQsHcyUsd

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWZEHVpM8SHaMxQsHcyUsd)_