### PR TITLE
Fix TSX interpreter: concise arrows returning object literals in method/IIFE call positions

### DIFF
--- a/gallery/game_engine/scripting/tsx_engine_demo.game.tsx
+++ b/gallery/game_engine/scripting/tsx_engine_demo.game.tsx
@@ -135,3 +135,19 @@ function consoleLogOk() {
   console.log("hello", 42);
   return 1;
 }
+
+// Concise arrow returning an object literal, invoked as an IIFE:
+// (() => ({ ... }))(). The parenthesized object body must round-trip through
+// the interpreter's call path.
+function iifeObjectReturn() {
+  const p = (() => ({ x: 3, y: 4 }))();
+  return p.x + p.y;
+}
+
+// Concise arrow returning an object literal stored as an object property,
+// invoked as a method: obj.make(). The stored closure is called directly.
+const arrowFactory = { make: () => ({ v: 9 }) };
+
+function objectMethodArrowReturn() {
+  return arrowFactory.make().v;
+}

--- a/gallery/game_engine/scripting/tsx_engine_demo.rgr
+++ b/gallery/game_engine/scripting/tsx_engine_demo.rgr
@@ -35,6 +35,8 @@ class TsxEngineDemo {
         def anyObjectKey:EvalValue (engine.callFunction("anyObjectKey" (EvalValue.null())))
         def staticObjectKey:EvalValue (engine.callFunction("staticObjectKey" (EvalValue.null())))
         def consoleLogOk:EvalValue (engine.callFunction("consoleLogOk" (EvalValue.null())))
+        def iifeObjectReturn:EvalValue (engine.callFunction("iifeObjectReturn" (EvalValue.null())))
+        def objectMethodArrowReturn:EvalValue (engine.callFunction("objectMethodArrowReturn" (EvalValue.null())))
 
         print ("whileLen=" + (to_int (whileLen.numberValue)))
         print ("constSum=" + (to_int (constSum.numberValue)))
@@ -63,6 +65,8 @@ class TsxEngineDemo {
         print ("anyObjectKey=" + (to_int (anyObjectKey.numberValue)))
         print ("staticObjectKey=" + (to_int (staticObjectKey.numberValue)))
         print ("consoleLogOk=" + (to_int (consoleLogOk.numberValue)))
+        print ("iifeObjectReturn=" + (to_int (iifeObjectReturn.numberValue)))
+        print ("objectMethodArrowReturn=" + (to_int (objectMethodArrowReturn.numberValue)))
         print "tsx-engine-demo done"
     }
 }

--- a/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
+++ b/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
@@ -5079,12 +5079,12 @@ class ComponentEngine {
                 }
                 if (arrStaticName == "console") {
                     if ((methodName == "log") || (methodName == "warn") || (methodName == "error") || (methodName == "info") || (methodName == "debug")) {
-                        def line:string ""
+                        ; Host stdout is shared with the engine; prefix with [tsx]
+                        ; so script logging is distinguishable (see engine.d.ts).
+                        def line:string "[tsx]"
                         def ci:int 0
                         while (ci < (array_length node.children)) {
-                            if (ci > 0) {
-                                line = (line + " ")
-                            }
+                            line = (line + " ")
                             line = (line + ((this.evaluateExpr((itemAt node.children ci))).toString()))
                             ci = (ci + 1)
                         }

--- a/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
+++ b/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
@@ -3988,6 +3988,21 @@ class ComponentEngine {
                     }
                 }
 
+                ; Plain-object method call: obj.method() where the property holds
+                ; a function value (e.g. a concise arrow `{ make: () => ({...}) }`).
+                ; The stored closure already carries its lexical scope, so invoke
+                ; it directly. Placed before the built-in method table so a user
+                ; property (e.g. a custom `toString`) wins over the fallback.
+                if (obj.valueType == 5) {
+                    def objMember:EvalValue (obj.getMember(methodName))
+                    if (objMember.valueType == 6) {
+                        if objMember.functionNode {
+                            def objCargs:[EvalValue] (this.collectCallArgs(node))
+                            return (this.callFnValueWithValues(objMember objCargs))
+                        }
+                    }
+                }
+
                 ; Handle Number methods
                 if (methodName == "toFixed") {
                     def numVal:double (obj.toNumber())
@@ -5300,6 +5315,18 @@ class ComponentEngine {
                         def callArgVals:[EvalValue] (this.collectCallArgs(node))
                         return (this.callFnValueWithValues(fnValue callArgVals))
                     }
+                }
+            }
+
+            ; Callee is itself an expression that yields a function value, e.g.
+            ; an IIFE `(() => ({...}))()` or `(cond ? a : b)()`. Inline arrow/
+            ; function expressions capture the current scope; anything else is
+            ; evaluated. MemberExpression/Identifier callees are handled above.
+            def calleeFn:EvalValue (this.resolveCallbackValue(callee))
+            if (calleeFn.isFunction()) {
+                if calleeFn.functionNode {
+                    def calleeArgs:[EvalValue] (this.collectCallArgs(node))
+                    return (this.callFnValueWithValues(calleeFn calleeArgs))
                 }
             }
         }

