### PR TITLE
Silence interpreter trace in .as source runner (perf)

### DIFF
--- a/gallery/game_engine/scripting/as_source_runner.rgr
+++ b/gallery/game_engine/scripting/as_source_runner.rgr
@@ -71,6 +71,12 @@ class AsSourceRunner {
         engine.setBasePath(dir)
         engine.setNativeBridge(bridge)
         engine.jsxParsing = false      ; .as is non-JSX: `<` is comparison / cast
+        ; Silence the interpreter's per-call trace: with quiet=false (the default)
+        ; ComponentEngine builds a string and `print`s it on EVERY function call,
+        ; method call, and member access. At 60fps that is thousands of stdout
+        ; writes per frame — the dominant cost that made the interpreted .as guest
+        ; run slower than the compiled/.tsx path (which sets quiet via game_runtime).
+        engine.quiet = true
         engine.loadScript(src)
         bridge.ensure()
         loaded = true


### PR DESCRIPTION
The interpreted .as guest ran with ComponentEngine.quiet=false (the default), so the interpreter built a trace string and printed it to stdout on every function call, method call, and member access. At 60fps that is thousands of stdout writes per frame, which made the interpreted .as path run slower than the compiled/.tsx path — the .tsx runner already sets quiet=true via game_runtime.

Set engine.quiet = true in AsSourceRunner.bindDir, matching the .tsx runtime, so the .as guest no longer pays the per-call trace/print cost.


Claude-Session: https://claude.ai/code/session_01PFgs628XMZ1dSD4wm7vFcf