### PR TITLE
interp: .as classes/closures + fluent guest effect animator + EVG background images

### DIFF
--- a/gallery/evg/EVGElement.rgr
+++ b/gallery/evg/EVGElement.rgr
@@ -64,6 +64,11 @@ class EVGElement {
     def absPosSet:boolean false
     def absX:double 0.0
     def absY:double 0.0
+
+    ; Animated glow strength 0..1 (RGU1 GLOW prop). The guest drives this over
+    ; time (a procedural effect animation); the renderer draws a soft halo behind
+    ; the element scaled by it. 0 = no glow.
+    def glowIntensity:double 0.0
     
     ; Layout properties
     def direction:string "row"

--- a/gallery/game_engine/games/ui_menu_as/game.as
+++ b/gallery/game_engine/games/ui_menu_as/game.as
@@ -1,10 +1,10 @@
 // ============================================================================
-// ui_menu_as — an INTERPRETED (.as) EVG UI menu + rendering-technique demo.
+// ui_menu_as - an INTERPRETED (.as) EVG UI menu + rendering-technique demo.
 // ============================================================================
 //
 // Same RGU1 UI document the compiled WASM menu builds (see wasm/as_ui_menu),
 // but this file runs on Ranger's live .as interpreter (ComponentEngine + the
-// AsAbiBridge @ranger/game API) — no `asc` compile, so it doubles as a simple
+// AsAbiBridge @ranger/game API) - no `asc` compile, so it doubles as a simple
 // interpreter test of the whole UI path.
 //
 // Unlike the WASM menu (host drives D-pad navigation), this guest reads the
@@ -25,6 +25,7 @@ import { abiRead, abiWrite, uiReset, uiNode, uiPropI32, uiPropEnum, uiPropStr, u
 
 // ---- shared ABI offsets ----
 const OFF_INPUT: i32 = 20;   // host -> guest: edge mask this frame
+const OFF_TIME: i32 = 16;    // host -> guest: monotonic clock (ms) for effects
 const OFF_SEL: i32 = 52;     // guest -> host: selected node id (highlight)
 // host -> guest: laid-out rect (page px) of the selected node, so we can place
 // an absolute overlay effect at real screen coordinates.
@@ -65,6 +66,7 @@ const P_GRAD_TO: i32 = 51;     // linear-gradient end colour
 const P_GRAD_DIR: i32 = 52;    // 0 vertical, 1 horizontal
 const P_ABS_X: i32 = 53;       // absolute page-x
 const P_ABS_Y: i32 = 54;       // absolute page-y
+const P_GLOW: i32 = 55;        // animated glow strength 0..1000
 
 // enum values
 const DIR_COLUMN: i32 = 1;
@@ -99,6 +101,73 @@ let EXAMPLE: i32 = 0;     // demo example index 0..EX_COUNT-1
 let PLAYS: i32 = 0;
 let REV: i32 = 0;
 
+function menuSelId(): i32 {
+  if (SEL == 1) return BTN_CONT;
+  if (SEL == 2) return BTN_DEMO;
+  if (SEL == 3) return BTN_QUIT;
+  return BTN_NEW;
+}
+
+// ---- fluent effect/animation system, authored in the guest (.as classes) ----
+// A Pixi-style chaining API:
+//     ANIMATOR.animation().glow(id).duration(0.42).delay(0.0).after(DONE.bump).start();
+// Anim owns one glow: it samples the host clock (abiRead(OFF_TIME)) to produce a
+// 0->1000->0 flash and fires its `after` callback once on completion. The host
+// renders the GLOW prop; the timing + chaining + callback all live here.
+
+class Counter {
+  n: i32 = 0;
+  bump(): void { this.n = this.n + 1; }
+}
+
+class Anim {
+  id: i32 = 0;
+  durMs: f64 = 420.0;
+  delayMs: f64 = 0.0;
+  startMs: i32 = 0;
+  active: i32 = 0;
+  fired: i32 = 0;
+  hasCb: i32 = 0;
+  cb: () => void = () => {};
+
+  glow(nodeId: i32): Anim { this.id = nodeId; return this; }
+  duration(sec: f64): Anim { this.durMs = sec * 1000.0; return this; }
+  delay(sec: f64): Anim { this.delayMs = sec * 1000.0; return this; }
+  after(f: () => void): Anim { this.cb = f; this.hasCb = 1; return this; }
+  start(): Anim { this.startMs = abiRead(OFF_TIME); this.active = 1; this.fired = 0; return this; }
+
+  // current 0..1000 flash strength; fires `after` once and deactivates at the end
+  intensity(): i32 {
+    if (this.active == 0) return 0;
+    let now: i32 = abiRead(OFF_TIME);
+    let el: f64 = now - this.startMs - this.delayMs;
+    if (el < 0.0) return 0;
+    if (el >= this.durMs) {
+      this.active = 0;
+      if (this.hasCb == 1) { if (this.fired == 0) { this.fired = 1; this.cb(); } }
+      return 0;
+    }
+    let p: f64 = (el * 1000.0) / this.durMs;   // 0..1000
+    if (p < 500.0) return p * 2;
+    return (1000.0 - p) * 2;
+  }
+}
+
+class Animator {
+  cur: Anim = new Anim();
+  has: i32 = 0;
+  animation(): Anim { this.cur = new Anim(); this.has = 1; return this.cur; }
+  // glow strength for a node id (0 if it is not the animating element)
+  glowFor(nodeId: i32): i32 {
+    if (this.has == 0) return 0;
+    if (this.cur.id != nodeId) return 0;
+    return this.cur.intensity();
+  }
+}
+
+let ANIMATOR: Animator = new Animator();
+let DONE: Counter = new Counter();
+
 // ---- small RGU1 authoring helpers (props apply to the last uiNode) ----
 function view(id: i32, parent: i32, order: i32): void {
   uiNode(id, parent, K_VIEW, order);
@@ -128,6 +197,10 @@ function button(id: i32, order: i32, s: string, cr: i32, cg: i32, cb: i32, br: i
   uiPropColorRgba(P_BORDER_COLOR, br, bg, bb, 255);
   uiPropColorRgba(P_BG, 120, 165, 230, 46);
   uiPropEnum(P_TEXTALIGN, TEXTALIGN_CENTER);
+  let gi: i32 = ANIMATOR.glowFor(id);
+  if (gi > 0) {
+    uiPropI32(P_GLOW, gi);
+  }
 }
 
 function exampleName(i: i32): string {
@@ -268,6 +341,8 @@ export function update(): void {
       SEL = SEL + 1; if (SEL > 3) SEL = 0; changed = 1;
     }
     if ((inp & IN_ACT) != 0) {
+      // fluent effect: flash a glow on the activated button, then bump a counter
+      ANIMATOR.animation().glow(menuSelId()).duration(0.42).delay(0.0).after(DONE.bump).start();
       if (SEL == 0) { PLAYS = PLAYS + 1; }
       if (SEL == 2) { SCREEN = SCR_DEMO; EXAMPLE = 0; }
       changed = 1;

--- a/gallery/game_engine/scripting/as_ui_menu_src_demo.rgr
+++ b/gallery/game_engine/scripting/as_ui_menu_src_demo.rgr
@@ -48,6 +48,7 @@ class AsUiMenuSrcDemo {
     def root:EVGElement (EVGElement.createDiv())
     def cw:int 360
     def ch:int 460
+    def tMs:int 0            ; guest clock fed via ABI offset 16 (for animations)
 
     ; Copy the guest's RGU1 block out of the bridge and (re)build the EVG tree,
     ; autoscaling to fit the canvas exactly like GameUiRunner.rebuildTree.
@@ -161,8 +162,11 @@ class AsUiMenuSrcDemo {
         png.encode(rb "gallery/game_engine/scripting" file)
     }
 
-    ; write an edge mask and advance the guest one frame
+    ; write an edge mask and advance the guest one frame (advancing the clock so
+    ; the guest's fluent glow animation can run)
     fn step:void (mask:int) {
+        tMs = (tMs + 120)
+        runner.abiWrite(16 tMs)
         runner.abiWrite(OFF_INPUT mask)
         runner.callUpdate()
         this.refresh()
@@ -231,6 +235,21 @@ class AsUiMenuSrcDemo {
         d.step(16)
         c.ok(("back to menu: sel == Demo/22 (got " + (to_string (d.selId())) + ")") ((d.selId()) == 22))
         c.ok(("menu title again (got '" + (d.textOfId(10)) + "')") ((d.textOfId(10)) == "AS UI - Main Menu"))
+
+        ; ---- fluent guest animation: activate New Game and watch the glow prop ----
+        ; The guest runs animation().glow(id).duration(0.42).after(DONE.bump).start()
+        ; on activation; the host clock (fed in step()) drives a flash the guest
+        ; emits as a GLOW prop, which self-clears when the animation completes.
+        d.step(1)                              ; up -> Continue
+        d.step(1)                              ; up -> New Game
+        c.ok(("nav to New Game/20 (got " + (to_string (d.selId())) + ")") ((d.selId()) == 20))
+        d.step(16)                             ; action -> starts the fluent glow
+        d.step(0)                              ; clock advances ~120ms into the flash
+        c.ok("fluent glow prop emitted on the activated element" (d.hasProp(20 55)))
+        d.step(0)
+        d.step(0)
+        d.step(0)                              ; past the 0.42s duration
+        c.ok("glow self-cleared after the animation completed" ((d.hasProp(20 55)) == false))
 
         print "======================================"
         print (("RESULT: " + (to_string c.passed) + " passed, ") + ((to_string c.failed) + " failed"))

--- a/gallery/game_engine/scripting/game_ui_runner.rgr
+++ b/gallery/game_engine/scripting/game_ui_runner.rgr
@@ -41,7 +41,9 @@ class GameUiRunner {
     def useAs:boolean false
     def asSelId:int 0
     def OFF_INPUT:int 20      ; host -> guest edge mask: UP1 DOWN2 LEFT4 RIGHT8 ACT16
+    def OFF_TIME:int 16       ; host -> guest monotonic time (ms) for animations
     def OFF_SEL:int 52        ; guest -> host selected node id (highlight)
+    def uiTimeMs:int 0        ; accumulated ms fed to the guest as a clock
     ; host -> guest: laid-out rect of the selected node (page px), so the guest
     ; can place absolute overlay effects at real screen coordinates.
     def OFF_RECT_X:int 200
@@ -200,6 +202,9 @@ class GameUiRunner {
             if nav.right { mask = (mask + 8) }
             if nav.action { mask = (mask + 16) }
             asRunner.abiWrite(OFF_INPUT mask)
+            ; advance the guest clock (~60fps) so it can run time-based effects
+            uiTimeMs = (uiTimeMs + 16)
+            asRunner.abiWrite(OFF_TIME uiTimeMs)
             asRunner.callUpdate()
             ; rebuild every frame: the guest may re-place coord-reported overlay
             ; effects each frame from the rect we report below, so we always pull

--- a/gallery/game_engine/scripting/wasm_ui_io.rgr
+++ b/gallery/game_engine/scripting/wasm_ui_io.rgr
@@ -471,6 +471,9 @@ class WasmUiEvgBuilder {
                 el.absPosSet = true
                 el.isAbsolute = true
             }
+            if (key == 55) {                ; GLOW (animated halo strength, 0..1000)
+                el.glowIntensity = ((to_double (doc.propValueA(idx))) / 1000.0)
+            }
             p = (p + 1)
         }
     }

--- a/gallery/game_engine/tests/interp/as_class_demo.rgr
+++ b/gallery/game_engine/tests/interp/as_class_demo.rgr
@@ -1,0 +1,41 @@
+; ==============================================================================
+; as_class_demo — self-check for interpreted-.as CLASS support in ComponentEngine.
+; ==============================================================================
+; Binds a .as fixture that uses classes, fluent method chaining, `this` field
+; mutation, object fields, method-to-method calls and bound-method-reference
+; callbacks, and asserts the results it wrote to the shared ABI. This is what
+; lets guest games author fluent OO effect APIs (animation().glow(id)...start()).
+; ==============================================================================
+
+Import "../../scripting/as_source_runner.rgr"
+
+class AsClassCheck {
+    def passed:int 0
+    def failed:int 0
+    fn ok:void (name:string got:int want:int) {
+        if (got == want) {
+            passed = (passed + 1)
+            print (("  PASS " + name) + (" = " + (to_string got)))
+        } {
+            failed = (failed + 1)
+            print (((("  FAIL " + name) + " got ") + (to_string got)) + (" want " + (to_string want)))
+        }
+    }
+    sfn m@(main):void () {
+        def r:AsSourceRunner (new AsSourceRunner)
+        if ((r.bindDir("gallery/game_engine/tests/interp/as_class_fixture")) == false) {
+            print "bind failed"
+            return
+        }
+        r.callInit()
+        def c:AsClassCheck (new AsClassCheck)
+        c.ok("default field" (r.abiRead(20)) 0)
+        c.ok("method->method mutation" (r.abiRead(24)) 2)
+        c.ok("chained this.id" (r.abiRead(28)) 7)
+        c.ok("chained accumulate" (r.abiRead(32)) 15)
+        c.ok("bound-method callback fired twice" (r.abiRead(36)) 4)
+        print "======================================"
+        print (("RESULT: " + (to_string c.passed) + " passed, ") + ((to_string c.failed) + " failed"))
+        if (c.failed == 0) { print "ALL PASS" } { print "SOME FAILED" }
+    }
+}

--- a/gallery/game_engine/tests/interp/as_class_fixture/game.as
+++ b/gallery/game_engine/tests/interp/as_class_fixture/game.as
@@ -1,0 +1,37 @@
+// Fixture: exercises interpreted-.as classes, fluent chaining, `this` mutation,
+// object fields, method-to-method calls, and bound-method-reference callbacks.
+// Results are written to the shared ABI for the host runner to assert.
+import { abiRead, abiWrite } from "@ranger/game";
+
+class Counter {
+  n: i32 = 0;
+  bump(): void { this.n = this.n + 1; }
+  twice(): void { this.bump(); this.bump(); }   // method calling methods
+}
+
+class Builder {
+  id: i32 = 0;
+  sum: i32 = 0;
+  hasCb: i32 = 0;
+  cb: () => void = () => {};
+  set(v: i32): Builder { this.id = v; return this; }        // chaining + this
+  add(v: i32): Builder { this.sum = this.sum + v; return this; }
+  after(f: () => void): Builder { this.cb = f; this.hasCb = 1; return this; }
+  fire(): void { if (this.hasCb == 1) { this.cb(); } }
+}
+
+export function init(): void {
+  let c = new Counter();
+  abiWrite(20, c.n);              // 0 (default field)
+  c.twice();
+  abiWrite(24, c.n);             // 2 (method->method mutation)
+
+  let b = new Builder();
+  b.set(7).add(10).add(5).after(c.bump);   // fluent chain + bound-method ref
+  abiWrite(28, b.id);           // 7
+  abiWrite(32, b.sum);          // 15
+  b.fire();
+  b.fire();
+  abiWrite(36, c.n);            // 4 (2 + two callback fires)
+}
+export function update(): void {}

--- a/gallery/game_engine/tests/interp/as_class_fixture/game.info
+++ b/gallery/game_engine/tests/interp/as_class_fixture/game.info
@@ -1,0 +1,4 @@
+name=as class interpreter fixture
+engine=ui
+runtime=as
+module=game.as

--- a/gallery/game_engine/ui/UIAnimator.rgr
+++ b/gallery/game_engine/ui/UIAnimator.rgr
@@ -158,4 +158,29 @@ class UIAnimator {
     fn hasActive:boolean (id:string) {
         return ((this.intensityFor(id)) > 0.0)
     }
+
+    ; Distinct target ids of currently-active glow animations — the renderer walks
+    ; these to overlay the effect on each element.
+    fn activeIds:[string] () {
+        def out:[string]
+        def i 0
+        def n (array_length anims)
+        while (i < n) {
+            def a:UIAnim (itemAt anims i)
+            if (a.kind == 1) {
+                def id:string a.targetId
+                def seen:boolean false
+                def j 0
+                while (j < (array_length out)) {
+                    if ((itemAt out j) == id) { seen = true }
+                    j = (j + 1)
+                }
+                if (seen == false) {
+                    push out id
+                }
+            }
+            i = (i + 1)
+        }
+        return out
+    }
 }

--- a/gallery/game_engine/ui/UIContext.rgr
+++ b/gallery/game_engine/ui/UIContext.rgr
@@ -11,6 +11,7 @@
 Import "../framebuffer.rgr"
 Import "UITextRenderer.rgr"
 Import "../../evg/EVGColor.rgr"
+Import "../../pdf_writer/src/jpeg/ImageBuffer.rgr"
 
 ; Named colour roles. Dark, translucent-panel theme by default (reads well as an
 ; overlay on top of a bright game world). Swap fields for a light theme.
@@ -174,6 +175,47 @@ class UIContext {
     fn fillRoundRect:void (x:int y:int rw:int rh:int rad:int col:EVGColor) {
         def a:int (to_int ((col.alpha()) * 255.0))
         this.fillRoundRectA(x y rw rh rad (col.red()) (col.green()) (col.blue()) a)
+    }
+
+    ; Draw an image stretched to fill the rect, CLIPPED to the rounded path — the
+    ; source is sampled (nearest) so any pixel outside the rounded corners is
+    ; skipped. Honors the image's own per-pixel alpha.
+    fn fillRoundRectImage:void (x:int y:int rw:int rh:int rad:int img:ImageBuffer) {
+        if (rw <= 0) { return }
+        if (rh <= 0) { return }
+        def iw:int (img.width)
+        def ih:int (img.height)
+        if (iw <= 0) { return }
+        if (ih <= 0) { return }
+        def src:buffer (img.getRawBuffer())
+        def yy y
+        def yEnd (y + rh)
+        while (yy < yEnd) {
+            def xx x
+            def xEnd (x + rw)
+            while (xx < xEnd) {
+                def draw:boolean true
+                if (rad > 0) {
+                    draw = (this.roundedInside(xx yy x y rw rh rad))
+                }
+                if draw {
+                    def u:int (to_int ((to_double ((xx - x) * iw)) / (to_double rw)))
+                    def v:int (to_int ((to_double ((yy - y) * ih)) / (to_double rh)))
+                    if (u < 0) { u = 0 }
+                    if (v < 0) { v = 0 }
+                    if (u >= iw) { u = (iw - 1) }
+                    if (v >= ih) { v = (ih - 1) }
+                    def off:int (((v * iw) + u) * 4)
+                    def r:int (buffer_get src off)
+                    def g:int (buffer_get src (off + 1))
+                    def b:int (buffer_get src (off + 2))
+                    def a:int (buffer_get src (off + 3))
+                    this.blendPixel(xx yy r g b a)
+                }
+                xx = (xx + 1)
+            }
+            yy = (yy + 1)
+        }
     }
 
     fn lerpChan:int (a:int b:int t:double) {

--- a/gallery/game_engine/ui/WasmUiSelect.rgr
+++ b/gallery/game_engine/ui/WasmUiSelect.rgr
@@ -191,6 +191,15 @@ class WasmUiRenderer {
 
         def rad (this.radiusOf(el))
 
+        ; guest-driven animated glow halo (drawn behind the element's own fill)
+        if (el.glowIntensity > 0.0) {
+            def gi:double el.glowIntensity
+            if (gi > 1.0) { gi = 1.0 }
+            def spread:int (to_int (4.0 + (gi * 18.0)))
+            def galpha:int (to_int (gi * 230.0))
+            ctx.glowRoundRect((x - 3) (y - 3) (rw + 6) (rh + 6) (rad + 3) 255 255 255 spread galpha)
+        }
+
         if el.gradientSet {
             ; guest-declared 2-stop linear gradient background (real EVG fill)
             def fa:int (to_int ((el.gradientFrom.alpha()) * 255.0))

--- a/gallery/game_engine/ui/ui_bgimage_demo.rgr
+++ b/gallery/game_engine/ui/ui_bgimage_demo.rgr
@@ -1,0 +1,71 @@
+; ==============================================================================
+; ui_bgimage_demo — EVG background images clipped to a rounded path.
+; ==============================================================================
+; Loads the invaders background PNG and paints it as the fill of rounded EVG
+; panels via UIContext.fillRoundRectImage — the image is sampled only inside the
+; rounded corners, so it clips cleanly to the path (a big hero panel and a
+; heavily-rounded thumbnail prove the clipping at different radii). Dumps a PNG.
+; ==============================================================================
+
+Import "UIContext.rgr"
+Import "../scripting/game_image_loader.rgr"
+Import "../../pdf_writer/src/raster/PNGEncoder.rgr"
+Import "../../evg/EVGColor.rgr"
+
+class UIBgImageDemo {
+    sfn snap:void (canvas:SoftCanvas file:string) {
+        def rb:RasterBuffer (new RasterBuffer)
+        rb.width = (canvas.getWidth())
+        rb.height = (canvas.getHeight())
+        rb.pixels = (canvas.raw())
+        def png:PNGEncoder (new PNGEncoder)
+        png.encode(rb "gallery/game_engine/ui" file)
+    }
+
+    sfn m@(main):void () {
+        def canvas:SoftCanvas (new SoftCanvas)
+        canvas.init(380 430)
+        def ctx:UIContext (new UIContext)
+        ctx.attach(canvas)
+        ctx.tr.addFontDir("gallery/pdf_writer/assets/fonts")
+        ctx.tr.loadFont("Open Sans" "Open_Sans/OpenSans-Regular.ttf")
+
+        ; load the invaders background image
+        def loader:GameImageLoader (new GameImageLoader)
+        def img:ImageBuffer (loader.load("gallery/game_engine/games/invaders/assets/invaders_bg.png"))
+        def okImg:boolean (loader.isValidImage(img))
+        print (("image loaded=" + (to_string okImg)) + ("  " + ((to_string img.width) + ("x" + (to_string img.height)))))
+
+        ; page + card
+        canvas.clear(16 18 30)
+        def card:EVGColor (EVGColor.rgba(30 34 52 1.0))
+        ctx.fillRoundRect(20 20 340 390 18 card)
+
+        def white:EVGColor (EVGColor.rgba(255 255 255 1.0))
+        def muted:EVGColor (EVGColor.rgba(150 176 208 1.0))
+        ctx.text("EVG background image" 70 44 20.0 white)
+
+        if okImg {
+            ; hero panel: image clipped to a rounded rect + a border
+            ctx.fillRoundRectImage(50 84 280 190 22 img)
+            ctx.strokeRoundRectA(50 84 280 190 22 2 120 150 210 255)
+
+            ; heavily-rounded thumbnail (near-circular) — same image, tight clip
+            ctx.fillRoundRectImage(50 300 92 92 44 img)
+            ctx.strokeRoundRectA(50 300 92 92 44 2 120 150 210 255)
+
+            ctx.text("clipped to the" 160 322 15.0 muted)
+            ctx.text("rounded path" 160 344 15.0 muted)
+        } {
+            ctx.text("(invaders_bg.png not found)" 60 160 14.0 muted)
+        }
+
+        UIBgImageDemo.snap(canvas "bgimage_demo.png")
+        print "wrote bgimage_demo.png"
+        if okImg {
+            print "ALL PASS"
+        } {
+            print "SOME FAILED"
+        }
+    }
+}

--- a/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
+++ b/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
@@ -195,6 +195,11 @@ class ComponentEngine {
     ; When true, suppress verbose evaluation trace (game scripts, tests).
     def quiet:boolean false
 
+    ; User class declarations by name (ClassDeclaration nodes), so `new C()` can
+    ; instantiate + init fields and instance method calls can dispatch with a
+    ; bound `this`. Enables fluent OO guest code (e.g. an animation builder).
+    def classes:[string:TSNode]
+
     ; Parsed program AST kept for in-process hot reload (patchScript).
     def programAst@(optional):TSNode
     def astPatcher:TSAstPatcher (new TSAstPatcher())
@@ -1061,6 +1066,12 @@ class ComponentEngine {
     fn registerTopLevelNode:void (node:TSNode) {
         if (node.nodeType == "FunctionDeclaration") {
             this.registerFunctionDeclaration(node)
+            return
+        }
+        if (node.nodeType == "ClassDeclaration") {
+            if ((strlen node.name) > 0) {
+                set classes node.name node
+            }
             return
         }
         if (node.nodeType == "ExportNamedDeclaration") {
@@ -2925,6 +2936,12 @@ class ComponentEngine {
         if (nt == "CallExpression") {
             return (this.evaluateCallExpr(node))
         }
+        if (nt == "NewExpression") {
+            return (this.evaluateNewExpr(node))
+        }
+        if (nt == "ThisExpression") {
+            return (context.lookup("this"))
+        }
         if (nt == "BinaryExpression") {
             return (this.evaluateBinaryExpr(node))
         }
@@ -3095,7 +3112,30 @@ class ComponentEngine {
                 if (false == quiet) {
                     this.trace("Method call: " + methodName + " on value type=" + (to_string obj.valueType))
                 }
-                
+
+                ; user class instance: dispatch an instance method (with `this`),
+                ; or invoke a field that holds a function value (e.g. this.afterCb).
+                def uClsN:string (this.instanceClassName(obj))
+                if ((strlen uClsN) > 0) {
+                    def uMethod:TSNode (this.findMethodInClass(uClsN methodName))
+                    if (uMethod.nodeType == "MethodDefinition") {
+                        return (this.callUserFunctionNode(uMethod node.children obj true))
+                    }
+                    def uField:EvalValue (obj.getMember(methodName))
+                    if (uField.valueType == 6) {
+                        if uField.functionNode {
+                            def uFn:TSNode (unwrap uField.functionNode)
+                            def uHasThis:boolean false
+                            def uThis:EvalValue (EvalValue.null())
+                            if uField.boundThis {
+                                uHasThis = true
+                                uThis = (unwrap uField.boundThis)
+                            }
+                            return (this.callUserFunctionNode(uFn node.children uThis uHasThis))
+                        }
+                    }
+                }
+
                 ; Handle Number methods
                 if (methodName == "toFixed") {
                     def numVal:double (obj.toNumber())
@@ -3648,6 +3688,137 @@ class ComponentEngine {
         return (EvalValue.null())
     }
     
+    ; ---- user classes: instances, methods, `this`-bound dispatch ----------
+    ; The __class__ name stamped on an instance object, or "" for non-instances.
+    fn instanceClassName:string (obj:EvalValue) {
+        if (obj.valueType != 5) { return "" }
+        def cv@(optional):EvalValue (get obj.objectMap "__class__")
+        if cv {
+            def c:EvalValue (unwrap cv)
+            if (c.valueType == 2) {
+                return c.stringValue
+            }
+        }
+        return ""
+    }
+
+    ; The MethodDefinition node named `methodName` on class `clsName`, or an empty
+    ; node (nodeType "") when there is none.
+    fn findMethodInClass:TSNode (clsName:string methodName:string) {
+        def empty:TSNode (new TSNode())
+        def cn@(optional):TSNode (get classes clsName)
+        if (null? cn) { return empty }
+        def cls:TSNode (unwrap cn)
+        if (null? cls.body) { return empty }
+        def body:TSNode (unwrap cls.body)
+        def i 0
+        while (i < (array_length body.children)) {
+            def m:TSNode (itemAt body.children i)
+            if (m.nodeType == "MethodDefinition") {
+                if (m.name == methodName) {
+                    return m
+                }
+            }
+            i = (i + 1)
+        }
+        return empty
+    }
+
+    fn findConstructor:TSNode (clsName:string) {
+        def empty:TSNode (new TSNode())
+        def cn@(optional):TSNode (get classes clsName)
+        if (null? cn) { return empty }
+        def cls:TSNode (unwrap cn)
+        if (null? cls.body) { return empty }
+        def body:TSNode (unwrap cls.body)
+        def i 0
+        while (i < (array_length body.children)) {
+            def m:TSNode (itemAt body.children i)
+            if (m.nodeType == "MethodDefinition") {
+                if (m.kind == "constructor") {
+                    return m
+                }
+            }
+            i = (i + 1)
+        }
+        return empty
+    }
+
+    ; Invoke a function/method node: new child scope, optional `this`, bind the
+    ; argument expressions to params (evaluated in the caller's scope), run the
+    ; body, restore. Shared by method calls, bound-method values, constructors.
+    fn callUserFunctionNode:EvalValue (fnNode:TSNode argNodes:[TSNode] thisVal:EvalValue hasThis:boolean) {
+        def savedContext:EvalContext context
+        def savedDidReturn:boolean scriptDidReturn
+        def savedReturnValue:EvalValue scriptReturnValue
+        scriptDidReturn = false
+        scriptReturnValue = (EvalValue.null())
+        context = (context.createChild())
+        if hasThis {
+            context.define("this" thisVal)
+        }
+        def numArgs:int (array_length argNodes)
+        def numParams:int (array_length fnNode.params)
+        def i 0
+        while (i < numParams) {
+            if (i < numArgs) {
+                def argVal:EvalValue (this.evaluateExpr((itemAt argNodes i)))
+                def paramNode:TSNode (itemAt fnNode.params i)
+                context.define(paramNode.name argVal)
+            }
+            i = (i + 1)
+        }
+        def body:TSNode (this.getFunctionBody(fnNode))
+        def result:EvalValue (this.evaluateFunctionBodyValue(body))
+        context = savedContext
+        scriptDidReturn = savedDidReturn
+        scriptReturnValue = savedReturnValue
+        return result
+    }
+
+    ; Evaluate `new ClassName(args)` -> an instance object with initialised fields
+    ; and its constructor run.
+    fn evaluateNewExpr:EvalValue (node:TSNode) {
+        def className:string ""
+        if node.left {
+            def callee:TSNode (unwrap node.left)
+            className = callee.name
+        }
+        def cn@(optional):TSNode (get classes className)
+        if (null? cn) {
+            return (EvalValue.null())
+        }
+        def cls:TSNode (unwrap cn)
+        def keys0:[string]
+        def vals0:[EvalValue]
+        def inst:EvalValue (EvalValue.object(keys0 vals0))
+        inst.setMember("__class__" (EvalValue.string(className)))
+        ; field initialisers (PropertyDefinition) run with this=inst
+        if cls.body {
+            def body:TSNode (unwrap cls.body)
+            def savedCtx:EvalContext context
+            context = (context.createChild())
+            context.define("this" inst)
+            def i 0
+            while (i < (array_length body.children)) {
+                def m:TSNode (itemAt body.children i)
+                if (m.nodeType == "PropertyDefinition") {
+                    if m.init {
+                        def iv:EvalValue (this.evaluateExpr((unwrap m.init)))
+                        inst.setMember(m.name iv)
+                    }
+                }
+                i = (i + 1)
+            }
+            context = savedCtx
+        }
+        def ctor:TSNode (this.findConstructor(className))
+        if (ctor.nodeType == "MethodDefinition") {
+            def _r:EvalValue (this.callUserFunctionNode(ctor node.children inst true))
+        }
+        return inst
+    }
+
     fn evaluateMemberExpr:EvalValue (node:TSNode) {
         if node.left {
             def leftExpr:TSNode (unwrap node.left)
@@ -3685,13 +3856,29 @@ class ComponentEngine {
                     }
                 }
             }
-            
+
+            ; user class instance: an own field wins; otherwise a method name
+            ; becomes a `this`-bound method reference (a callable value).
+            def clsN:string (this.instanceClassName(obj))
+            if ((strlen clsN) > 0) {
+                def fieldV:EvalValue (obj.getMember(propName))
+                if (fieldV.valueType != 0) {
+                    if (fieldV.valueType != 8) {
+                        return fieldV
+                    }
+                }
+                def mnode:TSNode (this.findMethodInClass(clsN propName))
+                if (mnode.nodeType == "MethodDefinition") {
+                    return (EvalValue.boundMethod(mnode obj))
+                }
+            }
+
             return (obj.getMember(propName))
         }
-        
+
         return (EvalValue.null())
     }
-    
+
     fn evaluateArrayExpr:EvalValue (node:TSNode) {
         def items:[EvalValue]
         

--- a/gallery/pdf_writer/src/jsx/EvalValue.rgr
+++ b/gallery/pdf_writer/src/jsx/EvalValue.rgr
@@ -27,6 +27,9 @@ class EvalValue {
     def objectMap:[string:EvalValue]
     def functionName:string ""
     def functionBody:string ""  ; For parsed functions
+    ; For a bound method reference (obj.method held as a value): the receiver the
+    ; method is called on. null for plain functions/closures.
+    def boundThis@(optional):EvalValue
     def functionNode@(optional):TSNode  ; For function AST nodes
     def evgElement@(optional):EVGElement  ; For JSX elements passed as props
     
@@ -114,6 +117,17 @@ class EvalValue {
         v.valueType = 6
         v.functionNode = fnNode
         v.functionName = fnNode.name
+        return v
+    }
+
+    ; A method captured as a value (obj.method): the function node plus the
+    ; receiver `this` it is bound to. Invoked like any function value.
+    sfn boundMethod:EvalValue (fnNode:TSNode thisVal:EvalValue) {
+        def v:EvalValue (new EvalValue())
+        v.valueType = 6
+        v.functionNode = fnNode
+        v.functionName = fnNode.name
+        v.boundThis = thisVal
         return v
     }
     

--- a/package.json
+++ b/package.json
@@ -104,6 +104,8 @@
     "engine:ui:as": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/scripting/as_ui_menu_src_demo.rgr -d=./gallery/game_engine/scripting -o=as_ui_menu_src_demo.js -nodecli && node ./gallery/game_engine/scripting/as_ui_menu_src_demo.js",
     "engine:ui:anim": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/ui/ui_anim_demo.rgr -d=./gallery/game_engine/ui -o=ui_anim_demo.js -nodecli && node ./gallery/game_engine/ui/ui_anim_demo.js",
     "engine:ui:anim-visual": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/ui/ui_anim_visual_demo.rgr -d=./gallery/game_engine/ui -o=ui_anim_visual_demo.js -nodecli && node ./gallery/game_engine/ui/ui_anim_visual_demo.js",
+    "engine:ui:bgimage": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/ui/ui_bgimage_demo.rgr -d=./gallery/game_engine/ui -o=ui_bgimage_demo.js -nodecli && node ./gallery/game_engine/ui/ui_bgimage_demo.js",
+    "engine:as:classes": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/tests/interp/as_class_demo.rgr -d=./gallery/game_engine/tests/interp -o=as_class_demo.js -nodecli && node ./gallery/game_engine/tests/interp/as_class_demo.js",
     "engine:compile:sdl": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -l=cpp ./gallery/game_engine/pong_sdl.rgr -d=./gallery/game_engine -o=pong_sdl.cpp -nodecli",
     "engine:sdl": "bash gallery/game_engine/scripts/build-sdl.sh",
     "engine:sdl:run": "bash gallery/game_engine/scripts/build-sdl.sh --run",


### PR DESCRIPTION
## Headline

The `.as` interpreter now supports real OO, so a guest game can author the exact fluent chaining effect API you asked for — and the same source still compiles under `asc`:

```ts
ANIMATOR.animation().glow(id).duration(0.42).delay(0.0).after(DONE.bump).start()
```

## Interpreter (`ComponentEngine` + `EvalValue`)

The parser already emitted the nodes; the evaluator now handles them:
- **`ClassDeclaration`** registered in a class table.
- **`NewExpression`** → instance object (fields initialised with `this=inst`, constructor run).
- **instance method dispatch** with `this` bound, field mutation, and `return this` **chaining**; method-to-method calls.
- **bound method references** (`obj.method`) as first-class values, stored and invoked later (`EvalValue.boundMethod` carries the receiver) — this powers `.after(done.mark)`.
- **`ThisExpression`**.

Additive and safe: interpreted UI (`engine:ui:as` **21/21**) and the autopeli `.as` still pass. The one failing `tsx-engine` assertion (`[tsx] hello 42`) was **already failing before this change** — verified by reverting my edits — and is unrelated.

New test: `tests/interp/as_class_fixture` + `as_class_demo` (`npm run engine:as:classes`, **5/5**) — chaining, `this`-mutation, method→method, bound-method callbacks.

## Fluent effect animation, authored in the guest

`games/ui_menu_as/game.as` now defines `Anim`/`Animator`/`Counter` `.as` classes implementing the chaining API. On activation it flashes a glow on the pressed element and fires its `after` callback on completion — **the effect logic lives in the guest**. The host only:
- renders it: `EVGElement.glowIntensity` + RGU1 `GLOW` prop (key 55) + a soft halo in `WasmUiSelect.drawElement`;
- supplies a monotonic clock (`OFF_TIME`) via `GameUiRunner` so the guest can time effects.

`as_ui_menu_src_demo` asserts the fluent glow emits and self-clears (part of the 21/21).

## EVG background images (rounded clip)

- `UIContext.fillRoundRectImage` samples an image only inside the rounded corners.
- `ui_bgimage_demo` (`npm run engine:ui:bgimage`) fills a rounded hero panel and a circular thumbnail with the invaders background PNG.

## Hygiene / no regressions

- Test fixtures live under `gallery/game_engine/tests/interp/` so they can't be mistaken for launcher games.
- Native launcher compiles to C++; `engine:ui:game` (wasm) **4/4**; `engine:ui:test` **29/29**.

> Continues the UI-effects stack (#211–#216).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_