### PR TITLE
Native fixes for WASM UI effects: escaping-closure segfault + C++ reserved words

### DIFF
--- a/bin/Lang.rgr
+++ b/bin/Lang.rgr
@@ -86,6 +86,17 @@ language {
             public _public
             private _private
             protected _protected
+            signed _signed
+            unsigned _unsigned
+            register _register
+            volatile _volatile
+            mutable _mutable
+            friend _friend
+            typename _typename
+            typedef _typedef
+            extern _extern
+            explicit _explicit
+            goto _goto
         }
         go {
             type _type

--- a/compiler/Lang.rgr
+++ b/compiler/Lang.rgr
@@ -86,6 +86,17 @@ language {
             public _public
             private _private
             protected _protected
+            signed _signed
+            unsigned _unsigned
+            register _register
+            volatile _volatile
+            mutable _mutable
+            friend _friend
+            typename _typename
+            typedef _typedef
+            extern _extern
+            explicit _explicit
+            goto _goto
         }
         go {
             type _type

--- a/dist/Lang.rgr
+++ b/dist/Lang.rgr
@@ -86,6 +86,17 @@ language {
             public _public
             private _private
             protected _protected
+            signed _signed
+            unsigned _unsigned
+            register _register
+            volatile _volatile
+            mutable _mutable
+            friend _friend
+            typename _typename
+            typedef _typedef
+            extern _extern
+            explicit _explicit
+            goto _goto
         }
         go {
             type _type


### PR DESCRIPTION
## Summary

Two native-build fixes for the WASM UI effects work merged in #233.

## 1. Segfault when an effect completes (main fix)

Triggering almost any effect crashed the native build ~0.5 s later, on completion.

**Root cause:** routing completion through `UIAnim.after()` compiles to a **capture-by-reference** lambda in the C++ backend:

```cpp
->after([&]() mutable { bind->fire(); }))->start();
```

The closure is stored in the animation and invoked long after `startEffect()` returns — by then the local `bind` binding is destroyed, so `bind->fire()` dereferences a **dangling stack reference**: use-after-free → SIGSEGV. The es6/interpreted paths kept the closure's captures alive (JS GC / synchronous scope), so only the compiled-native path crashed.

**Fix:** stop using the escaping closure. `WasmUiEffects` holds each completion binding in a field, stamps it with its `UIAnim`, and **polls `anim.done` in `tick()`** — firing the guest's `rg_ui_effect_done` once and dropping the binding. Nothing is captured by reference; nothing escapes.

**Hardened the same class of bug at guest-lifetime edges:**
- `WasmUiEffects.reset()` / `UIAnimator.reset()` drop all in-flight effects, and `GameUiRunner` calls it on every guest (re)load — so a late completion can't fire into a **closed or slot-reused guest** (which would deliver a spurious callback to the wrong module).
- `rg_wasm_call_void` now guards a null slot (matching `rg_wasm_call_i32`); combined with `rg_find_fn`'s null check, calling into a closed handle is a safe no-op.

> Underlying hazard: the cpp backend captures escaping closures by reference (`[&]`), unsafe whenever the closure outlives its scope. The effects path now avoids escaping closures entirely; a general fix belongs in the backend.

## 2. C++ reserved words in cpp codegen

The backend renames identifiers colliding with C++ keywords via the `cpp` `reserved_words` map in `Lang.rgr`, but `signed` was missing — so `ComponentEngine.wrapInt(v, bits, signed)` emitted invalid `bool signed`, breaking the native build. Added `signed`, `unsigned`, `register`, `volatile`, `mutable`, `friend`, `typename`, `typedef`, `extern`, `explicit`, `goto` (escaped with a leading underscore). Applied to `compiler/Lang.rgr` and mirrored to the `bin/`/`dist/` copies.

## Verification

- Native bridge compiles (`gcc -fsyntax-only` vs wasm3).
- `game_sdl_runner` transpiles to C++ with **zero escaping closures** in the effect path; a `signed` parameter emits `bool _signed` and passes `g++ -std=c++17 -fsyntax-only`.
- es6 self-tests: effects driver 19/19, visual demo 10/10, ui runner 4/4, UIAnimator 13/13.

Not link-run here (no SDL2/GL in this environment); the crash was diagnosed from the generated C++.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrauXum1KQ45wr9MrSzHgf