### PR TITLE
engine(vocal-fx): human-voice WAV pipeline (auto-load real recordings) + more natural synth

### DIFF
--- a/gallery/game_engine/docs/VOCAL_FX.md
+++ b/gallery/game_engine/docs/VOCAL_FX.md
@@ -47,19 +47,33 @@ runner.setNativeBridge(bridge)
 
 Both routes share the same synth, WAV overrides, and audio sink.
 
-## Overriding the synth with a real WAV
+## Getting genuinely human-sounding voices (real WAV overrides)
 
-Export a **16-bit mono WAV** and declare it as a `voice` resource; the host
-loads it instead of the synth:
+The built-in synth is a placeholder — formants + breath + jitter. It is
+recognisably "ha-ha", but it is **not** a human voice. For human-sounding
+laughter you drop in real recordings; the engine then plays the file instead of
+the synth, per effect id.
+
+1. **Generate** on your own machine (paralinguistic audio needs a model that
+   interprets the tags, e.g. [Voicebox](https://github.com/jamiepine/voicebox)
+   Chatterbox Turbo: `[laugh] [chuckle] [gasp] [cough] [sigh] [groan] …`). Any
+   source works — a Voicebox render, a recording, or a CC0 clip.
+2. **Convert** to **16-bit mono PCM WAV @ 44100 Hz** (the device rate; stereo is
+   auto-downmixed, other rates play at the wrong speed):
+   `ffmpeg -i in.wav -ac 1 -ar 44100 -sample_fmt s16 voices/laugh.wav`
+3. **Declare** it — `setupResources` auto-loads it (missing files fall back to
+   the synth, so nothing crashes):
 
 ```tsx
 function resources() {
-  return [{ kind: "voice", id: "laugh", path: "laugh.wav" }];
+  return [{ kind: "voice", id: "laugh", path: "voices/laugh.wav" }];
 }
 ```
 
-Then call `host.loadVoiceAsset("laugh")` after the game dir is set (or register
-programmatically with `GameVocalFx.registerAssetWav(id, dir, file)`).
+The WAV loader walks the RIFF chunks, so real files (with `LIST`/`fact`/…
+chunks before `data`) load fine. Programmatic API:
+`GameVocalFx.registerAssetWav(id, dir, file)` / `host.loadVoiceAsset(id)`.
+Any effect id without a WAV keeps the synth, so you can replace one at a time.
 
 ## Demo
 

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -636,7 +636,13 @@ class GameRunner {
             def arr:[EvalValue] res.arrayValue
             def i 0
             while (i < (array_length arr)) {
-                host.registerResource((this.resourceFromEval((itemAt arr i))))
+                def r:ResourceDefNative (this.resourceFromEval((itemAt arr i)))
+                host.registerResource(r)
+                ; Eagerly load a declared voice WAV override so a game only has to
+                ; drop the file in and declare { kind: "voice", id, path }.
+                if (r.kind == "voice") {
+                    host.loadVoiceAsset(r.id)
+                }
                 i = (i + 1)
             }
         }

--- a/gallery/game_engine/scripting/game_vocal_fx.rgr
+++ b/gallery/game_engine/scripting/game_vocal_fx.rgr
@@ -389,10 +389,15 @@ class GameVocalFx {
         }
         def pcm:buffer (buffer_alloc (frames * 2))
         def phase:double 0.0
+        def pluck:boolean (spec.envShape == "pluck")
         def i 0
         while (i < frames) {
             def t:double ((to_double i) / (to_double frames))
             def pitch:double (spec.basePitchHz + ((spec.endPitchHz - spec.basePitchHz) * t))
+            ; Jitter: slow incommensurate wobble = vocal-fold micro-variation.
+            ; Without it a steady tone reads as a synth/harmonica, not a voice.
+            def jit:double (1.0 + (0.014 * (synth.sampleSine((to_double i) / 301.0))) + (0.008 * (synth.sampleSine((to_double i) / 173.0))))
+            pitch = (pitch * jit)
             if (spec.vibrato > 0.0) {
                 def vib:double (1.0 + (spec.vibrato * (synth.sampleSine((to_double i) / 210.0))))
                 pitch = (pitch * vib)
@@ -400,6 +405,7 @@ class GameVocalFx {
             def burstIdx:int (to_int (i / periodFrames))
             def localFrame:int (i - (burstIdx * periodFrames))
             def env:double 0.0
+            def breathNow:double spec.breath
             if (localFrame < burstFrames) {
                 def bt:double ((to_double localFrame) / (to_double burstFrames))
                 env = (this.burstEnv(spec.envShape bt))
@@ -407,15 +413,27 @@ class GameVocalFx {
                 def sag:double (1.0 - (0.12 * (to_double burstIdx)))
                 if (sag < 0.4) { sag = 0.4 }
                 env = (env * sag)
+                if (pluck) {
+                    ; Each syllable ("ha") starts high and falls — natural contour.
+                    def arc:double (1.0 + (0.22 * (1.0 - bt) * (1.0 - bt)))
+                    pitch = (pitch * arc)
+                    ; Breathy [h] aspiration at the onset, easing into the vowel.
+                    if (bt < 0.20) {
+                        def hmix:double (1.0 - (bt / 0.20))
+                        breathNow = (spec.breath + ((1.0 - spec.breath) * hmix))
+                    }
+                }
             }
             def voiced:double (this.vowelSample(spec.vowel phase))
             def noise:double (synth.sampleInstrument("drums" phase i))
-            def sample:double ((voiced * (1.0 - spec.breath)) + (noise * spec.breath))
+            def sample:double ((voiced * (1.0 - breathNow)) + (noise * breathNow))
             ; Clamp to unity: summed formants (and the shared sine table's Taylor
             ; overshoot near wrap) can exceed 1.0, which would hit the rail.
             if (sample > 1.0) { sample = 1.0 }
             if (sample < -1.0) { sample = -1.0 }
-            def amp:double (sample * spec.volume * env * 0.92 * 32767.0)
+            ; Shimmer: small amplitude wobble (also anti-synthetic).
+            def shim:double (1.0 + (0.06 * (synth.sampleSine((to_double i) / 97.0))))
+            def amp:double (sample * spec.volume * env * shim * 0.92 * 32767.0)
             ; short fade at the very end to avoid a click
             if (i >= (frames - 12)) {
                 def tail:int (frames - i)
@@ -465,21 +483,89 @@ class GameVocalFx {
         return false
     }
 
-    ; Load a 16-bit mono PCM WAV (44-byte header) as an override for `id`.
+    ; Little-endian readers over a raw file buffer.
+    fn rdU16:int (b:buffer off:int) {
+        return ((buffer_get b off) + ((buffer_get b (off + 1)) * 256))
+    }
+
+    fn rdU32:int (b:buffer off:int) {
+        def v0:int (buffer_get b off)
+        def v1:int (buffer_get b (off + 1))
+        def v2:int (buffer_get b (off + 2))
+        def v3:int (buffer_get b (off + 3))
+        return (v0 + (v1 * 256) + (v2 * 65536) + (v3 * 16777216))
+    }
+
+    ; True when the 4 bytes at off equal the given ASCII codes (chunk tag).
+    fn tag4:boolean (b:buffer off:int a:int c:int d:int e:int) {
+        if ((buffer_get b off) != a) { return false }
+        if ((buffer_get b (off + 1)) != c) { return false }
+        if ((buffer_get b (off + 2)) != d) { return false }
+        if ((buffer_get b (off + 3)) != e) { return false }
+        return true
+    }
+
+    ; Load a 16-bit PCM WAV as an override for `id`. Walks the RIFF chunks (so a
+    ; real file with LIST/fact/etc. before `data` still works), downmixes stereo
+    ; to mono. Best at the audio device rate (44100 Hz) — a different rate plays
+    ; back at the wrong speed because the SDL device rate is fixed.
     fn registerAssetWav:boolean (id:string dir:string file:string) {
         def raw:buffer (buffer_read_file dir file)
         def total:int (buffer_length raw)
-        if (total <= 44) {
-            return false
+        if (total < 44) { return false }
+        if (false == (this.tag4(raw 0 82 73 70 70))) { return false }   ; "RIFF"
+        if (false == (this.tag4(raw 8 87 65 86 69))) { return false }   ; "WAVE"
+        def channels:int 1
+        def bits:int 16
+        def dataOff:int -1
+        def dataLen:int 0
+        def p:int 12
+        while ((p + 8) <= total) {
+            def csize:int (this.rdU32(raw (p + 4)))
+            def body:int (p + 8)
+            if (this.tag4(raw p 102 109 116 32)) {    ; "fmt "
+                channels = (this.rdU16(raw (body + 2)))
+                bits = (this.rdU16(raw (body + 14)))
+            }
+            if (this.tag4(raw p 100 97 116 97)) {      ; "data"
+                dataOff = body
+                dataLen = csize
+            }
+            def adv:int csize
+            if ((bit_and adv 1) == 1) { adv = (adv + 1) }
+            p = (body + adv)
         }
-        def dataBytes:int (total - 44)
-        def pcm:buffer (buffer_alloc dataBytes)
-        def i 0
-        while (i < dataBytes) {
-            buffer_set pcm i (buffer_get raw (44 + i))
-            i = (i + 1)
+        if (dataOff < 0) { return false }
+        if (bits != 16) { return false }
+        if (channels < 1) { channels = 1 }
+        if ((dataOff + dataLen) > total) { dataLen = (total - dataOff) }
+        def frameBytes:int (2 * channels)
+        def frames:int (to_int (dataLen / frameBytes))
+        if (frames < 1) { return false }
+        def pcm:buffer (buffer_alloc (frames * 2))
+        def fi 0
+        while (fi < frames) {
+            def base:int (dataOff + (fi * frameBytes))
+            def sum:int 0
+            def ch 0
+            while (ch < channels) {
+                def o:int (base + (ch * 2))
+                def sv:int ((buffer_get raw o) + ((buffer_get raw (o + 1)) * 256))
+                if (sv >= 32768) { sv = (sv - 65536) }
+                sum = (sum + sv)
+                ch = (ch + 1)
+            }
+            def m:int (to_int (sum / channels))
+            if (m > 32767) { m = 32767 }
+            if (m < -32768) { m = -32768 }
+            def uv:int m
+            if (uv < 0) { uv = (65536 + uv) }
+            def outOff:int (fi * 2)
+            buffer_set pcm outOff (bit_and uv 255)
+            buffer_set pcm (outOff + 1) (bit_and (to_int (uv / 256)) 255)
+            fi = (fi + 1)
         }
-        this.registerAsset(id pcm (to_int (dataBytes / 2)))
+        this.registerAsset(id pcm frames)
         return true
     }
 

--- a/gallery/ts_to_ranger/game_host.rgr
+++ b/gallery/ts_to_ranger/game_host.rgr
@@ -221,6 +221,11 @@ class GameHost {
             dir = (substring full 0 slash)
             file = (substring full (slash + 1) (strlen full))
         }
+        ; Missing file is fine — the synth supplies the effect. Never crash the
+        ; game just because a declared override WAV has not been dropped in yet.
+        if (false == (file_exists dir file)) {
+            return false
+        }
         return (vocalFx.registerAssetWav(id dir file))
     }
 


### PR DESCRIPTION
Kohde: **master**. Tavoite: aidosti ihmismäiset peliäänet.

## Ympäristön rajoite (rehellisesti)
En voi generoida oikeaa ihmisääntä tässä CI-hiekkalaatikossa: HuggingFace ja kaikki ääni-/CC0-palvelut ovat **saavuttamattomissa** (`000`), vain pypi/github läpäisevät proxyn. Docker-Voicebox tarvitsee samat HF-mallit. Geneerinen TTS ei osaa naurua/huokauksia (ne ovat paralingvistisiä). **Aito ihmisääni voidaan siis tuottaa vain sinun koneellasi** (missä Docker + mallit toimivat). Siksi tein enginestä sellaisen, että se **kuluttaa oikeat WAV-tiedostot** kun ne tiputat sisään — ja paransin syntetisaattoria fallbackina.

## Oikean WAV:n tuki (ihmisääni)
- `registerAssetWav` kävelee nyt **RIFF-chunkit** (kestää `LIST`/`fact`/… ennen `data`:aa), lukee `fmt` (kanavat/bitit), **downmiksaa stereo→mono**. (Ennen: naiivi kiinteä 44-tavun headeri.)
- `game_runtime.setupResources` **lataa automaattisesti** jokaisen `{ kind:"voice", id, path }` -overriden — peli vain julistaa sen ja tiputtaa tiedoston.
- `game_host.loadVoiceAsset` tarkistaa `file_exists` ensin: puuttuva override **ei kaada peliä**, vaan putoaa syntetisaattoriin.
- Formaatti: **16-bit mono PCM WAV @ 44100 Hz**. Workflow (Voicebox → ffmpeg → drop-in) dokumentoitu `VOCAL_FX.md`:ssä.

## Syntetisaattorin parannus (yhä placeholder, mutta vähemmän "harmonikka")
- Hengitys-**[h]**-aluke joka tavuun, sulautuu vokaaliin.
- Per-tavu **pitch-kaari** (alkaa korkealta, laskee).
- **Jitter** (äänenkorkeus) + **shimmer** (amplitudi) = ääniraon mikrovaihtelu.

## Testattu (g++ C++ ja es6)
- Renderöityy ilman leikkautumista; WAV-lataaja lukee oikeat **mono JA stereo** -tiedostot molemmilla backendeillä.
- Puuttuva override → synth-fallback ilman kaatumista.
- `vocal_fx`- ja `ylos2`-runnerit ennallaan (11/11 efektiä).

## Näin lisäät ihmisäänet
1. Generoi Voiceboxilla (Chatterbox Turbo, tagi tekstinä) omalla koneellasi.
2. `ffmpeg -i in.wav -ac 1 -ar 44100 -sample_fmt s16 voices/laugh.wav`
3. `resources()` → `{ kind:"voice", id:"laugh", path:"voices/laugh.wav" }` — latautuu automaattisesti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q)_