### PR TITLE
game_engine: re-detect output resolution each frame (fullscreen toggle)

### DIFF
--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -921,19 +921,32 @@ class GameSdlRunner {
     ; Self-contained loop for an engine=ui game: instantiate the RGU1 guest,
     ; render its menu, move the selection with the D-pad, forward the action
     ; button to the guest, and return to the launcher on Back/Quit.
+    ; Target UI canvas dimensions = the live output surface size (drawable px),
+    ; falling back to the pw*ph game buffer, capped to bound the software-canvas
+    ; cost. Queried live each frame so a fullscreen toggle / window resize is
+    ; picked up and the UI is re-rendered at the new native resolution.
+    fn uiTargetW:int () {
+        def uw:int pw
+        def sw:int (gfx_surface_width)
+        if (sw > uw) { uw = sw }
+        if (uw > 1600) { uw = 1600 }
+        return uw
+    }
+    fn uiTargetH:int () {
+        def uh:int ph
+        def sh:int (gfx_surface_height)
+        if (sh > uh) { uh = sh }
+        if (uh > 1200) { uh = 1200 }
+        return uh
+    }
+
     fn runUiGame:void (wasmPath:string) {
         ; Render the UI at the actual output surface resolution (not the small pw*ph
         ; game buffer) so text/borders/effects are crisp instead of upscaled. Cap
         ; to bound the CPU cost of the software UI canvas; the guest UI scales to
         ; fill it (GameUiRunner.fitScale), so it looks identical at any resolution.
-        def uw:int pw
-        def uh:int ph
-        def sw:int (gfx_surface_width)
-        def sh:int (gfx_surface_height)
-        if (sw > uw) { uw = sw }
-        if (sh > uh) { uh = sh }
-        if (uw > 1600) { uw = 1600 }
-        if (uh > 1200) { uh = 1200 }
+        def uw:int (this.uiTargetW())
+        def uh:int (this.uiTargetH())
         uiRunner.init(uw uh "gallery/game_engine/assets/fonts" "OpenSans-Regular.ttf" "Open Sans")
         ; engine=ui games come in two flavours: a compiled logic.wasm guest, or an
         ; interpreted .as source (runtime=as). Pick the backend by module suffix —
@@ -964,6 +977,16 @@ class GameSdlRunner {
         this.syncInputEdges()
         def nav:UiNavInput (new UiNavInput)
         while (running) {
+            ; the output surface may have changed size since last frame (the user
+            ; toggled fullscreen or resized the window). Re-target the canvas so the
+            ; UI keeps rendering at the new native resolution instead of stretching.
+            def nw:int (this.uiTargetW())
+            def nh:int (this.uiTargetH())
+            if ((nw != uw) || (nh != uh)) {
+                uw = nw
+                uh = nh
+                uiRunner.resize(uw uh)
+            }
             def m:int (this.uiNavMask())
             nav.clear()
             nav.up = (this.upEdge((bit_and m 1) != 0))

--- a/gallery/game_engine/scripting/game_ui_runner.rgr
+++ b/gallery/game_engine/scripting/game_ui_runner.rgr
@@ -79,6 +79,23 @@ class GameUiRunner {
         ctrl.highlightPad = 4
     }
 
+    ; Re-target the canvas to a new output resolution (fullscreen toggle / window
+    ; resize) so the UI keeps rendering 1:1 at the native pixel density instead of
+    ; being stretched from its original size. The already-loaded fonts live on the
+    ; text renderer (ctx.tr), so we only reallocate the canvas + re-lay-out the tree.
+    fn resize:void (width:int height:int) {
+        if ((width == w) && (height == h)) {
+            return
+        }
+        w = width
+        h = height
+        canvas.init(width height)
+        ctx.attach(canvas)
+        if loaded {
+            this.rebuildTree()
+        }
+    }
+
     ; --- native path: instantiate the wasm guest --------------------------------
     fn loadWasm:boolean (wasmPath:string) {
         handle = (wasm_load wasmPath)


### PR DESCRIPTION
## Problem

The native-resolution UI path (#222) sized the UI canvas **once at startup** from the output surface resolution, then presented at that fixed size for the whole run loop. But `rgfx_surface_dim` (`SDL_GL_GetDrawableSize`) always returns the **live** drawable size — nothing re-read it.

So toggling fullscreen (or resizing the window) in **either direction** changed the SDL drawable size while the UI canvas stayed at its original size, and SDL fell back to stretching / letterboxing it — reintroducing exactly the blur the native-resolution path was meant to remove.

## Fix

- Extracted the target-size logic into `GameSdlRunner.uiTargetW()` / `uiTargetH()`, queried **live every frame** (drawable size, `pw*ph` fallback, capped 1600×1200).
- Added `GameUiRunner.resize(w, h)` — reallocates the canvas and re-lays out the tree at the new native resolution. Fonts live on the text renderer (`ctx.tr`), so there's no font reload.
- `runUiGame`'s loop now compares the current drawable size to the canvas size each frame and calls `resize` only on a change, so the UI re-renders 1:1 crisp after a fullscreen toggle either way.

## Verification

Native path compiles to C++ — the generated `runUiGame` loop re-queries `rgfx_surface_dim` and calls `resize` inside the frame loop. Regressions green: `engine:ui:as` 22/22, `engine:ui:game` 4/4, `engine:ui:test` 29/29, `engine:ui:anim-visual` 4/4.

> Stacks on #222 (builds on its native-resolution / `gfx_surface_*` infrastructure). Once #222 merges this narrows to just the per-frame re-detect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_