### PR TITLE
fix: engine=ui wasm games hung when launched from the .as launcher menu

### DIFF
--- a/gallery/game_engine/scripting/game_ui_runner.rgr
+++ b/gallery/game_engine/scripting/game_ui_runner.rgr
@@ -76,6 +76,11 @@ class GameUiRunner {
     fn init:void (width:int height:int fontDir:string fontRelPath:string family:string) {
         w = width
         h = height
+        ; start in a clean mode: this runner is reused across the launcher menu (.as)
+        ; and launched engine=ui games (wasm or .as), so reset the backend flags —
+        ; loadWasm/loadAs set them again, and setMenuCatalog re-enables injection.
+        useAs = false
+        hasMenuCatalog = false
         canvas.init(width height)
         ctx.attach(canvas)
         if ((strlen fontDir) > 0) {
@@ -97,6 +102,12 @@ class GameUiRunner {
 
     ; --- native path: instantiate the wasm guest --------------------------------
     fn loadWasm:boolean (wasmPath:string) {
+        ; this runner may be reused after an interpreted .as guest (the launcher
+        ; menu), which set useAs=true; a compiled wasm guest drives itself, so
+        ; clear the flag or frame()/render() would take the .as path and the game
+        ; would never run (appears hung).
+        useAs = false
+        hasMenuCatalog = false
         handle = (wasm_load wasmPath)
         if (handle <= 0) {
             return false


### PR DESCRIPTION
## Problem

Launching a compiled `engine=ui` game (e.g. the **EVG Effects Demo** / `ui_effects`) from the new `.as` launcher menu hung — the screen froze right after `[game-engine] ui game: …/ui_effects/logic.wasm`, doing nothing.

## Root cause

The launcher menu and launched `engine=ui` games **share one `GameUiRunner`**. The menu runs as interpreted `.as`, and `loadAs` sets `useAs = true`. `loadWasm` never cleared that flag, so when a compiled wasm guest was loaded next, `useAs` stayed `true` and `frame()`/`render()` took the **interpreted path** — the wasm guest never ran, so it looked hung.

(The old host-rendered menu used a separate object for the menu, so `uiRunner` was always fresh for wasm games — which is why this only surfaced after the menu became an `.as` game sharing the runner.)

## Fix

- `loadWasm` resets `useAs = false` (and `hasMenuCatalog = false`).
- `init()` resets `useAs` / `hasMenuCatalog` too, so every reuse of the runner starts in a clean mode and a launched `.as` game doesn't inherit the menu's injected catalog.

The effects demo's own code (#233/#234) was fine — this was purely the shared-runner state leak from the `.as` menu integration.

## Verification

- `engine:ui:game` **4/4** (wasm `engine=ui` path)
- `engine:menu:launcher` **12/12**
- Native path compiles to C++.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8QpBoiCiJbA8geUm1pL91)_