### PR TITLE
engine(vocal-fx): voiceEvent() helper + vocal reactions in ylos2 (chuckle/gasp)

### DIFF
--- a/gallery/game_engine/games/ylos2/index.tsx
+++ b/gallery/game_engine/games/ylos2/index.tsx
@@ -11,7 +11,7 @@
 // game_native_types.ts) so the TS -> Ranger emitter produces precisely-typed
 // structs (and the C++ backend can pick narrow storage where marked).
 
-import { soundEvent, particleEvent, rumbleEvent, musicScoreEvent, stopMusicEvent } from "../../scripting/game_helpers";
+import { soundEvent, voiceEvent, particleEvent, rumbleEvent, musicScoreEvent, stopMusicEvent } from "../../scripting/game_helpers";
 
 // --- Core game structs (annotated so the native emitter unifies their types) ---
 
@@ -1214,6 +1214,7 @@ function applyEnemyHits(pl: Player, owner: i32, enemies: Enemy[], events: GameEv
         out = stompBounce(out, e.y);
         events.push(soundEvent("brick"));
         events.push(soundEvent("bounce"));
+        events.push(voiceEvent("chuckle"));
         events.push(rumbleForOwner(owner, 90, 18000));
       } else {
         if (kind == "hurt") {
@@ -1226,6 +1227,7 @@ function applyEnemyHits(pl: Player, owner: i32, enemies: Enemy[], events: GameEv
             out = respawnPlayer(owner);
             died = 1;
             events.push(soundEvent("lose"));
+            events.push(voiceEvent("gasp"));
             events.push(rumbleForOwner(owner, 280, 40000));
           }
         }

--- a/gallery/game_engine/scripting/game_helpers.tsx
+++ b/gallery/game_engine/scripting/game_helpers.tsx
@@ -32,6 +32,12 @@ export function soundEvent(id) {
   return { kind: "playSound", id: id };
 }
 
+/** Build a playVoice event for a predefined vocal effect (game_vocal_fx.rgr):
+ *  laugh, giggle, chuckle, sigh, gasp, cough, cheer, boo, hmm, huh, yawn. */
+export function voiceEvent(id) {
+  return { kind: "playVoice", id: id };
+}
+
 /** Start music from a registered score id (resources kind: music). */
 export function musicEvent(id, loop?) {
   const amount = loop === false ? 0 : 1;


### PR DESCRIPTION
Kohde: **master**. Testaa vokaaliefektejä oikeassa pelissä (ylos2), jonka ääniefektit jo toimivat — samalla event-putkella kuin `soundEvent`, vain `kind:"playVoice"`.

## Miksi
comedy_club-demossa ei kuulunut ääntä. C++-syntetisaattori tuottaa kuitenkin kunnollista PCM:ää (varmistin: laugh peak 10247, sigh 9043, gasp 10246 — ~−10 dBFS), ja vokaalipolku menee **täsmälleen saman** `sink.onSynthPlay → gfx_audio_queue`-reitin kuin `playSound`. Todennäköisin syy: SDL-binääri oli vanha (ei sisältänyt `playVoice`-kytkentää). Kytkemällä efekti peliin, jonka äänet jo toimivat, eristämme ongelman.

## Muutokset
- **`game_helpers.tsx`:** `voiceEvent(id)` → `{ kind: "playVoice", id }` (peilaa `soundEvent`:ia). id:t: laugh/giggle/chuckle/sigh/gasp/cough/cheer/boo/hmm/huh/yawn.
- **`games/ylos2/index.tsx`:** tyytyväinen **"chuckle"** kun pelaaja tömäyttää vihollisen, **"gasp"** kun pelaaja saa osuman. Molemmat ovat harvoja gameplay-tapahtumia → klipit eivät mene päällekkäin.

## Testaus
1. `git pull` ja **käännä binääri uudelleen** (tärkeää — engine-kytkentä on binäärissä):
   ```bash
   npm run engine:game-sdl:run:ylos2
   ```
2. Hyppää vihollisen päälle → **naurahdus**; ota osuma → **haukahdus (gasp)**.

Jos kuulet `brick`/`bounce`-äänet mutta et vokaaliefektiä, kyseessä on aito reititysbugi vokaalipolussa (jota en pysty toistamaan ilman SDL:ää — silloin auttaisi terminaalin tuloste). Jos kuulet molemmat, aiempi hiljaisuus oli vanha binääri.

Verifioitu headless: ylos2-runner lataa + ajaa 400 framea muuttumatta (entities=56).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q)_