### PR TITLE
game_engine: game.info categories + catalog grouping (Games / Tests)

### DIFF
--- a/gallery/game_engine/games/autopeli_as/game.info
+++ b/gallery/game_engine/games/autopeli_as/game.info
@@ -6,3 +6,5 @@ physics=true
 assets=assets
 splitScreen=auto
 autoscale=true
+
+category=Games

--- a/gallery/game_engine/games/autopeli_as_src/game.info
+++ b/gallery/game_engine/games/autopeli_as_src/game.info
@@ -6,3 +6,5 @@ physics=true
 assets=assets
 splitScreen=auto
 autoscale=true
+
+category=Tests

--- a/gallery/game_engine/games/autopeli_physics/game.info
+++ b/gallery/game_engine/games/autopeli_physics/game.info
@@ -2,3 +2,5 @@ name=Autopeli
 splitScreen=auto
 autoscale=true
 soloScript=index.tsx
+
+category=Games

--- a/gallery/game_engine/games/autopeli_wasm/game.info
+++ b/gallery/game_engine/games/autopeli_wasm/game.info
@@ -6,3 +6,5 @@ physics=true
 assets=assets
 splitScreen=auto
 autoscale=true
+
+category=Games

--- a/gallery/game_engine/games/breakout/game.info
+++ b/gallery/game_engine/games/breakout/game.info
@@ -1,2 +1,3 @@
 name=Breakout
 splitScreen=auto
+category=Games

--- a/gallery/game_engine/games/invaders/game.info
+++ b/gallery/game_engine/games/invaders/game.info
@@ -1,2 +1,3 @@
 name=Space Invaders
 splitScreen=auto
+category=Games

--- a/gallery/game_engine/games/pacman/game.info
+++ b/gallery/game_engine/games/pacman/game.info
@@ -1,2 +1,4 @@
 splitScreen=auto
 name=Pac-Man
+
+category=Games

--- a/gallery/game_engine/games/physics_sandbox/game.info
+++ b/gallery/game_engine/games/physics_sandbox/game.info
@@ -1,2 +1,4 @@
 name=Physics Sandbox
 soloScript=index.tsx
+
+category=Games

--- a/gallery/game_engine/games/pinpall/game.info
+++ b/gallery/game_engine/games/pinpall/game.info
@@ -1,3 +1,4 @@
 name=Flipperitorni
 soloScript=index.tsx
 splitScreen=auto
+category=Games

--- a/gallery/game_engine/games/pong/game.info
+++ b/gallery/game_engine/games/pong/game.info
@@ -1,1 +1,3 @@
 name=Pong
+
+category=Games

--- a/gallery/game_engine/games/rust_pong/game.info
+++ b/gallery/game_engine/games/rust_pong/game.info
@@ -1,3 +1,5 @@
 name=Rust Pong (WASM)
 engine=wasm
 module=logic.wasm
+
+category=Games

--- a/gallery/game_engine/games/streaming_world/game.info
+++ b/gallery/game_engine/games/streaming_world/game.info
@@ -1,3 +1,5 @@
 name=Streaming World
 engine=streaming
 module=worker.wasm
+
+category=Games

--- a/gallery/game_engine/games/ui_menu/game.info
+++ b/gallery/game_engine/games/ui_menu/game.info
@@ -1,3 +1,5 @@
 name=EVG UI Menu
 engine=ui
 module=logic.wasm
+
+category=Tests

--- a/gallery/game_engine/games/ui_menu_as/game.info
+++ b/gallery/game_engine/games/ui_menu_as/game.info
@@ -2,3 +2,5 @@ name=AS UI Menu (.as demo)
 engine=ui
 runtime=as
 module=game.as
+
+category=Tests

--- a/gallery/game_engine/games/ylos2/game.info
+++ b/gallery/game_engine/games/ylos2/game.info
@@ -3,3 +3,5 @@ icon=icon.png
 splitScreen=auto
 autoscale=false
 soloScript=index.tsx
