### PR TITLE
menu(tsx): don't exit the launcher on back/quit from the main screen

### DIFF
--- a/gallery/game_engine/menu/launcher.tsx
+++ b/gallery/game_engine/menu/launcher.tsx
@@ -76,13 +76,15 @@ function update(props) {
   let cat = s.cat;
 
   // Back/quit is context-sensitive: from a category's game list it goes back up
-  // to the categories screen; only from the top categories screen does it exit
-  // the app.
+  // to the categories screen. The top categories screen is the app root — back
+  // there is a no-op so the launcher never exits itself (you'd otherwise drop to
+  // the Linux desktop with no easy way back). It stays put until the host is
+  // killed externally.
   if (props.quit) {
     if (screen === "games") {
       return { screen: "cats", sel: cat, cat, launchPath: "", quitApp: 0, now, anim: null, onDone: null };
     }
-    return { screen, sel, cat, launchPath: "", quitApp: 1, now, anim: null, onDone: null };
+    return { screen, sel, cat, launchPath: "", quitApp: 0, now, anim: null, onDone: null };
   }
 
   // A glow flash is running: when it finishes, call the stashed callback to


### PR DESCRIPTION
## What

The main menu (tsx launcher) no longer quits the whole application when you press **q** / gamepad **Back** on the top categories screen.

## Why

Back/quit on the top screen set `quitApp: 1`, which ended the host loop and dropped the user to the Linux desktop — from where relaunching was awkward and didn't reliably work. The launcher is meant to run kiosk-style on the Pi, so it should never exit itself.

## Behavior

- **Games list → Back**: returns to the categories screen (unchanged).
- **Top categories screen → Back/q**: now a **no-op**, the launcher stays put.
- Remaining exits: window close button (`SDL_QUIT`) on desktop, or killing the host process externally.

## Notes for reviewer

Single-file change: `gallery/game_engine/menu/launcher.tsx`. The input chain is unchanged — the host still feeds the Back/Quit edge to the guest ([game_sdl_runner.rgr](gallery/game_engine/scripting/game_sdl_runner.rgr)), which now simply chooses not to quit at the root. Native Q/Esc/Back map to the quit input mask (not the window-close flag), so nothing bypasses this decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)