### PR TITLE
as: support a shared fluent ui.as builder module across .as games

### DIFF
--- a/gallery/game_engine/games/ui_menu_as/game.as
+++ b/gallery/game_engine/games/ui_menu_as/game.as
@@ -21,7 +21,8 @@
 //    DEMO  left/right cycle the EVG technique, action returns to the menu
 // ============================================================================
 
-import { abiRead, abiWrite, uiReset, uiNode, uiPropI32, uiPropEnum, uiPropStr, uiPropColorRgba, uiFinish } from "@ranger/game";
+import { abiRead, abiWrite, uiPropI32, uiPropEnum, uiPropColorRgba } from "@ranger/game";
+import { ui } from "./ui";
 
 // ---- shared ABI offsets ----
 const OFF_INPUT: i32 = 20;   // host -> guest: edge mask this frame
@@ -41,37 +42,15 @@ const IN_LEFT: i32 = 4;
 const IN_RIGHT: i32 = 8;
 const IN_ACT: i32 = 16;
 
-// RGU1 node kinds
-const K_VIEW: i32 = 1;
-const K_TEXT: i32 = 2;
-const K_BUTTON: i32 = 5;
-
-// RGU1 property keys
-const P_TEXT: i32 = 1;
-const P_BG: i32 = 2;
-const P_COLOR: i32 = 3;
-const P_FONT: i32 = 4;
-const P_WIDTH: i32 = 10;
-const P_HEIGHT: i32 = 11;
-const P_PAD: i32 = 12;
-const P_MARGIN: i32 = 13;
-const P_RADIUS: i32 = 14;
-const P_BORDER_COLOR: i32 = 15;
-const P_BORDER_W: i32 = 16;
-const P_FLEXDIR: i32 = 21;
-const P_ALIGN: i32 = 22;
-const P_TEXTALIGN: i32 = 24;
+// Extra RGU1 property keys this demo needs beyond the shared `ui` builder
+// (./ui.as already provides K_VIEW/K_TEXT/K_BUTTON, P_TEXT/P_BG/P_COLOR/...,
+// and the DIR_*/ALIGN_*/TEXTALIGN_* enum values via its own top-level consts).
 const P_GRAD_FROM: i32 = 50;   // linear-gradient start colour
 const P_GRAD_TO: i32 = 51;     // linear-gradient end colour
 const P_GRAD_DIR: i32 = 52;    // 0 vertical, 1 horizontal
 const P_ABS_X: i32 = 53;       // absolute page-x
 const P_ABS_Y: i32 = 54;       // absolute page-y
 const P_GLOW: i32 = 55;        // animated glow strength 0..1000
-
-// enum values
-const DIR_COLUMN: i32 = 1;
-const ALIGN_CENTER: i32 = 1;
-const TEXTALIGN_CENTER: i32 = 1;
 
 // node ids
 const ROOT: i32 = 1;
@@ -188,35 +167,19 @@ let ANIMATOR: Animator = new Animator();
 let DONE: Counter = new Counter();
 let NAV: Nav = new Nav();
 
-// ---- small RGU1 authoring helpers (props apply to the last uiNode) ----
-function view(id: i32, parent: i32, order: i32): void {
-  uiNode(id, parent, K_VIEW, order);
-}
-function column(): void {
-  uiPropEnum(P_FLEXDIR, DIR_COLUMN);
-  uiPropEnum(P_ALIGN, ALIGN_CENTER);
-}
+// ---- small authoring helpers over the shared `ui` builder (./ui.as) ----
 function label(id: i32, parent: i32, order: i32, s: string, r: i32, g: i32, b: i32, size: i32): void {
-  uiNode(id, parent, K_TEXT, order);
-  uiPropStr(P_TEXT, s);
-  uiPropI32(P_FONT, size);
-  uiPropColorRgba(P_COLOR, r, g, b, 255);
+  ui.label(id, parent, order).text(s).font(size).color(r, g, b, 255);
 }
 // A uniform menu button; `on` = currently selected (host draws the glow, but we