--- a/tests/tsx-engine.test.ts
+++ b/tests/tsx-engine.test.ts
@@ -34,6 +34,8 @@ describe("TSX engine - ComponentEngine regressions", () => {
     expect(out).toContain("staticObjectKey=18");
     expect(out).toContain("[tsx] hello 42");
     expect(out).toContain("consoleLogOk=1");
+    expect(out).toContain("iifeObjectReturn=7");
+    expect(out).toContain("objectMethodArrowReturn=9");
     expect(out).toContain("tsx-engine-demo done");
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Background

Reported against the `gallery/game_engine` route when `.tsx` files are evaluated by `ComponentEngine`: a concise arrow that returns an object literal — `() => ({ ... })` — appeared to be unsupported by the interpreter, while a concise arrow that returns a plain value (as used by `.filter`/`.sort`) worked.

## Investigation

I reproduced by compiling small scripts through `ComponentEngine.loadScript` + `callFunction`. The concise-arrow object-literal form itself is actually **well supported** — it works as a `const`, inside `.map`/`.filter`/`.reduce`/`.find`, with typed params, nested parens, nested objects, ternaries, object spread `{...s}`, and as a direct top-level game entry (`update(state)`), on both the value and block-body paths.

The real gap is in the **call site**. `evaluateCallExpr` could not invoke a function value in two positions, and both fail regardless of body style (concise or block), which is what made `() => ({...})` look broken:

1. **Object-property method call** — `obj.method()` where the property holds a function value (e.g. `const factory = { make: () => ({...}) }; factory.make()`). This fell through the built-in method table and returned `null`.
2. **IIFE / expression callee** — `(() => ({...}))()`. This callee shape was never dispatched, returning `null`.

## Fix

In `gallery/pdf_writer/src/jsx/ComponentEngine.rgr` → `evaluateCallExpr`:

- For a `MemberExpression` callee whose receiver is a plain object (`valueType == 5`), if the named member is a function value, call it via `callFnValueWithValues` (which preserves the captured closure, so arrows keep lexical `this`). Placed before the built-in method table so a user-defined property wins.
- Added a final fallback that resolves any remaining callee expression to a function value (capturing the closure for inline arrow/function expressions) and calls it — covering IIFEs such as `(() => ({...}))()` and `(cond ? a : b)()`.

Verified all previously-failing forms now work (object method calls, IIFEs, IIFE-based spread reducers, closure capture in IIFEs, object methods with args) and existing forms (`.map(n => ({...}))`, etc.) still work.

## Secondary fix

While getting the tsx engine test suite green, I found a **pre-existing** failure unrelated to the above: `engine.d.ts` documents that script `console.log` prints to host stdout as `[tsx] ...` and `tests/tsx-engine.test.ts` asserts it, but the interpreter emitted the message without the prefix. Added the `[tsx]` prefix. (Committed separately.)

## Tests

- Extended `gallery/game_engine/scripting/tsx_engine_demo.game.tsx` + `tsx_engine_demo.rgr` with regression functions `iifeObjectReturn` (`=7`) and `objectMethodArrowReturn` (`=9`), asserted in `tests/tsx-engine.test.ts`.
- `tsx-engine.test.ts`: 6/6 pass. `game-scripting`, `game-catalog`, `game-engine-features`, `game-engine-render`: pass.
- `game-runner.test.ts` has 5 failures that are **pre-existing on `master`** (missing game asset files `games/ylos/index.tsx`, `games/physics_race/index.tsx`; an undefined `SdlGameHost` in `game_split_screen.rgr`; a physics-collision assertion) and are untouched by this change.

## Commits

1. Fix TSX interpreter: call concise-arrow object methods and IIFEs
2. Fix TSX console.log to emit documented `[tsx]` prefix
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76cfac8d-3d48-441c-b20f-e112fb2ae0cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76cfac8d-3d48-441c-b20f-e112fb2ae0cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

