### PR TITLE
game_engine: EVG tile launcher front page + host wiring (merges to master)

### DIFF
--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -20,6 +20,7 @@ Import "../wasm_runtime.rgr"
 Import "./wasm_game_runner.rgr"
 Import "./wasm_physics_runner.rgr"
 Import "./game_ui_runner.rgr"
+Import "../ui/EvgLauncherMenu.rgr"
 Import "../gfx_sdl.rgr"
 Import "./game_audio_sdl.rgr"
 Import "./game_catalog.rgr"
@@ -97,6 +98,10 @@ class GameSdlRunner {
     def prevRightHeld:boolean false
     def prevActionHeld:boolean false
     def uiRunner:GameUiRunner (new GameUiRunner)
+    ; EVG tile front page (crisp TTF category/game tiles). Default launcher; the
+    ; old pixel-font tsx menu is still available with --classic-menu.
+    def evgMenu:EvgLauncherMenu (new EvgLauncherMenu)
+    def useEvgLauncher:boolean true
     def uiDirectPath:string ""
     def gpuModeWanted:boolean true
     def gpuModeActive:boolean false
@@ -1026,6 +1031,98 @@ class GameSdlRunner {
         return false
     }
 
+    ; Target EVG-menu canvas size = live output surface (native resolution) so the
+    ; tile art + TTF stay crisp on a big window; falls back to the pw*ph buffer.
+    fn evgMenuTargetW:int () {
+        def uw:int pw
+        def sw:int (gfx_surface_width)
+        if (sw > uw) { uw = sw }
+        if (uw > 1600) { uw = 1600 }
+        return uw
+    }
+    fn evgMenuTargetH:int () {
+        def uh:int ph
+        def sh:int (gfx_surface_height)
+        if (sh > uh) { uh = sh }
+        if (uh > 1200) { uh = 1200 }
+        return uh
+    }
+
+    ; The EVG tile launcher: crisp category tiles -> per-category game grid ->
+    ; launch. Drives EvgLauncherMenu with the launcher D-pad edges, routes the
+    ; chosen game path through the same dispatch the tsx menu uses, and returns
+    ; here when the game exits. Back walks up a level (games -> categories),
+    ; and Back on the categories page quits the app.
+    fn runEvgMenuLoop:void () {
+        gfx_audio_clear
+        this.clearNavStack()
+        nativeBridge.clearPendingNav()
+        def uw:int (this.evgMenuTargetW())
+        def uh:int (this.evgMenuTargetH())
+        evgMenu.init(uw uh "gallery/game_engine/assets/fonts" "OpenSans-Regular.ttf" "Open Sans" gamesDir)
+        print ("[menu] EVG launcher: " + (to_string (catalog.entryCount())) + " games in " + (to_string (array_length (evgMenu.cats))) + " categories")
+        inMenu = true
+        inGame = false
+        gfx_set_title("Ranger Game Engine")
+        gfx_clear_should_close
+        this.syncInputEdges()
+        def nav:UiNavInput (new UiNavInput)
+        while (running) {
+            def m:int (this.launcherNavMask())
+            nav.clear()
+            nav.up = (this.upEdge((bit_and m 1) != 0))
+            nav.down = (this.downEdge((bit_and m 2) != 0))
+            nav.left = (this.leftEdge((bit_and m 16) != 0))
+            nav.right = (this.rightEdge((bit_and m 32) != 0))
+            nav.action = (this.actionEdge((bit_and m 4) != 0))
+            evgMenu.navFrame(nav)
+            evgMenu.draw()
+            gfx_present (evgMenu.raw()) uw uh
+
+            ; Back (Q/Esc / gamepad Select|B): walk up a level, or quit from the top
+            if (this.quitEdge((this.gameMenuBackHeld()))) {
+                evgMenu.back()
+                if evgMenu.wantQuit {
+                    running = false
+                    return
+                }
+            }
+
+            ; a game tile was activated -> launch it, then come back to the menu
+            if evgMenu.chosen {
+                def launchPath:string evgMenu.chosenPath
+                evgMenu.chosen = false
+                if ((strlen launchPath) > 0) {
+                    if ((this.engineOf(launchPath)) == "ui") {
+                        this.runUiGame(launchPath)
+                    } {
+                        this.loadGame(launchPath)
+                        this.runGameLoop()
+                    }
+                    if (running == false) {
+                        return
+                    }
+                    ; returned from the game: restore the menu window + input state
+                    gfx_clear_should_close
+                    inMenu = true
+                    inGame = false
+                    gfx_set_title("Ranger Game Engine")
+                    this.syncInputEdges()
+                }
+            }
+
+            if (gfx_should_close) {
+                running = false
+            }
+            frames = (frames + 1)
+            if (maxFrames > 0) {
+                if (frames >= maxFrames) {
+                    running = false
+                }
+            }
+        }
+    }
+
     fn runMenuLoop:void () {
         this.loadMenuGame()
         while (running) {
@@ -1256,7 +1353,11 @@ class GameSdlRunner {
         gfx_audio_open(44100)
         this.refreshWasmAudioSampleRate()
         if (launcherMode) {
-            this.runMenuLoop()
+            if useEvgLauncher {
+                this.runEvgMenuLoop()
+            } {
+                this.runMenuLoop()
+            }
         } {
             if ((strlen uiDirectPath) > 0) {
                 this.runUiGame(uiDirectPath)
@@ -1341,6 +1442,13 @@ class GameSdlRunner {
         def pendingGamesDir:boolean false
         while (i < (shell_arg_cnt)) {
             def arg:string (shell_arg i)
+            ; launcher front-page style: EVG tile menu (default) vs the old tsx menu
+            if (arg == "--classic-menu") {
+                useEvgLauncher = false
+            }
+            if (arg == "--evg-menu") {
+                useEvgLauncher = true
+            }
             if (pendingGamesDir) {
                 gamesDir = arg
                 launcherMode = true

--- a/gallery/game_engine/ui/EvgLauncherMenu.rgr
+++ b/gallery/game_engine/ui/EvgLauncherMenu.rgr
@@ -1,0 +1,367 @@
+; ==============================================================================
+; EvgLauncherMenu - the crisp EVG tile front page for the game launcher.
+; ==============================================================================
+;
+; A host-authored (not guest) EVG screen that replaces the old pixel-font tsx
+; menu front page. It renders TWO levels, both as big rounded image tiles with a
+; TTF label under each (kids read words, not pixel fonts):
+;
+;   * CATEGORIES page - one large tile per top-level group (Games, Tests, ...),
+;     each with a background image from menu/assets/<category>.png. Selecting a
+;     category drills into:
+;   * GAMES page       - one tile per game in that category (its icon image, or a
+;     coloured text tile when it has none). Selecting a game reports its launch
+;     path back to the host, which loads it through the existing dispatch.
+;
+; It draws everything itself through UIContext (rounded image fills, gradients,
+; glow highlight, TTF text) over a manual grid, so it needs no RGU1 document and
+; no guest - it reads the live GameCatalog directly. Navigation is pointer-free
+; (D-pad / arrow edges via UiNavInput), matching the rest of the EVG UI layer.
+; ==============================================================================
+
+Import "UIContext.rgr"
+Import "WasmUiSelect.rgr"
+Import "../scripting/game_catalog.rgr"
+Import "../scripting/game_image_loader.rgr"
+Import "../../evg/EVGColor.rgr"
+
+; One laid-out tile: the image square plus the label bar under it.
+class LauncherTile {
+    def x:int 0
+    def y:int 0
+    def side:int 0        ; image square side (px)
+    def labelH:int 0      ; label bar height under the square
+    def label:string ""
+    def image:string ""   ; background image path ("" = coloured text tile)
+    def path:string ""    ; launch path (games page) or category name (categories)
+    def r:int 60          ; fallback tile colour
+    def g:int 70
+    def b:int 110
+}
+
+class EvgLauncherMenu {
+    def canvas:SoftCanvas (new SoftCanvas)
+    def ctx:UIContext (new UIContext)
+    def loader:GameImageLoader (new GameImageLoader)
+    def catalog:GameCatalog (new GameCatalog)
+
+    def w:int 0
+    def h:int 0
+
+    ; page: 0 = categories, 1 = games in the current category
+    def page:int 0
+    def cats:[string]
+    def curCat:string ""
+    def sel:int 0                 ; selected tile index on the current page
+
+    ; outputs the host polls each frame
+    def chosen:boolean false      ; a game was activated this frame
+    def chosenPath:string ""      ; its launch path
+    def wantQuit:boolean false    ; back pressed on the categories page
+
+    ; where the category background images live
+    def assetsDir:string "gallery/game_engine/menu/assets"
+
+    Constructor () {
+    }
+
+    fn init:void (width:int height:int fontDir:string fontRel:string family:string gamesDir:string) {
+        w = width
+        h = height
+        canvas.init(width height)
+        ctx.attach(canvas)
+        if ((strlen fontDir) > 0) {
+            ctx.tr.addFontDir(fontDir)
+            def ok:boolean (ctx.tr.loadFont(family fontRel))
+            if (ok == false) {
+                ctx.tr.addFontDir("gallery/pdf_writer/assets/fonts")
+                ctx.tr.loadFont(family "Open_Sans/OpenSans-Regular.ttf")
+            }
+        }
+        catalog.setGamesDir(gamesDir)
+        catalog.scan()
+        cats = (catalog.categories())
+        this.reset()
+    }
+
+    ; return to the top-level categories page
+    fn reset:void () {
+        page = 0
+        curCat = ""
+        sel = 0
+        chosen = false
+        chosenPath = ""
+        wantQuit = false
+    }
+
+    ; true if an image file exists on disk (guards the loader, whose PNG/JPEG
+    ; decoders throw on a missing path rather than returning an invalid image).
+    fn fileThere:boolean (path:string) {
+        if ((strlen path) == 0) { return false }
+        def slash:int (lastIndexOf path "/")
+        if (slash < 0) { return (file_exists "." path) }
+        def dir:string (substring path 0 slash)
+        def file:string (substring path (slash + 1) (strlen path))
+        return (file_exists dir file)
+    }
+
+    ; the background image file for a category tile. Known groups map to the
+    ; authored art (Tests uses the tools/shield image); a missing/unknown asset
+    ; falls through to a coloured text tile.
+    fn assetForCategory:string (cat:string) {
+        def p:string ""
+        if (cat == "Games") { p = (assetsDir + "/games.png") }
+        if (cat == "Tests") { p = (assetsDir + "/tools.png") }
+        if (this.fileThere(p)) { return p }
+        return ""
+    }
+
+    ; --- build the tile list for the current page ------------------------------
+    fn tiles:[LauncherTile] () {
+        if (page == 0) {
+            return (this.categoryTiles())
+        }
+        return (this.gameTiles())
+    }
+
+    fn categoryTiles:[LauncherTile] () {
+        def out:[LauncherTile]
+        def i:int 0
+        while (i < (array_length cats)) {
+            def c:string (itemAt cats i)
+            def t:LauncherTile (new LauncherTile)
+            t.label = c
+            t.path = c
+            t.image = (this.assetForCategory(c))
+            ; distinct fallback colour per common category
+            if (c == "Games") {
+                t.r = 210
+                t.g = 90
+                t.b = 40
+            }
+            if (c == "Tests") {
+                t.r = 60
+                t.g = 90
+                t.b = 150
+            }
+            push out t
+            i = (i + 1)
+        }
+        return out
+    }
+
+    fn gameTiles:[LauncherTile] () {
+        def out:[LauncherTile]
+        def es:[GameCatalogEntry] (catalog.entriesInCategory(curCat))
+        def i:int 0
+        while (i < (array_length es)) {
+            def e:GameCatalogEntry (itemAt es i)
+            def t:LauncherTile (new LauncherTile)
+            t.label = e.title
+            t.path = e.entryPath
+            ; a game's own icon (relative to its folder) is its tile image, when
+            ; the file is actually present (game.info may name a missing icon)
+            if ((strlen e.iconPath) > 0) {
+                def ip:string (e.dir + "/" + e.iconPath)
+                if (this.fileThere(ip)) {
+                    t.image = ip
+                }
+            }
+            push out t
+            i = (i + 1)
+        }
+        return out
+    }
+
+    ; --- grid geometry ---------------------------------------------------------
+    ; columns for a given tile count: categories read as a bold 2-up row; game
+    ; grids use up to 4 columns.
+    fn columnsFor:int (n:int) {
+        if (page == 0) {
+            if (n <= 1) { return 1 }
+            return 2
+        }
+        if (n <= 1) { return 1 }
+        if (n <= 4) { return n }
+        if (n <= 6) { return 3 }
+        return 4
+    }
+
+    ; lay out tile rects into a centred grid and fill x/y/side/labelH
+    fn layout:[LauncherTile] () {
+        def ts:[LauncherTile] (this.tiles())
+        def n:int (array_length ts)
+        if (n == 0) { return ts }
+        def cols:int (this.columnsFor(n))
+        def rows:int (idiv (n + cols - 1) cols)
+        def marginX:int 40
+        def topArea:int 96                 ; title band at the top
+        def gap:int 22
+        def labelH:int 38
+        def availW:int (w - (marginX * 2) - ((cols - 1) * gap))
+        def side:int (idiv availW cols)
+        ; cap tile size so a 2-up categories row doesn't get absurdly tall
+        def maxSide:int (idiv (h - topArea - 60 - (rows * labelH) - ((rows - 1) * gap)) rows)
+        if (maxSide > 0) {
+            if (side > maxSide) { side = maxSide }
+        }
+        if (side < 40) { side = 40 }
+        def tileH:int (side + labelH)
+        def gridW:int ((cols * side) + ((cols - 1) * gap))
+        def gridH:int ((rows * tileH) + ((rows - 1) * gap))
+        def startX:int (idiv (w - gridW) 2)
+        def startY:int (topArea + (idiv ((h - topArea) - gridH) 2))
+        if (startY < topArea) { startY = topArea }
+        def i:int 0
+        while (i < n) {
+            def row:int (idiv i cols)
+            def col:int (i - (row * cols))
+            def t:LauncherTile (itemAt ts i)
+            t.x = (startX + (col * (side + gap)))
+            t.y = (startY + (row * (tileH + gap)))
+            t.side = side
+            t.labelH = labelH
+            i = (i + 1)
+        }
+        return ts
+    }
+
+    ; --- navigation ------------------------------------------------------------
+    fn navFrame:void (nav:UiNavInput) {
+        chosen = false
+        wantQuit = false
+        def ts:[LauncherTile] (this.tiles())
+        def n:int (array_length ts)
+        if (n == 0) { return }
+        def cols:int (this.columnsFor(n))
+        if nav.left  { this.moveSel((0 - 1) n) }
+        if nav.right { this.moveSel(1 n) }
+        if nav.up    { this.moveSel((0 - cols) n) }
+        if nav.down  { this.moveSel(cols n) }
+        if nav.action { this.activate() }
+    }
+
+    fn moveSel:void (delta:int n:int) {
+        def ns:int (sel + delta)
+        if (ns < 0) { return }
+        if (ns >= n) { return }
+        sel = ns
+    }
+
+    fn activate:void () {
+        def ts:[LauncherTile] (this.tiles())
+        if (sel >= (array_length ts)) { return }
+        def t:LauncherTile (itemAt ts sel)
+        if (page == 0) {
+            ; enter this category's games page
+            curCat = t.path
+            page = 1
+            sel = 0
+        } {
+            ; launch this game
+            chosenPath = t.path
+            chosen = true
+        }
+    }
+
+    ; back: submenu -> categories; categories -> quit signal
+    fn back:void () {
+        if (page == 1) {
+            page = 0
+            sel = 0
+        } {
+            wantQuit = true
+        }
+    }
+
+    ; --- rendering -------------------------------------------------------------
+    fn draw:void () {
+        canvas.clear(16 18 30)
+        ; title band
+        def white:EVGColor (EVGColor.rgba(236 240 250 1.0))
+        def muted:EVGColor (EVGColor.rgba(150 176 208 1.0))
+        def title:string "GAMES"
+        if (page == 1) { title = curCat }
+        def tsz:double 40.0
+        def tw:double (ctx.measureWidth(title tsz))
+        ctx.text(title (to_int (((to_double w) - tw) / 2.0)) 30 tsz white)
+        def hint:string "arrows: move    enter: open"
+        if (page == 1) { hint = "arrows: move    enter: play    back: categories" }
+        def hsz:double 15.0
+        def hw:double (ctx.measureWidth(hint hsz))
+        ctx.text(hint (to_int (((to_double w) - hw) / 2.0)) (h - 34) hsz muted)
+
+        def ts:[LauncherTile] (this.layout())
+        def i:int 0
+        while (i < (array_length ts)) {
+            def t:LauncherTile (itemAt ts i)
+            this.drawTile(t (i == sel))
+            i = (i + 1)
+        }
+    }
+
+    ; truncate a label with an ellipsis so it fits within maxw px at `size`
+    fn fitLabel:string (s:string maxw:double size:double) {
+        if ((ctx.measureWidth(s size)) <= maxw) { return s }
+        def n:int (strlen s)
+        while (n > 1) {
+            def cand:string ((substring s 0 n) + "..")
+            if ((ctx.measureWidth(cand size)) <= maxw) { return cand }
+            n = (n - 1)
+        }
+        return ".."
+    }
+
+    fn drawTile:void (t:LauncherTile selected:boolean) {
+        def rad:int 16
+        ; image square (or coloured fallback with a big initial)
+        def drawn:boolean false
+        if ((strlen t.image) > 0) {
+            def img:ImageBuffer (loader.load(t.image))
+            if (loader.isValidImage(img)) {
+                ctx.fillRoundRectImage(t.x t.y t.side t.side rad img)
+                drawn = true
+            }
+        }
+        if (drawn == false) {
+            ; gradient fallback so a text tile still looks intentional
+            ctx.fillRoundRectGrad(t.x t.y t.side t.side rad 0
+                t.r t.g t.b 255
+                (idiv (t.r * 6) 10) (idiv (t.g * 6) 10) (idiv (t.b * 6) 10) 255)
+        }
+        ; border
+        def bR:int 120
+        def bG:int 150
+        def bB:int 210
+        if selected {
+            bR = 255
+            bG = 232
+            bB = 120
+        }
+        ctx.strokeRoundRectA(t.x t.y t.side t.side rad 2 bR bG bB 255)
+
+        ; label bar under the square
+        def ly:int (t.y + t.side + 6)
+        def lh:int (t.labelH - 6)
+        def barCol:EVGColor (EVGColor.rgba(28 32 48 1.0))
+        if selected { barCol = (EVGColor.rgba(60 66 96 1.0)) }
+        ctx.fillRoundRect(t.x ly t.side lh 8 barCol)
+        def lblCol:EVGColor (EVGColor.rgba(236 240 250 1.0))
+        def lsz:double 17.0
+        ; keep the label inside the tile width (truncate long game titles)
+        def shown:string (this.fitLabel(t.label (to_double (t.side - 14)) lsz))
+        def lw:double (ctx.measureWidth(shown lsz))
+        def lx:int (t.x + (to_int (((to_double t.side) - lw) / 2.0)))
+        def lty:int (ly + (to_int (((to_double lh) - (ctx.lineHeight(lsz))) / 2.0)))
+        ctx.text(shown lx lty lsz lblCol)
+
+        ; selection glow around the whole tile
+        if selected {
+            ctx.glowRoundRect((t.x - 4) (t.y - 4) (t.side + 8) (t.side + t.labelH + 8) (rad + 4) 255 232 120 14 200)
+        }
+    }
+
+    fn raw:buffer () {
+        return (canvas.raw())
+    }
+}

--- a/gallery/game_engine/ui/EvgLauncherMenu.rgr
+++ b/gallery/game_engine/ui/EvgLauncherMenu.rgr
@@ -355,9 +355,9 @@ class EvgLauncherMenu {
         def lty:int (ly + (to_int (((to_double lh) - (ctx.lineHeight(lsz))) / 2.0)))
         ctx.text(shown lx lty lsz lblCol)
 
-        ; selection glow around the whole tile
+        ; selection glow around the image box only (not the label bar)
         if selected {
-            ctx.glowRoundRect((t.x - 4) (t.y - 4) (t.side + 8) (t.side + t.labelH + 8) (rad + 4) 255 232 120 14 200)
+            ctx.glowRoundRect((t.x - 4) (t.y - 4) (t.side + 8) (t.side + 8) (rad + 4) 255 232 120 14 200)
         }
     }
 

--- a/gallery/game_engine/ui/evg_launcher_demo.rgr
+++ b/gallery/game_engine/ui/evg_launcher_demo.rgr
@@ -1,0 +1,91 @@
+; ==============================================================================
+; evg_launcher_demo - headless self-check + screenshots for EvgLauncherMenu.
+; ==============================================================================
+; Builds the EVG tile launcher over the real games dir, drives it with D-pad
+; edges, and asserts: the categories page lists Games + Tests, entering a
+; category drills into its game tiles, selecting a game reports a launch path,
+; and Back walks up the levels. Dumps a PNG of each page for a visual check.
+; ==============================================================================
+
+Import "EvgLauncherMenu.rgr"
+Import "../../pdf_writer/src/raster/PNGEncoder.rgr"
+
+class EvgLauncherDemo {
+    def passed:int 0
+    def failed:int 0
+    fn ok:void (name:string cond:boolean) {
+        if cond {
+            passed = (passed + 1)
+            print ("  PASS " + name)
+        } {
+            failed = (failed + 1)
+            print ("  FAIL " + name)
+        }
+    }
+
+    sfn snap:void (m:EvgLauncherMenu file:string) {
+        m.draw()
+        def rb:RasterBuffer (new RasterBuffer)
+        rb.width = (m.canvas.getWidth())
+        rb.height = (m.canvas.getHeight())
+        rb.pixels = (m.canvas.raw())
+        def png:PNGEncoder (new PNGEncoder)
+        png.encode(rb "gallery/game_engine/ui" file)
+    }
+
+    ; build one frame of D-pad input and drive the menu with it
+    fn tap:void (m:EvgLauncherMenu up:boolean down:boolean left:boolean right:boolean action:boolean) {
+        def nav:UiNavInput (new UiNavInput)
+        nav.up = up
+        nav.down = down
+        nav.left = left
+        nav.right = right
+        nav.action = action
+        m.navFrame(nav)
+    }
+
+    sfn m@(main):void () {
+        def d:EvgLauncherDemo (new EvgLauncherDemo)
+        def m:EvgLauncherMenu (new EvgLauncherMenu)
+        m.init(760 560 "gallery/game_engine/assets/fonts" "OpenSans-Regular.ttf" "Open Sans" "gallery/game_engine/games")
+
+        ; ---- categories page ----
+        d.ok(("has category tiles (got " + (to_string (array_length (m.tiles()))) + ")") ((array_length (m.tiles())) >= 2))
+        d.ok("starts on categories page" (m.page == 0))
+        d.ok(("first category is Games (got '" + (itemAt m.cats 0) + "')") ((itemAt m.cats 0) == "Games"))
+        EvgLauncherDemo.snap(m "launcher_1_categories.png")
+
+        ; ---- enter Games ----
+        d.tap(m false false false false true)   ; activate Games
+        d.ok("entered games page" (m.page == 1))
+        d.ok(("current category Games (got '" + m.curCat + "')") (m.curCat == "Games"))
+        d.ok(("games page has tiles (got " + (to_string (array_length (m.tiles()))) + ")") ((array_length (m.tiles())) > 0))
+        EvgLauncherDemo.snap(m "launcher_2_games.png")
+
+        ; ---- move + launch a game ----
+        d.tap(m false false false true false)   ; right
+        d.tap(m false false false false true)   ; activate
+        d.ok("a game was chosen" m.chosen)
+        d.ok(("chosen path is non-empty (got '" + m.chosenPath + "')") ((strlen m.chosenPath) > 0))
+
+        ; ---- back walks up: games -> categories ----
+        m.back()
+        d.ok("back returns to categories" (m.page == 0))
+
+        ; ---- Tests category is a text menu (tools art may be absent) ----
+        d.tap(m false false false true false)   ; right -> Tests
+        d.tap(m false false false false true)   ; activate Tests
+        d.ok(("entered Tests (got '" + m.curCat + "')") (m.curCat == "Tests"))
+        d.ok(("Tests has tiles (got " + (to_string (array_length (m.tiles()))) + ")") ((array_length (m.tiles())) > 0))
+        EvgLauncherDemo.snap(m "launcher_3_tests.png")
+
+        ; ---- back on categories signals quit ----
+        m.back()
+        m.back()
+        d.ok("back on categories signals quit" m.wantQuit)
+
+        print "======================================"
+        print (("RESULT: " + (to_string d.passed) + " passed, ") + ((to_string d.failed) + " failed"))
+        if (d.failed == 0) { print "ALL PASS" } { print "SOME FAILED" }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "engine:ui:bgimage": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/ui/ui_bgimage_demo.rgr -d=./gallery/game_engine/ui -o=ui_bgimage_demo.js -nodecli && node ./gallery/game_engine/ui/ui_bgimage_demo.js",
     "engine:as:classes": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/tests/interp/as_class_demo.rgr -d=./gallery/game_engine/tests/interp -o=as_class_demo.js -nodecli && node ./gallery/game_engine/tests/interp/as_class_demo.js",
     "engine:catalog:categories": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/scripting/game_catalog_category_demo.rgr -d=./gallery/game_engine/scripting -o=game_catalog_category_demo.js -nodecli && node ./gallery/game_engine/scripting/game_catalog_category_demo.js",
+    "engine:ui:launcher": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 ./gallery/game_engine/ui/evg_launcher_demo.rgr -d=./gallery/game_engine/ui -o=evg_launcher_demo.js -nodecli && node ./gallery/game_engine/ui/evg_launcher_demo.js",
     "engine:compile:sdl": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -l=cpp ./gallery/game_engine/pong_sdl.rgr -d=./gallery/game_engine -o=pong_sdl.cpp -nodecli",
     "engine:sdl": "bash gallery/game_engine/scripts/build-sdl.sh",
     "engine:sdl:run": "bash gallery/game_engine/scripts/build-sdl.sh --run",


### PR DESCRIPTION
## Why this PR

The EVG tile launcher was split across #228 (component) and #229 (wiring), stacked on each other's branches. Merging them landed the work on those intermediate branches, **not on master** — so `EvgLauncherMenu.rgr` and `runEvgMenuLoop` never reached master and the app still opened the old pixel-font tsx menu.

This PR **rebases the complete work onto current master** as a single, directly-mergeable change (categories #226 and the `menu/assets/` art are already on master). Merge this one PR and the front page changes.

## What's included

- **`EvgLauncherMenu`** — host-authored EVG front page: big rounded **image tiles with a TTF label** under each. Categories page (comic **GAMES** / shield **Tests** art) → per-category **game grid** (icon or coloured text tile) → launch. Pointer-free nav, glow scoped to the image box, ellipsis-truncated labels, missing-file guards.
- **Host wiring** (`runEvgMenuLoop`) — `run()` opens the EVG launcher **by default**, drives it with the launcher D-pad edges at native resolution, routes a chosen game through the existing dispatch (`runUiGame` / `loadGame`+`runGameLoop`), returns to the menu on exit; **Back** walks up (games → categories → quit). `--classic-menu` restores the old tsx menu.

## Verification

- Native path **compiles to C++** (SDL2 window can't run in CI).
- Headless `engine:ui:launcher` — **12/12** (category listing, drill-in, launch-path reporting, back traversal).

## Follow-ups (not in this PR)

- Live fullscreen-resize for the menu (same pattern as `runUiGame`).
- Game-tile `icon=` art (tiles are text placeholders until games ship icons).

> Supersedes the now-closed #228 / #229, which were stranded on stacked branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_