### PR TITLE
engine(voicebox): fix C++/SDL build — vector != NULL on buffer maps

### DIFF
--- a/gallery/game_engine/scripting/game_voicebox.rgr
+++ b/gallery/game_engine/scripting/game_voicebox.rgr
@@ -446,8 +446,11 @@ class GameVoicebox {
     }
 
     fn hasAsset:boolean (id:string) {
-        def v@(optional):buffer (get assetPcm id)
-        return (!null? v)
+        ; Probe the int frames map, not the buffer map: optional<int> lowers to
+        ; a proper has_value flag on every target, while a map<string,buffer>
+        ; value is a bare vector in C++ and cannot be null-checked.
+        def fr@(optional):int (get assetFrames id)
+        return (!null? fr)
     }
 
     ; Load a 16-bit mono PCM WAV (44-byte header) as an override for `id`.
@@ -478,16 +481,17 @@ class GameVoicebox {
             print ("[voicebox] play " + id + " " + (this.tagFor(id)))
         }
         if (this.hasAsset(id)) {
+            ; Presence already confirmed via assetFrames (int optional). Unwrap
+            ; the buffer WITHOUT a null? check: `unwrap` is identity on the C++
+            ; vector, whereas null? would emit an invalid `vector != NULL`.
             def pcm@(optional):buffer (get assetPcm id)
             def fr@(optional):int (get assetFrames id)
-            if (!null? pcm) {
-                def frames:int 0
-                if (!null? fr) {
-                    frames = (unwrap fr)
-                }
-                sink.onSynthPlay(("voice:" + id) synth.sampleRate frames (unwrap pcm))
-                return
+            def frames:int 0
+            if (!null? fr) {
+                frames = (unwrap fr)
             }
+            sink.onSynthPlay(("voice:" + id) synth.sampleRate frames (unwrap pcm))
+            return
         }
         def rendered:ScoreVoiceRender (this.render(id))
         if (rendered.frames <= 0) {


### PR DESCRIPTION
Kohde: **master**. Korjaa #249:n mukana masteriin päätyneen C++/SDL-käännösvirheen. Diff on yksi tiedosto (`game_voicebox.rgr`).

## Ongelma
SDL/native-käännös (`-l=cpp`, `build-game-sdl.sh`) kaatui:

```
game_sdl.cpp: error: invalid operands to binary expression
              ('std::vector<uint8_t>' and 'long')   ->   v != NULL
```

C++-backend madaltaa `map<string, buffer>`-arvon paljaaksi `std::vector<uint8_t>`:ksi, joten optionaalisen bufferin `null?` / `!null?` tuottaa `vector != NULL`, mikä ei käänny. Vain JS-backend salli tämän.

## Korjaus
- `GameVoicebox.hasAsset`: tarkistaa läsnäolon rinnakkaisesta `int`-frames-mapista — `optional<int>` madaltuu kunnolliseksi `.has_value`-lipuksi joka kohdekielellä.
- `GameVoicebox.play`: purkaa bufferin (`unwrap`) ilman `null?`-tarkistusta (`unwrap` on identiteetti C++-vektorille; läsnäolo on jo varmistettu `hasAsset`:lla).

Generoituu nyt:
```cpp
bool GameVoicebox::hasAsset(...) { ...; return fr.has_value; }
void GameVoicebox::play(...)     { ...; std::vector<uint8_t> pcm = r_map_get_val(assetPcm, id); ... }
```

## Testattu
- `g++ -std=c++17` kääntää generoidun C++-selftestin ja se ajaa (11/11 efektiä); koko `game_sdl_runner`-ketju generoi puhtaan C++:n.
- JS-backend ennallaan: `voicebox_runner_demo` toimii (voicePlays=14, WAV kirjoitetaan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q)_