### PR TITLE
Fix non-ASCII text crash + Pyörretris polish (fast drop, sounds, score, no ghost)

### DIFF
--- a/gallery/game_engine/games/pyorretris/game.as
+++ b/gallery/game_engine/games/pyorretris/game.as
@@ -16,7 +16,7 @@
 // Controls (edge mask in OFF_INPUT): LEFT/RIGHT move, UP rotates, DOWN soft
 // drops, ACTION hard drops (and restarts after a top-out).
 // ============================================================================
-import { abiRead, abiWrite, spriteReset, drawSprite, hostRect } from "@ranger/game";
+import { abiRead, abiWrite, spriteReset, drawSprite, playSound, hostRect } from "@ranger/game";
 
 // ---- shared RGW1 header offsets (host -> guest / guest -> host) ----
 const OFF_MAGIC: i32 = 0;
@@ -145,6 +145,7 @@ function spawnPiece(): void {
   spinDeg = 0;
   if (collides(curPiece, curRot, curPx, curPy) == 1) {
     gameOver = 1;
+    playSound(4);
   }
 }
 
@@ -161,6 +162,10 @@ function lockPiece(): void {
     }
     k = k + 1;
   }
+  // every placed piece is worth points, so the score climbs even without a
+  // line clear ("more pieces -> more points").
+  score = score + 12;
+  playSound(2);
 }
 
 function spawnConfetti(r: i32, c: i32, v: i32): void {
@@ -221,6 +226,7 @@ function clearLines(): void {
     if (cleared == 4) { pts = 800; }
     score = score + pts * level;
     level = idiv(lines, 10) + 1;
+    playSound(3);
   }
 }
 
@@ -235,18 +241,21 @@ function tryRotate(): void {
   if (collides(curPiece, nrot, curPx, curPy) == 0) {
     curRot = nrot;
     spinDeg = 90;
+    playSound(1);
     return;
   }
   if (collides(curPiece, nrot, curPx - 1, curPy) == 0) {
     curPx = curPx - 1;
     curRot = nrot;
     spinDeg = 90;
+    playSound(1);
     return;
   }
   if (collides(curPiece, nrot, curPx + 1, curPy) == 0) {
     curPx = curPx + 1;
     curRot = nrot;
     spinDeg = 90;
+    playSound(1);
   }
 }
 
@@ -354,24 +363,6 @@ function drawLocked(): void {
   }
 }
 