+
+category=Games

--- a/gallery/game_engine/scripting/game_catalog.rgr
+++ b/gallery/game_engine/scripting/game_catalog.rgr
@@ -37,6 +37,10 @@ class GameCatalogEntry {
     def abi:string "getter"
     ; physics: true | false — host runs GamePhysics; WASM writes controls via ABI.
     def physics:string "false"
+    ; category: which top-level launcher group this entry lands in ("Games",
+    ; "Tests", ...). Set by `category=` in game.info; when omitted the catalog
+    ; infers one (engine=ui/as demos -> Tests, everything else -> Games).
+    def category:string ""
 }
 
 class GameCatalog {
@@ -61,6 +65,59 @@ class GameCatalog {
             return fail
         }
         return (itemAt entries idx)
+    }
+
+    ; Distinct category names in catalog order (first-seen), so the launcher can
+    ; build one top-level tile per group. "Games" is forced first when present so
+    ; the front page always leads with the real games.
+    fn categories:[string] () {
+        def cats:[string]
+        def i:int 0
+        while (i < (array_length entries)) {
+            def e:GameCatalogEntry (itemAt entries i)
+            def c:string e.category
+            if ((strlen c) > 0) {
+                def seen:boolean false
+                def j:int 0
+                while (j < (array_length cats)) {
+                    if ((itemAt cats j) == c) { seen = true }
+                    j = (j + 1)
+                }
+                if (seen == false) { push cats c }
+            }
+            i = (i + 1)
+        }
+        ; force "Games" to the front if present
+        def ordered:[string]
+        def k:int 0
+        while (k < (array_length cats)) {
+            if ((itemAt cats k) == "Games") { push ordered "Games" }
+            k = (k + 1)
+        }
+        def m:int 0
+        while (m < (array_length cats)) {
+            def cc:string (itemAt cats m)
+            if (cc != "Games") { push ordered cc }
+            m = (m + 1)
+        }
+        return ordered
+    }
+
+    ; All entries whose category matches (in catalog order).
+    fn entriesInCategory:[GameCatalogEntry] (cat:string) {
+        def out:[GameCatalogEntry]
+        def i:int 0
+        while (i < (array_length entries)) {
+            def e:GameCatalogEntry (itemAt entries i)
+            if (e.category == cat) { push out e }
+            i = (i + 1)
+        }
+        return out
+    }
+
+    ; Count of entries in a category (convenience for tile subtitles).
+    fn categoryCount:int (cat:string) {
+        return (array_length (this.entriesInCategory(cat)))
     }
 
     fn trim:string (s:string) {
@@ -176,6 +233,9 @@ class GameCatalog {
         if (key == "physics") {
             entry.physics = val
         }
+        if (key == "category") {
+            entry.category = val
+        }
     }
 
     fn readMetadata:void (entry:GameCatalogEntry) {
@@ -191,6 +251,19 @@ class GameCatalog {
         }
         if ((strlen entry.title) == 0) {
             entry.title = entry.id
+        }
+        ; default category when game.info doesn't declare one: engine=ui menus and
+        ; engine=as interpreted sources are demos/tests; everything else is a game.
+        if ((strlen entry.category) == 0) {
+            if (entry.engine == "ui") {
+                entry.category = "Tests"
+            } {
+                if (entry.engine == "as") {
+                    entry.category = "Tests"
+                } {
+                    entry.category = "Games"
+                }
+            }
         }
         if (entry.engine == "tsx") {
             entry.entryPath = (this.joinPath(entry.dir entry.entryFile))
@@ -377,6 +450,8 @@ class GameCatalog {
             push vals (EvalValue.string(e.entryPath))
             push keys "engine"
             push vals (EvalValue.string(e.engine))
+            push keys "category"
+            push vals (EvalValue.string(e.category))
             if ((strlen e.iconPath) > 0) {
                 push keys "icon"
                 push vals (EvalValue.string(e.iconPath))

--- a/gallery/game_engine/scripting/game_catalog_category_demo.rgr
+++ b/gallery/game_engine/scripting/game_catalog_category_demo.rgr
@@ -1,0 +1,97 @@
+; ==============================================================================
+; game_catalog_category_demo — self-check for game.info category grouping.
+; ==============================================================================
+; Scans the real games dir and asserts the catalog groups entries into the
+; top-level launcher categories the new EVG tile menu navigates: "Games" for the
+; real playable games, "Tests" for the UI/interpreter demos. Also verifies the
+; category ordering (Games first) and the per-category membership helpers.
+; ==============================================================================
+
+Import "./game_catalog.rgr"
+
+class CatalogCategoryCheck {
+    def passed:int 0
+    def failed:int 0
+    fn ok:void (name:string cond:boolean) {
+        if cond {
+            passed = (passed + 1)
+            print ("  PASS " + name)
+        } {
+            failed = (failed + 1)
+            print ("  FAIL " + name)
+        }
+    }
+
+    ; true if `cat` contains a game whose title contains `needle`
+    fn catHas:boolean (catalog:GameCatalog cat:string needle:string) {
+        def es:[GameCatalogEntry] (catalog.entriesInCategory(cat))
+        def i:int 0
+        while (i < (array_length es)) {
+            def e:GameCatalogEntry (itemAt es i)
+            if ((indexOf e.title needle) >= 0) { return true }
+            i = (i + 1)
+        }
+        return false
+    }
+
+    ; the category assigned to the entry whose title contains `needle` ("" = none)
+    fn catOf:string (catalog:GameCatalog needle:string) {
+        def i:int 0
+        while (i < (catalog.entryCount())) {
+            def e:GameCatalogEntry (catalog.entryAt(i))
+            if ((indexOf e.title needle) >= 0) { return e.category }
+            i = (i + 1)
+        }
+        return ""
+    }
+
+    sfn m@(main):void () {
+        def catalog:GameCatalog (new GameCatalog)
+        catalog.setGamesDir("gallery/game_engine/games")
+        catalog.scan()
+        def c:CatalogCategoryCheck (new CatalogCategoryCheck)
+
+        c.ok(("catalog has entries (got " + (to_string (catalog.entryCount())) + ")") ((catalog.entryCount()) > 0))
+
+        ; ---- every entry gets a category (explicit or inferred) ----
+        def uncategorised:int 0
+        def i:int 0
+        while (i < (catalog.entryCount())) {
+            def e:GameCatalogEntry (catalog.entryAt(i))
+            if ((strlen e.category) == 0) { uncategorised = (uncategorised + 1) }
+            i = (i + 1)
+        }
+        c.ok(("every entry categorised (uncategorised=" + (to_string uncategorised) + ")") (uncategorised == 0))
+
+        ; ---- the two expected groups exist, Games first ----
+        def cats:[string] (catalog.categories())
+        c.ok(("at least 2 categories (got " + (to_string (array_length cats)) + ")") ((array_length cats) >= 2))
+        if ((array_length cats) >= 1) {
+            c.ok(("Games is the first category (got '" + (itemAt cats 0) + "')") ((itemAt cats 0) == "Games"))
+        }
+        def hasTests:boolean false
+        def k:int 0
+        while (k < (array_length cats)) {
+            if ((itemAt cats k) == "Tests") { hasTests = true }
+            k = (k + 1)
+        }
+        c.ok("Tests category present" hasTests)
+
+        ; ---- membership: real games in Games, UI demos in Tests ----
+        c.ok("Invaders in Games" (c.catHas(catalog "Games" "Invaders")))
+        c.ok("Pac-Man in Games" (c.catHas(catalog "Games" "Pac-Man")))
+        c.ok(("EVG UI Menu is a Test (got '" + (c.catOf(catalog "EVG UI Menu")) + "')") ((c.catOf(catalog "EVG UI Menu")) == "Tests"))
+        c.ok(("AS UI Menu is a Test (got '" + (c.catOf(catalog "AS UI Menu")) + "')") ((c.catOf(catalog "AS UI Menu")) == "Tests"))
+
+        ; ---- counts add up: Games + Tests == total (only two groups here) ----
+        def gN:int (catalog.categoryCount("Games"))
+        def tN:int (catalog.categoryCount("Tests"))
+        c.ok(("Games has games (" + (to_string gN) + ")") (gN > 0))
+        c.ok(("Tests has tests (" + (to_string tN) + ")") (tN > 0))
+        c.ok(("Games+Tests == total (" + (to_string (gN + tN)) + " vs " + (to_string (catalog.entryCount())) + ")") ((gN + tN) == (catalog.entryCount())))
+
+        print "======================================"
+        print (("RESULT: " + (to_string c.passed) + " passed, ") + ((to_string c.failed) + " failed"))
+        if (c.failed == 0) { print "ALL PASS" } { print "SOME FAILED" }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "engine:ui:anim-visual": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/ui/ui_anim_visual_demo.rgr -d=./gallery/game_engine/ui -o=ui_anim_visual_demo.js -nodecli && node ./gallery/game_engine/ui/ui_anim_visual_demo.js",
     "engine:ui:bgimage": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/ui/ui_bgimage_demo.rgr -d=./gallery/game_engine/ui -o=ui_bgimage_demo.js -nodecli && node ./gallery/game_engine/ui/ui_bgimage_demo.js",
     "engine:as:classes": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/tests/interp/as_class_demo.rgr -d=./gallery/game_engine/tests/interp -o=as_class_demo.js -nodecli && node ./gallery/game_engine/tests/interp/as_class_demo.js",
+    "engine:catalog:categories": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/scripting/game_catalog_category_demo.rgr -d=./gallery/game_engine/scripting -o=game_catalog_category_demo.js -nodecli && node ./gallery/game_engine/scripting/game_catalog_category_demo.js",
     "engine:compile:sdl": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -l=cpp ./gallery/game_engine/pong_sdl.rgr -d=./gallery/game_engine -o=pong_sdl.cpp -nodecli",
     "engine:sdl": "bash gallery/game_engine/scripts/build-sdl.sh",
     "engine:sdl:run": "bash gallery/game_engine/scripts/build-sdl.sh --run",


### PR DESCRIPTION
## What

Groundwork for the category-driven launcher front page (the big-tile menu). Each game declares which **top-level group** it belongs to, and the catalog can enumerate the groups and list the games in each — so the launcher can show one tile per category (Games, Tests) and drill into a per-category submenu.

## Changes

- **`GameCatalogEntry.category`**, parsed from `category=` in `game.info`. When omitted the catalog **infers** one: `engine=ui` / `engine=as` demos → `Tests`, everything else → `Games`.
- **`GameCatalog.categories()`** — distinct category names, `"Games"` forced first so the front page leads with the real games — plus **`entriesInCategory(cat)`** and **`categoryCount(cat)`**. `category` is also exported in `toEvalArray` for script consumers.
- **Every `game.info` tagged**: real playable games → `Games`; UI / interpreter demos (EVG UI Menu, AS UI Menu, interpreted Autopeli) → `Tests`.

## Verification

New self-check `engine:catalog:categories` — **12/12**: 16 catalog entries split **12 Games / 4 Tests**, `Games` ordered first, real games land in Games, UI demos in Tests, and per-category counts sum to the total. Existing `game_catalog_demo` still compiles (the `toEvalArray` addition is additive).

## Next

This is phase 1 of the launcher refactor. Phase 2 is the EVG tile front page itself (category tiles → per-category game submenu → launch), which consumes these APIs and the bg-image support (#225) for the tile art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_