### PR TITLE
engine(comedy-club): fix SDL load + crackling audio (device-rate voice, interpreter-safe scene)

### DIFF
--- a/gallery/game_engine/games/comedy_club/game.info
+++ b/gallery/game_engine/games/comedy_club/game.info
@@ -1,4 +1,3 @@
 name=Comedy Club
-soloScript=index.tsx
 
 category=Games

--- a/gallery/game_engine/games/comedy_club/index.tsx
+++ b/gallery/game_engine/games/comedy_club/index.tsx
@@ -1,69 +1,121 @@
 /// <reference path="../../scripting/game.d.ts" />
 //
 // Comedy Club — a tiny stage whose performer triggers predefined VOCAL effects
-// through the engine's audio ABI (game_vocal_fx.rgr).
-//
-// Effects are rendered by the engine's own vocal synth — no external
-// dependency. The first four map to Voicebox paralinguistic tags
-// ([laugh]/[sigh]/[gasp]/[cough]); the rest are engine extensions. You can
-// optionally override any effect with a real 16-bit mono WAV (e.g. rendered in
-// the Voicebox app) via a { kind: "voice", id, path } resource.
+// through the engine's audio ABI (game_vocal_fx.rgr). The effects are rendered
+// by the engine's own vocal synth (no external dependency); the first four map
+// to Voicebox paralinguistic tags ([laugh]/[sigh]/[gasp]/[cough]).
 //
 // Controls:  space = laugh   up = cheer   down = boo   left = gasp   right = sigh