-// also brighten the border so it reads on a static screenshot).
+// also brighten the border so it reads on a static screenshot). P_GLOW isn't
+// part of the shared `El` chain (it's specific to this demo's animator), so it
+// is set with a raw uiPropI32() call - that's fine, it still targets whatever
+// node ui.button() just opened.
 function button(id: i32, order: i32, s: string, cr: i32, cg: i32, cb: i32, br: i32, bg: i32, bb: i32): void {
-  uiNode(id, CARD, K_BUTTON, order);
-  uiPropStr(P_TEXT, s);
-  uiPropI32(P_FONT, 16);
-  uiPropColorRgba(P_COLOR, cr, cg, cb, 255);
-  uiPropI32(P_WIDTH, 180);
-  uiPropI32(P_PAD, 10);
-  uiPropI32(P_MARGIN, 6);
-  uiPropI32(P_RADIUS, 9);
-  uiPropI32(P_BORDER_W, 2);
-  uiPropColorRgba(P_BORDER_COLOR, br, bg, bb, 255);
-  uiPropColorRgba(P_BG, 120, 165, 230, 46);
-  uiPropEnum(P_TEXTALIGN, TEXTALIGN_CENTER);
+  ui.button(id, CARD, order).text(s).font(16).color(cr, cg, cb, 255)
+    .width(180).pad(10).margin(6).radius(9)
+    .border(2, br, bg, bb, 255).bg(120, 165, 230, 46).textCenter();
   let gi: i32 = ANIMATOR.glowFor(id);
   if (gi > 0) {
     uiPropI32(P_GLOW, gi);
@@ -232,9 +195,8 @@ function exampleName(i: i32): string {
 
 // ---- document builders ----
 function buildMenu(): void {
-  view(ROOT, 0, 0); column(); uiPropI32(P_PAD, 22);
-  view(CARD, ROOT, 0); column(); uiPropI32(P_PAD, 18); uiPropI32(P_WIDTH, 280);
-  uiPropColorRgba(P_BG, 36, 42, 64, 255); uiPropI32(P_RADIUS, 16);
+  ui.view(ROOT, 0, 0).column().center().pad(22);
+  ui.view(CARD, ROOT, 0).column().center().pad(18).width(280).bg(36, 42, 64, 255).radius(16);
 
   label(10, CARD, 0, "AS UI - Main Menu", 255, 255, 255, 20);
 
@@ -254,9 +216,8 @@ function buildMenu(): void {
 }
 
 function buildDemo(): void {
-  view(ROOT, 0, 0); column(); uiPropI32(P_PAD, 18);
-  view(CARD, ROOT, 0); column(); uiPropI32(P_PAD, 18); uiPropI32(P_WIDTH, 300);
-  uiPropColorRgba(P_BG, 30, 34, 52, 255); uiPropI32(P_RADIUS, 16);
+  ui.view(ROOT, 0, 0).column().center().pad(18);
+  ui.view(CARD, ROOT, 0).column().center().pad(18).width(300).bg(30, 34, 52, 255).radius(16);
 
   label(100, CARD, 0, "EVG Demo", 255, 255, 255, 20);
   label(101, CARD, 1, (EXAMPLE + 1).toString() + "/" + EX_COUNT.toString() + "  " + exampleName(EXAMPLE), 143, 176, 208, 13);
@@ -264,38 +225,22 @@ function buildDemo(): void {
   // the preview element demonstrates the current technique
   if (EXAMPLE == EX_BG) {
     // background color: a vivid rounded panel
-    uiNode(PREVIEW, CARD, K_VIEW, 2);
-    uiPropI32(P_WIDTH, 220);
-    uiPropI32(P_PAD, 26);
-    uiPropI32(P_RADIUS, 12);
-    uiPropI32(P_MARGIN, 8);
-    uiPropColorRgba(P_BG, 232, 140, 60, 255);
+    ui.view(PREVIEW, CARD, 2).width(220).pad(26).radius(12).margin(8).bg(232, 140, 60, 255);
     label(122, PREVIEW, 0, "background", 30, 22, 12, 15);
   } else if (EXAMPLE == EX_FONT_COLOR) {
     // font color: text in a vivid colour on a neutral panel
-    uiNode(PREVIEW, CARD, K_VIEW, 2);
-    uiPropI32(P_WIDTH, 220);
-    uiPropI32(P_PAD, 26);
-    uiPropI32(P_RADIUS, 12);
-    uiPropI32(P_MARGIN, 8);
-    uiPropColorRgba(P_BG, 22, 26, 40, 255);
+    ui.view(PREVIEW, CARD, 2).width(220).pad(26).radius(12).margin(8).bg(22, 26, 40, 255);
     label(122, PREVIEW, 0, "Ranger EVG", 80, 220, 130, 22);
   } else if (EXAMPLE == EX_FONT_SIZE) {
     // font size: large glyphs
-    uiNode(PREVIEW, CARD, K_VIEW, 2);
-    uiPropI32(P_WIDTH, 220);
-    uiPropI32(P_PAD, 18);
-    uiPropI32(P_RADIUS, 12);
-    uiPropI32(P_MARGIN, 8);
-    uiPropColorRgba(P_BG, 22, 26, 40, 255);
+    ui.view(PREVIEW, CARD, 2).width(220).pad(18).radius(12).margin(8).bg(22, 26, 40, 255);
     label(122, PREVIEW, 0, "Big 42", 220, 224, 236, 42);
   } else {
-    // linear gradient: a real 2-stop vertical gradient fill in the host EVG renderer
-    uiNode(PREVIEW, CARD, K_VIEW, 2);
-    uiPropI32(P_WIDTH, 220);
-    uiPropI32(P_PAD, 26);
-    uiPropI32(P_RADIUS, 12);
-    uiPropI32(P_MARGIN, 8);
+    // linear gradient: a real 2-stop vertical gradient fill in the host EVG
+    // renderer. P_GRAD_* isn't part of the shared `El` chain, so those two
+    // props are set with raw calls right after opening the node - they still
+    // target it, exactly like the chained ones above.
+    ui.view(PREVIEW, CARD, 2).width(220).pad(26).radius(12).margin(8);
     uiPropColorRgba(P_GRAD_FROM, 90, 130, 245, 255);   // blue
     uiPropColorRgba(P_GRAD_TO, 210, 90, 200, 255);     // magenta
     uiPropEnum(P_GRAD_DIR, 0);                          // vertical
@@ -318,11 +263,7 @@ function emitEffect(): void {
     let ry: i32 = abiRead(OFF_RECT_Y);
     let ex: i32 = rx + rw - 7;
     let ey: i32 = ry - 7;
-    uiNode(EFFECT, ROOT, K_VIEW, 999);   // high order -> drawn on top
-    uiPropI32(P_WIDTH, 14);
-    uiPropI32(P_HEIGHT, 14);
-    uiPropI32(P_RADIUS, 7);
-    uiPropColorRgba(P_BG, 255, 230, 120, 235);
+    ui.view(EFFECT, ROOT, 999).width(14).height(14).radius(7).bg(255, 230, 120, 235);   // high order -> drawn on top
     uiPropI32(P_ABS_X, ex);
     uiPropI32(P_ABS_Y, ey);
   }
@@ -330,14 +271,14 @@ function emitEffect(): void {
 
 function build(): void {
   ANIMATOR.tick();          // advance effects once per frame (time-driven)
-  uiReset();
+  ui.reset();
   if (SCREEN == SCR_MENU) {
     buildMenu();
   } else {
     buildDemo();
   }
   emitEffect();
-  uiFinish(REV);
+  ui.finish(REV);
 }
 
 // ---- exports the host calls ----

--- a/gallery/game_engine/lib/ui.as
+++ b/gallery/game_engine/lib/ui.as
@@ -1,0 +1,93 @@
+// ============================================================================
+// Shared fluent EVG builder for .as games, over the flat RGU1 bridge.
+// ============================================================================
+// `ui.view/label/button(id, parent, order)` opens an RGU1 node and returns an
+// `El` whose chained setters style that SAME node:
+//
+//   ui.view(imgId, colId, 0).width(176).height(176).radius(16).image(art)
+//     .border(3, br, bg, bb, 255);
+//   ui.label(lblId, colId, 1).text(name).font(20).color(236, 240, 250, 255).margin(6);
+//
+// `uiProp*()` always applies to whichever node `uiNode()` opened LAST, so `El`
+// carries no node identity of its own - it is a stateless chain API. That is
+// why every open() call below hands back the SAME shared `CURRENT` instance
+// instead of allocating a fresh `El` per node.
+//
+// IMPORTANT: a chain must be used right after the `ui.view/label/button(...)`
+// call that produced it - do NOT hold a reference across a second open() call:
+//   let a = ui.view(10, ROOT, 0);
+//   ui.view(20, ROOT, 1);
+//   a.width(100);   // restyles node 20 (the last one opened), not node 10
+//
+// Import into a game with:
+//   import { ui } from "./ui";
+// (falls back to this shared file when the game's own folder has no ui.as -
+// see as_source_runner.rgr's engine.addAssetPath("gallery/game_engine/lib")).
+// ============================================================================
+
+import { uiReset, uiNode, uiPropI32, uiPropEnum, uiPropStr, uiPropColorRgba, uiFinish } from "@ranger/game";
+
+// RGU1 node kinds
+const K_VIEW: i32 = 1;
+const K_TEXT: i32 = 2;
+const K_BUTTON: i32 = 5;
+
+// RGU1 property keys
+const P_TEXT: i32 = 1;
+const P_BG: i32 = 2;
+const P_COLOR: i32 = 3;
+const P_FONT: i32 = 4;
+const P_WIDTH: i32 = 10;
+const P_HEIGHT: i32 = 11;
+const P_PAD: i32 = 12;
+const P_MARGIN: i32 = 13;
+const P_RADIUS: i32 = 14;
+const P_BORDER_COLOR: i32 = 15;
+const P_BORDER_W: i32 = 16;
+const P_FLEXDIR: i32 = 21;
+const P_ALIGN: i32 = 22;
+const P_TEXTALIGN: i32 = 24;
+const P_BG_IMAGE: i32 = 56;   // background image path, clipped to the rounded box
+
+const DIR_ROW: i32 = 0;
+const DIR_COLUMN: i32 = 1;
+const ALIGN_CENTER: i32 = 1;
+const TEXTALIGN_CENTER: i32 = 1;
+
+class El {
+  row(): El { uiPropEnum(P_FLEXDIR, DIR_ROW); return this; }
+  column(): El { uiPropEnum(P_FLEXDIR, DIR_COLUMN); return this; }
+  center(): El { uiPropEnum(P_ALIGN, ALIGN_CENTER); return this; }
+  pad(v: i32): El { uiPropI32(P_PAD, v); return this; }
+  margin(v: i32): El { uiPropI32(P_MARGIN, v); return this; }
+  width(v: i32): El { uiPropI32(P_WIDTH, v); return this; }
+  height(v: i32): El { uiPropI32(P_HEIGHT, v); return this; }
+  radius(v: i32): El { uiPropI32(P_RADIUS, v); return this; }
+  font(v: i32): El { uiPropI32(P_FONT, v); return this; }
+  text(s: string): El { uiPropStr(P_TEXT, s); return this; }
+  image(path: string): El { uiPropStr(P_BG_IMAGE, path); return this; }
+  textCenter(): El { uiPropEnum(P_TEXTALIGN, TEXTALIGN_CENTER); return this; }
+  bg(r: i32, g: i32, b: i32, a: i32): El { uiPropColorRgba(P_BG, r, g, b, a); return this; }
+  color(r: i32, g: i32, b: i32, a: i32): El { uiPropColorRgba(P_COLOR, r, g, b, a); return this; }
+  border(w: i32, r: i32, g: i32, b: i32, a: i32): El {
+    uiPropI32(P_BORDER_W, w);
+    uiPropColorRgba(P_BORDER_COLOR, r, g, b, a);
+    return this;
+  }
+}
+
+// One shared, allocation-free chain instance - see the file header for why a
+// fresh `El` per node is unnecessary (and wasteful on a managed heap at ship
+// time): uiProp*() is stateless from El's point of view, it always targets
+// whatever node uiNode() opened last.
+const CURRENT: El = new El();
+
+class Ui {
+  reset(): void { uiReset(); }
+  finish(rev: i32): void { uiFinish(rev); }
+  view(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_VIEW, order); return CURRENT; }
+  label(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_TEXT, order); return CURRENT; }
+  button(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_BUTTON, order); return CURRENT; }
+}
+
+export const ui: Ui = new Ui();

--- a/gallery/game_engine/menu/game.as
+++ b/gallery/game_engine/menu/game.as
@@ -16,7 +16,8 @@
 //   enter/A              open a category, or launch the selected game
 //   left/back            games screen -> categories
 // ============================================================================
-import { abiRead, abiWrite, uiReset, uiNode, uiPropI32, uiPropEnum, uiPropStr, uiPropColorRgba, uiFinish } from "@ranger/game";
+import { abiRead, abiWrite } from "@ranger/game";
+import { ui } from "./ui";
 
 // shared ABI offsets (ints)
 const OFF_INPUT: i32 = 20;    // host -> guest: edge mask this frame
@@ -28,30 +29,6 @@ const IN_DOWN: i32 = 2;
 const IN_LEFT: i32 = 4;
 const IN_RIGHT: i32 = 8;
 const IN_ACT: i32 = 16;
-
-// RGU1 node kinds + property keys
-const K_VIEW: i32 = 1;
-const K_TEXT: i32 = 2;
-const K_BUTTON: i32 = 5;
-const P_TEXT: i32 = 1;
-const P_BG: i32 = 2;
-const P_COLOR: i32 = 3;
-const P_FONT: i32 = 4;
-const P_WIDTH: i32 = 10;
-const P_HEIGHT: i32 = 11;
-const P_PAD: i32 = 12;
-const P_MARGIN: i32 = 13;
-const P_RADIUS: i32 = 14;
-const P_BORDER_COLOR: i32 = 15;
-const P_BORDER_W: i32 = 16;
-const P_FLEXDIR: i32 = 21;
-const P_ALIGN: i32 = 22;
-const P_TEXTALIGN: i32 = 24;
-const P_BG_IMAGE: i32 = 56;   // background image path, clipped to the rounded box
-const DIR_ROW: i32 = 0;
-const DIR_COLUMN: i32 = 1;
-const ALIGN_CENTER: i32 = 1;
-const TEXTALIGN_CENTER: i32 = 1;
 
 // category background art (host-resolvable paths; the host loads the pixels)
 const ART_GAMES: string = "gallery/game_engine/menu/assets/games.png";
@@ -68,43 +45,6 @@ let SCREEN: i32 = 0;
 let SEL: i32 = 0;      // selection index on the current screen
 let CAT: i32 = 0;      // 0 = Games, 1 = Tests
 let REV: i32 = 0;
-
-// ============================================================================
-// Fluent EVG builder over the flat bridge. Each `ui.view/text/button(...)`
-// opens a node and returns an `El` whose chained setters style that node —
-// so authoring reads like `ui.view(id,parent,order).column().center().pad(22)`.
-// ============================================================================
-class El {
-  row(): El { uiPropEnum(P_FLEXDIR, DIR_ROW); return this; }
-  column(): El { uiPropEnum(P_FLEXDIR, DIR_COLUMN); return this; }
-  center(): El { uiPropEnum(P_ALIGN, ALIGN_CENTER); return this; }
-  pad(v: i32): El { uiPropI32(P_PAD, v); return this; }
-  margin(v: i32): El { uiPropI32(P_MARGIN, v); return this; }
-  width(v: i32): El { uiPropI32(P_WIDTH, v); return this; }
-  height(v: i32): El { uiPropI32(P_HEIGHT, v); return this; }
-  radius(v: i32): El { uiPropI32(P_RADIUS, v); return this; }
-  font(v: i32): El { uiPropI32(P_FONT, v); return this; }
-  text(s: string): El { uiPropStr(P_TEXT, s); return this; }
-  image(path: string): El { uiPropStr(P_BG_IMAGE, path); return this; }
-  textCenter(): El { uiPropEnum(P_TEXTALIGN, TEXTALIGN_CENTER); return this; }
-  bg(r: i32, g: i32, b: i32, a: i32): El { uiPropColorRgba(P_BG, r, g, b, a); return this; }
-  color(r: i32, g: i32, b: i32, a: i32): El { uiPropColorRgba(P_COLOR, r, g, b, a); return this; }
-  border(w: i32, r: i32, g: i32, b: i32, a: i32): El {
-    uiPropI32(P_BORDER_W, w);
-    uiPropColorRgba(P_BORDER_COLOR, r, g, b, a);
-    return this;
-  }
-}
-
-class Ui {
-  reset(): void { uiReset(); }
-  finish(rev: i32): void { uiFinish(rev); }
-  view(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_VIEW, order); return new El(); }
-  label(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_TEXT, order); return new El(); }
-  button(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_BUTTON, order); return new El(); }
-}
-
-let ui: Ui = new Ui();
 
 function catName(i: i32): string {
   if (i == 1) return "Tests";

--- a/gallery/game_engine/scripting/as_source_runner.rgr
+++ b/gallery/game_engine/scripting/as_source_runner.rgr
@@ -70,6 +70,11 @@ class AsSourceRunner {
         src = (this.stripBridgeImport(src))
         engine.setBasePath(dir)
         engine.setNativeBridge(bridge)
+        ; Shared .as modules (e.g. the fluent `ui` builder) live in lib/ and
+        ; resolve via relative imports like `import { ui } from "./ui"`: found
+        ; first in the game's own dir, else here (same convention game_runtime
+        ; uses for .tsx `game_helpers`).
+        engine.addAssetPath("gallery/game_engine/lib")
         engine.jsxParsing = false      ; .as is non-JSX: `<` is comparison / cast
         ; Silence the interpreter's per-call trace: with quiet=false (the default)
         ; ComponentEngine builds a string and `print`s it on EVERY function call,

--- a/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
+++ b/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
@@ -848,7 +848,16 @@ class ComponentEngine {
         if ((indexOf modulePath ".d.ts") >= 0) {
             return
         }
-        
+        ; Skip the flat native-bridge import ("@ranger/game"). The entry .as
+        ; file already has this line stripped before loadScript() (see
+        ; as_source_runner.rgr's stripBridgeImport), so its names fall through
+        ; to nativeBridge at call time; a shared .as module imported via a
+        ; relative path keeps this import (for asc compile-time typing) and
+        ; would otherwise fail resolution here on every load, spamming stderr.
+        if ((indexOf modulePath "@ranger/game") >= 0) {
+            return
+        }
+
         ; Get imported symbols from node.children (import specifiers)
         def importExportNames:[string]
         def importLocalNames:[string]
@@ -1018,6 +1027,17 @@ class ComponentEngine {
             }
             return
         }
+        if (node.nodeType == "ClassDeclaration") {
+            ; `classes` is a single engine-wide name->node map (see
+            ; registerTopLevelNode / evaluateNewExpr), so a class declared in
+            ; an imported module becomes constructible (`new Foo()`) by both
+            ; that module's own top-level initializers and the importer,
+            ; exactly like a class declared in the entry script.
+            if ((strlen node.name) > 0) {
+                set classes node.name node
+            }
+            return
+        }
         if (node.nodeType == "VariableDeclaration") {
             this.processModuleVariableDeclaration(node)
             return
@@ -1073,22 +1093,38 @@ class ComponentEngine {
             if ((strlen path) == 0) {
                 return ""
             }
-            ; Add .tsx extension if needed
-            if ((indexOf path ".tsx") < 0) {
-                if ((indexOf path ".ts") < 0) {
-                    path = path + ".tsx"
-                }
-            }
-            return path
+            return (this.appendModuleExtension(path))
         }
-        
+
         ; For now, just add extension
-        if ((indexOf modulePath ".tsx") < 0) {
-            if ((indexOf modulePath ".ts") < 0) {
-                return (modulePath + ".tsx")
+        return (this.appendModuleExtension(modulePath))
+    }
+
+    ; Append the interpreter's default module extension, unless `path` already
+    ; names one explicitly (.tsx/.ts/.as pass through untouched). A `.as` game
+    ; (jsxParsing == false, set by as_source_runner.rgr) resolves an
+    ; extensionless relative import to `.as` instead of `.tsx`, so a shared
+    ; builder module can be authored as e.g. `./ui.as` and imported as
+    ; `import { ui } from "./ui"`.
+    fn appendModuleExtension:string (path:string) {
+        def n:int (strlen path)
+        if (n >= 4) {
+            if ((substring path (n - 4) n) == ".tsx") {
+                return path
             }
         }
-        return modulePath
+        if (n >= 3) {
+            if ((substring path (n - 3) n) == ".ts") {
+                return path
+            }
+            if ((substring path (n - 3) n) == ".as") {
+                return path
+            }
+        }
+        if (jsxParsing == false) {
+            return (path + ".as")
+        }
+        return (path + ".tsx")
     }
     
     fn isInList:boolean (name:string list:[string]) {


### PR DESCRIPTION
## Summary

Fixes the .as UI authoring runtime to support a shared fluent EVG builder module across `.as` game files, per feedback that `games/ui_menu_as/game.as`'s procedural `view()/column()/label()/button()` free functions were hard to read compared to `menu/game.as`'s local fluent `El`/`Ui` chain - and that duplicating that chain per-game (with a fresh `El` allocation per node) doesn't scale.

- **`gallery/pdf_writer/src/jsx/ComponentEngine.rgr`**: relative `.as` imports (`import { ui } from "./ui"`) previously resolved to a bogus path (the resolver only ever appended `.tsx`) and silently failed. Fixed module-path extension handling to preserve `.as`/`.ts`/`.tsx` suffixes and default extensionless imports to `.as` when the importing engine is in non-JSX mode. Also registered imported modules' top-level `class` declarations (previously ignored), so `new Foo()` works across an import boundary, and skipped `@ranger/game` in import resolution the same way entry files already do, so a shared module's own bridge import doesn't spam load-error diagnostics.
- **`gallery/game_engine/scripting/as_source_runner.rgr`**: registers `gallery/game_engine/lib` as an asset-path fallback for `.as` games, mirroring the existing convention for shared `.tsx` `game_helpers`.
- **`gallery/game_engine/lib/ui.as`** (new): the shared fluent builder (`ui.view/label/button(id, parent, order).column().pad(...)`) - one reusable `El` chain instance instead of allocating a fresh object per node, since `uiProp*()` always targets whichever node `uiNode()` opened last.
- **`gallery/game_engine/menu/game.as`** and **`gallery/game_engine/games/ui_menu_as/game.as`**: now `import { ui } from "./ui"` instead of duplicating the builder (menu) or hand-rolling it as raw procedural calls (ui_menu_as).

## Test plan

- [x] `as_ui_menu_src_demo.rgr` (interprets `games/ui_menu_as/game.as` end-to-end): 22/22 assertions pass
- [x] `menu_launcher_demo.rgr` (interprets `menu/game.as` end-to-end): 12/12 assertions pass
- [x] `import_chain_demo.rgr` (existing `.tsx`-to-`.tsx` transitive import regression): still passes, confirming the resolver change doesn't affect `.tsx` imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)