### PR TITLE
game_engine: render UI at native resolution + scale-to-fill + smoother glow

### DIFF
--- a/gallery/game_engine/games/ui_menu_as/game.as
+++ b/gallery/game_engine/games/ui_menu_as/game.as
@@ -136,20 +136,28 @@ class Anim {
   after(f: () => void): Anim { this.cb = f; this.hasCb = 1; return this; }
   start(): Anim { this.startMs = abiRead(OFF_TIME); this.active = 1; this.fired = 0; return this; }
 
-  // current 0..1000 flash strength; fires `after` once and deactivates at the end
-  intensity(): i32 {
-    if (this.active == 0) return 0;
+  // Advance the flash once per frame from the host clock, storing the current
+  // 0..1000 strength; fires `after` once and deactivates when it completes. This
+  // is time-driven, NOT render-driven, so the callback fires even if the target
+  // element is not currently on screen.
+  cur: i32 = 0;
+  tick(): void {
+    if (this.active == 0) { this.cur = 0; return; }
     let now: i32 = abiRead(OFF_TIME);
     let el: f64 = now - this.startMs - this.delayMs;
-    if (el < 0.0) return 0;
+    if (el < 0.0) { this.cur = 0; return; }
     if (el >= this.durMs) {
       this.active = 0;
+      this.cur = 0;
       if (this.hasCb == 1) { if (this.fired == 0) { this.fired = 1; this.cb(); } }
-      return 0;
+      return;
     }
     let p: f64 = (el * 1000.0) / this.durMs;   // 0..1000
-    if (p < 500.0) return p * 2;
-    return (1000.0 - p) * 2;
+    if (p < 500.0) { this.cur = p * 2; } else { this.cur = (1000.0 - p) * 2; }
+  }
+  intensityAt(nodeId: i32): i32 {
+    if (this.id != nodeId) return 0;
+    return this.cur;
   }
 }
 
@@ -157,16 +165,28 @@ class Animator {
   cur: Anim = new Anim();
   has: i32 = 0;
   animation(): Anim { this.cur = new Anim(); this.has = 1; return this.cur; }
+  // advance the active animation one frame (call once per frame)
+  tick(): void { if (this.has == 1) { this.cur.tick(); } }
   // glow strength for a node id (0 if it is not the animating element)
   glowFor(nodeId: i32): i32 {
     if (this.has == 0) return 0;
-    if (this.cur.id != nodeId) return 0;
-    return this.cur.intensity();
+    return this.cur.intensityAt(nodeId);
   }
+}
+
+// Deferred screen transition: an animation's `after` callback records the screen
+// to switch to; update() applies it on the next frame. This is how we "react only
+// after the effect ran" — the menu->demo switch waits for the glow to finish.
+class Nav {
+  target: i32 = 0;
+  has: i32 = 0;
+  toDemo(): void { this.target = SCR_DEMO; this.has = 1; }
+  toMenu(): void { this.target = SCR_MENU; this.has = 1; }
 }
 
 let ANIMATOR: Animator = new Animator();
 let DONE: Counter = new Counter();
+let NAV: Nav = new Nav();
 
 // ---- small RGU1 authoring helpers (props apply to the last uiNode) ----
 function view(id: i32, parent: i32, order: i32): void {
@@ -309,6 +329,7 @@ function emitEffect(): void {
 }
 
 function build(): void {
+  ANIMATOR.tick();          // advance effects once per frame (time-driven)
   uiReset();
   if (SCREEN == SCR_MENU) {
     buildMenu();
@@ -330,8 +351,18 @@ export function init(): void {
 }
 
 export function update(): void {
-  let inp: i32 = abiRead(OFF_INPUT);
   let changed: i32 = 0;
+
+  // apply a deferred transition that an animation's `after` callback requested
+  // once its effect finished (menu<->demo switch happens AFTER the glow).
+  if (NAV.has == 1) {
+    SCREEN = NAV.target;
+    if (SCREEN == SCR_DEMO) { EXAMPLE = 0; }
+    NAV.has = 0;
+    changed = 1;
+  }
+
+  let inp: i32 = abiRead(OFF_INPUT);
 
   if (SCREEN == SCR_MENU) {
     if ((inp & IN_UP) != 0) {
@@ -341,10 +372,14 @@ export function update(): void {
       SEL = SEL + 1; if (SEL > 3) SEL = 0; changed = 1;
     }
     if ((inp & IN_ACT) != 0) {
-      // fluent effect: flash a glow on the activated button, then bump a counter
-      ANIMATOR.animation().glow(menuSelId()).duration(0.42).delay(0.0).after(DONE.bump).start();
       if (SEL == 0) { PLAYS = PLAYS + 1; }
-      if (SEL == 2) { SCREEN = SCR_DEMO; EXAMPLE = 0; }
+      if (SEL == 2) {
+        // Demo: flash the button, then switch screens when the effect completes
+        ANIMATOR.animation().glow(menuSelId()).duration(0.42).delay(0.0).after(NAV.toDemo).start();
+      } else {
+        // other buttons: just flash
+        ANIMATOR.animation().glow(menuSelId()).duration(0.42).delay(0.0).after(DONE.bump).start();
+      }
       changed = 1;
     }
   } else {
@@ -355,7 +390,9 @@ export function update(): void {
       EXAMPLE = EXAMPLE + 1; if (EXAMPLE >= EX_COUNT) EXAMPLE = 0; changed = 1;
     }
     if ((inp & IN_ACT) != 0) {
-      SCREEN = SCR_MENU; changed = 1;
+      // flash the preview, then return to the menu when the effect completes
+      ANIMATOR.animation().glow(PREVIEW).duration(0.42).delay(0.0).after(NAV.toMenu).start();
+      changed = 1;
     }
   }
 

--- a/gallery/game_engine/gfx_sdl.rgr
+++ b/gallery/game_engine/gfx_sdl.rgr
@@ -1633,6 +1633,17 @@ static int rgfx_open(const std::string& title, int w, int h) {
     if (g_rgfx_tex == nullptr) { return 0; }
     return 1;
 }
+// Actual output surface size in pixels (drawable / window), so UI can be
+// rendered at native resolution instead of a low internal buffer that gets
+// upscaled (blocky text). Falls back to the logical window size.
+static int rgfx_surface_dim(int wantWidth) {
+    if (g_rgfx_win == nullptr) { return 0; }
+    int w = 0; int h = 0;
+    SDL_GL_GetDrawableSize(g_rgfx_win, &w, &h);
+    if (w <= 0 || h <= 0) { SDL_GetWindowSize(g_rgfx_win, &w, &h); }
+    return wantWidth ? w : h;
+}
+
 static void rgfx_present(const uint8_t* pixels, int w, int h) {
     if (g_rgfx_gpu_mode) {
         rgfx_gpu_start_frame(w, h);
@@ -1722,6 +1733,21 @@ static void rgfx_close() {
         templates {
             cpp ( "rgfx_present(" (e 1) ".data(), " (e 2) ", " (e 3) ")" (imp "<SDL2/SDL.h>") )
             es6 ( "undefined" )
+        }
+    }
+
+    ; Actual output surface width/height in pixels (0 in es6). Lets a UI render at
+    ; native resolution rather than a small upscaled buffer.
+    gfx_surface_width _:int () {
+        templates {
+            cpp ( "rgfx_surface_dim(1)" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+    gfx_surface_height _:int () {
+        templates {
+            cpp ( "rgfx_surface_dim(0)" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
         }
     }
 

--- a/gallery/game_engine/scripting/as_ui_menu_src_demo.rgr
+++ b/gallery/game_engine/scripting/as_ui_menu_src_demo.rgr
@@ -173,6 +173,15 @@ class AsUiMenuSrcDemo {
         this.reportRect()
     }
 
+    ; advance several idle frames so a deferred (after-effect) transition fires
+    fn settle:void () {
+        def k 0
+        while (k < 6) {
+            this.step(0)
+            k = (k + 1)
+        }
+    }
+
     sfn m@(main):void () {
         def d:AsUiMenuSrcDemo (new AsUiMenuSrcDemo)
         def c:AsUiCheck (new AsUiCheck)
@@ -203,9 +212,12 @@ class AsUiMenuSrcDemo {
         d.step(2)
         c.ok(("Down x2 -> Demo/22 (got " + (to_string (d.selId())) + ")") ((d.selId()) == 22))
 
-        ; ---- action opens the Demo screen ----
+        ; ---- action flashes the button, then opens the Demo screen AFTER the
+        ; effect finishes (the whole point of .after()) ----
         d.step(16)
-        c.ok(("action opens demo: sel == PREVIEW/40 (got " + (to_string (d.selId())) + ")") ((d.selId()) == 40))
+        c.ok(("stays on menu during the effect: sel still Demo/22 (got " + (to_string (d.selId())) + ")") ((d.selId()) == 22))
+        d.settle()
+        c.ok(("after the effect -> demo screen: sel == PREVIEW/40 (got " + (to_string (d.selId())) + ")") ((d.selId()) == 40))
         c.ok(("demo title (got '" + (d.textOfId(100)) + "')") ((d.textOfId(100)) == "EVG Demo"))
         c.ok(("example 0 is Background color (got '" + (d.textOfId(101)) + "')") ((indexOf (d.textOfId(101)) "Background color") >= 0))
         d.drawFrame("as_ui_2_demo_bg.png")
@@ -231,8 +243,9 @@ class AsUiMenuSrcDemo {
         d.step(4)
         c.ok(("left -> Font size (got '" + (d.textOfId(101)) + "')") ((indexOf (d.textOfId(101)) "Font size") >= 0))
 
-        ; ---- action returns to the menu, selection preserved on Demo/22 ----
+        ; ---- action flashes the preview, then returns to the menu AFTER it ----
         d.step(16)
+        d.settle()
         c.ok(("back to menu: sel == Demo/22 (got " + (to_string (d.selId())) + ")") ((d.selId()) == 22))
         c.ok(("menu title again (got '" + (d.textOfId(10)) + "')") ((d.textOfId(10)) == "AS UI - Main Menu"))
 

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -922,7 +922,19 @@ class GameSdlRunner {
     ; render its menu, move the selection with the D-pad, forward the action
     ; button to the guest, and return to the launcher on Back/Quit.
     fn runUiGame:void (wasmPath:string) {
-        uiRunner.init(pw ph "gallery/game_engine/assets/fonts" "OpenSans-Regular.ttf" "Open Sans")
+        ; Render the UI at the actual output surface resolution (not the small pw*ph
+        ; game buffer) so text/borders/effects are crisp instead of upscaled. Cap
+        ; to bound the CPU cost of the software UI canvas; the guest UI scales to
+        ; fill it (GameUiRunner.fitScale), so it looks identical at any resolution.
+        def uw:int pw
+        def uh:int ph
+        def sw:int (gfx_surface_width)
+        def sh:int (gfx_surface_height)
+        if (sw > uw) { uw = sw }
+        if (sh > uh) { uh = sh }
+        if (uw > 1600) { uw = 1600 }
+        if (uh > 1200) { uh = 1200 }
+        uiRunner.init(uw uh "gallery/game_engine/assets/fonts" "OpenSans-Regular.ttf" "Open Sans")
         ; engine=ui games come in two flavours: a compiled logic.wasm guest, or an
         ; interpreted .as source (runtime=as). Pick the backend by module suffix —
         ; loading a .as through wasm_load fails with "malformed Wasm binary".
@@ -961,7 +973,7 @@ class GameSdlRunner {
             nav.action = (this.actionEdge((bit_and m 4) != 0))
             def _a:int (uiRunner.frame(nav))
             uiRunner.render()
-            gfx_present (uiRunner.raw()) pw ph
+            gfx_present (uiRunner.raw()) uw uh
 
             if (this.quitEdge((this.gameMenuBackHeld()))) {
                 inGame = false

--- a/gallery/game_engine/scripting/game_ui_runner.rgr
+++ b/gallery/game_engine/scripting/game_ui_runner.rgr
@@ -153,7 +153,7 @@ class GameUiRunner {
         ; Rebuild once at a uniform scale so every element AND its font shrink
         ; together to fit (never scales up).
         def s:double (this.fitScale())
-        if (s < 1.0) {
+        if ((s < 0.999) || (s > 1.001)) {
             def b2:WasmUiEvgBuilder (new WasmUiEvgBuilder)
             b2.scale = s
             root = (b2.build(doc))
@@ -162,27 +162,30 @@ class GameUiRunner {
         ctrl.rebuild(doc root)
     }
 
-    ; Uniform scale (<= 1) that makes the laid-out content fit the canvas, with
-    ; a small margin so nothing touches the edges. 1.0 when it already fits.
+    ; Uniform scale that makes the guest-authored (fixed-px) UI FILL the canvas —
+    ; up as well as down. The whole tree (sizes + fonts) is re-authored at this
+    ; scale, so the UI renders at the canvas's native pixel density: on a big /
+    ; high-DPI surface the text and borders stay crisp instead of being drawn small
+    ; and upscaled. Fills ~92% of the height, but never wider than ~96%.
     fn fitScale:double () {
-        def s:double 1.0
         def fh:double (to_double h)
         def fw:double (to_double w)
-        def needH:double (ctrl.renderer.contentBottom(root))
-        if (needH > 0.0) {
-            if (needH > fh) {
-                def sy:double ((fh * 0.96) / needH)
-                if (sy < s) { s = sy }
-            }
-        }
-        def needW:double (ctrl.renderer.contentRight(root))
-        if (needW > 0.0) {
-            if (needW > fw) {
-                def sx:double ((fw * 0.98) / needW)
-                if (sx < s) { s = sx }
-            }
+        ; measure the content SPAN (not absolute edges) so a centred UI scales by
+        ; its intrinsic size, not its offset position.
+        def bot:double (ctrl.renderer.contentBottom(root))
+        def top:double (ctrl.renderer.contentTop(root))
+        def rgt:double (ctrl.renderer.contentRight(root))
+        def lft:double (ctrl.renderer.contentLeft(root))
+        def ch:double (bot - top)
+        def cw:double (rgt - lft)
+        if (ch <= 0.0) { return 1.0 }
+        def s:double ((fh * 0.92) / ch)
+        if (cw > 0.0) {
+            def sx:double ((fw * 0.96) / cw)
+            if (sx < s) { s = sx }
         }
         if (s < 0.2) { s = 0.2 }
+        if (s > 6.0) { s = 6.0 }
         return s
     }
 

--- a/gallery/game_engine/ui/UIContext.rgr
+++ b/gallery/game_engine/ui/UIContext.rgr
@@ -335,9 +335,12 @@ class UIContext {
         def i 0
         while (i < spread) {
             def num (spread - i)
-            ; linear falloff: brightest ring at the edge (i=0), fading outward.
-            def a (to_int ((maxAlpha * num) / spread))
-            this.strokeRoundRectA((x - i) (y - i) (rw + (i * 2)) (rh + (i * 2)) (rad + i) 1 r g b a)
+            ; quadratic falloff: brightest ring at the edge (i=0), fading softly
+            ; outward (num^2) so the halo reads as a smooth drop shadow, not a
+            ; stack of hard rings. Draw a 2px-wide ring so neighbouring rings
+            ; overlap and there is no 1px gap banding at higher resolutions.
+            def a (to_int (((maxAlpha * num) * num) / (spread * spread)))
+            this.strokeRoundRectA((x - i) (y - i) (rw + (i * 2)) (rh + (i * 2)) (rad + i) 2 r g b a)
             i = (i + 1)
         }
     }

--- a/gallery/game_engine/ui/WasmUiSelect.rgr
+++ b/gallery/game_engine/ui/WasmUiSelect.rgr
@@ -156,6 +156,67 @@ class WasmUiRenderer {
         }
         return m
     }
+    ; Top-most / left-most laid-out edges (min), so callers can measure content
+    ; SPANS (bottom-top, right-left) rather than absolute edges — the intrinsic
+    ; content size, independent of any centring offset. Absolute overlays excluded.
+    fn contentTop:double (root:EVGElement) {
+        def m:double 1000000000.0
+        def i 0
+        def n (array_length root.children)
+        while (i < n) {
+            def c:EVGElement (itemAt root.children i)
+            if (c.absPosSet == false) {
+                def t:double (this.minTop(c))
+                if (t < m) { m = t }
+            }
+            i = (i + 1)
+        }
+        if (m > 999999999.0) { m = 0.0 }
+        return m
+    }
+    fn minTop:double (el:EVGElement) {
+        def b:double el.calculatedY
+        def i 0
+        def n (array_length el.children)
+        while (i < n) {
+            def c:EVGElement (itemAt el.children i)
+            if (c.absPosSet == false) {
+                def cb:double (this.minTop(c))
+                if (cb < b) { b = cb }
+            }
+            i = (i + 1)
+        }
+        return b
+    }
+    fn contentLeft:double (root:EVGElement) {
+        def m:double 1000000000.0
+        def i 0
+        def n (array_length root.children)
+        while (i < n) {
+            def c:EVGElement (itemAt root.children i)
+            if (c.absPosSet == false) {
+                def t:double (this.minLeft(c))
+                if (t < m) { m = t }
+            }
+            i = (i + 1)
+        }
+        if (m > 999999999.0) { m = 0.0 }
+        return m
+    }
+    fn minLeft:double (el:EVGElement) {
+        def b:double el.calculatedX
+        def i 0
+        def n (array_length el.children)
+        while (i < n) {
+            def c:EVGElement (itemAt el.children i)
+            if (c.absPosSet == false) {
+                def cb:double (this.minLeft(c))
+                if (cb < b) { b = cb }
+            }
+            i = (i + 1)
+        }
+        return b
+    }
     fn maxRight:double (el:EVGElement) {
         def b:double (el.calculatedX + el.calculatedWidth)
         def i 0


### PR DESCRIPTION
## Problem

On a big / high-DPI window the interpreted UI menu, its fonts, and the drop-shadow glow looked heavily pixelated: the EVG UI was rendered into the small `pw*ph` game buffer and SDL then stretched it to the whole window (blocky), and the glow was a stack of hard 1px rings.

## Fixes

**1. Native-resolution UI.** Added `gfx_surface_width` / `gfx_surface_height` (`SDL_GL_GetDrawableSize`, window-size fallback) and `runUiGame` now renders the `engine=ui` canvas at the **actual output resolution** (capped 1600×1200 to bound the software-canvas cost), presenting near 1:1. Text/borders/effects are drawn at the display's pixel density.

**2. Scale-to-fill.** `GameUiRunner.fitScale` now scales the guest-authored (fixed-px) UI to **fill** the canvas — up as well as down — measuring the content **span** (`bottom−top`, `right−left`) rather than absolute edges, so a *centred* menu scales by its intrinsic size, not its offset. Added `contentTop`/`contentLeft` to the renderer. Combined with (1), the same UI looks identical at any resolution, but crisp.

**3. Softer glow.** `glowRoundRect` uses a quadratic (`num²`) alpha falloff and 2px-wide rings, so the halo reads as a smooth drop shadow instead of a ring stack (also less banding at higher resolution).

## Verification

A 1080×1400 headless render fills the canvas with crisp large text, sharp borders, and a smooth glow halo (vs. the previous blocky low-res upscale). Native launcher compiles to C++. Regressions green: `engine:ui:game` 4/4, `engine:ui:as` 22/22, `engine:ui:test` 29/29, `engine:ui:anim-visual` 4/4.

> Stacks on #221 (uses the glow/scale/effect infrastructure). Once #221 merges this narrows to just the resolution/scale/glow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_