-// Idle: the crowd auto-reacts on a timer, cycling the whole catalogue.
+// Idle: the crowd auto-reacts every ~110 frames (well past the longest clip so
+// the SDL audio queue never piles up), cycling the whole catalogue.
+//
+// Written in the interpreter-safe subset (no `%`, no dynamic array indexing) so
+// it loads identically under the JS and the C++/SDL ComponentEngine — see
+// pong.game.tsx for the same discipline. Coordinates are a 480x270 buffer.
 
 function sprites() {
   return [
-    { id: "face", kind: "circle", rad: 12, r: 255, g: 210, b: 90 }
+    { id: "stage", kind: "rect", w: 420, h: 8, r: 90, g: 70, b: 110 },
+    { id: "perf", kind: "circle", rad: 16, r: 255, g: 210, b: 90 },
+    { id: "a0", kind: "circle", rad: 7, r: 120, g: 150, b: 210 },
+    { id: "a1", kind: "circle", rad: 7, r: 130, g: 160, b: 220 },
+    { id: "a2", kind: "circle", rad: 7, r: 120, g: 150, b: 210 },
+    { id: "a3", kind: "circle", rad: 7, r: 130, g: 160, b: 220 },
+    { id: "a4", kind: "circle", rad: 7, r: 120, g: 150, b: 210 }
   ];
 }
 
 function initState() {
   return {
-    entities: { face: { x: 60, y: 70 } },
+    playerSlots: 1,
+    entities: {
+      stage: { x: 240, y: 210 },
+      perf: { x: 240, y: 150 },
+      a0: { x: 80, y: 244 },
+      a1: { x: 160, y: 244 },
+      a2: { x: 240, y: 244 },
+      a3: { x: 320, y: 244 },
+      a4: { x: 400, y: 244 }
+    },
     t: 0,
+    phase: 0,
+    since: 0,
+    bob: 0,
+    bobDir: 1,
     reactions: 0
   };
+}
+
+function pickEffect(phase) {
+  if (phase == 0) { return "laugh"; }
+  if (phase == 1) { return "giggle"; }
+  if (phase == 2) { return "chuckle"; }
+  if (phase == 3) { return "sigh"; }
+  if (phase == 4) { return "gasp"; }
+  if (phase == 5) { return "cough"; }
+  if (phase == 6) { return "cheer"; }
+  if (phase == 7) { return "boo"; }
+  if (phase == 8) { return "hmm"; }
+  if (phase == 9) { return "huh"; }
+  return "yawn";
 }
 
 function update(props) {
   const s = props.state;
   const t = s.t + 1;
 
-  // Bob the performer left/right so the stage has some life.
-  let x = 40 + (t % 80);
+  // Performer bobs left/right (no modulo — bounce a counter between limits).
+  let bob = s.bob + s.bobDir * 2;
+  let bobDir = s.bobDir;
+  if (bob > 40) { bob = 40; bobDir = -1; }
+  if (bob < -40) { bob = -40; bobDir = 1; }
+  const perfX = 240 + bob;
 
   // Interactive triggers (any press wins over the ambient timer).
   let picked = "";
   if (props.action) { picked = "laugh"; }
-  if (props.up)     { picked = "cheer"; }
-  if (props.down)   { picked = "boo"; }
-  if (props.left)   { picked = "gasp"; }
-  if (props.right)  { picked = "sigh"; }
+  if (props.up) { picked = "cheer"; }
+  if (props.down) { picked = "boo"; }
+  if (props.left) { picked = "gasp"; }
+  if (props.right) { picked = "sigh"; }
 
-  // Ambient auto-reactions: cycle the whole catalogue, one every 18 frames.
-  const seq = [
-    "laugh", "giggle", "chuckle", "sigh", "gasp", "cough",
-    "cheer", "boo", "hmm", "huh", "yawn"
-  ];
-  if (picked == "" && t % 18 == 0) {
-    const idx = (t / 18 - 1) % 11;
-    picked = seq[idx];
+  // Ambient: one effect every ~110 frames, cycling the catalogue via a counter.
+  let phase = s.phase;
+  let since = s.since + 1;
+  if (picked == "") {
+    if (since >= 110) {
+      since = 0;
+      picked = pickEffect(phase);
+      phase = phase + 1;
+      if (phase > 10) { phase = 0; }
+    }
+  } else {
+    since = 0;
   }
 
   let ev = [];
   let reactions = s.reactions;
   if (picked != "") {
-    ev = [
-      { kind: "playSound", id: "blip" },
-      { kind: "playVoice", id: picked }
-    ];
+    ev = [{ kind: "playVoice", id: picked }];
     reactions = reactions + 1;
   }
 
   return {
-    entities: { face: { x: x, y: 70 } },
+    playerSlots: 1,
+    entities: {
+      stage: { x: 240, y: 210 },
+      perf: { x: perfX, y: 150 },
+      a0: { x: 80, y: 244 },
+      a1: { x: 160, y: 244 },
+      a2: { x: 240, y: 244 },
+      a3: { x: 320, y: 244 },
+      a4: { x: 400, y: 244 }
+    },
     t: t,
+    phase: phase,
+    since: since,
+    bob: bob,
+    bobDir: bobDir,
     reactions: reactions,
     events: ev
   };

--- a/gallery/ts_to_ranger/game_host.rgr
+++ b/gallery/ts_to_ranger/game_host.rgr
@@ -256,6 +256,11 @@ class GameHost {
             if audio {
                 def a:GameAudio (unwrap audio)
                 this.wireVoice()
+                ; Render at the device's sample rate. The SDL host retunes
+                ; a.sampleRate to the opened device (e.g. 48000); the vocal
+                ; synth has its own GameAudio, so mirror the rate or the PCM
+                ; plays back at the wrong speed and sounds like crackle.
+                vocalFx.synth.sampleRate = a.sampleRate
                 if (vocalFx.has(e.id)) {
                     vocalFx.play(e.id a.sink)
                 } {


### PR DESCRIPTION
Kohde: **master** (rebasattu; #253 on jo mergattu, joten diff on vain nämä 3 tiedostoa). Korjaa SDL-testissä havaitut ongelmat: Comedy Club avasi Pong-näkymän ja audio rätisi.

## Havainto
Kuvakaappaus oli **Pong** (värit täsmäävät: keltainen pallo, vihreä + lohenpunainen maila). Comedy Club siis ei latautunut kunnolla SDL-hostissa. Jäljitin koko latauspolun (molemmat valikot, `game_catalog`→`toEvalArray`, `loadGame`/`loadScriptAt`, argv) — **kovakoodattua pong-fallbackia ei ole** ja indeksointi on johdonmukaista. Ainoa konkreettinen ero toimiviin peleihin oli `soloScript`.

## Korjaukset
- **`games/comedy_club/game.info`:** poistettu `soloScript=index.tsx` (kopioitu physics_sandboxista). Toimivat .tsx-pelit (Pong, Breakout) eivät aseta sitä; `entryFile` on oletuksena `index.tsx`. Comedy Club on nyt rakenteeltaan **identtinen Pongin kanssa** (`engine=tsx`, `index.tsx`).
- **`games/comedy_club/index.tsx`:** kirjoitettu uusiksi tulkkiturvallisella osajoukolla kuten `pong.game.tsx` — ei `%`, ei laskettua taulukkoindeksointia (laskuri kimpoaa rajojen välissä; efekti valitaan if-ketjulla). Näkymä yksiselitteinen (lava + esiintyjä + yleisörivi). Ambient-efektit laukeavat ~110 framen välein, joten SDL:n audiojono ei kasaannu → ei rätinää.
- **`game_host.rgr`:** `playVoice` asettaa nyt vokaalisyntetisaattorin näytetaajuuden **laitteen taajuuteen**. SDL virittää `GameAudio`:n avattuun laitteeseen (esim. 48000); vokaalisyntillä on oma `GameAudio`, joten ilman tätä sen 44100 PCM soi väärällä nopeudella → rätinä.

## Testattu (headless)
- `comedy_club/index.tsx` latautuu ja ajaa ComponentEnginessä (es6): `perfX` liikkuu, `voicePlays` kasvaa oikein.
- `vocal_fx_runner_demo` + C++ `vocal_fx_selftest` (g++) läpäisevät.
- Katalogi listaa "Comedy Club" Games-kategoriaan oikealla `index.tsx`-polulla.

Huom: engine-puolen muutos (`game_host.rgr`) tulee voimaan vasta kun **SDL-binääri käännetään uudelleen** (`npm run engine:game-sdl:launcher`). Jos Pong yhä ilmestyy puhtaan uudelleenkäännöksen jälkeen, terminaalin `[game-engine] …`-tuloste paljastaa mitä polkua käynnistetään.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q)_