### PR TITLE
Fix native segfault when a WASM UI effect completes

### DIFF
--- a/gallery/game_engine/scripting/game_ui_runner.rgr
+++ b/gallery/game_engine/scripting/game_ui_runner.rgr
@@ -147,6 +147,7 @@ class GameUiRunner {
 
     ; --- interpreted .as path: bind + init the guest, pull its first document ----
     fn loadAs:boolean (dir:string) {
+        effects.reset()
         useAs = true
         if ((asRunner.bindDir(dir)) == false) {
             return false
@@ -183,6 +184,7 @@ class GameUiRunner {
 
     ; --- headless/test path: an already-authored RGU1 byte block ----------------
     fn loadDoc:boolean (bytes:[int] n:int) {
+        effects.reset()
         doc.loadBytes(bytes n)
         if (doc.valid == false) {
             return false

--- a/gallery/game_engine/ui/UIAnimator.rgr
+++ b/gallery/game_engine/ui/UIAnimator.rgr
@@ -159,6 +159,12 @@ class UIAnimator {
         push anims a
     }
 
+    ; Drop all active animations (e.g. when the UI they animate is torn down).
+    fn reset:void () {
+        def empty:[UIAnim]
+        anims = empty
+    }
+
     fn activeCount:int () {
         return (array_length anims)
     }

--- a/gallery/game_engine/ui/WasmUiSelect.rgr
+++ b/gallery/game_engine/ui/WasmUiSelect.rgr
@@ -39,11 +39,17 @@ Import "../../evg/EVGElement.rgr"
 
 ; Completion binding for one guest-requested effect. When the effect finishes the
 ; host calls the guest's rg_ui_effect_done(node, tag) export so it can react
-; (navigate, bump a counter) — the WASM-side equivalent of UIAnim's `after` hook.
+; (navigate, bump a counter). WasmUiEffects.tick() polls `anim.done` and fires
+; this once — deliberately NOT via UIAnim's `after` hook: that path compiles to a
+; capture-by-reference lambda that escapes startEffect() and use-after-frees its
+; local binding in the native build (segfault). Polling holds the binding in a
+; field for its whole lifetime, so nothing dangles.
 class WasmFxDone {
     def handle:int 0
     def node:int 0
     def tag:int 0
+    def anim:UIAnim            ; the effect this binding completes with
+    def fired:boolean false    ; rg_ui_effect_done called exactly once
 
     Constructor () {
     }
@@ -60,6 +66,11 @@ class WasmFxDone {
 ; The renderer samples glowFor(id) to draw the animated halo.
 class WasmUiEffects {
     def animator:UIAnimator (new UIAnimator)
+    ; Strong-holds the per-effect completion bindings for the lifetime of their
+    ; animations. UIAnim already retains its callback strongly; this is a second,
+    ; explicit owner so the binding can never be freed while its effect is live
+    ; (the callback would otherwise use-after-free natively -> segfault).
+    def binds:[WasmFxDone]
 
     Constructor () {
     }
@@ -68,10 +79,6 @@ class WasmUiEffects {
     ; 2 pulse. target: 0 node (node id -> stringified to match el.id), 1 screen.
     ; Split out of drain() so it is drivable from a host test without a wasm engine.
     fn startEffect:void (kind:int target:int node:int durMs:int delayMs:int r:int g:int b:int handle:int tag:int) {
-        def bind:WasmFxDone (new WasmFxDone)
-        bind.handle = handle
-        bind.node = node
-        bind.tag = tag
         def durSec:double ((to_double durMs) / 1000.0)
         def delaySec:double ((to_double delayMs) / 1000.0)
         def a:UIAnim (animator.animation())
@@ -86,7 +93,16 @@ class WasmUiEffects {
                 a.glow(key)
             }
         }
-        a.color(r g b).duration(durSec).delay(delaySec).after(bind.fire).start()
+        a.color(r g b).duration(durSec).delay(delaySec).start()
+        ; Route completion by polling this binding in tick() (not a.after(): that
+        ; escaping closure use-after-frees natively). The binding strong-holds the
+        ; anim, so a.done stays readable after the animator drops the finished anim.
+        def bind:WasmFxDone (new WasmFxDone)
+        bind.handle = handle
+        bind.node = node
+        bind.tag = tag
+        bind.anim = a
+        push binds bind
     }
 
     ; Convenience used by the host self-test: a white node glow.
@@ -117,6 +133,33 @@ class WasmUiEffects {
 
     fn tick:void (dtMs:int) {
         animator.tick(dtMs)
+        ; Poll each binding: when its effect has finished, notify the guest once
+        ; (rg_ui_effect_done) and drop the binding; keep the rest for next frame.
+        def kept:[WasmFxDone]
+        def i 0
+        def n (array_length binds)
+        while (i < n) {
+            def bind:WasmFxDone (itemAt binds i)
+            if (bind.anim.done) {
+                if (bind.fired == false) {
+                    bind.fired = true
+                    bind.fire()
+                }
+            } {
+                push kept bind
+            }
+            i = (i + 1)
+        }
+        binds = kept
+    }
+
+    ; Drop all in-flight effects + their completion bindings. Call this when the
+    ; guest is (re)loaded so no binding outlives its guest — otherwise a late
+    ; completion could fire rg_ui_effect_done into a closed or slot-reused guest.
+    fn reset:void () {
+        def empty:[WasmFxDone]
+        binds = empty
+        animator.reset()
     }
 
     ; --- render-side queries ---

--- a/runtime/rg_wasm_bridge.c
+++ b/runtime/rg_wasm_bridge.c
@@ -456,6 +456,9 @@ void rg_wasm_call_void(int handle, const char* name, int nargs,
     IM3Function fn;
     M3Result r;
 
+    if (!s) {
+        return;
+    }
     fn = rg_find_fn(s, name);
     if (!fn) {
         return;


### PR DESCRIPTION
Triggering almost any effect crashed the native build ~half a second later, when the effect finished. Root cause: routing completion through UIAnim.after() compiles to a capture-by-reference lambda in the C++ backend — `->after([&]() mutable { bind->fire(); })` — that is stored in the animation and invoked long after startEffect() returns. By then the local `bind` binding is destroyed, so `bind->fire()` dereferences a dangling stack reference: use-after -free -> SIGSEGV. (The es6/interpreted paths kept the closure's captures alive, so only the compiled-native path crashed.)

Fix — stop using the escaping closure. WasmUiEffects now holds each completion binding in a field (`binds`), stamps it with its UIAnim, and polls `anim.done` in tick(): when an effect finishes it calls the guest's rg_ui_effect_done once and drops the binding. Nothing is captured by reference, nothing escapes.

Also hardened the guest-lifetime edges the same class of bug can hit:
  * WasmUiEffects.reset() / UIAnimator.reset() drop all in-flight effects, and GameUiRunner calls it on every guest (re)load — so a late completion can't fire rg_ui_effect_done into a closed or slot-reused guest (which would deliver a spurious callback to the wrong module).
  * rg_wasm_call_void now guards a null slot (matching rg_wasm_call_i32); with rg_find_fn's existing null check, calling into a closed handle is a safe no-op rather than relying on the caller.

Note: the underlying hazard is a compiler codegen choice — escaping closures are captured by reference (`[&]`) in the cpp backend, which is unsafe whenever the closure outlives its defining scope. The effects path now avoids escaping closures entirely; a general fix belongs in the backend.

Verified: native bridge compiles (gcc -fsyntax-only vs wasm3); game_sdl_runner transpiles to C++ with zero escaping closures in the effect path; es6 self-tests pass — effects driver 19/19, visual demo 10/10, ui runner 4/4, UIAnimator 13/13.


Claude-Session: https://claude.ai/code/session_01QrauXum1KQ45wr9MrSzHgf