### PR TITLE
engine(voicebox): predefined vocal effects via the ABI (+ C++/SDL build fix)

### DIFF
--- a/gallery/game_engine/scripting/game_voicebox.rgr
+++ b/gallery/game_engine/scripting/game_voicebox.rgr
@@ -446,8 +446,11 @@ class GameVoicebox {
     }
 
     fn hasAsset:boolean (id:string) {
-        def v@(optional):buffer (get assetPcm id)
-        return (!null? v)
+        ; Probe the int frames map, not the buffer map: optional<int> lowers to
+        ; a proper has_value flag on every target, while a map<string,buffer>
+        ; value is a bare vector in C++ and cannot be null-checked.
+        def fr@(optional):int (get assetFrames id)
+        return (!null? fr)
     }
 
     ; Load a 16-bit mono PCM WAV (44-byte header) as an override for `id`.
@@ -478,16 +481,17 @@ class GameVoicebox {
             print ("[voicebox] play " + id + " " + (this.tagFor(id)))
         }
         if (this.hasAsset(id)) {
+            ; Presence already confirmed via assetFrames (int optional). Unwrap
+            ; the buffer WITHOUT a null? check: `unwrap` is identity on the C++
+            ; vector, whereas null? would emit an invalid `vector != NULL`.
             def pcm@(optional):buffer (get assetPcm id)
             def fr@(optional):int (get assetFrames id)
-            if (!null? pcm) {
-                def frames:int 0
-                if (!null? fr) {
-                    frames = (unwrap fr)
-                }
-                sink.onSynthPlay(("voice:" + id) synth.sampleRate frames (unwrap pcm))
-                return
+            def frames:int 0
+            if (!null? fr) {
+                frames = (unwrap fr)
             }
+            sink.onSynthPlay(("voice:" + id) synth.sampleRate frames (unwrap pcm))
+            return
         }
         def rendered:ScoreVoiceRender (this.render(id))
         if (rendered.frames <= 0) {


### PR DESCRIPTION
Kohde: **master**. Sisältää koko voicebox-työn **ja** C++/SDL-käännöskorjauksen, joten tämä on itsenäinen, käännöskelpoinen kokonaisuus (korvaa #249:n).

## Ominaisuus: ennalta määritellyt vokaaliefektit enginen ABI:n kautta
[Voicebox](https://github.com/jamiepine/voicebox)-henkiset ääniefektit (nauru, kikatus, hörähdys, huokaus, gasp, yskä + laajennukset cheer/boo/hmm/huh/haukotus). Neljä ensimmäistä vastaa Voiceboxin oikeita paralingvistisiä tageja (`[laugh]`/`[sigh]`/`[gasp]`/`[cough]`), loput ovat enginen laajennuksia. Efektit renderöi pieni proseduraalinen vokaalisyntetisaattori (äänenkorkeuden liuku + formantit + hengityskohina, purskeisiin jaettuna); oikean Voiceboxin renderöimä 16-bit mono-WAV ohittaa synteesin.

Kaksi ABI-reittiä:
- **Eventti:** `update()` → `{ kind: "playVoice", id: "laugh" }`
- **Natiivikutsu:** `laugh()` / `voice("sigh")` (`GameVoiceboxBridge`)

Tiedostot: `game_voicebox.rgr`, `game_voicebox_bridge.rgr`, `game_host.rgr` (reititys), `voicebox_demo.game.tsx` + `voicebox_runner_demo.rgr` (demo + WAV-kaappaus), `engine.d.ts`-tyypit, `VOICEBOX.md`, `npm run engine:voicebox`.

## C++/SDL-käännöskorjaus
SDL/native-käännös (`-l=cpp`) kaatui: C++-backend madaltaa `map<string, buffer>`-arvon paljaaksi `std::vector<uint8_t>`:ksi, joten optionaalisen bufferin `null?` tuotti `vector != NULL` (ei käänny; vain JS salli sen).
- `GameVoicebox.hasAsset`: läsnäolo rinnakkaisesta `int`-mapista (`optional<int>` → `.has_value`).
- `GameVoicebox.play`: `unwrap` ilman `null?`-tarkistusta.

## Testattu
- JS: `voicebox_runner_demo` toimii (voicePlays=14, ~11 s WAV 44.1 kHz mono).
- C++: `g++ -std=c++17` kääntää generoidun selftestin ja se ajaa; koko `game_sdl_runner`-ketju generoi puhtaan C++:n.
- Regressio: `audio_runner`, `soundscore_runner`, `spawner_runner` ennallaan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q