### PR TITLE
debug(vocal-fx): [VFX] logging across the audio path (temporary, for diagnosing silent playVoice)

### DIFF
--- a/gallery/game_engine/scripting/game_audio_sdl.rgr
+++ b/gallery/game_engine/scripting/game_audio_sdl.rgr
@@ -12,9 +12,12 @@ class SdlGameAudioSink extends GameAudioSink {
 
     fn onSynthPlay:void (soundId:string sampleRate:int sampleCount:int pcm:buffer) {
         def byteCount:int (sampleCount * 2)
+        print ("[VFX] SDL.onSynthPlay id=" + soundId + " rate=" + (to_string sampleRate) + " samples=" + (to_string sampleCount) + " bytes=" + (to_string byteCount) + " pcmLen=" + (to_string (buffer_length pcm)))
         if (byteCount <= 0) {
+            print ("[VFX] SDL.onSynthPlay SKIP (bytes<=0) id=" + soundId)
             return
         }
         gfx_audio_queue pcm byteCount)
+        print ("[VFX] SDL.onSynthPlay QUEUED id=" + soundId + " bytes=" + (to_string byteCount))
     }
 }

--- a/gallery/game_engine/scripting/game_vocal_fx.rgr
+++ b/gallery/game_engine/scripting/game_vocal_fx.rgr
@@ -477,6 +477,7 @@ class GameVocalFx {
     fn play:void (id:string sink:GameAudioSink) {
         playCount = (playCount + 1)
         lastId = id
+        print ("[VFX] vocalFx.play id=" + id + " hasAsset=" + (to_string (this.hasAsset(id))) + " rate=" + (to_string synth.sampleRate))
         if verbose {
             print ("[vocalfx] play " + id + " " + (this.tagFor(id)))
         }
@@ -494,7 +495,9 @@ class GameVocalFx {
             return
         }
         def rendered:ScoreVoiceRender (this.render(id))
+        print ("[VFX] vocalFx.play rendered id=" + id + " frames=" + (to_string rendered.frames) + " pcmLen=" + (to_string (buffer_length rendered.pcm)))
         if (rendered.frames <= 0) {
+            print ("[VFX] vocalFx.play ZERO frames id=" + id)
             return
         }
         sink.onSynthPlay(("voice:" + id) synth.sampleRate rendered.frames rendered.pcm)

--- a/gallery/ts_to_ranger/game_host.rgr
+++ b/gallery/ts_to_ranger/game_host.rgr
@@ -240,6 +240,9 @@ class GameHost {
         }
         if (e.kind == "playSound") {
             push soundsPlayed e.id
+            def hasAudioS:boolean false
+            if audio { hasAudioS = true }
+            print ("[VFX] handleEvent playSound id=" + e.id + " audio=" + (to_string hasAudioS))
             if audio {
                 def a:GameAudio (unwrap audio)
                 if (a.hasBuiltin(e.id)) {
@@ -253,6 +256,9 @@ class GameHost {
         }
         if (e.kind == "playVoice") {
             push voicesPlayed e.id
+            def hasAudioV:boolean false
+            if audio { hasAudioV = true }
+            print ("[VFX] handleEvent playVoice id=" + e.id + " audio=" + (to_string hasAudioV) + " hasEffect=" + (to_string (vocalFx.has(e.id))))
             if audio {
                 def a:GameAudio (unwrap audio)
                 this.wireVoice()
@@ -261,11 +267,14 @@ class GameHost {
                 ; synth has its own GameAudio, so mirror the rate or the PCM
                 ; plays back at the wrong speed and sounds like crackle.
                 vocalFx.synth.sampleRate = a.sampleRate
+                print ("[VFX] handleEvent playVoice routing id=" + e.id + " synthRate=" + (to_string vocalFx.synth.sampleRate))
                 if (vocalFx.has(e.id)) {
                     vocalFx.play(e.id a.sink)
                 } {
-                    if verbose { print ("[host] playVoice (unknown effect) " + e.id) }
+                    print ("[VFX] handleEvent playVoice UNKNOWN effect id=" + e.id)
                 }
+            } {
+                print ("[VFX] handleEvent playVoice NO AUDIO id=" + e.id)
             }
             if verbose { print ("[host] playVoice " + e.id) }
             return


### PR DESCRIPTION
Kohde: **master**. Väliaikainen diagnostiikka: `playVoice` ei tuota SDL-hostissa ääntä, vaikka `playSound` toimii. Tämä lokittaa **koko** ääniketjun (aina päällä, ei `verbose`-takana, prefix `[VFX]`), jotta terminaali näyttää tarkalleen missä vokaalipolku eroaa toimivista äänistä.

## Mitä lokitetaan (3 tiedostoa)
- `game_host.handleEvent` — `playSound` (id, audio) ja `playVoice` (id, audio, hasEffect, routing/synthRate, tai NO AUDIO / UNKNOWN).
- `game_vocal_fx.play` — id/hasAsset/rate, `rendered frames + pcmLen`, ja ZERO-frames-poistuma.
- `game_audio_sdl.SdlGameAudioSink.onSynthPlay` — id/rate/samples/bytes/pcmLen, SKIP (bytes<=0), ja **QUEUED** — ratkaiseva kohta (mikä oikeasti päätyy `gfx_audio_queue`:hun). Toimivat äänet: `id=blip/bounce/lose`; vokaali: `id=voice:gasp`.

## Näin testaat
Tämä haara on masterin päällä, jossa on **comedy_club** (laukoo vokaaliefektejä automaattisesti ~75 framen välein — ei tarvita edes pelaamista):
```bash
git pull
npm run engine:game-sdl:launcher   # avaa launcher → Games → Comedy Club
```
tai ylos2 (jos yhdistät #256:n). Kopioi kaikki `[VFX]`-rivit.

## Tulkinta
- `SDL.onSynthPlay QUEUED id=voice:gasp` näkyy mutta ääntä ei kuulu (ja `id=lose` kuuluu) → data/laite `gfx_sdl`:ssä.
- `vocalFx.play rendered` näkyy mutta EI `SDL.onSynthPlay id=voice:*` → sink-kutsu katoaa välissä.
- Ei `handleEvent playVoice` → eventti ei tule drainiin.

Headless (es6) -jälki menee jo läpi (`rendered frames=11466 pcmLen=22932`), joten koodi on oikein siihen asti; jäljellä on SDL-binäärin käyttäytyminen. **Peruuta poistamalla tämä commit** kun vika on löytynyt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q)_