### PR TITLE
fix(vocal-fx): silent voices in SDL host — hasAsset true on empty map (C++)

### DIFF
--- a/gallery/game_engine/scripting/game_audio_sdl.rgr
+++ b/gallery/game_engine/scripting/game_audio_sdl.rgr
@@ -12,12 +12,9 @@ class SdlGameAudioSink extends GameAudioSink {
 
     fn onSynthPlay:void (soundId:string sampleRate:int sampleCount:int pcm:buffer) {
         def byteCount:int (sampleCount * 2)
-        print ("[VFX] SDL.onSynthPlay id=" + soundId + " rate=" + (to_string sampleRate) + " samples=" + (to_string sampleCount) + " bytes=" + (to_string byteCount) + " pcmLen=" + (to_string (buffer_length pcm)))
         if (byteCount <= 0) {
-            print ("[VFX] SDL.onSynthPlay SKIP (bytes<=0) id=" + soundId)
             return
         }
         gfx_audio_queue pcm byteCount)
-        print ("[VFX] SDL.onSynthPlay QUEUED id=" + soundId + " bytes=" + (to_string byteCount))
     }
 }

--- a/gallery/game_engine/scripting/game_vocal_fx.rgr
+++ b/gallery/game_engine/scripting/game_vocal_fx.rgr
@@ -53,6 +53,11 @@ class GameVocalFx {
     ; Pre-rendered Voicebox WAV overrides (16-bit mono PCM), keyed by effect name.
     def assetPcm:[string:buffer]
     def assetFrames:[string:int]
+    ; Registered override ids. A string-list membership test is reliable on every
+    ; target; probing an int/buffer map for a MISSING key returns has_value=true
+    ; under the C++ backend (empty map), which wrongly sent every effect down the
+    ; empty-asset path -> 0 bytes -> silent voices in the SDL host.
+    def assetIds:[string]
 
     fn init:void () {
         synth.init()
@@ -443,14 +448,21 @@ class GameVocalFx {
     fn registerAsset:void (id:string pcm:buffer frames:int) {
         set assetPcm id pcm
         set assetFrames id frames
+        if (false == (this.hasAsset(id))) {
+            push assetIds id
+        }
     }
 
     fn hasAsset:boolean (id:string) {
-        ; Probe the int frames map, not the buffer map: optional<int> lowers to
-        ; a proper has_value flag on every target, while a map<string,buffer>
-        ; value is a bare vector in C++ and cannot be null-checked.
-        def fr@(optional):int (get assetFrames id)
-        return (!null? fr)
+        ; Explicit membership test — reliable on every target (see assetIds note).
+        def i 0
+        while (i < (array_length assetIds)) {
+            if ((itemAt assetIds i) == id) {
+                return true
+            }
+            i = (i + 1)
+        }
+        return false
     }
 
     ; Load a 16-bit mono PCM WAV (44-byte header) as an override for `id`.
@@ -477,27 +489,24 @@ class GameVocalFx {
     fn play:void (id:string sink:GameAudioSink) {
         playCount = (playCount + 1)
         lastId = id
-        print ("[VFX] vocalFx.play id=" + id + " hasAsset=" + (to_string (this.hasAsset(id))) + " rate=" + (to_string synth.sampleRate))
         if verbose {
             print ("[vocalfx] play " + id + " " + (this.tagFor(id)))
         }
         if (this.hasAsset(id)) {
-            ; Presence already confirmed via assetFrames (int optional). Unwrap
-            ; the buffer WITHOUT a null? check: `unwrap` is identity on the C++
-            ; vector, whereas null? would emit an invalid `vector != NULL`.
             def pcm@(optional):buffer (get assetPcm id)
             def fr@(optional):int (get assetFrames id)
             def frames:int 0
             if (!null? fr) {
                 frames = (unwrap fr)
             }
-            sink.onSynthPlay(("voice:" + id) synth.sampleRate frames (unwrap pcm))
-            return
+            ; Only use the override when it truly has audio; otherwise synthesize.
+            if (frames > 0) {
+                sink.onSynthPlay(("voice:" + id) synth.sampleRate frames (unwrap pcm))
+                return
+            }
         }
         def rendered:ScoreVoiceRender (this.render(id))
-        print ("[VFX] vocalFx.play rendered id=" + id + " frames=" + (to_string rendered.frames) + " pcmLen=" + (to_string (buffer_length rendered.pcm)))
         if (rendered.frames <= 0) {
-            print ("[VFX] vocalFx.play ZERO frames id=" + id)
             return
         }
         sink.onSynthPlay(("voice:" + id) synth.sampleRate rendered.frames rendered.pcm)

--- a/gallery/ts_to_ranger/game_host.rgr
+++ b/gallery/ts_to_ranger/game_host.rgr
@@ -240,9 +240,6 @@ class GameHost {
         }
         if (e.kind == "playSound") {
             push soundsPlayed e.id
-            def hasAudioS:boolean false
-            if audio { hasAudioS = true }
-            print ("[VFX] handleEvent playSound id=" + e.id + " audio=" + (to_string hasAudioS))
             if audio {
                 def a:GameAudio (unwrap audio)
                 if (a.hasBuiltin(e.id)) {
@@ -256,9 +253,6 @@ class GameHost {
         }
         if (e.kind == "playVoice") {
             push voicesPlayed e.id
-            def hasAudioV:boolean false
-            if audio { hasAudioV = true }
-            print ("[VFX] handleEvent playVoice id=" + e.id + " audio=" + (to_string hasAudioV) + " hasEffect=" + (to_string (vocalFx.has(e.id))))
             if audio {
                 def a:GameAudio (unwrap audio)
                 this.wireVoice()
@@ -267,14 +261,11 @@ class GameHost {
                 ; synth has its own GameAudio, so mirror the rate or the PCM
                 ; plays back at the wrong speed and sounds like crackle.
                 vocalFx.synth.sampleRate = a.sampleRate
-                print ("[VFX] handleEvent playVoice routing id=" + e.id + " synthRate=" + (to_string vocalFx.synth.sampleRate))
                 if (vocalFx.has(e.id)) {
                     vocalFx.play(e.id a.sink)
                 } {
-                    print ("[VFX] handleEvent playVoice UNKNOWN effect id=" + e.id)
+                    if verbose { print ("[host] playVoice (unknown effect) " + e.id) }
                 }
-            } {
-                print ("[VFX] handleEvent playVoice NO AUDIO id=" + e.id)
             }
             if verbose { print ("[host] playVoice " + e.id) }
             return


### PR DESCRIPTION
Kohde: **master**. Korjaa hiljaiset vokaaliefektit SDL-hostissa. Löydetty `[VFX]`-lokituksella (kiitos ajoista) — ei arvausta.

## Juurisyy
SDL-host on **C++**, jossa `get` tyhjästä `[string:int]`-mapista palauttaa optionaalin, jonka `has_value=true` **puuttuvalle avaimelle**. `hasAsset()` kysyi tuota mappia, joten se palautti `true` jokaiselle efektille, vaikka yhtään WAV-overridea ei ollut rekisteröity. `play()` meni asset-haaraan, haki 0-mittaisen bufferin ja antoi 0 tavua sinkille → `onSynthPlay` skippasi → hiljaisuus.

es6 palautti `false` (oikein) — siksi headless toimi mutta käännetty SDL-binääri oli hiljainen. Todiste lokista:
```
[VFX] vocalFx.play id=gasp hasAsset=true        ← väärin
[VFX] SDL.onSynthPlay id=voice:gasp samples=0 bytes=0 → SKIP
```

## Korjaus
- Rekisteröidyt override-id:t eksplisiittiseen string-listaan (`assetIds`); jäsenyys tarkistetaan iteroimalla — luotettava kaikilla backendeillä.
- `frames > 0` -suoja `play()`:ssä → tyhjä/puuttuva override palaa aina syntetisaattoriin.
- Poistettu väliaikainen `[VFX]`-lokitus (game_host, game_vocal_fx, game_audio_sdl) nyt kun syy on löytynyt.

## Verifioitu (g++ C++ ja es6)
```
hasAsset("gasp")=false
sinkSamples=11466 sinkBytes=22932   (oikea PCM sinkille)
```
SDL-hostissa tuo PCM menee nyt `gfx_audio_queue`:hun → nauru/huokaus/gasp/… kuuluvat.

## Testaa
```bash
git pull
npm run engine:game-sdl:run:ylos2   # tömäytä vihollinen → chuckle, ota osuma → gasp
# tai launcher → Games → Comedy Club (auto-laukoo efektejä)
```

Tämä korvaa debug-lokitus-PR:n (#259) — sen voi sulkea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q)_