### PR TITLE
Add TypeScript/TSX launcher menu with rich EVG rendering

### DIFF
--- a/gallery/evg/EVGElement.rgr
+++ b/gallery/evg/EVGElement.rgr
@@ -624,7 +624,38 @@ class EVGElement {
             box.borderRadius = (EVGUnit.parse(value))
             return
         }
-        
+
+        ; ---- rich EVG effect props, drawn by WasmUiRenderer from these fields.
+        ; camelCase spellings so the TSX parser (which splits '-') can carry them.
+        ; Animated glow halo strength (0..1).
+        if (name == "glow") {
+            def gv@(optional):double (to_double value)
+            glowIntensity = (unwrap gv)
+            return
+        }
+        ; Background art clipped to the rounded box (the .as menu's tile image).
+        if ((name == "background-image") || (name == "backgroundImage")) {
+            bgImageSet = true
+            bgImagePath = value
+            return
+        }
+        ; 2-stop linear gradient fill (RGU1 GRAD_FROM/GRAD_TO/GRAD_DIR).
+        if ((name == "gradient-from") || (name == "gradientFrom")) {
+            gradientFrom = (EVGColor.parse(value))
+            gradientSet = true
+            return
+        }
+        if ((name == "gradient-to") || (name == "gradientTo")) {
+            gradientTo = (EVGColor.parse(value))
+            gradientSet = true
+            return
+        }
+        if ((name == "gradient-dir") || (name == "gradientDir")) {
+            def dv@(optional):int (to_int value)
+            gradientDir = (unwrap dv)
+            return
+        }
+
         ; Colors
         if ((name == "background-color") || (name == "backgroundColor")) {
             backgroundColor = (EVGColor.parse(value))

--- a/gallery/game_engine/games/autopeli_as/game.info
+++ b/gallery/game_engine/games/autopeli_as/game.info
@@ -7,4 +7,4 @@ assets=assets
 splitScreen=auto
 autoscale=true
 
-category=Games
+category=Tests

--- a/gallery/game_engine/games/autopeli_physics/game.info
+++ b/gallery/game_engine/games/autopeli_physics/game.info
@@ -3,4 +3,4 @@ splitScreen=auto
 autoscale=true
 soloScript=index.tsx
 
-category=Games
+category=Tests

--- a/gallery/game_engine/games/autopeli_wasm/game.info
+++ b/gallery/game_engine/games/autopeli_wasm/game.info
@@ -1,4 +1,4 @@
-name=Rust Autopeli (WASM)
+name=Autot
 engine=wasm
 module=logic.wasm
 abi=linear

--- a/gallery/game_engine/games/physics_sandbox/game.info
+++ b/gallery/game_engine/games/physics_sandbox/game.info
@@ -1,4 +1,4 @@
 name=Physics Sandbox
 soloScript=index.tsx
 
-category=Games
+category=Tests

--- a/gallery/game_engine/games/pose_demo/game.info
+++ b/gallery/game_engine/games/pose_demo/game.info
@@ -4,3 +4,4 @@ module=game.as
 abi=linear
 physics=false
 assets=assets
+category=Tests

--- a/gallery/game_engine/games/streaming_world/game.info
+++ b/gallery/game_engine/games/streaming_world/game.info
@@ -2,4 +2,4 @@ name=Streaming World
 engine=streaming
 module=worker.wasm
 
-category=Games
+category=Tests

--- a/gallery/game_engine/games/ui_menu_as/game.as
+++ b/gallery/game_engine/games/ui_menu_as/game.as
@@ -23,34 +23,8 @@
 
 import { abiRead, abiWrite } from "@ranger/game";
 import { ui, El } from "./ui";
-
-// ---- shared ABI offsets ----
-const OFF_INPUT: i32 = 20;   // host -> guest: edge mask this frame
-const OFF_TIME: i32 = 16;    // host -> guest: monotonic clock (ms) for effects
-const OFF_SEL: i32 = 52;     // guest -> host: selected node id (highlight)
-// host -> guest: laid-out rect (page px) of the selected node, so we can place
-// an absolute overlay effect at real screen coordinates.
-const OFF_RECT_X: i32 = 200;
-const OFF_RECT_Y: i32 = 204;
-const OFF_RECT_W: i32 = 208;
-const OFF_RECT_H: i32 = 212;
-
-// input edge bits
-const IN_UP: i32 = 1;
-const IN_DOWN: i32 = 2;
-const IN_LEFT: i32 = 4;
-const IN_RIGHT: i32 = 8;
-const IN_ACT: i32 = 16;
-
-// Extra RGU1 property keys this demo needs beyond the shared `ui` builder
-// (./ui.as already provides K_VIEW/K_TEXT/K_BUTTON, P_TEXT/P_BG/P_COLOR/...,
-// and the DIR_*/ALIGN_*/TEXTALIGN_* enum values via its own top-level consts).
-const P_GRAD_FROM: i32 = 50;   // linear-gradient start colour
-const P_GRAD_TO: i32 = 51;     // linear-gradient end colour
-const P_GRAD_DIR: i32 = 52;    // 0 vertical, 1 horizontal
-const P_ABS_X: i32 = 53;       // absolute page-x
-const P_ABS_Y: i32 = 54;       // absolute page-y
-const P_GLOW: i32 = 55;        // animated glow strength 0..1000
+import { OFF_INPUT, OFF_TIME, OFF_SEL, OFF_RECT_X, OFF_RECT_Y, OFF_RECT_W, OFF_RECT_H, IN_UP, IN_DOWN, IN_LEFT, IN_RIGHT, IN_ACT } from "./abi";
+import { P_GRAD_FROM, P_GRAD_TO, P_GRAD_DIR, P_ABS_X, P_ABS_Y, P_GLOW } from "./uiProtocol";
 
 // node ids
 const ROOT: i32 = 1;

--- a/gallery/game_engine/games/ui_menu_as/game.as
+++ b/gallery/game_engine/games/ui_menu_as/game.as
@@ -21,8 +21,8 @@
 //    DEMO  left/right cycle the EVG technique, action returns to the menu
 // ============================================================================
 
-import { abiRead, abiWrite, uiPropI32, uiPropEnum, uiPropColorRgba } from "@ranger/game";
-import { ui } from "./ui";
+import { abiRead, abiWrite } from "@ranger/game";
+import { ui, El } from "./ui";
 
 // ---- shared ABI offsets ----
 const OFF_INPUT: i32 = 20;   // host -> guest: edge mask this frame
@@ -168,21 +168,22 @@ let DONE: Counter = new Counter();
 let NAV: Nav = new Nav();
 
 // ---- small authoring helpers over the shared `ui` builder (./ui.as) ----
-function label(id: i32, parent: i32, order: i32, s: string, r: i32, g: i32, b: i32, size: i32): void {
-  ui.label(id, parent, order).text(s).font(size).color(r, g, b, 255);
+// Both take the container `El` and hang a child off it (parent.label / .button),
+// so callers read top-down from the card they opened.
+function label(parent: El, id: i32, order: i32, s: string, r: i32, g: i32, b: i32, size: i32): void {
+  parent.label(id, order).text(s).font(size).color(r, g, b, 255);
 }
-// A uniform menu button; `on` = currently selected (host draws the glow, but we
-// also brighten the border so it reads on a static screenshot). P_GLOW isn't
-// part of the shared `El` chain (it's specific to this demo's animator), so it
-// is set with a raw uiPropI32() call - that's fine, it still targets whatever
-// node ui.button() just opened.
-function button(id: i32, order: i32, s: string, cr: i32, cg: i32, cb: i32, br: i32, bg: i32, bb: i32): void {
-  ui.button(id, CARD, order).text(s).font(16).color(cr, cg, cb, 255)
+// A uniform menu button. The host draws the glow highlight, but we also brighten
+// the border so selection reads on a static screenshot. The animated P_GLOW is
+// this demo's own protocol property, so it rides the fluent chain via the El
+// escape hatch (.propI32) rather than a bare uiProp*() call.
+function button(parent: El, id: i32, order: i32, s: string, cr: i32, cg: i32, cb: i32, br: i32, bg: i32, bb: i32): void {
+  let b: El = parent.button(id, order).text(s).font(16).color(cr, cg, cb, 255)
     .width(180).pad(10).margin(6).radius(9)
     .border(2, br, bg, bb, 255).bg(120, 165, 230, 46).textCenter();
   let gi: i32 = ANIMATOR.glowFor(id);
   if (gi > 0) {
-    uiPropI32(P_GLOW, gi);
+    b.propI32(P_GLOW, gi);
   }
 }
 
@@ -195,17 +196,17 @@ function exampleName(i: i32): string {
 
 // ---- document builders ----
 function buildMenu(): void {
-  ui.view(ROOT, 0, 0).column().center().pad(22);
-  ui.view(CARD, ROOT, 0).column().center().pad(18).width(280).bg(36, 42, 64, 255).radius(16);
+  let root: El = ui.view(ROOT, 0, 0).column().center().pad(22);
+  let card: El = root.view(CARD, 0).column().center().pad(18).width(280).bg(36, 42, 64, 255).radius(16);
 
-  label(10, CARD, 0, "AS UI - Main Menu", 255, 255, 255, 20);
+  label(card, 10, 0, "AS UI - Main Menu", 255, 255, 255, 20);
 
-  button(BTN_NEW, 1, "New Game", 208, 220, 240, 120, 150, 210);
-  button(BTN_CONT, 2, "Continue", 208, 220, 240, 120, 150, 210);
-  button(BTN_DEMO, 3, "Demo", 208, 220, 240, 120, 150, 210);
-  button(BTN_QUIT, 4, "Quit", 255, 106, 106, 200, 110, 110);
+  button(card, BTN_NEW, 1, "New Game", 208, 220, 240, 120, 150, 210);
+  button(card, BTN_CONT, 2, "Continue", 208, 220, 240, 120, 150, 210);
+  button(card, BTN_DEMO, 3, "Demo", 208, 220, 240, 120, 150, 210);
+  button(card, BTN_QUIT, 4, "Quit", 255, 106, 106, 200, 110, 110);
 
-  label(90, CARD, 5, "plays: " + PLAYS.toString(), 143, 176, 208, 13);
+  label(card, 90, 5, "plays: " + PLAYS.toString(), 143, 176, 208, 13);
 
   // report the selected button id to the host for the glow highlight
   let selId: i32 = BTN_NEW;
@@ -216,38 +217,37 @@ function buildMenu(): void {
 }
 
 function buildDemo(): void {
-  ui.view(ROOT, 0, 0).column().center().pad(18);
-  ui.view(CARD, ROOT, 0).column().center().pad(18).width(300).bg(30, 34, 52, 255).radius(16);
+  let root: El = ui.view(ROOT, 0, 0).column().center().pad(18);
+  let card: El = root.view(CARD, 0).column().center().pad(18).width(300).bg(30, 34, 52, 255).radius(16);
 
-  label(100, CARD, 0, "EVG Demo", 255, 255, 255, 20);
-  label(101, CARD, 1, (EXAMPLE + 1).toString() + "/" + EX_COUNT.toString() + "  " + exampleName(EXAMPLE), 143, 176, 208, 13);
+  label(card, 100, 0, "EVG Demo", 255, 255, 255, 20);
+  label(card, 101, 1, (EXAMPLE + 1).toString() + "/" + EX_COUNT.toString() + "  " + exampleName(EXAMPLE), 143, 176, 208, 13);
 
   // the preview element demonstrates the current technique
   if (EXAMPLE == EX_BG) {
     // background color: a vivid rounded panel
-    ui.view(PREVIEW, CARD, 2).width(220).pad(26).radius(12).margin(8).bg(232, 140, 60, 255);
-    label(122, PREVIEW, 0, "background", 30, 22, 12, 15);
+    let preview: El = card.view(PREVIEW, 2).width(220).pad(26).radius(12).margin(8).bg(232, 140, 60, 255);
+    label(preview, 122, 0, "background", 30, 22, 12, 15);
   } else if (EXAMPLE == EX_FONT_COLOR) {
     // font color: text in a vivid colour on a neutral panel
-    ui.view(PREVIEW, CARD, 2).width(220).pad(26).radius(12).margin(8).bg(22, 26, 40, 255);
-    label(122, PREVIEW, 0, "Ranger EVG", 80, 220, 130, 22);
+    let preview: El = card.view(PREVIEW, 2).width(220).pad(26).radius(12).margin(8).bg(22, 26, 40, 255);
+    label(preview, 122, 0, "Ranger EVG", 80, 220, 130, 22);
   } else if (EXAMPLE == EX_FONT_SIZE) {
     // font size: large glyphs
-    ui.view(PREVIEW, CARD, 2).width(220).pad(18).radius(12).margin(8).bg(22, 26, 40, 255);
-    label(122, PREVIEW, 0, "Big 42", 220, 224, 236, 42);
+    let preview: El = card.view(PREVIEW, 2).width(220).pad(18).radius(12).margin(8).bg(22, 26, 40, 255);
+    label(preview, 122, 0, "Big 42", 220, 224, 236, 42);
   } else {
     // linear gradient: a real 2-stop vertical gradient fill in the host EVG
-    // renderer. P_GRAD_* isn't part of the shared `El` chain, so those two
-    // props are set with raw calls right after opening the node - they still
-    // target it, exactly like the chained ones above.
-    ui.view(PREVIEW, CARD, 2).width(220).pad(26).radius(12).margin(8);
-    uiPropColorRgba(P_GRAD_FROM, 90, 130, 245, 255);   // blue
-    uiPropColorRgba(P_GRAD_TO, 210, 90, 200, 255);     // magenta
-    uiPropEnum(P_GRAD_DIR, 0);                          // vertical
-    label(122, PREVIEW, 0, "linear gradient", 255, 255, 255, 15);
+    // renderer. P_GRAD_* are this demo's own protocol props, so they ride the
+    // fluent chain through the El escape hatches (.propColor/.propEnum).
+    let preview: El = card.view(PREVIEW, 2).width(220).pad(26).radius(12).margin(8)
+      .propColor(P_GRAD_FROM, 90, 130, 245, 255)   // blue
+      .propColor(P_GRAD_TO, 210, 90, 200, 255)     // magenta
+      .propEnum(P_GRAD_DIR, 0);                     // vertical
+    label(preview, 122, 0, "linear gradient", 255, 255, 255, 15);
   }
 
-  label(130, CARD, 3, "< left/right >   enter: back", 143, 176, 208, 12);
+  label(card, 130, 3, "< left/right >   enter: back", 143, 176, 208, 12);
 
   // the preview is the focused element on this screen
   abiWrite(OFF_SEL, PREVIEW);
@@ -263,9 +263,9 @@ function emitEffect(): void {
     let ry: i32 = abiRead(OFF_RECT_Y);
     let ex: i32 = rx + rw - 7;
     let ey: i32 = ry - 7;
-    ui.view(EFFECT, ROOT, 999).width(14).height(14).radius(7).bg(255, 230, 120, 235);   // high order -> drawn on top
-    uiPropI32(P_ABS_X, ex);
-    uiPropI32(P_ABS_Y, ey);
+    // high order -> drawn on top; P_ABS_* place it at the reported screen coords
+    ui.view(EFFECT, ROOT, 999).width(14).height(14).radius(7).bg(255, 230, 120, 235)
+      .propI32(P_ABS_X, ex).propI32(P_ABS_Y, ey);
   }
 }
 

--- a/gallery/game_engine/games/ui_menu_as/game.as
+++ b/gallery/game_engine/games/ui_menu_as/game.as
@@ -59,6 +59,11 @@ const BTN_NEW: i32 = 20;
 const BTN_CONT: i32 = 21;
 const BTN_DEMO: i32 = 22;
 const BTN_QUIT: i32 = 23;
+// caption text nodes (one per button; a free id range next to the buttons)
+const CAP_NEW: i32 = 24;
+const CAP_CONT: i32 = 25;
+const CAP_DEMO: i32 = 26;
+const CAP_QUIT: i32 = 27;
 const PREVIEW: i32 = 40;
 const EFFECT: i32 = 200;   // coord-reported absolute overlay accent
 
@@ -168,23 +173,25 @@ let DONE: Counter = new Counter();
 let NAV: Nav = new Nav();
 
 // ---- small authoring helpers over the shared `ui` builder (./ui.as) ----
-// Both take the container `El` and hang a child off it (parent.label / .button),
-// so callers read top-down from the card they opened.
-function label(parent: El, id: i32, order: i32, s: string, r: i32, g: i32, b: i32, size: i32): void {
-  parent.label(id, order).text(s).font(size).color(r, g, b, 255);
+// Both take the container `El` and hang a child off it, so callers read top-down
+// from the card they opened. A label is a text box; a button is an interactive
+// box whose caption is a text child (composition, not a text-carrying button).
+function label(parent: El, id: i32, s: string, r: i32, g: i32, b: i32, size: i32): void {
+  parent.label(id, s).font(size).color(r, g, b, 255);
 }
 // A uniform menu button. The host draws the glow highlight, but we also brighten
 // the border so selection reads on a static screenshot. The animated P_GLOW is
-// this demo's own protocol property, so it rides the fluent chain via the El
-// escape hatch (.propI32) rather than a bare uiProp*() call.
-function button(parent: El, id: i32, order: i32, s: string, cr: i32, cg: i32, cb: i32, br: i32, bg: i32, bb: i32): void {
-  let b: El = parent.button(id, order).text(s).font(16).color(cr, cg, cb, 255)
+// this demo's own protocol property; it rides the fluent chain via the El escape
+// hatch (.propI32) and MUST be set on the button before its caption child opens.
+function button(parent: El, id: i32, capId: i32, s: string, cr: i32, cg: i32, cb: i32, br: i32, bg: i32, bb: i32): void {
+  let b: El = parent.button(id)
     .width(180).pad(10).margin(6).radius(9)
-    .border(2, br, bg, bb, 255).bg(120, 165, 230, 46).textCenter();
+    .border(2, br, bg, bb, 255).bg(120, 165, 230, 46).column().center();
   let gi: i32 = ANIMATOR.glowFor(id);
   if (gi > 0) {
     b.propI32(P_GLOW, gi);
   }
+  b.label(capId, s).font(16).color(cr, cg, cb, 255).textCenter();
 }
 
 function exampleName(i: i32): string {
@@ -195,18 +202,18 @@ function exampleName(i: i32): string {
 }
 
 // ---- document builders ----
-function buildMenu(): void {
-  let root: El = ui.view(ROOT, 0, 0).column().center().pad(22);
-  let card: El = root.view(CARD, 0).column().center().pad(18).width(280).bg(36, 42, 64, 255).radius(16);
+function buildMenu(root: El): void {
+  root.column().center().pad(22);
+  let card: El = root.box(CARD).column().center().pad(18).width(280).bg(36, 42, 64, 255).radius(16);
 
-  label(card, 10, 0, "AS UI - Main Menu", 255, 255, 255, 20);
+  label(card, 10, "AS UI - Main Menu", 255, 255, 255, 20);
 
-  button(card, BTN_NEW, 1, "New Game", 208, 220, 240, 120, 150, 210);
-  button(card, BTN_CONT, 2, "Continue", 208, 220, 240, 120, 150, 210);
-  button(card, BTN_DEMO, 3, "Demo", 208, 220, 240, 120, 150, 210);
-  button(card, BTN_QUIT, 4, "Quit", 255, 106, 106, 200, 110, 110);
+  button(card, BTN_NEW, CAP_NEW, "New Game", 208, 220, 240, 120, 150, 210);
+  button(card, BTN_CONT, CAP_CONT, "Continue", 208, 220, 240, 120, 150, 210);
+  button(card, BTN_DEMO, CAP_DEMO, "Demo", 208, 220, 240, 120, 150, 210);
+  button(card, BTN_QUIT, CAP_QUIT, "Quit", 255, 106, 106, 200, 110, 110);
 
-  label(card, 90, 5, "plays: " + PLAYS.toString(), 143, 176, 208, 13);
+  label(card, 90, "plays: " + PLAYS.toString(), 143, 176, 208, 13);
 
   // report the selected button id to the host for the glow highlight
   let selId: i32 = BTN_NEW;
@@ -216,38 +223,38 @@ function buildMenu(): void {
   abiWrite(OFF_SEL, selId);
 }
 
-function buildDemo(): void {
-  let root: El = ui.view(ROOT, 0, 0).column().center().pad(18);
-  let card: El = root.view(CARD, 0).column().center().pad(18).width(300).bg(30, 34, 52, 255).radius(16);
+function buildDemo(root: El): void {
+  root.column().center().pad(18);
+  let card: El = root.box(CARD).column().center().pad(18).width(300).bg(30, 34, 52, 255).radius(16);
 
-  label(card, 100, 0, "EVG Demo", 255, 255, 255, 20);
-  label(card, 101, 1, (EXAMPLE + 1).toString() + "/" + EX_COUNT.toString() + "  " + exampleName(EXAMPLE), 143, 176, 208, 13);
+  label(card, 100, "EVG Demo", 255, 255, 255, 20);
+  label(card, 101, (EXAMPLE + 1).toString() + "/" + EX_COUNT.toString() + "  " + exampleName(EXAMPLE), 143, 176, 208, 13);
 
   // the preview element demonstrates the current technique
   if (EXAMPLE == EX_BG) {
     // background color: a vivid rounded panel
-    let preview: El = card.view(PREVIEW, 2).width(220).pad(26).radius(12).margin(8).bg(232, 140, 60, 255);
-    label(preview, 122, 0, "background", 30, 22, 12, 15);
+    let preview: El = card.box(PREVIEW).width(220).pad(26).radius(12).margin(8).bg(232, 140, 60, 255);
+    label(preview, 122, "background", 30, 22, 12, 15);
   } else if (EXAMPLE == EX_FONT_COLOR) {
     // font color: text in a vivid colour on a neutral panel
-    let preview: El = card.view(PREVIEW, 2).width(220).pad(26).radius(12).margin(8).bg(22, 26, 40, 255);
-    label(preview, 122, 0, "Ranger EVG", 80, 220, 130, 22);
+    let preview: El = card.box(PREVIEW).width(220).pad(26).radius(12).margin(8).bg(22, 26, 40, 255);
+    label(preview, 122, "Ranger EVG", 80, 220, 130, 22);
   } else if (EXAMPLE == EX_FONT_SIZE) {
     // font size: large glyphs
-    let preview: El = card.view(PREVIEW, 2).width(220).pad(18).radius(12).margin(8).bg(22, 26, 40, 255);
-    label(preview, 122, 0, "Big 42", 220, 224, 236, 42);
+    let preview: El = card.box(PREVIEW).width(220).pad(18).radius(12).margin(8).bg(22, 26, 40, 255);
+    label(preview, 122, "Big 42", 220, 224, 236, 42);
   } else {
     // linear gradient: a real 2-stop vertical gradient fill in the host EVG
     // renderer. P_GRAD_* are this demo's own protocol props, so they ride the
     // fluent chain through the El escape hatches (.propColor/.propEnum).
-    let preview: El = card.view(PREVIEW, 2).width(220).pad(26).radius(12).margin(8)
+    let preview: El = card.box(PREVIEW).width(220).pad(26).radius(12).margin(8)
       .propColor(P_GRAD_FROM, 90, 130, 245, 255)   // blue
       .propColor(P_GRAD_TO, 210, 90, 200, 255)     // magenta
       .propEnum(P_GRAD_DIR, 0);                     // vertical
-    label(preview, 122, 0, "linear gradient", 255, 255, 255, 15);
+    label(preview, 122, "linear gradient", 255, 255, 255, 15);
   }
 
-  label(card, 130, 3, "< left/right >   enter: back", 143, 176, 208, 12);
+  label(card, 130, "< left/right >   enter: back", 143, 176, 208, 12);
 
   // the preview is the focused element on this screen
   abiWrite(OFF_SEL, PREVIEW);
@@ -256,15 +263,16 @@ function buildDemo(): void {
 // Coord-reported effect: read the selected node's laid-out rect (the host wrote
 // it last frame) and drop a small absolute accent at its top-right corner. The
 // guest never sees the layout, only the reported rect.
-function emitEffect(): void {
+function emitEffect(root: El): void {
   let rw: i32 = abiRead(OFF_RECT_W);
   if (rw > 0) {
     let rx: i32 = abiRead(OFF_RECT_X);
     let ry: i32 = abiRead(OFF_RECT_Y);
     let ex: i32 = rx + rw - 7;
     let ey: i32 = ry - 7;
-    // high order -> drawn on top; P_ABS_* place it at the reported screen coords
-    ui.view(EFFECT, ROOT, 999).width(14).height(14).radius(7).bg(255, 230, 120, 235)
+    // opened last among ROOT's children -> drawn on top; P_ABS_* place it at the
+    // reported screen coords
+    root.box(EFFECT).width(14).height(14).radius(7).bg(255, 230, 120, 235)
       .propI32(P_ABS_X, ex).propI32(P_ABS_Y, ey);
   }
 }
@@ -272,12 +280,13 @@ function emitEffect(): void {
 function build(): void {
   ANIMATOR.tick();          // advance effects once per frame (time-driven)
   ui.reset();
+  let root: El = ui.box(ROOT);
   if (SCREEN == SCR_MENU) {
-    buildMenu();
+    buildMenu(root);
   } else {
-    buildDemo();
+    buildDemo(root);
   }
-  emitEffect();
+  emitEffect(root);
   ui.finish(REV);
 }
 

--- a/gallery/game_engine/lib/abi.as
+++ b/gallery/game_engine/lib/abi.as
@@ -1,0 +1,33 @@
+// ============================================================================
+// Shared host <-> guest ABI: the flat RGW1 integer mailbox both sides agree on.
+// ============================================================================
+// The host writes input into these byte offsets before each update() and reads
+// the guest's replies back afterwards; the guest does the mirror. These offsets
+// (and the input edge bits) are the CONTRACT - identical for the interpreted .as
+// bridge and the compiled WASM guest - so they live in one shared module instead
+// of being re-declared in every game.
+//
+//   import { OFF_INPUT, OFF_SEL, IN_ACT } from "./abi";
+// (resolves to gallery/game_engine/lib/abi.as via the runner's asset path.)
+// ============================================================================
+
+// host -> guest
+export const OFF_TIME: i32 = 16;     // monotonic clock (ms), for time-based effects
+export const OFF_INPUT: i32 = 20;    // edge mask this frame (see IN_* below)
+// host -> guest: laid-out rect (page px) of the selected node, so a guest can
+// place an absolute overlay effect at real screen coordinates.
+export const OFF_RECT_X: i32 = 200;
+export const OFF_RECT_Y: i32 = 204;
+export const OFF_RECT_W: i32 = 208;
+export const OFF_RECT_H: i32 = 212;
+
+// guest -> host
+export const OFF_SEL: i32 = 52;      // selected node id to highlight (0 = none)
+export const OFF_LAUNCH: i32 = 56;   // catalog index + 1 to launch (0 = none)
+
+// input edge bits packed into OFF_INPUT
+export const IN_UP: i32 = 1;
+export const IN_DOWN: i32 = 2;
+export const IN_LEFT: i32 = 4;
+export const IN_RIGHT: i32 = 8;
+export const IN_ACT: i32 = 16;

--- a/gallery/game_engine/lib/ui.as
+++ b/gallery/game_engine/lib/ui.as
@@ -1,23 +1,27 @@
 // ============================================================================
 // Shared fluent EVG builder for .as games, over the flat RGU1 bridge.
 // ============================================================================
-// `ui.view/label/button(id, parent, order)` opens an RGU1 node and returns an
-// `El` whose chained setters style that SAME node:
+// A node is opened AND styled AND given its children through one `El` handle:
 //
-//   ui.view(imgId, colId, 0).width(176).height(176).radius(16).image(art)
-//     .border(3, br, bg, bb, 255);
-//   ui.label(lblId, colId, 1).text(name).font(20).color(236, 240, 250, 255).margin(6);
+//   const card = ui.view(CARD, ROOT, 0)      // open CARD under ROOT
+//     .column().center().pad(SPACE_LARGE)    // ...style THIS node...
+//     .bg(36, 42, 64, 255).radius(16);
+//   card.label(TITLE, 0).text("Main Menu").font(20).color(255, 255, 255, 255);
+//   card.button(BTN_NEW, 1).text("New Game").font(16).textCenter();
+//   card.button(BTN_CONT, 2).text("Continue").font(16).textCenter();
 //
-// `uiProp*()` always applies to whichever node `uiNode()` opened LAST, so `El`
-// carries no node identity of its own - it is a stateless chain API. That is
-// why every open() call below hands back the SAME shared `CURRENT` instance
-// instead of allocating a fresh `El` per node.
+// `ui.view/label/button(id, parent, order)` opens a node with an explicit parent
+// and returns its `El`. `el.view/label/button(childId, order)` opens a CHILD of
+// that node (parent = el.id) - so a container is authored as a value you keep and
+// hang children off, instead of repeating the parent id at every call.
 //
-// IMPORTANT: a chain must be used right after the `ui.view/label/button(...)`
-// call that produced it - do NOT hold a reference across a second open() call:
-//   let a = ui.view(10, ROOT, 0);
-//   ui.view(20, ROOT, 1);
-//   a.width(100);   // restyles node 20 (the last one opened), not node 10
+// The style setters (`.column()`, `.pad()`, `.color()`, ...) apply to whichever
+// node the bridge opened LAST via uiNode(). Opening a child re-arms that "last"
+// node, so the one authoring rule is: STYLE A NODE BEFORE OPENING ITS CHILDREN.
+//   const v = ui.view(10, ROOT, 0).column();  // ok: styles node 10
+//   v.button(20, 0).text("A");                // ok: opens 20, .text styles 20
+//   v.pad(8);   // WRONG: pads node 20 (last opened), not node 10
+// Written parent-first / top-down (as above) this rule is automatic.
 //
 // Import into a game with:
 //   import { ui } from "./ui";
@@ -54,7 +58,19 @@ const DIR_COLUMN: i32 = 1;
 const ALIGN_CENTER: i32 = 1;
 const TEXTALIGN_CENTER: i32 = 1;
 
-class El {
+// A handle to one opened RGU1 node. It carries its own `id` so children can be
+// hung off it (`el.button(...)`), and its style setters chain over the bridge's
+// last-opened node (see the file header for the one authoring rule). Exported so
+// games can type container handles they pass into their own authoring helpers.
+export class El {
+  id: i32 = 0;
+
+  // ---- children: open a node parented to THIS one, return the child's handle --
+  view(id: i32, order: i32): El { uiNode(id, this.id, K_VIEW, order); return newEl(id); }
+  label(id: i32, order: i32): El { uiNode(id, this.id, K_TEXT, order); return newEl(id); }
+  button(id: i32, order: i32): El { uiNode(id, this.id, K_BUTTON, order); return newEl(id); }
+
+  // ---- style setters (target the last-opened node, i.e. this one) ------------
   row(): El { uiPropEnum(P_FLEXDIR, DIR_ROW); return this; }
   column(): El { uiPropEnum(P_FLEXDIR, DIR_COLUMN); return this; }
   center(): El { uiPropEnum(P_ALIGN, ALIGN_CENTER); return this; }
@@ -74,20 +90,26 @@ class El {
     uiPropColorRgba(P_BORDER_COLOR, r, g, b, a);
     return this;
   }
+
+  // ---- escape hatches: chain a game-specific RGU1 property on this node ------
+  // Keeps app-defined props (gradient/glow/absolute placement/...) inside the
+  // fluent chain instead of a bare uiProp*() call breaking out of it.
+  propI32(key: i32, v: i32): El { uiPropI32(key, v); return this; }
+  propEnum(key: i32, v: i32): El { uiPropEnum(key, v); return this; }
+  propStr(key: i32, s: string): El { uiPropStr(key, s); return this; }
+  propColor(key: i32, r: i32, g: i32, b: i32, a: i32): El { uiPropColorRgba(key, r, g, b, a); return this; }
 }
 
-// One shared, allocation-free chain instance - see the file header for why a
-// fresh `El` per node is unnecessary (and wasteful on a managed heap at ship
-// time): uiProp*() is stateless from El's point of view, it always targets
-// whatever node uiNode() opened last.
-const CURRENT: El = new El();
+// El allocates per opened node (each carries its own id) - constructors with
+// args aren't relied on here, so a tiny factory sets the field instead.
+function newEl(id: i32): El { let e: El = new El(); e.id = id; return e; }
 
 class Ui {
   reset(): void { uiReset(); }
   finish(rev: i32): void { uiFinish(rev); }
-  view(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_VIEW, order); return CURRENT; }
-  label(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_TEXT, order); return CURRENT; }
-  button(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_BUTTON, order); return CURRENT; }
+  view(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_VIEW, order); return newEl(id); }
+  label(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_TEXT, order); return newEl(id); }
+  button(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_BUTTON, order); return newEl(id); }
 }
 
 export const ui: Ui = new Ui();

--- a/gallery/game_engine/lib/ui.as
+++ b/gallery/game_engine/lib/ui.as
@@ -1,30 +1,40 @@
 // ============================================================================
 // Shared fluent EVG builder for .as games, over the flat RGU1 bridge.
 // ============================================================================
-// A node is opened AND styled AND given its children through one `El` handle:
+// Everything is a BOX (an EVG div). You open a box, style it, and hang children
+// off it - a button is just a box that is interactive, a label is just a box
+// that carries text:
 //
-//   const card = ui.view(CARD, ROOT, 0)      // open CARD under ROOT
-//     .column().center().pad(SPACE_LARGE)    // ...style THIS node...
+//   const card = ui.box(ROOT);              // the root box (parent 0)
+//   const menu = card.box(CARD).column().center().pad(SPACE_LARGE)
 //     .bg(36, 42, 64, 255).radius(16);
-//   card.label(TITLE, 0).text("Main Menu").font(20).color(255, 255, 255, 255);
-//   card.button(BTN_NEW, 1).text("New Game").font(16).textCenter();
-//   card.button(BTN_CONT, 2).text("Continue").font(16).textCenter();
+//   menu.label(TITLE, "Main Menu").font(20).color(255, 255, 255, 255);
+//   menu.button(BTN_NEW).width(180).pad(10).radius(9)
+//     .label(CAP_NEW, "New Game").font(16).textCenter();   // caption is a child
 //
-// `ui.view/label/button(id, parent, order)` opens a node with an explicit parent
-// and returns its `El`. `el.view/label/button(childId, order)` opens a CHILD of
-// that node (parent = el.id) - so a container is authored as a value you keep and
-// hang children off, instead of repeating the parent id at every call.
+// - `parent.box(id)`     opens a plain container child (an EVG div).
+// - `parent.button(id)`  opens an INTERACTIVE box child (RGU1 kind BUTTON). It is
+//                        the same El with the same setters - "a view + a handler".
+//                        (RGU1 fixes a node's kind at creation, so this is an
+//                        opener, not a `.button()` you bolt onto an existing box.)
+// - `parent.label(id,s)` opens a TEXT box child already carrying `s`, and returns
+//                        it so you can style the text (`.font()`, `.color()`).
+//
+// Child ORDER is assigned automatically in call order (each parent counts its
+// own children), so you never pass an order. IDs stay explicit: the host maps a
+// selection cursor / glow highlight back to a node by id, and the guest reports
+// that id to the host, so those ids are part of the contract - not incidental.
 //
 // The style setters (`.column()`, `.pad()`, `.color()`, ...) apply to whichever
-// node the bridge opened LAST via uiNode(). Opening a child re-arms that "last"
-// node, so the one authoring rule is: STYLE A NODE BEFORE OPENING ITS CHILDREN.
-//   const v = ui.view(10, ROOT, 0).column();  // ok: styles node 10
-//   v.button(20, 0).text("A");                // ok: opens 20, .text styles 20
-//   v.pad(8);   // WRONG: pads node 20 (last opened), not node 10
-// Written parent-first / top-down (as above) this rule is automatic.
+// node the bridge opened LAST. Opening a child re-arms that "last" node, so the
+// one authoring rule is: STYLE A NODE (and set its glow / gradient / ... props)
+// BEFORE OPENING ITS CHILDREN. Written parent-first / top-down this is automatic:
+//   const b = card.button(BTN).width(180);  // style the button...
+//   b.propI32(P_GLOW, g);                    // ...and its own props...
+//   b.label(CAP, "Go").font(16);             // ...THEN open its caption child.
 //
 // Import into a game with:
-//   import { ui } from "./ui";
+//   import { ui, El } from "./ui";
 // (falls back to this shared file when the game's own folder has no ui.as -
 // see as_source_runner.rgr's engine.addAssetPath("gallery/game_engine/lib")).
 // ============================================================================
@@ -58,17 +68,22 @@ const DIR_COLUMN: i32 = 1;
 const ALIGN_CENTER: i32 = 1;
 const TEXTALIGN_CENTER: i32 = 1;
 
-// A handle to one opened RGU1 node. It carries its own `id` so children can be
-// hung off it (`el.button(...)`), and its style setters chain over the bridge's
-// last-opened node (see the file header for the one authoring rule). Exported so
-// games can type container handles they pass into their own authoring helpers.
+// A handle to one opened RGU1 box. It carries its own `id` (so children hang off
+// it) and an auto-incrementing child `order`; its style setters chain over the
+// bridge's last-opened node (see the file header for the one authoring rule).
+// Exported so games can type the container handles they pass into their own
+// authoring helpers.
 export class El {
   id: i32 = 0;
+  order: i32 = 0;   // next child order; bumped by every box/button/label opened
 
-  // ---- children: open a node parented to THIS one, return the child's handle --
-  view(id: i32, order: i32): El { uiNode(id, this.id, K_VIEW, order); return newEl(id); }
-  label(id: i32, order: i32): El { uiNode(id, this.id, K_TEXT, order); return newEl(id); }
-  button(id: i32, order: i32): El { uiNode(id, this.id, K_BUTTON, order); return newEl(id); }
+  // ---- children: open a box parented to THIS one, return the child's handle --
+  // A plain container.
+  box(id: i32): El { let o: i32 = this.order; this.order = o + 1; uiNode(id, this.id, K_VIEW, o); return newEl(id); }
+  // An interactive box (RGU1 BUTTON kind) - same El surface, just activatable.
+  button(id: i32): El { let o: i32 = this.order; this.order = o + 1; uiNode(id, this.id, K_BUTTON, o); return newEl(id); }
+  // A text box already carrying `s`; returned so the caller styles the text.
+  label(id: i32, s: string): El { let o: i32 = this.order; this.order = o + 1; uiNode(id, this.id, K_TEXT, o); uiPropStr(P_TEXT, s); return newEl(id); }
 
   // ---- style setters (target the last-opened node, i.e. this one) ------------
   row(): El { uiPropEnum(P_FLEXDIR, DIR_ROW); return this; }
@@ -100,16 +115,16 @@ export class El {
   propColor(key: i32, r: i32, g: i32, b: i32, a: i32): El { uiPropColorRgba(key, r, g, b, a); return this; }
 }
 
-// El allocates per opened node (each carries its own id) - constructors with
-// args aren't relied on here, so a tiny factory sets the field instead.
+// El allocates per opened node (each carries its own id + child counter) -
+// constructors with args aren't relied on here, so a tiny factory sets the id.
 function newEl(id: i32): El { let e: El = new El(); e.id = id; return e; }
 
 class Ui {
   reset(): void { uiReset(); }
   finish(rev: i32): void { uiFinish(rev); }
-  view(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_VIEW, order); return newEl(id); }
-  label(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_TEXT, order); return newEl(id); }
-  button(id: i32, parent: i32, order: i32): El { uiNode(id, parent, K_BUTTON, order); return newEl(id); }
+  // Open the root box (parent 0, order 0) and return its handle; children hang
+  // off it via .box()/.button()/.label().
+  box(id: i32): El { uiNode(id, 0, K_VIEW, 0); return newEl(id); }
 }
 
 export const ui: Ui = new Ui();

--- a/gallery/game_engine/lib/uiProtocol.as
+++ b/gallery/game_engine/lib/uiProtocol.as
@@ -1,0 +1,20 @@
+// ============================================================================
+// Extra RGU1 protocol property keys - the app-defined ones the `ui` builder does
+// not wrap as fluent setters.
+// ============================================================================
+// ui.as already owns the everyday keys (text/bg/color/font/width/.../bg-image)
+// behind El's setters. These are the extra rendering-technique props a game sets
+// through El's escape hatches (.propColor / .propEnum / .propI32). They are part
+// of the host's RGU1 reader contract (see wasm_ui_io.rgr's applyProps), so they
+// belong in one shared module rather than re-declared per game.
+//
+//   import { P_GLOW, P_GRAD_FROM } from "./uiProtocol";
+//   preview.propColor(P_GRAD_FROM, 90, 130, 245, 255);
+// ============================================================================
+
+export const P_GRAD_FROM: i32 = 50;   // linear-gradient start colour
+export const P_GRAD_TO: i32 = 51;     // linear-gradient end colour
+export const P_GRAD_DIR: i32 = 52;    // 0 vertical, 1 horizontal
+export const P_ABS_X: i32 = 53;       // absolute page-x placement
+export const P_ABS_Y: i32 = 54;       // absolute page-y placement
+export const P_GLOW: i32 = 55;        // animated glow strength 0..1000

--- a/gallery/game_engine/menu/game.as
+++ b/gallery/game_engine/menu/game.as
@@ -18,17 +18,7 @@
 // ============================================================================
 import { abiRead, abiWrite } from "@ranger/game";
 import { ui, El } from "./ui";
-
-// shared ABI offsets (ints)
-const OFF_INPUT: i32 = 20;    // host -> guest: edge mask this frame
-const OFF_SEL: i32 = 52;      // guest -> host: selected node id (highlight)
-const OFF_LAUNCH: i32 = 56;   // guest -> host: catalog index + 1 to launch (0 = none)
-
-const IN_UP: i32 = 1;
-const IN_DOWN: i32 = 2;
-const IN_LEFT: i32 = 4;
-const IN_RIGHT: i32 = 8;
-const IN_ACT: i32 = 16;
+import { OFF_INPUT, OFF_SEL, OFF_LAUNCH, IN_UP, IN_DOWN, IN_LEFT, IN_RIGHT, IN_ACT } from "./abi";
 
 // category background art (host-resolvable paths; the host loads the pixels)
 const ART_GAMES: string = "gallery/game_engine/menu/assets/games.png";

--- a/gallery/game_engine/menu/game.as
+++ b/gallery/game_engine/menu/game.as
@@ -80,46 +80,48 @@ function nthInCat(cat: string, k: i32): i32 {
 
 // A big rounded art tile with a TTF label under it (imgId is what the host
 // highlights). `parent` is the row it sits in; `on` = currently selected.
-function catTile(parent: El, colId: i32, imgId: i32, lblId: i32, order: i32, name: string, art: string, on: i32): void {
-  let col: El = parent.view(colId, order).column().center().width(200).margin(12);
+function catTile(parent: El, colId: i32, imgId: i32, lblId: i32, name: string, art: string, on: i32): void {
+  let col: El = parent.box(colId).column().center().width(200).margin(12);
   let br: i32 = 120; let bg: i32 = 150; let bb: i32 = 210;
   if (on == 1) { br = 255; bg = 232; bb = 120; }
-  col.view(imgId, 0).width(176).height(176).radius(16).image(art).border(3, br, bg, bb, 255);
-  col.label(lblId, 1).text(name).font(20).color(236, 240, 250, 255).margin(6);
+  col.box(imgId).width(176).height(176).radius(16).image(art).border(3, br, bg, bb, 255);
+  col.label(lblId, name).font(20).color(236, 240, 250, 255).margin(6);
 }
 
-// A uniform menu button; `parent` is the card it lives in; `on` = selected.
-function gameButton(parent: El, id: i32, order: i32, s: string, on: i32): void {
+// A uniform menu button; `parent` is the card it lives in; `on` = selected. The
+// caption is a text child (composition), so a highlighted button is just a box.
+function gameButton(parent: El, id: i32, capId: i32, s: string, on: i32): void {
   let br: i32 = 120; let bg: i32 = 150; let bb: i32 = 210; let ba: i32 = 40;
   if (on == 1) { br = 255; bg = 232; bb = 120; ba = 70; }
-  parent.button(id, order).text(s).font(18).color(236, 240, 250, 255)
+  let b: El = parent.button(id)
     .width(280).pad(12).margin(6).radius(10)
-    .border(2, br, bg, bb, 255).bg(120, 165, 230, ba).textCenter();
+    .border(2, br, bg, bb, 255).bg(120, 165, 230, ba).column().center();
+  b.label(capId, s).font(18).color(236, 240, 250, 255).textCenter();
 }
 
-function buildCats(): void {
-  let root: El = ui.view(ROOT, 0, 0).column().center().pad(24);
-  root.label(10, 0).text("GAMES").font(34).color(236, 240, 250, 255);
-  let row: El = root.view(ROW, 1).row().center();
+function buildCats(root: El): void {
+  root.column().center().pad(24);
+  root.label(10, "GAMES").font(34).color(236, 240, 250, 255);
+  let row: El = root.box(ROW).row().center();
   let on0: i32 = 0; if (SEL == 0) on0 = 1;
   let on1: i32 = 0; if (SEL == 1) on1 = 1;
-  catTile(row, 60, 61, 62, 0, "Games", ART_GAMES, on0);
-  catTile(row, 70, 71, 72, 1, "Tests", ART_TESTS, on1);
+  catTile(row, 60, 61, 62, "Games", ART_GAMES, on0);
+  catTile(row, 70, 71, 72, "Tests", ART_TESTS, on1);
   let selId: i32 = 61; if (SEL == 1) selId = 71;
   abiWrite(OFF_SEL, selId);
 }
 
-function buildGames(): void {
-  let root: El = ui.view(ROOT, 0, 0).column().center().pad(18);
-  let card: El = root.view(CARD, 0).column().center().pad(16).width(340).radius(16).bg(30, 34, 52, 255);
+function buildGames(root: El): void {
+  root.column().center().pad(18);
+  let card: El = root.box(CARD).column().center().pad(16).width(340).radius(16).bg(30, 34, 52, 255);
   let cat: string = catName(CAT);
-  card.label(10, 0).text(cat).font(24).color(236, 240, 250, 255);
+  card.label(10, cat).font(24).color(236, 240, 250, 255);
   let n: i32 = countInCat(cat);
   let k: i32 = 0;
   while (k < n) {
     let gi: i32 = nthInCat(cat, k);
     let on: i32 = 0; if (SEL == k) on = 1;
-    gameButton(card, 100 + k, k + 1, gameCatalog[gi].title, on);
+    gameButton(card, 100 + k, 300 + k, gameCatalog[gi].title, on);
     k = k + 1;
   }
   abiWrite(OFF_SEL, 100 + SEL);
@@ -127,7 +129,8 @@ function buildGames(): void {
 
 function build(): void {
   ui.reset();
-  if (SCREEN == SCR_CATS) { buildCats(); } else { buildGames(); }
+  let root: El = ui.box(ROOT);
+  if (SCREEN == SCR_CATS) { buildCats(root); } else { buildGames(root); }
   ui.finish(REV);
 }
 

--- a/gallery/game_engine/menu/game.as
+++ b/gallery/game_engine/menu/game.as
@@ -17,7 +17,7 @@
 //   left/back            games screen -> categories
 // ============================================================================
 import { abiRead, abiWrite } from "@ranger/game";
-import { ui } from "./ui";
+import { ui, El } from "./ui";
 
 // shared ABI offsets (ints)
 const OFF_INPUT: i32 = 20;    // host -> guest: edge mask this frame
@@ -79,47 +79,47 @@ function nthInCat(cat: string, k: i32): i32 {
 // ---- screen builders ----
 
 // A big rounded art tile with a TTF label under it (imgId is what the host
-// highlights). `on` = currently selected.
-function catTile(colId: i32, imgId: i32, lblId: i32, order: i32, name: string, art: string, on: i32): void {
-  ui.view(colId, ROW, order).column().center().width(200).margin(12);
+// highlights). `parent` is the row it sits in; `on` = currently selected.
+function catTile(parent: El, colId: i32, imgId: i32, lblId: i32, order: i32, name: string, art: string, on: i32): void {
+  let col: El = parent.view(colId, order).column().center().width(200).margin(12);
   let br: i32 = 120; let bg: i32 = 150; let bb: i32 = 210;
   if (on == 1) { br = 255; bg = 232; bb = 120; }
-  ui.view(imgId, colId, 0).width(176).height(176).radius(16).image(art).border(3, br, bg, bb, 255);
-  ui.label(lblId, colId, 1).text(name).font(20).color(236, 240, 250, 255).margin(6);
+  col.view(imgId, 0).width(176).height(176).radius(16).image(art).border(3, br, bg, bb, 255);
+  col.label(lblId, 1).text(name).font(20).color(236, 240, 250, 255).margin(6);
 }
 
-// A uniform menu button; `on` = currently selected.
-function gameButton(id: i32, order: i32, s: string, on: i32): void {
+// A uniform menu button; `parent` is the card it lives in; `on` = selected.
+function gameButton(parent: El, id: i32, order: i32, s: string, on: i32): void {
   let br: i32 = 120; let bg: i32 = 150; let bb: i32 = 210; let ba: i32 = 40;
   if (on == 1) { br = 255; bg = 232; bb = 120; ba = 70; }
-  ui.button(id, CARD, order).text(s).font(18).color(236, 240, 250, 255)
+  parent.button(id, order).text(s).font(18).color(236, 240, 250, 255)
     .width(280).pad(12).margin(6).radius(10)
     .border(2, br, bg, bb, 255).bg(120, 165, 230, ba).textCenter();
 }
 
 function buildCats(): void {
-  ui.view(ROOT, 0, 0).column().center().pad(24);
-  ui.label(10, ROOT, 0).text("GAMES").font(34).color(236, 240, 250, 255);
-  ui.view(ROW, ROOT, 1).row().center();
+  let root: El = ui.view(ROOT, 0, 0).column().center().pad(24);
+  root.label(10, 0).text("GAMES").font(34).color(236, 240, 250, 255);
+  let row: El = root.view(ROW, 1).row().center();
   let on0: i32 = 0; if (SEL == 0) on0 = 1;
   let on1: i32 = 0; if (SEL == 1) on1 = 1;
-  catTile(60, 61, 62, 0, "Games", ART_GAMES, on0);
-  catTile(70, 71, 72, 1, "Tests", ART_TESTS, on1);
+  catTile(row, 60, 61, 62, 0, "Games", ART_GAMES, on0);
+  catTile(row, 70, 71, 72, 1, "Tests", ART_TESTS, on1);
   let selId: i32 = 61; if (SEL == 1) selId = 71;
   abiWrite(OFF_SEL, selId);
 }
 
 function buildGames(): void {
-  ui.view(ROOT, 0, 0).column().center().pad(18);
-  ui.view(CARD, ROOT, 0).column().center().pad(16).width(340).radius(16).bg(30, 34, 52, 255);
+  let root: El = ui.view(ROOT, 0, 0).column().center().pad(18);
+  let card: El = root.view(CARD, 0).column().center().pad(16).width(340).radius(16).bg(30, 34, 52, 255);
   let cat: string = catName(CAT);
-  ui.label(10, CARD, 0).text(cat).font(24).color(236, 240, 250, 255);
+  card.label(10, 0).text(cat).font(24).color(236, 240, 250, 255);
   let n: i32 = countInCat(cat);
   let k: i32 = 0;
   while (k < n) {
     let gi: i32 = nthInCat(cat, k);
     let on: i32 = 0; if (SEL == k) on = 1;
-    gameButton(100 + k, k + 1, gameCatalog[gi].title, on);
+    gameButton(card, 100 + k, k + 1, gameCatalog[gi].title, on);
     k = k + 1;
   }
   abiWrite(OFF_SEL, 100 + SEL);

--- a/gallery/game_engine/menu/game.info
+++ b/gallery/game_engine/menu/game.info
@@ -1,4 +1,4 @@
 name=Ranger Launcher
 engine=ui
-runtime=as
-module=game.as
+runtime=tsx
+module=launcher.tsx

--- a/gallery/game_engine/menu/launcher.tsx
+++ b/gallery/game_engine/menu/launcher.tsx
@@ -7,23 +7,28 @@
 // games), but authored with real JS: gameCatalog is filtered/mapped with array
 // methods, state is a plain object, and the layout is JSX. The host renders the
 // EVGElement tree this returns with the SAME WasmUiRenderer the .as menu uses,
-// so borders / rounded corners / TTF text (and, once wired, glow + art) all come
-// out identical — the renderer is the shared core, only the front-end language
-// changed.
+// so borders / rounded corners / TTF text / background art / the glow halo all
+// come out identical — the renderer is the shared core, only the front-end
+// language changed.
+//
+// The activation glow is a real closure callback: pressing A on a category
+// starts a glow flash and stashes an `onDone` FUNCTION in state; when the flash
+// finishes a frame later, update() calls it to perform the deferred screen
+// switch. That capture-a-callback pattern was fragile in the .as bridge (method
+// binding through asc); here it is just how JS works.
 //
 // NOTE: JSX attribute names are camelCase (flexDirection, backgroundColor,
-// borderRadius, ...). The TSX parser tokenises `-`, so kebab-case attribute
-// names (flex-direction) are NOT valid here; EVGElement.setAttribute accepts the
-// camelCase spelling.
+// borderRadius, backgroundImage, glow, ...). The TSX parser tokenises `-`, so
+// kebab-case names are NOT valid here.
 //
 //   up/down/left/right   move selection
-//   enter / A            open a category, or launch the selected game
+//   enter / A            open a category (after a glow flash), or launch a game
 //   left / back          games screen -> categories
 // ============================================================================
 
-// Distinct categories in catalog order, "Games" forced first (mirrors the .as
-// launcher's game_catalog ordering). Pure JS - the kind of thing that was
-// painful in the .as bridge.
+const FLASH_MS = 420;
+
+// Distinct categories in catalog order, "Games" forced first. Pure JS.
 function categories() {
   const seen = {};
   const order = [];
@@ -42,30 +47,77 @@ function gamesIn(cat) {
   return gameCatalog.filter((e) => (e.category || "Games") === cat);
 }
 
+// Background art for a category tile (host loads the pixels; missing = none).
+function artFor(cat) {
+  if (cat === "Games") return "gallery/game_engine/menu/assets/games.png";
+  if (cat === "Tests") return "gallery/game_engine/menu/assets/tools.png";
+  return "";
+}
+
+// A 0 -> 1 -> 0 flash sampled from the host clock; 0 when no flash is running.
+function flashLevel(anim, now) {
+  if (!anim) return 0;
+  const t = now - anim.start;
+  if (t < 0 || t >= anim.dur) return 0;
+  const p = t / anim.dur;
+  return p < 0.5 ? p * 2 : (1 - p) * 2;
+}
+
 function initState() {
-  return { screen: "cats", sel: 0, cat: 0, launchPath: "", quitApp: 0 };
+  return { screen: "cats", sel: 0, cat: 0, launchPath: "", quitApp: 0, now: 0, anim: null, onDone: null };
 }
 
 function update(props) {
   const s = props.state;
+  const now = props.time;
   const cats = categories();
   let screen = s.screen;
   let sel = s.sel;
   let cat = s.cat;
-  let launchPath = "";
 
   if (props.quit) {
-    return { screen, sel, cat, launchPath: "", quitApp: 1 };
+    return { screen, sel, cat, launchPath: "", quitApp: 1, now, anim: null, onDone: null };
   }
 
+  // A glow flash is running: when it finishes, call the stashed callback to
+  // apply the deferred transition it captured, then clear the animation.
+  if (s.anim) {
+    if (now - s.anim.start >= s.anim.dur) {
+      // Bind the callback to a local before calling it: the interpreter invokes
+      // a closure through a plain identifier, not through a member-access call
+      // (s.onDone() returns undefined; cb() runs it).
+      const cb = s.onDone;
+      const next = cb ? cb() : {};
+      return {
+        screen: next.screen ? next.screen : screen,
+        sel: next.sel === undefined ? sel : next.sel,
+        cat: next.cat === undefined ? cat : next.cat,
+        launchPath: "",
+        quitApp: 0,
+        now,
+        anim: null,
+        onDone: null
+      };
+    }
+    // hold state while the flash plays out
+    return { screen, sel, cat, launchPath: "", quitApp: 0, now, anim: s.anim, onDone: s.onDone };
+  }
+
+  let launchPath = "";
   if (screen === "cats") {
     const n = cats.length;
     if (props.up || props.left) sel = (sel + n - 1) % n;
     if (props.down || props.right) sel = (sel + 1) % n;
     if (props.action) {
-      cat = sel;
-      screen = "games";
-      sel = 0;
+      // start a flash on the selected tile; the callback opens that category
+      const targetCat = sel;
+      return {
+        screen, sel, cat, launchPath: "", quitApp: 0, now,
+        anim: { start: now, dur: FLASH_MS },
+        onDone: () => {
+          return { screen: "games", cat: targetCat, sel: 0 };
+        }
+      };
     }
   } else {
     const list = gamesIn(cats[cat]);
@@ -81,13 +133,21 @@ function update(props) {
     }
   }
 
-  return { screen, sel, cat, launchPath, quitApp: 0 };
+  return { screen, sel, cat, launchPath, quitApp: 0, now, anim: null, onDone: null };
 }
 
-// gold when selected, muted blue otherwise (the .as menu does the same so a
-// static screenshot reads the selection even before the animated glow lands).
+// gold when selected, muted blue otherwise (reads on a static screenshot even
+// before the animated glow lands).
 function borderColor(on) {
   return on ? "#ffe878" : "#7896d2";
+}
+
+// Glow for a tile: the bright animated flash while it plays, otherwise a steady
+// soft halo on the current selection.
+function glowFor(s, on) {
+  if (on && s.anim) return flashLevel(s.anim, s.now);
+  if (on) return 0.55;
+  return 0;
 }
 
 function categoryScreen(s) {
@@ -100,7 +160,8 @@ function categoryScreen(s) {
           <View flexDirection="column" alignItems="center" width="200px" margin="12px">
             <View width="176px" height="176px" borderRadius="16px"
                   borderWidth="3px" borderColor={borderColor(i === s.sel)}
-                  backgroundColor="#242a40" />
+                  backgroundColor="#242a40" backgroundImage={artFor(c)}
+                  glow={glowFor(s, i === s.sel)} />
             <Label color="#ecf0fa" fontSize="20px" margin="6px">{c}</Label>
           </View>
         ))}
@@ -120,7 +181,7 @@ function gamesScreen(s) {
         {list.map((e, i) => (
           <View width="280px" padding="12px" margin="6px" borderRadius="10px"
                 borderWidth="2px" borderColor={borderColor(i === s.sel)}
-                backgroundColor="#3c5aa0">
+                backgroundColor="#3c5aa0" glow={glowFor(s, i === s.sel)}>
             <Label color="#ecf0fa" fontSize="18px" textAlign="center">{e.title}</Label>
           </View>
         ))}

--- a/gallery/game_engine/menu/launcher.tsx
+++ b/gallery/game_engine/menu/launcher.tsx
@@ -1,0 +1,138 @@
+/// <reference path="../scripting/game.d.ts" />
+/// <reference path="./menu.d.ts" />
+//
+// Ranger Launcher — rich EVG front page authored in TypeScript/TSX.
+// ============================================================================
+// Same two-screen launcher as menu/game.as (categories -> that category's
+// games), but authored with real JS: gameCatalog is filtered/mapped with array
+// methods, state is a plain object, and the layout is JSX. The host renders the
+// EVGElement tree this returns with the SAME WasmUiRenderer the .as menu uses,
+// so borders / rounded corners / TTF text (and, once wired, glow + art) all come
+// out identical — the renderer is the shared core, only the front-end language
+// changed.
+//
+// NOTE: JSX attribute names are camelCase (flexDirection, backgroundColor,
+// borderRadius, ...). The TSX parser tokenises `-`, so kebab-case attribute
+// names (flex-direction) are NOT valid here; EVGElement.setAttribute accepts the
+// camelCase spelling.
+//
+//   up/down/left/right   move selection
+//   enter / A            open a category, or launch the selected game
+//   left / back          games screen -> categories
+// ============================================================================
+
+// Distinct categories in catalog order, "Games" forced first (mirrors the .as
+// launcher's game_catalog ordering). Pure JS - the kind of thing that was
+// painful in the .as bridge.
+function categories() {
+  const seen = {};
+  const order = [];
+  for (const e of gameCatalog) {
+    const c = e.category || "Games";
+    if (!seen[c]) {
+      seen[c] = 1;
+      order.push(c);
+    }
+  }
+  order.sort((a, b) => (a === "Games" ? -1 : b === "Games" ? 1 : 0));
+  return order;
+}
+
+function gamesIn(cat) {
+  return gameCatalog.filter((e) => (e.category || "Games") === cat);
+}
+
+function initState() {
+  return { screen: "cats", sel: 0, cat: 0, launchPath: "", quitApp: 0 };
+}
+
+function update(props) {
+  const s = props.state;
+  const cats = categories();
+  let screen = s.screen;
+  let sel = s.sel;
+  let cat = s.cat;
+  let launchPath = "";
+
+  if (props.quit) {
+    return { screen, sel, cat, launchPath: "", quitApp: 1 };
+  }
+
+  if (screen === "cats") {
+    const n = cats.length;
+    if (props.up || props.left) sel = (sel + n - 1) % n;
+    if (props.down || props.right) sel = (sel + 1) % n;
+    if (props.action) {
+      cat = sel;
+      screen = "games";
+      sel = 0;
+    }
+  } else {
+    const list = gamesIn(cats[cat]);
+    const n = Math.max(1, list.length);
+    if (props.up) sel = (sel + n - 1) % n;
+    if (props.down) sel = (sel + 1) % n;
+    if (props.left) {
+      screen = "cats";
+      sel = cat;
+    }
+    if (props.action && list.length > 0) {
+      launchPath = list[sel].path;
+    }
+  }
+
+  return { screen, sel, cat, launchPath, quitApp: 0 };
+}
+
+// gold when selected, muted blue otherwise (the .as menu does the same so a
+// static screenshot reads the selection even before the animated glow lands).
+function borderColor(on) {
+  return on ? "#ffe878" : "#7896d2";
+}
+
+function categoryScreen(s) {
+  const cats = categories();
+  return (
+    <View flexDirection="column" alignItems="center" padding="24px">
+      <Label color="#ecf0fa" fontSize="34px">GAMES</Label>
+      <View flexDirection="row" alignItems="center">
+        {cats.map((c, i) => (
+          <View flexDirection="column" alignItems="center" width="200px" margin="12px">
+            <View width="176px" height="176px" borderRadius="16px"
+                  borderWidth="3px" borderColor={borderColor(i === s.sel)}
+                  backgroundColor="#242a40" />
+            <Label color="#ecf0fa" fontSize="20px" margin="6px">{c}</Label>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function gamesScreen(s) {
+  const cats = categories();
+  const list = gamesIn(cats[s.cat]);
+  return (
+    <View flexDirection="column" alignItems="center" padding="18px">
+      <View flexDirection="column" alignItems="center" padding="16px" width="340px"
+            borderRadius="16px" backgroundColor="#1e2234">
+        <Label color="#ecf0fa" fontSize="24px">{cats[s.cat]}</Label>
+        {list.map((e, i) => (
+          <View width="280px" padding="12px" margin="6px" borderRadius="10px"
+                borderWidth="2px" borderColor={borderColor(i === s.sel)}
+                backgroundColor="#3c5aa0">
+            <Label color="#ecf0fa" fontSize="18px" textAlign="center">{e.title}</Label>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function hud(props) {
+  const s = props.state;
+  if (s.screen === "cats") {
+    return categoryScreen(s);
+  }
+  return gamesScreen(s);
+}

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -97,11 +97,17 @@ class GameSdlRunner {
     def prevRightHeld:boolean false
     def prevActionHeld:boolean false
     def uiRunner:GameUiRunner (new GameUiRunner)
-    ; Launcher front page: the interpreted .as menu (menu/game.as), crisp EVG UI,
-    ; hot-reloadable. The old pixel-font tsx menu is still available (--classic-menu).
-    def useEvgLauncher:boolean true
+    ; Which launcher front page to run. The choice comes from menu/game.info's
+    ; `runtime` field (runtime=tsx -> the rich TypeScript menu/launcher.tsx;
+    ; runtime=as -> the interpreted menu/game.as), both rendered through the same
+    ; WasmUiRenderer. A CLI flag (--tsx-menu / --evg-menu / --classic-menu) sets
+    ; `menuModeForced` to override game.info. Empty = follow game.info; the code
+    ; default when neither resolves is "tsx" (dynamic heap tree, so a long game
+    ; list is never clipped by the .as bridge's fixed node/property caps).
+    def menuModeForced:string ""
     def menuAsDir:string "gallery/game_engine/menu"
     def menuAsMtime:int 0     ; last-seen menu/game.as mtime (live-reload poll)
+    def menuTsxMtime:int 0    ; last-seen menu/launcher.tsx mtime (live-reload poll)
     def uiDirectPath:string ""
     def gpuModeWanted:boolean true
     def gpuModeActive:boolean false
@@ -910,6 +916,38 @@ class GameSdlRunner {
         return false
     }
 
+    ; The launcher backend menu/game.info selects via its `runtime` field:
+    ; "tsx" (menu/launcher.tsx), "as" (menu/game.as), or "" if unspecified.
+    fn menuRuntimeOf:string () {
+        if (file_exists menuAsDir "game.info") {
+            def buf:buffer (buffer_read_file menuAsDir "game.info")
+            def txt:string (buffer_to_string buf)
+            if ((indexOf txt "runtime=tsx") >= 0) {
+                return "tsx"
+            }
+            if ((indexOf txt "runtime=as") >= 0) {
+                return "as"
+            }
+        }
+        return ""
+    }
+
+    ; Effective launcher mode: an explicit CLI flag wins; else menu/game.info's
+    ; runtime; else the "tsx" default (dynamic heap tree, no fixed caps).
+    fn effectiveMenuMode:string () {
+        if ((strlen menuModeForced) > 0) {
+            return menuModeForced
+        }
+        def rt:string (this.menuRuntimeOf())
+        if (rt == "as") {
+            return "as"
+        }
+        if (rt == "classic") {
+            return "classic"
+        }
+        return "tsx"
+    }
+
     ; True when the game folder for `path` declares engine=ui.
     fn engineOf:string (path:string) {
         def dir:string (this.dirOf(path))
@@ -1075,6 +1113,18 @@ class GameSdlRunner {
         return (uiRunner.loadAs(menuAsDir))
     }
 
+    ; Bind the rich TypeScript launcher (menu/launcher.tsx) with the live catalog
+    ; injected as `gameCatalog`, rendered through the same WasmUiRenderer. Returns
+    ; false if the source can't be loaded (caller falls back to the .as menu).
+    fn openTsxMenu:boolean (uw:int uh:int) {
+        catalog.setGamesDir(gamesDir)
+        catalog.scan()
+        uiRunner.init(uw uh "gallery/game_engine/assets/fonts" "OpenSans-Regular.ttf" "Open Sans")
+        uiRunner.setMenuCatalog((catalog.toEvalArray()))
+        menuTsxMtime = (file_mtime menuAsDir "launcher.tsx")
+        return (uiRunner.loadTsx(menuAsDir "launcher.tsx"))
+    }
+
     ; Run the launcher menu — a normal interpreted .as engine=ui game living in
     ; menu/ that receives the catalog and reports (via OFF_LAUNCH) which sub-app to
     ; load. Being interpreted it hot-reloads like any other game. The crisp EVG UI
@@ -1159,6 +1209,95 @@ class GameSdlRunner {
                     gfx_set_title("Ranger Game Engine")
                     this.syncInputEdges()
                 }
+            }
+
+            if (gfx_should_close) {
+                running = false
+            }
+            frames = (frames + 1)
+            if (maxFrames > 0) {
+                if (frames >= maxFrames) {
+                    running = false
+                }
+            }
+        }
+    }
+
+    ; Run the rich TypeScript launcher (menu/launcher.tsx). Same present/input loop
+    ; as runEvgMenuLoop, but the guest is a .tsx evaluated by ComponentEngine into
+    ; the EVGElement tree WasmUiRenderer draws, and it reports a launch PATH (not a
+    ; catalog index) directly in its state.
+    fn runTsxMenuLoop:void () {
+        gfx_audio_clear
+        this.clearNavStack()
+        nativeBridge.clearPendingNav()
+        def uw:int (this.evgMenuTargetW())
+        def uh:int (this.evgMenuTargetH())
+        if ((this.openTsxMenu(uw uh)) == false) {
+            print "[menu] menu/launcher.tsx failed to load — using the .as menu"
+            this.runEvgMenuLoop()
+            return
+        }
+        print ("[menu] .tsx launcher: " + (to_string (catalog.entryCount())) + " games")
+        inMenu = true
+        inGame = false
+        gfx_set_title("Ranger Game Engine")
+        gfx_clear_should_close
+        this.syncInputEdges()
+        def nav:UiNavInput (new UiNavInput)
+        while (running) {
+            ; re-open at the live output resolution on window resize (crisp tiles)
+            def nw:int (this.evgMenuTargetW())
+            def nh:int (this.evgMenuTargetH())
+            if ((nw != uw) || (nh != uh)) {
+                uw = nw
+                uh = nh
+                this.openTsxMenu(uw uh)
+            }
+            ; live-reload: re-bind when menu/launcher.tsx changes on disk
+            def curMtime:int (file_mtime menuAsDir "launcher.tsx")
+            if (curMtime > menuTsxMtime) {
+                this.openTsxMenu(uw uh)
+                print "[menu] reloaded menu/launcher.tsx"
+            }
+            def m:int (this.launcherNavMask())
+            nav.clear()
+            nav.up = (this.upEdge((bit_and m 1) != 0))
+            nav.down = (this.downEdge((bit_and m 2) != 0))
+            nav.left = (this.leftEdge((bit_and m 16) != 0))
+            nav.right = (this.rightEdge((bit_and m 32) != 0))
+            nav.action = (this.actionEdge((bit_and m 4) != 0))
+            def _a:int (uiRunner.frame(nav))
+            uiRunner.render()
+            gfx_present (uiRunner.raw()) uw uh
+
+            if (this.quitEdge((this.gameMenuBackHeld()))) {
+                running = false
+                return
+            }
+            if (uiRunner.wantsQuitTsx()) {
+                running = false
+                return
+            }
+
+            ; the launcher reported a game PATH to open -> dispatch + reopen
+            def lp:string (uiRunner.launchPathTsx())
+            if ((strlen lp) > 0) {
+                if ((this.engineOf(lp)) == "ui") {
+                    this.runUiGame(lp)
+                } {
+                    this.loadGame(lp)
+                    this.runGameLoop()
+                }
+                if (running == false) {
+                    return
+                }
+                this.openTsxMenu(uw uh)
+                gfx_clear_should_close
+                inMenu = true
+                inGame = false
+                gfx_set_title("Ranger Game Engine")
+                this.syncInputEdges()
             }
 
             if (gfx_should_close) {
@@ -1403,10 +1542,15 @@ class GameSdlRunner {
         gfx_audio_open(44100)
         this.refreshWasmAudioSampleRate()
         if (launcherMode) {
-            if useEvgLauncher {
+            def mode:string (this.effectiveMenuMode())
+            if (mode == "as") {
                 this.runEvgMenuLoop()
             } {
-                this.runMenuLoop()
+                if (mode == "classic") {
+                    this.runMenuLoop()
+                } {
+                    this.runTsxMenuLoop()
+                }
             }
         } {
             if ((strlen uiDirectPath) > 0) {
@@ -1494,10 +1638,13 @@ class GameSdlRunner {
             def arg:string (shell_arg i)
             ; launcher front-page style: EVG tile menu (default) vs the old tsx menu
             if (arg == "--classic-menu") {
-                useEvgLauncher = false
+                menuModeForced = "classic"
             }
             if (arg == "--evg-menu") {
-                useEvgLauncher = true
+                menuModeForced = "as"
+            }
+            if (arg == "--tsx-menu") {
+                menuModeForced = "tsx"
             }
             if (pendingGamesDir) {
                 gamesDir = arg

--- a/gallery/game_engine/scripting/game_ui_runner.rgr
+++ b/gallery/game_engine/scripting/game_ui_runner.rgr
@@ -20,6 +20,7 @@ Import "../gfx_sdl.rgr"
 Import "../ui/WasmUiSelect.rgr"
 Import "./as_source_runner.rgr"
 Import "../../pdf_writer/src/jsx/EvalValue.rgr"
+Import "../../pdf_writer/src/jsx/ComponentEngine.rgr"
 
 class GameUiRunner {
     def canvas:SoftCanvas (new SoftCanvas)
@@ -65,6 +66,19 @@ class GameUiRunner {
     def OFF_RECT_W:int 208
     def OFF_RECT_H:int 212
 
+    ; --- interpreted .tsx backend (engine=ui, runtime=tsx) ---
+    ; A TypeScript/TSX guest evaluated by ComponentEngine straight into the same
+    ; EVGElement tree the renderer draws (rich glow/gradient/art) - the JS
+    ; front-end to the identical rendering core. Like the classic .tsx menu it
+    ; drives its own selection and returns a launch PATH (not a catalog index) in
+    ; its state; its glow highlight is baked into the tree (the `glow` prop), so
+    ; the host draws no extra cursor for it.
+    def tsxEngine:ComponentEngine (new ComponentEngine)
+    def useTsx:boolean false
+    def tsxState:EvalValue (EvalValue.null())
+    def tsxLaunch:string ""
+    def tsxQuit:boolean false
+
     ; page background behind the menu card
     def bgR:int 16
     def bgG:int 18
@@ -76,10 +90,12 @@ class GameUiRunner {
     fn init:void (width:int height:int fontDir:string fontRelPath:string family:string) {
         w = width
         h = height
-        ; start in a clean mode: this runner is reused across the launcher menu (.as)
-        ; and launched engine=ui games (wasm or .as), so reset the backend flags —
-        ; loadWasm/loadAs set them again, and setMenuCatalog re-enables injection.
+        ; start in a clean mode: this runner is reused across the launcher menu
+        ; (.tsx or .as) and launched engine=ui games (wasm or .as), so reset the
+        ; backend flags — loadWasm/loadAs/loadTsx set them again, and
+        ; setMenuCatalog re-enables injection.
         useAs = false
+        useTsx = false
         hasMenuCatalog = false
         canvas.init(width height)
         ctx.attach(canvas)
@@ -102,11 +118,12 @@ class GameUiRunner {
 
     ; --- native path: instantiate the wasm guest --------------------------------
     fn loadWasm:boolean (wasmPath:string) {
-        ; this runner may be reused after an interpreted .as guest (the launcher
-        ; menu), which set useAs=true; a compiled wasm guest drives itself, so
-        ; clear the flag or frame()/render() would take the .as path and the game
-        ; would never run (appears hung).
+        ; this runner may be reused after an interpreted guest (the launcher menu),
+        ; which set useAs/useTsx; a compiled wasm guest drives itself, so clear both
+        ; or frame()/render() would take an interpreted path and the game would
+        ; never run (appears hung).
         useAs = false
+        useTsx = false
         hasMenuCatalog = false
         handle = (wasm_load wasmPath)
         if (handle <= 0) {
@@ -149,6 +166,7 @@ class GameUiRunner {
     fn loadAs:boolean (dir:string) {
         effects.reset()
         useAs = true
+        useTsx = false
         if ((asRunner.bindDir(dir)) == false) {
             return false
         }
@@ -163,6 +181,71 @@ class GameUiRunner {
         rev = (asRunner.uiRevision())
         asSelId = (asRunner.abiRead(OFF_SEL))
         return true
+    }
+
+    ; --- interpreted .tsx path: bind + init the guest, render its first tree ----
+    fn loadTsx:boolean (dir:string file:string) {
+        useTsx = true
+        useAs = false
+        handle = 0
+        def buf:buffer (buffer_read_file dir file)
+        def src:string (buffer_to_string buf)
+        tsxEngine.quiet = true
+        ; a launcher menu reads the injected catalog to build its tiles
+        if hasMenuCatalog {
+            tsxEngine.registerGlobal("gameCatalog" menuCatalog)
+        }
+        tsxEngine.loadScript(src)
+        tsxState = (tsxEngine.callFunction("initState" (EvalValue.null())))
+        this.refreshFromTsx()
+        return true
+    }
+
+    ; props object handed to the guest's hud()/update(), matching the shape
+    ; game_runtime feeds a normal .tsx game (state + host clock + edge flags).
+    fn tsxProps:EvalValue (nav:UiNavInput withInput:boolean) {
+        def k:[string]
+        def v:[EvalValue]
+        push k "state"
+        push v tsxState
+        push k "time"
+        push v (EvalValue.fromInt(uiTimeMs))
+        push k "up"
+        push v (EvalValue.boolean((withInput && nav.up)))
+        push k "down"
+        push v (EvalValue.boolean((withInput && nav.down)))
+        push k "left"
+        push v (EvalValue.boolean((withInput && nav.left)))
+        push k "right"
+        push v (EvalValue.boolean((withInput && nav.right)))
+        push k "action"
+        push v (EvalValue.boolean((withInput && nav.action)))
+        push k "quit"
+        push v (EvalValue.boolean(false))
+        return (EvalValue.object(k v))
+    }
+
+    ; Re-render the guest's hud() into `root` and lay it out. No autoscale rebuild
+    ; (unlike the .as path's WasmUiEvgBuilder.scale) - the JSX tree has no scale
+    ; knob; it is authored to the menu canvas.
+    fn refreshFromTsx:void () {
+        def none:UiNavInput (new UiNavInput)
+        root = (tsxEngine.callRender("hud" (this.tsxProps(none false))))
+        ctrl.renderer.layoutTree(ctx root w h)
+        loaded = true
+    }
+
+    fn tsxStr:string (key:string) {
+        def mv:EvalValue (tsxState.getMember(key))
+        return (mv.toString())
+    }
+
+    ; launch PATH the tsx menu wants opened this frame ("" = none)
+    fn launchPathTsx:string () {
+        return tsxLaunch
+    }
+    fn wantsQuitTsx:boolean () {
+        return tsxQuit
     }
 
     ; Copy the guest's RGU1 block out of the bridge and rebuild the EVG tree.
@@ -185,6 +268,8 @@ class GameUiRunner {
     ; --- headless/test path: an already-authored RGU1 byte block ----------------
     fn loadDoc:boolean (bytes:[int] n:int) {
         effects.reset()
+        useAs = false
+        useTsx = false
         doc.loadBytes(bytes n)
         if (doc.valid == false) {
             return false
@@ -243,6 +328,16 @@ class GameUiRunner {
     ; Advance one frame with nav input; returns the activated node id, or -1.
     fn frame:int (nav:UiNavInput) {
         if (loaded == false) {
+            return -1
+        }
+        if useTsx {
+            ; advance the host clock (~60fps) so the guest's time-based glow runs,
+            ; feed the D-pad edges to update(), then re-render its hud() tree.
+            uiTimeMs = (uiTimeMs + 16)
+            tsxState = (tsxEngine.callFunction("update" (this.tsxProps(nav true))))
+            this.refreshFromTsx()
+            tsxLaunch = (this.tsxStr("launchPath"))
+            tsxQuit = ((this.tsxStr("quitApp")) == "1")
             return -1
         }
         if useAs {
@@ -315,6 +410,11 @@ class GameUiRunner {
     fn render:void () {
         canvas.clear(bgR bgG bgB)
         ctrl.renderer.draw(ctx root)
+        ; the .tsx menu bakes its selection glow into the tree (the `glow` prop),
+        ; drawn by ctrl.renderer.draw above, so it needs no host-drawn cursor.
+        if useTsx {
+            return
+        }
         if useAs {
             ; highlight the node the interpreted guest reports selected
             if (asSelId > 0) {

--- a/gallery/game_engine/scripting/menu_tsx_render_demo.rgr
+++ b/gallery/game_engine/scripting/menu_tsx_render_demo.rgr
@@ -1,0 +1,156 @@
+; ==============================================================================
+; menu_tsx_render_demo - render the TSX launcher through the RICH EVG renderer.
+; ==============================================================================
+; Proves Approach A+: a menu authored in TypeScript/TSX (menu/launcher.tsx) is
+; evaluated by ComponentEngine into an EVGElement tree, then drawn with the SAME
+; WasmUiRenderer the .as menu uses (rounded corners, borders, TTF text) - NOT the
+; pixel-font game_hud. Same rendering core, JSX front-end.
+;
+;   ComponentEngine(loadScript) -> callFunction("update") -> callRender("hud")
+;     -> EVGElement -> WasmUiRenderer.layoutTree/draw -> PNG
+;
+; It injects a real game catalog exactly like the SDL host, drives the guest's
+; own screen/selection state machine with D-pad edges, and asserts the rich
+; EVGElement props (borderRadius / borderColor) survived the JSX -> EVG mapping.
+; ==============================================================================
+
+Import "../ui/WasmUiSelect.rgr"
+Import "./game_catalog.rgr"
+Import "../../pdf_writer/src/jsx/ComponentEngine.rgr"
+Import "../../pdf_writer/src/jsx/EvalValue.rgr"
+Import "../../pdf_writer/src/raster/PNGEncoder.rgr"
+
+class TsxCheck {
+    def passed:int 0
+    def failed:int 0
+    fn ok:void (name:string cond:boolean) {
+        if cond {
+            passed = (passed + 1)
+            print ("  PASS " + name)
+        } {
+            failed = (failed + 1)
+            print ("  FAIL " + name)
+        }
+    }
+}
+
+class TsxMenuRenderDemo {
+    def engine:ComponentEngine (new ComponentEngine)
+    def canvas:SoftCanvas (new SoftCanvas)
+    def ctx:UIContext (new UIContext)
+    def rnd:WasmUiRenderer (new WasmUiRenderer)
+    def root:EVGElement (EVGElement.createDiv())
+    def state:EvalValue (EvalValue.null())
+    def cw:int 360
+    def ch:int 460
+
+    ; input props object matching game_runtime.stepUpdateScript's shape
+    fn props:EvalValue (up:boolean down:boolean left:boolean right:boolean action:boolean) {
+        def k:[string]
+        def v:[EvalValue]
+        push k "up"
+        push v (EvalValue.boolean(up))
+        push k "down"
+        push v (EvalValue.boolean(down))
+        push k "left"
+        push v (EvalValue.boolean(left))
+        push k "right"
+        push v (EvalValue.boolean(right))
+        push k "action"
+        push v (EvalValue.boolean(action))
+        push k "quit"
+        push v (EvalValue.boolean(false))
+        push k "state"
+        push v state
+        return (EvalValue.object(k v))
+    }
+
+    ; (re)build the EVGElement tree for the current state and lay it out, scaling
+    ; down to fit the canvas exactly like the .as menu demo.
+    fn refresh:void () {
+        root = (engine.callRender("hud" (this.props(false false false false false))))
+        rnd.layoutTree(ctx root cw ch)
+    }
+
+    ; drive one input edge: update() advances the guest state, then rebuild.
+    fn step:void (up:boolean down:boolean left:boolean right:boolean action:boolean) {
+        state = (engine.callFunction("update" (this.props(up down left right action))))
+        this.refresh()
+    }
+
+    fn stateStr:string (key:string) {
+        def mv:EvalValue (state.getMember(key))
+        return (mv.toString())
+    }
+
+    fn drawFrame:void (file:string) {
+        canvas.clear(16 18 30)
+        rnd.draw(ctx root)
+        def rb:RasterBuffer (new RasterBuffer)
+        rb.width = (canvas.getWidth())
+        rb.height = (canvas.getHeight())
+        rb.pixels = (canvas.raw())
+        def png:PNGEncoder (new PNGEncoder)
+        png.encode(rb "gallery/game_engine/scripting" file)
+    }
+
+    ; walk the tree; true if any element has a borderRadius set
+    fn anyRounded:boolean (el:EVGElement) {
+        if (el.box.borderRadius.isSet) { return true }
+        def c 0
+        while (c < (array_length el.children)) {
+            if (this.anyRounded((itemAt el.children c))) { return true }
+            c = (c + 1)
+        }
+        return false
+    }
+
+    sfn m@(main):void () {
+        def d:TsxMenuRenderDemo (new TsxMenuRenderDemo)
+        def c:TsxCheck (new TsxCheck)
+
+        d.canvas.init(d.cw d.ch)
+        d.ctx.attach(d.canvas)
+        d.ctx.tr.addFontDir("gallery/pdf_writer/assets/fonts")
+        d.ctx.tr.loadFont("Open Sans" "Open_Sans/OpenSans-Regular.ttf")
+
+        ; real catalog, injected exactly like the SDL host
+        def catalog:GameCatalog (new GameCatalog)
+        catalog.setGamesDir("gallery/game_engine/games")
+        catalog.scan()
+        c.ok(("catalog scanned (" + (to_string (catalog.entryCount())) + ")") ((catalog.entryCount()) > 0))
+
+        def buf:buffer (buffer_read_file "gallery/game_engine/menu" "launcher.tsx")
+        def src:string (buffer_to_string buf)
+        d.engine.quiet = true
+        d.engine.registerGlobal("gameCatalog" (catalog.toEvalArray()))
+        d.engine.loadScript(src)
+
+        d.state = (d.engine.callFunction("initState" (EvalValue.null())))
+        d.refresh()
+
+        ; ---- categories screen ----
+        c.ok(("starts on cats screen (got '" + (d.stateStr("screen")) + "')") ((d.stateStr("screen")) == "cats"))
+        c.ok("category screen has rounded EVG boxes (rich props survived JSX->EVG)" (d.anyRounded(d.root)))
+        d.drawFrame("tsx_menu_1_cats.png")
+
+        ; ---- open the first category ----
+        d.step(false false false false true)
+        c.ok(("action -> games screen (got '" + (d.stateStr("screen")) + "')") ((d.stateStr("screen")) == "games"))
+        c.ok("games screen has rounded EVG boxes" (d.anyRounded(d.root)))
+        d.drawFrame("tsx_menu_2_games.png")
+
+        ; ---- move down, then launch ----
+        d.step(false true false false false)
+        d.step(false false false false true)
+        c.ok(("launch path reported (got '" + (d.stateStr("launchPath")) + "')") ((strlen (d.stateStr("launchPath"))) > 0))
+
+        ; ---- left returns to categories ----
+        d.step(false false true false false)
+        c.ok(("left -> cats (got '" + (d.stateStr("screen")) + "')") ((d.stateStr("screen")) == "cats"))
+
+        print "======================================"
+        print (("RESULT: " + (to_string c.passed) + " passed, ") + ((to_string c.failed) + " failed"))
+        if (c.failed == 0) { print "ALL PASS" } { print "SOME FAILED" }
+    }
+}

--- a/gallery/game_engine/scripting/menu_tsx_render_demo.rgr
+++ b/gallery/game_engine/scripting/menu_tsx_render_demo.rgr
@@ -43,11 +43,14 @@ class TsxMenuRenderDemo {
     def state:EvalValue (EvalValue.null())
     def cw:int 360
     def ch:int 460
+    def tMs:int 0            ; host clock (ms) fed via props.time, drives the glow
 
     ; input props object matching game_runtime.stepUpdateScript's shape
     fn props:EvalValue (up:boolean down:boolean left:boolean right:boolean action:boolean) {
         def k:[string]
         def v:[EvalValue]
+        push k "time"
+        push v (EvalValue.fromInt(tMs))
         push k "up"
         push v (EvalValue.boolean(up))
         push k "down"
@@ -65,17 +68,50 @@ class TsxMenuRenderDemo {
         return (EvalValue.object(k v))
     }
 
-    ; (re)build the EVGElement tree for the current state and lay it out, scaling
-    ; down to fit the canvas exactly like the .as menu demo.
+    ; (re)build the EVGElement tree for the current state and lay it out.
     fn refresh:void () {
         root = (engine.callRender("hud" (this.props(false false false false false))))
         rnd.layoutTree(ctx root cw ch)
     }
 
-    ; drive one input edge: update() advances the guest state, then rebuild.
+    ; drive one input edge (advancing the clock ~120ms so the glow flash runs);
+    ; update() advances the guest state, then rebuild.
     fn step:void (up:boolean down:boolean left:boolean right:boolean action:boolean) {
+        tMs = (tMs + 120)
         state = (engine.callFunction("update" (this.props(up down left right action))))
         this.refresh()
+    }
+
+    ; advance several idle frames so a deferred (post-flash) callback fires
+    fn settle:void () {
+        def k 0
+        while (k < 6) {
+            this.step(false false false false false)
+            k = (k + 1)
+        }
+    }
+
+    ; peak glow anywhere in the tree (proves the animated halo reached EVGElement)
+    fn maxGlow:double (el:EVGElement) {
+        def g:double el.glowIntensity
+        def c 0
+        while (c < (array_length el.children)) {
+            def cg:double (this.maxGlow((itemAt el.children c)))
+            if (cg > g) { g = cg }
+            c = (c + 1)
+        }
+        return g
+    }
+
+    ; true if any element carries a background image (the tile art)
+    fn anyBgImage:boolean (el:EVGElement) {
+        if (el.bgImageSet) { return true }
+        def c 0
+        while (c < (array_length el.children)) {
+            if (this.anyBgImage((itemAt el.children c))) { return true }
+            c = (c + 1)
+        }
+        return false
     }
 
     fn stateStr:string (key:string) {
@@ -129,14 +165,22 @@ class TsxMenuRenderDemo {
         d.state = (d.engine.callFunction("initState" (EvalValue.null())))
         d.refresh()
 
-        ; ---- categories screen ----
+        ; ---- categories screen: rich props + tile art + steady selection glow ----
         c.ok(("starts on cats screen (got '" + (d.stateStr("screen")) + "')") ((d.stateStr("screen")) == "cats"))
         c.ok("category screen has rounded EVG boxes (rich props survived JSX->EVG)" (d.anyRounded(d.root)))
+        c.ok("category tiles carry background art (backgroundImage prop)" (d.anyBgImage(d.root)))
+        c.ok("selected tile has a steady glow halo (glow prop)" ((d.maxGlow(d.root)) > 0.0))
         d.drawFrame("tsx_menu_1_cats.png")
 
-        ; ---- open the first category ----
+        ; ---- action starts a GLOW FLASH; the screen switch is DEFERRED to the
+        ; closure callback that fires only after the flash completes ----
         d.step(false false false false true)
-        c.ok(("action -> games screen (got '" + (d.stateStr("screen")) + "')") ((d.stateStr("screen")) == "games"))
+        c.ok(("stays on cats during the flash (got '" + (d.stateStr("screen")) + "')") ((d.stateStr("screen")) == "cats"))
+        d.step(false false false false false)
+        c.ok("flash glow is animating on the tile mid-flash" ((d.maxGlow(d.root)) > 0.0))
+        d.drawFrame("tsx_menu_1b_flash.png")
+        d.settle()
+        c.ok(("after the flash the callback opened the category (got '" + (d.stateStr("screen")) + "')") ((d.stateStr("screen")) == "games"))
         c.ok("games screen has rounded EVG boxes" (d.anyRounded(d.root)))
         d.drawFrame("tsx_menu_2_games.png")
 

--- a/gallery/game_engine/scripting/menu_tsx_uirunner_demo.rgr
+++ b/gallery/game_engine/scripting/menu_tsx_uirunner_demo.rgr
@@ -1,0 +1,72 @@
+; ==============================================================================
+; menu_tsx_uirunner_demo - drive the TSX launcher through GameUiRunner (the host
+; path), not just ComponentEngine directly.
+; ==============================================================================
+; menu_tsx_render_demo proves the tsx -> EVGElement -> WasmUiRenderer rendering.
+; This one proves the SDL HOST integration: GameUiRunner.loadTsx binds the guest,
+; frame(nav) feeds the D-pad + re-renders, render() draws the rich tree, and
+; launchPathTsx() reports the path the host launches - exactly what
+; GameSdlRunner's menu loop consumes. Runs headless (SoftCanvas, no SDL window).
+; ==============================================================================
+
+Import "./game_ui_runner.rgr"
+Import "./game_catalog.rgr"
+
+class TsxUiCheck {
+    def passed:int 0
+    def failed:int 0
+    fn ok:void (name:string cond:boolean) {
+        if cond {
+            passed = (passed + 1)
+            print ("  PASS " + name)
+        } {
+            failed = (failed + 1)
+            print ("  FAIL " + name)
+        }
+    }
+}
+
+class MenuTsxUiRunnerDemo {
+    sfn m@(main):void () {
+        def c:TsxUiCheck (new TsxUiCheck)
+
+        def catalog:GameCatalog (new GameCatalog)
+        catalog.setGamesDir("gallery/game_engine/games")
+        catalog.scan()
+        c.ok(("catalog scanned (" + (to_string (catalog.entryCount())) + ")") ((catalog.entryCount()) > 0))
+
+        def r:GameUiRunner (new GameUiRunner)
+        r.init(360 460 "gallery/pdf_writer/assets/fonts" "Open_Sans/OpenSans-Regular.ttf" "Open Sans")
+        r.setMenuCatalog((catalog.toEvalArray()))
+        c.ok("loadTsx bound the launcher" (r.loadTsx("gallery/game_engine/menu" "launcher.tsx")))
+        c.ok("no launch on the category screen" ((strlen (r.launchPathTsx())) == 0))
+
+        ; ---- press A on a category: a glow flash starts, launch stays empty ----
+        def act:UiNavInput (new UiNavInput)
+        act.action = true
+        def _a0:int (r.frame(act))
+        c.ok("still no launch during the category flash" ((strlen (r.launchPathTsx())) == 0))
+
+        ; ---- idle frames: the flash (420ms at ~16ms/frame) completes and its
+        ; callback opens the category ----
+        def idle:UiNavInput (new UiNavInput)
+        def k 0
+        while (k < 30) {
+            def _i:int (r.frame(idle))
+            k = (k + 1)
+        }
+
+        ; ---- press A on the first game: the launcher reports its path ----
+        def _a1:int (r.frame(act))
+        def lp:string (r.launchPathTsx())
+        c.ok(("launcher reported a launch path (got '" + lp + "')") ((strlen lp) > 0))
+
+        ; the rich render path runs without error
+        r.render()
+        c.ok("render() ran on the tsx tree without error" true)
+
+        print "======================================"
+        print (("RESULT: " + (to_string c.passed) + " passed, ") + ((to_string c.failed) + " failed"))
+        if (c.failed == 0) { print "ALL PASS" } { print "SOME FAILED" }
+    }
+}


### PR DESCRIPTION
## Summary
Introduces a new TypeScript/TSX-based launcher menu (`menu/launcher.tsx`) that is evaluated by `ComponentEngine` into an `EVGElement` tree and rendered through the same `WasmUiRenderer` used by the `.as` menu. This provides a modern JavaScript front-end while maintaining identical visual rendering (rounded corners, borders, TTF text, background art, animated glow effects).

## Key Changes

- **New TSX Launcher** (`gallery/game_engine/menu/launcher.tsx`):
  - Two-screen interface: categories → games in category
  - Pure JavaScript state management and array filtering
  - JSX-authored layout with camelCase attribute names (flexDirection, backgroundColor, borderRadius, backgroundImage, glow)
  - Closure-based callback pattern for deferred screen transitions after glow flash animations
  - Reports launch paths directly (not catalog indices)

- **ComponentEngine Integration** (`GameUiRunner`):
  - Added `loadTsx()` method to bind and initialize TSX guests
  - Added `tsxProps()` to construct props objects matching the shape of normal `.tsx` games
  - Added `refreshFromTsx()` and `frame()` support for TSX rendering pipeline
  - Added `launchPathTsx()` and `wantsQuitTsx()` accessors for host integration

- **SDL Host Integration** (`GameSdlRunner`):
  - Added `runTsxMenuLoop()` for the main menu loop (mirrors `runEvgMenuLoop`)
  - Added `menuRuntimeOf()` to read launcher backend from `game.info`'s `runtime` field
  - Added `effectiveMenuMode()` to resolve CLI flags vs. game.info vs. default ("tsx")
  - Live-reload support for `menu/launcher.tsx` changes on disk
  - Window resize handling for crisp tile rendering

- **EVGElement Rich Props**:
  - Added `glow` property for animated halo intensity (0..1)
  - Added `backgroundImage` / `background-image` for tile art
  - Added `gradientFrom` / `gradientTo` / `gradientDir` for 2-stop linear gradients
  - All camelCase spellings to support TSX parser (which splits on `-`)

- **Shared ABI & Protocol**:
  - Extracted common ABI offsets to `gallery/game_engine/lib/abi.as`
  - Extracted RGU1 protocol properties to `gallery/game_engine/lib/uiProtocol.as`
  - Refactored `.as` menu and demo to import from shared modules

- **Fluent UI Builder Redesign** (`gallery/game_engine/lib/ui.as`):
  - Simplified API: everything is a box (container, button, or label)
  - `parent.box(id)` opens a plain container child
  - `parent.button(id)` opens an interactive box child
  - `parent.label(id, string)` opens a text box child
  - Child order assigned automatically; IDs remain explicit for host selection mapping
  - Escape hatches (`.propI32()`, `.propColor()`) for app-defined properties

- **Test Coverage**:
  - Added `menu_tsx_render_demo.rgr`: proves ComponentEngine → EVGElement → WasmUiRenderer rendering with real catalog injection
  - Added `menu_tsx_uirunner_demo.rgr`: proves GameUiRunner integration (frame/render/launch path reporting)

- **Menu Configuration**:
  - Updated `gallery/game_engine/menu/game.info` to default to `runtime=tsx`
  - Reorganized test games into "Tests" category (autopeli_as, autopeli_physics, physics_sandbox, streaming_world, pose_demo)

## Notable Implementation Details

- The glow flash is a real closure callback: pressing A captures a function in state that fires when the animation completes, enabling deferred screen transitions without explicit state machines
- JSX attribute names use camelCase (not kebab-case) because the TSX parser tokenizes `-` as a separator
- The launcher reports launch paths directly (not catalog indices), matching the shape of normal `.tsx`

https://claude.ai/code/session_01Wx9nK477PFzpuGUmKkEs5q