-function drawGhost(): void {
-  if (gameOver == 1) { return; }
-  let gy: i32 = curPy;
-  while (collides(curPiece, curRot, curPx, gy + 1) == 0) {
-    gy = gy + 1;
-  }
-  if (gy <= curPy) { return; }
-  computeCells(curPiece, curRot, curPx, gy);
-  let k: i32 = 0;
-  while (k < 4) {
-    const r: i32 = AROW[k];
-    if (r >= 0) {
-      drawCellBlock(ACOL[k], r, T_GHOST, 0);
-    }
-    k = k + 1;
-  }
-}
-
 function drawActive(): void {
   if (gameOver == 1) { return; }
   computeCells(curPiece, curRot, curPx, curPy);
@@ -409,7 +400,6 @@ function renderScene(): void {
   spriteReset();
   drawWell();
   drawLocked();
-  drawGhost();
   drawActive();
   drawConfetti();
   drawNext();
@@ -473,7 +463,9 @@ export function update(): void {
   if ((inp & IN_LEFT) != 0) { tryMove(0 - 1); }
   if ((inp & IN_RIGHT) != 0) { tryMove(1); }
   if ((inp & IN_UP) != 0) { tryRotate(); }
-  if ((inp & IN_DOWN) != 0) { stepDown(); }
+  // Down = fast drop: snap the piece straight down into place (much quicker than
+  // waiting for gravity). Action/hard-drop does the same.
+  if ((inp & IN_DOWN) != 0) { hardDrop(); }
   if ((inp & IN_ACT) != 0) { hardDrop(); }
 
   if (gameOver == 0) {

--- a/gallery/game_engine/games/pyorretris/game.info
+++ b/gallery/game_engine/games/pyorretris/game.info
@@ -1,4 +1,4 @@
-name=Pyörretris
+name=Pyorretris
 engine=as
 render=sprites
 module=game.as

--- a/gallery/game_engine/scripting/as_abi_bridge.rgr
+++ b/gallery/game_engine/scripting/as_abi_bridge.rgr
@@ -39,6 +39,11 @@ class AsAbiBridge {
     def sprAng:[int]       ; rotation in degrees (clockwise, Y-down)
     def sprFrame:[int]     ; sheet frame column (0 for rect templates)
 
+    ; guest sound queue: the guest calls playSound(id) for one-shot effects; the
+    ; host drains + clears it each frame (so the guest never resets it). Small
+    ; integer ids the host maps to synth voices (see AsSpriteScene.soundName).
+    def sndQueue:[int]
+
     ; RGU1 builder state
     def nodeCount:int 0
     def propCount:int 0
@@ -373,6 +378,22 @@ class AsAbiBridge {
         return v
     }
 
+    ; ---- guest sound queue -------------------------------------------------
+    fn sndPush:void (id:int) {
+        push sndQueue id
+    }
+    fn sndCount:int () {
+        return (array_length sndQueue)
+    }
+    fn sndAt:int (i:int) {
+        def v:int (itemAt sndQueue i)
+        return v
+    }
+    fn sndClear:void () {
+        def a:[int]
+        sndQueue = a
+    }
+
     ; ---- RGP1 pose block (host->guest streaming input provider) -------------
     ; A separate, independently-versioned block (the pose counterpart of RGU1).
     ; The host PoseProvider writes a fresh sample each frame BEFORE update(); the
@@ -481,6 +502,7 @@ class AsAbiBridge {
         if (name == "hostRect") { return true }
         if (name == "spriteReset") { return true }
         if (name == "drawSprite") { return true }
+        if (name == "playSound") { return true }
         if (name == "posePresent") { return true }
         if (name == "poseGesture") { return true }
         if (name == "poseCount") { return true }
@@ -680,6 +702,10 @@ class AsAbiBridge {
         }
         if (name == "drawSprite") {
             this.sprPush((this.argInt(args 0)) (this.argInt(args 1)) (this.argInt(args 2)) (this.argInt(args 3)) (this.argInt(args 4)))
+            return (EvalValue.null())
+        }
+        if (name == "playSound") {
+            this.sndPush((this.argInt(args 0)))
             return (EvalValue.null())
         }
         if (name == "posePresent") {

--- a/gallery/game_engine/scripting/as_sprite_runner.rgr
+++ b/gallery/game_engine/scripting/as_sprite_runner.rgr
@@ -18,14 +18,18 @@
 
 Import "../framebuffer.rgr"
 Import "./as_source_runner.rgr"
+Import "./game_audio.rgr"
 
 class AsSpriteScene {
     def runner:AsSourceRunner (new AsSourceRunner)
     def canvas:SoftCanvas (new SoftCanvas)
+    def audio:GameAudio (new GameAudio)
+    def audioOn:boolean false
     def pw:int 480
     def ph:int 270
     def timeMs:int 0
     def loaded:boolean false
+    def OFF_SCORE:int 40
 
     ; rect templates by declaration index (only rect templates are drawn here;
     ; sheet templates fall back to a plain grey square so a game still renders).
@@ -49,6 +53,31 @@ class AsSpriteScene {
         pw = w
         ph = h
         canvas.init(w h)
+        audio.init()
+    }
+
+    ; Map a guest sound id to a synth voice. The guest emits small ints via
+    ; playSound(id); the host owns the voice choice.
+    fn soundName:string (id:int) {
+        if (id == 1) { return "blip" }     ; move / rotate
+        if (id == 2) { return "brick" }    ; piece locks
+        if (id == 3) { return "win" }      ; line cleared
+        if (id == 4) { return "lose" }     ; top-out / game over
+        return "blip"
+    }
+
+    ; Drain the guest's one-shot sound queue and play each (host clears it, so the
+    ; guest never resets it). No-op audio when no sink is wired (headless).
+    fn drainSounds:void () {
+        def n:int (runner.bridge.sndCount())
+        if audioOn {
+            def i 0
+            while (i < n) {
+                audio.play((this.soundName((runner.bridge.sndAt(i)))))
+                i = (i + 1)
+            }
+        }
+        runner.bridge.sndClear()
     }
 
     fn setBg:void (r:int g:int b:int) {
@@ -123,6 +152,7 @@ class AsSpriteScene {
         runner.abiWrite(OFF_TIME timeMs)
         runner.abiWrite(OFF_INPUT (this.inputMask(up down left right action)))
         runner.callUpdate()
+        this.drainSounds()
     }
 
     fn frameMask:void (dtMs:int mask:int) {
@@ -134,6 +164,7 @@ class AsSpriteScene {
         runner.abiWrite(OFF_TIME timeMs)
         runner.abiWrite(OFF_INPUT mask)
         runner.callUpdate()
+        this.drainSounds()
     }
 
     ; Draw the guest's current sprite list to the canvas (rotated blocks).
@@ -158,6 +189,65 @@ class AsSpriteScene {
             }
             i = (i + 1)
         }
+        this.drawScoreHud()
+    }
+
+    ; ---- score HUD: a compact 3x5 block-font readout of OFF_SCORE ----
+    fn drawScoreHud:void () {
+        def score:int (runner.abiRead(OFF_SCORE))
+        if (score < 0) { score = 0 }
+        this.drawInt(score 12 14 4 236 224 120)
+    }
+
+    fn drawInt:void (value:int x:int y:int s:int r:int g:int b:int) {
+        def digits:[int]
+        if (value == 0) {
+            push digits 0
+        } {
+            def v:int value
+            while (v > 0) {
+                def d:int (v - (idiv v 10) * 10)
+                push digits d
+                v = (idiv v 10)
+            }
+        }
+        def n:int (array_length digits)
+        def i 0
+        while (i < n) {
+            def d:int (itemAt digits (n - 1 - i))
+            this.drawDigit(d (x + (i * (s * 4))) y s r g b)
+            i = (i + 1)
+        }
+    }
+
+    fn drawDigit:void (d:int x:int y:int s:int r:int g:int b:int) {
+        def bits:string (this.digitBits(d))
+        def row 0
+        while (row < 5) {
+            def col 0
+            while (col < 3) {
+                def idx ((row * 3) + col)
+                if ((substring bits idx (idx + 1)) == "1") {
+                    canvas.fillRect((x + (col * s)) (y + (row * s)) s s r g b)
+                }
+                col = (col + 1)
+            }
+            row = (row + 1)
+        }
+    }
+
+    fn digitBits:string (d:int) {
+        if (d == 0) { return "111101101101111" }
+        if (d == 1) { return "010110010010111" }
+        if (d == 2) { return "111001111100111" }
+        if (d == 3) { return "111001111001111" }
+        if (d == 4) { return "101101111001001" }
+        if (d == 5) { return "111100111001111" }
+        if (d == 6) { return "111100111101111" }
+        if (d == 7) { return "111001010010010" }
+        if (d == 8) { return "111101111101111" }
+        if (d == 9) { return "111101111001111" }
+        return "000000000000000"
     }
 
     fn raw:buffer () {

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -1018,6 +1018,8 @@ class GameSdlRunner {
             print ("[game-engine] sprite game load failed: " + asPath)
             return
         }
+        scene.audio.setSink((new SdlGameAudioSink))
+        scene.audioOn = true
         print ("[game-engine] sprite game: " + asPath)
         currentScriptPath = asPath
         currentGamePath = asPath

--- a/gallery/pdf_writer/src/fonts/TrueTypeFont.rgr
+++ b/gallery/pdf_writer/src/fonts/TrueTypeFont.rgr
@@ -343,7 +343,7 @@ class TrueTypeFont {
         
         ; Format 0: Byte encoding table (simple, limited to 256 chars)
         if (cmapFormat == 0) {
-            if (charCode < 256) {
+            if ((charCode >= 0) && (charCode < 256)) {
                 return (this.readUInt8(cmapOffset + 6 + charCode))
             }
         }
@@ -422,8 +422,12 @@ class TrueTypeFont {
     }
     
     fn getCharWidth:int (charCode:int) {
-        ; Get width for a character in font units
-        if (charWidthsLoaded && (charCode < 256)) {
+        ; Get width for a character in font units. The (charCode >= 0) guard is
+        ; essential: charAt can yield a NEGATIVE value for bytes >= 0x80 (a signed
+        ; char, e.g. UTF-8 lead byte 0xC3 -> -61), which passes "< 256" and would
+        ; index the 256-entry cache out of range (std::out_of_range on the native
+        ; build). Negative / >=256 codes fall through to the cmap glyph lookup.
+        if (charWidthsLoaded && (charCode >= 0) && (charCode < 256)) {
             return (itemAt charWidths charCode)
         }
         def glyphIdx:int (this.getGlyphIndex(charCode))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #252 (merged). Those improvements were pushed after #252 merged, so per the repo workflow they're moved onto this fresh branch off `master`.

## Engine fix: non-ASCII text crashed the native build

A game titled with `ä`/`ö` crashed the SDL launcher when opening its category:

```
libc++abi: terminating due to uncaught exception of type std::out_of_range: vector
```

Root cause: `TrueTypeFont.getCharWidth` (and the format-0 cmap lookup) indexed a 256-entry table with only a `charCode < 256` guard, but `charAt` returns a **negative** value for bytes ≥ 0x80 (signed `char`; a UTF-8 lead byte `0xC3` → `-61`). `-61` passes `< 256` and indexes the vector out of range → `std::out_of_range` the instant any accented text is measured. Added the missing `charCode >= 0` guards so non-ASCII bytes fall through to the cmap glyph lookup instead of crashing.

Verified: the Tests menu with an `ö` title now runs instead of aborting.

## Pyörretris gameplay polish

- **Fast drop** — Down now hard-drops the piece straight into place (was a one-row soft drop).
- **Sounds** — new `playSound()` bridge call; the guest fires move/rotate, lock, line-clear and top-out cues. `AsSpriteScene` drains the queue through `GameAudio`, wired to the SDL host in `runSpriteGame`.
- **On-screen score** — every locked piece scores points (not just line clears); the runner draws the score as a 3×5 block-font readout.
- **No ghost** — removed the landing ghost so the game is less trivial.
- Display title is ASCII (`Pyorretris`) to render cleanly in the byte-wise menu; the engine no longer crashes on non-ASCII regardless.

## Testing

- `npm run engine:as:sprites` → **8/8 PASS** on the current `master` base.
- SDL host rebuilt (g++ + SDL2); Pyorretris runs headless (`SDL_VIDEODRIVER=dummy … game.as 120`, clean exit) and the Tests menu no longer crashes with a non-ASCII title.

## Note / follow-on

Full UTF-8 menu text (so `ä`/`ö` *render* correctly rather than just not crashing) would touch shared `pdf_writer` text code (PDF-regression risk), so it's intentionally left out here — the crash guard covers safety.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5f8f-37c2-7616-bd14-950bb8369962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5f8f-37c2-7616-bd14-950bb8369962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

