### PR TITLE
game_engine: runtime-correctness fixes (fixed-step, input edges, transactional .as load, double entities)

### DIFF
--- a/gallery/game_engine/IDEAL_TODO.md
+++ b/gallery/game_engine/IDEAL_TODO.md
@@ -300,28 +300,26 @@ regression test (Phase 5.x / roadmap delta-time + gamepad gaps).
   true active count can get it, while drop-in co-op stays the default.
   *Test (if refined):* `availableSlots == 2` while `activePlayerCount == 1` until a
   join input arrives — and the always-joinable P2 path is unchanged.
-- [ ] **R.3 (High) Input-edge sync omits left/right.**
-  `game_sdl_runner.rgr:558-564` — `syncInputEdges()` reseeds quit/up/down/action
-  but not `prevLeftHeld`/`prevRightHeld`, which ARE used as edges at 981-998. After
-  a mode switch / view open, a held left/right registers as a phantom fresh press.
-  Fix: seed `prevLeftHeld`/`prevRightHeld` from the mask too; route every edge
-  through one shared sync helper so this can't drift again.
-  *Test:* switching mode while left/right is held produces no phantom edge.
-- [ ] **R.4 (High) Failed `.as` load leaves the runner half-switched.**
-  `game_sdl_runner.rgr:448-460` — `loadAsAt` sets `useWasmRunner`/`useWasmPhysics =
-  true` and replaces `wasmPhysicsRunner` with a fresh instance BEFORE
-  `loadAsGame()`; on failure it prints and returns, leaving WASM-physics mode
-  active with a dead runner and the old game gone. Fix: load transactionally —
-  build a candidate in a local, load+validate, and only on success tear down the
-  old backend and flip the active flags; on failure keep prior state untouched.
-  (Same shape applies to the sprite/stream/wasm loaders that set flags first.)
-  *Test:* a failing `.as` load preserves the previous runner and mode.
-- [ ] **R.5 (Medium) `entities()` called twice per scene setup.**
-  `game_runtime.rgr:1079` and `1090` — `setupScene` calls the script's `entities()`
-  once for activation/seed and again for retained-sprite spawn; a side-effecting or
-  non-deterministic function makes the two diverge. Fix: call once, reuse the one
-  `EvalValue` for both activation and retained spawn.
-  *Test:* `entities()` is invoked exactly once per scene init.
+- [x] **R.3 (High) Input-edge sync omits left/right.** Fixed:
+  `game_sdl_runner.syncInputEdges()` now reseeds `prevLeftHeld` (mask bit 16) and
+  `prevRightHeld` (bit 32) alongside quit/up/down/action, so a button held across a
+  mode switch / view open is no longer re-counted as a fresh press. Mirrors the
+  existing up/down/action pattern with the bits the edge readers actually use.
+  *Check:* `game_sdl_runner.rgr` compiles Ranger→C++. (Runtime edge behaviour needs
+  the SDL build to exercise; the fix is a direct mirror of the working edges.)
+- [x] **R.4 (High) Failed `.as` load leaves the runner half-switched.** Fixed:
+  `loadAsAt` now loads **transactionally** — it builds a `candidate`
+  `WasmPhysicsRunner` in a local, `init`s + `loadAsGame`s + `setupScene`s it
+  WITHOUT touching active state, and only on success swaps `wasmPhysicsRunner =
+  candidate` and flips the mode flags. A failed load returns with the prior runner
+  and every mode flag untouched.
+  *Check:* `game_sdl_runner.rgr` compiles Ranger→C++.
+- [x] **R.5 (Medium) `entities()` called twice per scene setup.** Fixed:
+  `setupScene` now calls the script's `entities()` exactly once, hoisting the
+  result into `spawnEntities` and reusing it for both activation/seed and the
+  retained-sprite spawn — a side-effecting/non-deterministic `entities()` can no
+  longer diverge between the two uses.
+  *Check:* `game_runtime.rgr` compiles Ranger→C++.
 - [ ] **R.6 (Medium) Runner boolean-flag soup permits illegal states.**
   `game_sdl_runner.rgr` routes TSX / WASM / `.as` / UI / sprite / stream /
   split-screen through many independent booleans (`useWasmRunner`,

--- a/gallery/game_engine/IDEAL_TODO.md
+++ b/gallery/game_engine/IDEAL_TODO.md
@@ -328,14 +328,34 @@ regression test (Phase 5.x / roadmap delta-time + gamepad gaps).
   backend interface (`load`/`update`/`draw`/`resize`/`unload`); split
   `game_sdl_runner` into per-backend adapters. (Complements the §7 provider work.)
   *Check:* mode is a single value; a second backend is an adapter, not new flags.
-- [ ] **R.7 (Medium) `auto` split-screen == `always`; `game.info` parsed by
-  `indexOf`.** `game_sdl_runner.rgr:645-649` — `shouldUseSplitScreen()` returns
-  true for both `"always"` and `"auto"` with no actual automatic condition, so the
-  name over-promises; and `game.info` is read in several places via substring
-  `indexOf`, fragile to whitespace/comments/false matches. Fix: give `auto` a real
-  predicate (e.g. players ≥ 2) or drop it; parse `game.info` once into a validated
-  key/value map against a known schema.
-  *Check:* `auto` differs from `always`; `game.info` has one typed parser.
+- [~] **R.7 Split-screen semantics — clarified with the maintainer; a second axis
+  added.** The review read `auto == always` as a bug. Per the maintainer it is
+  **not**: `"auto"` means the *engine* splits a single-player-authored game into
+  two panes/cameras with **zero game-side work** (`"always"` is an alias; every
+  shipped game uses `auto`). `dualPlayerMode` (a natively two-player game) already
+  short-circuits the split. Documented that in `shouldUseSplitScreen()`.
+  The real gap the maintainer surfaced is a **second, orthogonal axis** the config
+  couldn't express: the *world model* behind a split —
+  - **separate**: two independent sessions, one per pane (pinball — two unrelated
+    boards). Today's implicit behaviour for tsx games (`loadPanes(same, same)`).
+  - **shared**: one simulated world/physics viewed by two cameras following
+    different players (autopeli — one road+physics, two views). Today's implicit
+    behaviour for the wasm+physics split path (`WasmSplitScreenHost`, one `runner`).
+
+  Landed: a `splitWorld = shared | separate` field on `GameCatalogEntry`, parsed
+  from `game.info`, plus `GameCatalog.resolveSplitWorld(entry)` — an explicit value
+  wins, otherwise it infers `shared` for wasm+physics and `separate` otherwise, so
+  **today's behaviour is preserved** and the choice is now *decoupled from the
+  backend*.
+  *Check:* `game_split_world_demo.rgr` self-test — 6/6 (default inference for
+  wasm+physics/tsx, explicit override both ways, `game.info` parse);
+  `game_catalog.rgr` + `game_sdl_runner.rgr` compile Ranger→C++.
+  *Remaining (needs SDL build to verify):* route `loadGame` by `resolveSplitWorld`
+  instead of by backend, so a tsx game can request a shared world and a wasm game
+  separate sessions — i.e. make the split hosts honour the axis, not just record it.
+  (Note: `game.info` for these fields is already a clean `key=value` parser
+  (`parseInfoLine`), so 7b's "fragile `indexOf`" concern does not apply to them; the
+  raw-text `indexOf "engine=…"` fallback is the only substring path left.)
 - [ ] **R.8 (Medium) Script return values assigned without contract checks.**
   `game_runtime.rgr` — `update`'s return goes straight into `state`; a null/wrong
   type surfaces far from the cause. Fix: validate `update` / `initState` /

--- a/gallery/game_engine/IDEAL_TODO.md
+++ b/gallery/game_engine/IDEAL_TODO.md
@@ -278,15 +278,16 @@ all confirmed. These are the highest production risk today (the review's words:
 scripting idea"). Fix order follows the review's recommendation; each fix gets a
 regression test (Phase 5.x / roadmap delta-time + gamepad gaps).
 
-- [ ] **R.1 (High) Fixed-step loop runs one extra step + leaves accumulator
-  negative.** `game_runtime.rgr:1315-1326` — on `steps >= maxFixedSteps` it zeros
-  `timeAccumulator` but still runs `stepUpdate` and subtracts `fixedStepMs`, so it
-  executes `maxFixedSteps + 1` steps and exits with `timeAccumulator = -fixedStepMs`
-  (next frame may skip a step). Fix: `break` right after zeroing (run exactly
-  `maxFixedSteps`, leave accumulator at 0); ideally clamp the backlog before the
-  loop so `0 <= accumulator < fixedStepMs`.
-  *Test:* a large frame-dt runs ≤ `maxFixedSteps` updates and never leaves the
-  accumulator negative.
+- [x] **R.1 (High) Fixed-step loop runs one extra step + leaves accumulator
+  negative.** Fixed by extracting the scheduling into a pure planner
+  `scripting/game_fixed_step.rgr` (`FixedStep.plan` → `FixedStepPlan{steps,
+  residualMs}`): runs at most `maxSteps`, residual always in `[0, fixedStepMs)`
+  (or 0 when the backlog is dropped at the cap) — never `maxSteps+1`, never
+  negative. `game_runtime.frameWithInput` now calls the planner and loops
+  `plan.steps` times. The tested code IS the shipped code.
+  *Check:* `game_fixed_step_demo.rgr` self-test — 16/16 pass (incl. huge-dt caps at
+  exactly `maxSteps` with residual 0, the boundary 48/49/100ms cases, and no
+  negative residual); `game_runtime.rgr` compiles Ranger→C++.
 - [ ] **R.2 (Low / semantics — likely intended, NOT a bug) `playerCount = 2` in
   the 1-player branch.** `game_input.rgr:262` — `buildFromSdl(1)` builds a P2
   "join" mask and sets `playerCount = 2`. The review read this as a bug, but it is

--- a/gallery/game_engine/scripting/game_catalog.rgr
+++ b/gallery/game_engine/scripting/game_catalog.rgr
@@ -23,8 +23,19 @@ class GameCatalogEntry {
     def title:string ""
     def iconPath:string ""
     def entryPath:string ""
-    ; splitScreen: auto | always | never — host picks two-pane mode when supported
+    ; splitScreen: auto | always | never. "auto"/"always" both mean the ENGINE
+    ; splits the screen into two panes for a game authored from a single-player
+    ; perspective — the game itself does nothing. "never" = single pane.
     def splitScreen:string ""
+    ; splitWorld: shared | separate — the world model behind a two-pane split.
+    ;   separate = two INDEPENDENT game sessions, one per pane (e.g. pinball: two
+    ;              unrelated boards). This is the default for tsx games.
+    ;   shared   = ONE simulated world/physics viewed by two cameras following
+    ;              different players (e.g. autopeli: one road + physics, two views).
+    ;              This is the default for wasm+physics games.
+    ; When empty the host infers it from the backend (see resolveSplitWorld) to keep
+    ; today's behaviour; setting it explicitly decouples the choice from the engine.
+    def splitWorld:string ""
     ; autoscale: true | false — host renders at full width and scales to pane (default true)
     def autoscale:string ""
     ; Relative path to a single-player script for split-screen panes (from games dir).
@@ -197,6 +208,26 @@ class GameCatalog {
         return entry.soloScript
     }
 
+    ; Resolve the world model for a two-pane split: "shared" (one world/physics,
+    ; two cameras) or "separate" (two independent sessions). An explicit
+    ; splitWorld= wins; otherwise infer from the backend to preserve today's
+    ; behaviour — wasm+physics games share a world (autopeli), everything else
+    ; runs separate sessions (pinball and the other tsx games).
+    fn resolveSplitWorld:string (entry:GameCatalogEntry) {
+        if (entry.splitWorld == "shared") {
+            return "shared"
+        }
+        if (entry.splitWorld == "separate") {
+            return "separate"
+        }
+        if (entry.engine == "wasm") {
+            if (entry.physics == "true") {
+                return "shared"
+            }
+        }
+        return "separate"
+    }
+
     fn parseInfoLine:void (entry:GameCatalogEntry line:string) {
         def eq:int (indexOf line "=")
         if (eq < 0) {
@@ -214,6 +245,9 @@ class GameCatalog {
         }
         if (key == "splitScreen") {
             entry.splitScreen = val
+        }
+        if (key == "splitWorld") {
+            entry.splitWorld = val
         }
         if (key == "autoscale") {
             entry.autoscale = val

--- a/gallery/game_engine/scripting/game_fixed_step.rgr
+++ b/gallery/game_engine/scripting/game_fixed_step.rgr
@@ -1,0 +1,53 @@
+; ==============================================================================
+; game_fixed_step — pure fixed-timestep scheduling (IDEAL_TODO R.1)
+; ==============================================================================
+;
+; The former inline loop in game_runtime.frameWithInput ran ONE step too many and
+; left the accumulator NEGATIVE: on `steps >= maxFixedSteps` it zeroed the
+; accumulator but still ran `stepUpdate` and subtracted `fixedStepMs`, so it
+; executed maxFixedSteps+1 steps and exited with `timeAccumulator = -fixedStepMs`
+; (the next frame could then skip a step).
+;
+; This extracts the scheduling into a PURE function so it is unit-testable and the
+; tested code is the shipped code. Contract:
+;   * run at most `maxSteps` fixed steps per frame (spiral-of-death guard);
+;   * the residual accumulator is always in [0, fixedStepMs) on a normal frame,
+;     and 0 when the backlog was dropped at the cap — never negative;
+;   * fixedStepMs <= 0 means "no fixed step" (caller runs a single variable step).
+; ==============================================================================
+
+class FixedStepPlan {
+    def steps:int 0        ; how many fixed steps to run this frame
+    def residualMs:int 0   ; accumulator to carry to the next frame (>= 0)
+}
+
+class FixedStep {
+    ; Pure planner. Given the carried accumulator and this frame's dt, decide how
+    ; many fixed steps to run and what accumulator remains.
+    sfn plan:FixedStepPlan (accumulatorMs:int dtMs:int fixedStepMs:int maxSteps:int) {
+        def out:FixedStepPlan (new FixedStepPlan)
+        if (fixedStepMs <= 0) {
+            out.steps = 0
+            out.residualMs = 0
+            return out
+        }
+        def acc:int (accumulatorMs + dtMs)
+        def n:int 0
+        while (true) {
+            if (acc < fixedStepMs) {
+                break
+            }
+            if (n >= maxSteps) {
+                ; Hit the cap with backlog still pending: drop it so the sim runs
+                ; slightly slow instead of spiralling. Residual = 0, never negative.
+                acc = 0
+                break
+            }
+            acc = (acc - fixedStepMs)
+            n = (n + 1)
+        }
+        out.steps = n
+        out.residualMs = acc
+        return out
+    }
+}

--- a/gallery/game_engine/scripting/game_fixed_step_demo.rgr
+++ b/gallery/game_engine/scripting/game_fixed_step_demo.rgr
@@ -1,0 +1,80 @@
+; Headless self-test for the fixed-step planner (IDEAL_TODO R.1). Run:
+;   RANGER_LIB=compiler/Lang.rgr:lib/stdops.rgr node bin/output.js -es6 \
+;     gallery/game_engine/scripting/game_fixed_step_demo.rgr \
+;     -d=gallery/game_engine/scripting -o=game_fixed_step_demo.js -nodecli \
+;   && node gallery/game_engine/scripting/game_fixed_step_demo.js
+
+Import "./game_fixed_step.rgr"
+
+class StepCheck {
+    def passed:int 0
+    def failed:int 0
+    fn ok:void (name:string cond:boolean) {
+        if cond {
+            passed = (passed + 1)
+            print ("  PASS " + name)
+        } {
+            failed = (failed + 1)
+            print ("  FAIL " + name)
+        }
+    }
+}
+
+class GameFixedStepDemo {
+    sfn m@(main):void () {
+        def c:StepCheck (new StepCheck)
+        print "FixedStep.plan self-test  (fixedStepMs=16, maxSteps=3)"
+
+        ; Normal frame at ~60fps: one step, small residual carried.
+        def p1:FixedStepPlan (FixedStep.plan(0 16 16 3))
+        c.ok("16ms dt -> 1 step" (p1.steps == 1))
+        c.ok("16ms dt -> 0 residual" (p1.residualMs == 0))
+
+        ; Sub-step dt accumulates without running.
+        def p2:FixedStepPlan (FixedStep.plan(0 10 16 3))
+        c.ok("10ms dt -> 0 steps" (p2.steps == 0))
+        c.ok("10ms dt -> 10 residual" (p2.residualMs == 10))
+        def p3:FixedStepPlan (FixedStep.plan(10 10 16 3))
+        c.ok("carried 10 + 10 -> 1 step" (p3.steps == 1))
+        c.ok("carried 10 + 10 -> 4 residual" (p3.residualMs == 4))
+
+        ; Two steps' worth of dt, under the cap.
+        def p4:FixedStepPlan (FixedStep.plan(0 40 16 3))
+        c.ok("40ms dt -> 2 steps" (p4.steps == 2))
+        c.ok("40ms dt -> 8 residual" (p4.residualMs == 8))
+
+        ; THE BUG: a huge frame must run EXACTLY maxSteps (3), not 4, and the
+        ; residual must be 0 (never negative). 1000ms would be 62 steps unclamped.
+        def big:FixedStepPlan (FixedStep.plan(0 1000 16 3))
+        c.ok("huge dt -> exactly maxSteps (3)" (big.steps == 3))
+        c.ok("huge dt -> residual dropped to 0 (not negative)" (big.residualMs == 0))
+
+        ; Exactly at the cap boundary: 48ms = 3 full steps, residual 0, no drop.
+        def edge:FixedStepPlan (FixedStep.plan(0 48 16 3))
+        c.ok("48ms -> 3 steps, 0 residual" ((edge.steps == 3) && (edge.residualMs == 0)))
+
+        ; 49ms = 3*16 + 1: exactly 3 steps with a 1ms residual (< fixedStepMs, so
+        ; NOT a cap-drop — the loop exits normally). Residual stays 1, never negative.
+        def over:FixedStepPlan (FixedStep.plan(0 49 16 3))
+        c.ok("49ms -> 3 steps" (over.steps == 3))
+        c.ok("49ms -> residual 1 (normal exit, not negative)" (over.residualMs == 1))
+
+        ; 100ms = 3 steps consume 48ms, leaving 52ms backlog >= fixedStepMs at the
+        ; cap -> the real spiral-of-death drop: residual forced to 0.
+        def cap:FixedStepPlan (FixedStep.plan(0 100 16 3))
+        c.ok("100ms -> capped at 3 steps" (cap.steps == 3))
+        c.ok("100ms -> backlog dropped to 0" (cap.residualMs == 0))
+
+        ; No fixed step configured.
+        def none:FixedStepPlan (FixedStep.plan(5 16 0 3))
+        c.ok("fixedStepMs<=0 -> 0 steps, 0 residual" ((none.steps == 0) && (none.residualMs == 0)))
+
+        print "======================================"
+        print (("RESULT: " + (to_string c.passed) + " passed, ") + ((to_string c.failed) + " failed"))
+        if (c.failed == 0) {
+            print "ALL PASS"
+        } {
+            print "SOME FAILED"
+        }
+    }
+}

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -1075,11 +1075,16 @@ class GameRunner {
         this.applyCamera()
         this.applyPhysics()
         state = (engine.callFunction("initState" (EvalValue.null())))
+        ; Call the script's entities() EXACTLY ONCE per scene setup and reuse the
+        ; result for both activation/seeding and retained-sprite spawn. Calling it
+        ; twice let a side-effecting or non-deterministic function diverge between
+        ; the two uses (IDEAL_TODO R.5).
         def hasEntitiesFn:boolean (this.scriptHasFunction("entities"))
+        def spawnEntities:EvalValue (EvalValue.null())
         if (hasEntitiesFn) {
-            def spawn:EvalValue (engine.callFunction("entities" (EvalValue.null())))
-            entityStore.activateFromScript(spawn)
-            entityStore.seedWorldEntities(state spawn)
+            spawnEntities = (engine.callFunction("entities" (EvalValue.null())))
+            entityStore.activateFromScript(spawnEntities)
+            entityStore.seedWorldEntities(state spawnEntities)
         }
         this.syncBackgroundFromState()
         if (this.multiScreenMode()) {
@@ -1088,8 +1093,7 @@ class GameRunner {
         } {
             def sprites:EvalValue (engine.callFunction("sprites" (EvalValue.null())))
             if (hasEntitiesFn) {
-                def spawn:EvalValue (engine.callFunction("entities" (EvalValue.null())))
-                entities = (entityStore.spawnRetained(spawn sprites spriteRenderer))
+                entities = (entityStore.spawnRetained(spawnEntities sprites spriteRenderer))
             } {
                 if (sprites.isArray()) {
                     def arr:[EvalValue] sprites.arrayValue

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -24,6 +24,7 @@ Import "../../ts_to_ranger/game_host.rgr"
 Import "./game_audio.rgr"
 Import "./game_image_loader.rgr"
 Import "./game_input.rgr"
+Import "./game_fixed_step.rgr"
 Import "./game_composite_bridge.rgr"
 Import "./game_static_bg_bridge.rgr"
 Import "./game_particles.rgr"
@@ -1310,21 +1311,19 @@ class GameRunner {
 
     fn frameWithInput:void (dtMs:int snap:GameInputSnapshot) {
         if (fixedStepMs > 0) {
-            timeAccumulator = (timeAccumulator + dtMs)
-            def steps:int 0
-            while (timeAccumulator >= fixedStepMs) {
-                if (steps >= maxFixedSteps) {
-                    ; Spiral-of-death guard: on a slow device (e.g. Pi) a heavy
-                    ; frame would otherwise run many fixed steps, multiplying the
-                    ; interpreter/physics cost per rendered frame and locking fps
-                    ; low. Drop the backlog so the sim runs slightly slow instead.
-                    timeAccumulator = 0
-                }
+            ; Pure planner (game_fixed_step.rgr, IDEAL_TODO R.1): runs at most
+            ; maxFixedSteps steps and leaves the accumulator in [0, fixedStepMs) —
+            ; never one extra step, never a negative accumulator. The former inline
+            ; loop zeroed the accumulator on the cap but still ran + subtracted,
+            ; giving maxFixedSteps+1 steps and a negative residual.
+            def plan:FixedStepPlan (FixedStep.plan(timeAccumulator dtMs fixedStepMs maxFixedSteps))
+            def i:int 0
+            while (i < plan.steps) {
                 this.stepUpdate(fixedStepMs snap)
-                timeAccumulator = (timeAccumulator - fixedStepMs)
-                steps = (steps + 1)
+                i = (i + 1)
             }
-            if (steps == 0) {
+            timeAccumulator = plan.residualMs
+            if (plan.steps == 0) {
                 this.syncFromState()
             }
             return

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -445,23 +445,29 @@ class GameSdlRunner {
 
     ; Load an interpreted .as game folder — reuses the wasm physics/render path
     ; (the ABI is identical); only the guest is an interpreted .as file.
+    ; Load transactionally (IDEAL_TODO R.4): build + validate a CANDIDATE runner
+    ; without touching active state; only after it loads do we swap the runner and
+    ; flip the mode flags. A failed load previously left useWasmRunner/Physics=true
+    ; with the old runner already discarded — a half-switched dead state.
     fn loadAsAt:void (asPath:string) {
+        def dir:string (this.dirOf(asPath))
+        def candidate:WasmPhysicsRunner (new WasmPhysicsRunner)
+        candidate.init(pw ph)
+        this.presentLoadingScreen("LOADING .AS")
+        if ((candidate.loadAsGame(dir)) == false) {
+            print ("[as] load failed (prior game kept): " + dir)
+            return
+        }
+        candidate.setupScene()
+        def sdlHost:SdlGameHost (new SdlGameHost)
+        this.wireWasmAudio(candidate.audio sdlHost)
+        candidate.host = sdlHost
+        ; --- commit: the candidate loaded, now swap in and flip modes ---
+        wasmPhysicsRunner = candidate
         useSpriteRunner = false
         useStreamRunner = false
         useWasmRunner = true
         useWasmPhysics = true
-        def dir:string (this.dirOf(asPath))
-        wasmPhysicsRunner = (new WasmPhysicsRunner)
-        wasmPhysicsRunner.init(pw ph)
-        this.presentLoadingScreen("LOADING .AS")
-        if ((wasmPhysicsRunner.loadAsGame(dir)) == false) {
-            print ("[as] load failed: " + dir)
-            return
-        }
-        wasmPhysicsRunner.setupScene()
-        def sdlHost:SdlGameHost (new SdlGameHost)
-        this.wireWasmAudio(wasmPhysicsRunner.audio sdlHost)
-        wasmPhysicsRunner.host = sdlHost
         currentScriptPath = asPath
         currentGamePath = asPath
         inMenu = false
@@ -555,11 +561,17 @@ class GameSdlRunner {
 
     ; After script swap, match edge state to keys still held (avoids double Q:
     ; game exit on Q then immediate menu quit while the key is still down).
+    ; Reseed every edge's "previously held" state from the current poll mask, so a
+    ; button already held across a mode switch / view open is NOT re-counted as a
+    ; fresh press. Must cover ALL edges the runner reads: left(16)/right(32) were
+    ; missing, so a held left/right produced a phantom edge (IDEAL_TODO R.3).
     fn syncInputEdges:void () {
         def m:int (gfx_poll_mask)
         prevQuitHeld = ((bit_and m 8) != 0)
         prevUpHeld = ((bit_and m 1) != 0)
         prevDownHeld = ((bit_and m 2) != 0)
+        prevLeftHeld = ((bit_and m 16) != 0)
+        prevRightHeld = ((bit_and m 32) != 0)
         prevActionHeld = ((bit_and m 4) != 0)
     }
 

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -647,6 +647,16 @@ class GameSdlRunner {
         splitAutoscale = (this.resolveSplitAutoscale(entry))
     }
 
+    ; Whether the ENGINE should split the screen into two panes for a game
+    ; authored from a single-player perspective (the game does nothing itself).
+    ;   never  -> single pane.
+    ;   auto   -> engine auto-splits a single-player game into two panes/cameras.
+    ;   always -> same as auto (kept as an alias; no game currently uses it).
+    ; This decides WHETHER to split; the world model (shared one-world vs two
+    ; separate sessions) is a separate axis resolved from game.info splitWorld
+    ; (GameCatalog.resolveSplitWorld) — today shared for wasm+physics (autopeli),
+    ; separate for tsx (pinball). dualPlayerMode short-circuits: a game that is
+    ; natively two-player handles both players itself, so the engine does not split.
     fn shouldUseSplitScreen:boolean () {
         if (dualPlayerMode) {
             return false

--- a/gallery/game_engine/scripting/game_split_world_demo.rgr
+++ b/gallery/game_engine/scripting/game_split_world_demo.rgr
@@ -1,0 +1,67 @@
+; Headless self-test for split-screen world-model resolution (IDEAL_TODO R.7). Run:
+;   RANGER_LIB=compiler/Lang.rgr:lib/stdops.rgr node bin/output.js -es6 \
+;     gallery/game_engine/scripting/game_split_world_demo.rgr \
+;     -d=gallery/game_engine/scripting -o=game_split_world_demo.js -nodecli \
+;   && node gallery/game_engine/scripting/game_split_world_demo.js
+
+Import "./game_catalog.rgr"
+
+class SplitWorldCheck {
+    def passed:int 0
+    def failed:int 0
+    fn ok:void (name:string cond:boolean) {
+        if cond {
+            passed = (passed + 1)
+            print ("  PASS " + name)
+        } {
+            failed = (failed + 1)
+            print ("  FAIL " + name)
+        }
+    }
+}
+
+class GameSplitWorldDemo {
+    sfn entry:GameCatalogEntry (engine:string physics:string splitWorld:string) {
+        def e:GameCatalogEntry (new GameCatalogEntry)
+        e.engine = engine
+        e.physics = physics
+        e.splitWorld = splitWorld
+        return e
+    }
+
+    sfn m@(main):void () {
+        def c:SplitWorldCheck (new SplitWorldCheck)
+        def cat:GameCatalog (new GameCatalog)
+        print "GameCatalog.resolveSplitWorld self-test"
+
+        ; --- default inference (splitWorld empty), preserves today's behaviour ---
+        ; wasm + physics (autopeli) -> shared one world, two cameras.
+        c.ok("wasm+physics default -> shared"
+            ((cat.resolveSplitWorld((GameSplitWorldDemo.entry("wasm" "true" "")))) == "shared"))
+        ; wasm without physics -> separate sessions.
+        c.ok("wasm no-physics default -> separate"
+            ((cat.resolveSplitWorld((GameSplitWorldDemo.entry("wasm" "false" "")))) == "separate"))
+        ; tsx (pinball etc.) -> separate independent sessions.
+        c.ok("tsx default -> separate"
+            ((cat.resolveSplitWorld((GameSplitWorldDemo.entry("tsx" "false" "")))) == "separate"))
+
+        ; --- explicit splitWorld overrides the backend inference ---
+        c.ok("explicit shared on a tsx game -> shared"
+            ((cat.resolveSplitWorld((GameSplitWorldDemo.entry("tsx" "false" "shared")))) == "shared"))
+        c.ok("explicit separate on wasm+physics -> separate"
+            ((cat.resolveSplitWorld((GameSplitWorldDemo.entry("wasm" "true" "separate")))) == "separate"))
+
+        ; --- parse: splitWorld arrives from game.info as key=value ---
+        def e:GameCatalogEntry (new GameCatalogEntry)
+        cat.parseInfoLine(e "splitWorld=shared")
+        c.ok("game.info splitWorld=shared parsed" (e.splitWorld == "shared"))
+
+        print "======================================"
+        print (("RESULT: " + (to_string c.passed) + " passed, ") + ((to_string c.failed) + " failed"))
+        if (c.failed == 0) {
+            print "ALL PASS"
+        } {
+            print "SOME FAILED"
+        }
+    }
+}


### PR DESCRIPTION
## What & why

Follow-up to #267. That PR's `IDEAL_TODO.md` folded in an external static review that surfaced a class of **runtime state-management bugs** (Phase R) orthogonal to the ABI-parity work. This PR fixes the concrete ones, each re-verified against source with a fix that keeps the tested code = shipped code.

## Fixes

**R.1 (High) — fixed-step loop ran one step too many + left a negative accumulator.**
`game_runtime.frameWithInput` zeroed `timeAccumulator` on `steps >= maxFixedSteps` but still ran `stepUpdate` and subtracted, so it executed `maxFixedSteps+1` steps and exited with `timeAccumulator = -fixedStepMs`. Extracted the scheduling into a **pure planner** `scripting/game_fixed_step.rgr` (`FixedStep.plan`): at most `maxSteps`, residual always in `[0, fixedStepMs)` — never `maxSteps+1`, never negative.

**R.3 (High) — input-edge sync forgot left/right.**
`syncInputEdges()` reseeded quit/up/down/action but not `prevLeftHeld`/`prevRightHeld`, which *are* used as edges — a held left/right across a mode switch registered as a phantom press. Now reseeds both (mask bits 16/32).

**R.4 (High) — a failed `.as` load left the runner half-switched.**
`loadAsAt` set the WASM-physics mode flags and replaced `wasmPhysicsRunner` *before* `loadAsGame()`; on failure it left a dead half-switched state. Now loads **transactionally**: builds a `candidate` runner in a local, loads + `setupScene`s it without touching active state, and only on success swaps the runner and flips the flags. A failure keeps the prior game intact.

**R.5 (Medium) — `entities()` called twice per scene setup.**
`setupScene` now calls the script's `entities()` once, hoists the result into `spawnEntities`, and reuses it — a side-effecting/non-deterministic function can no longer diverge between activation and retained-sprite spawn.

**R.7 — split-screen world-model option (shared vs separate).**
Clarified with the maintainer: `auto` split is **not** a bug — it means the engine splits a single-player-authored game into two panes/cameras with zero game-side work (`always` is an alias). The real gap was a second, orthogonal axis the config couldn't express — the **world model**:
- *separate*: two independent sessions per pane (pinball); today's implicit tsx behaviour.
- *shared*: one physics world viewed by two cameras following different players (autopeli); today's implicit wasm+physics behaviour.

Added `splitWorld = shared | separate` to `GameCatalogEntry` (parsed from `game.info`) + `GameCatalog.resolveSplitWorld` — explicit value wins, else infers `shared` for wasm+physics and `separate` otherwise, **preserving today's behaviour** while decoupling the choice from the backend. Wiring the split hosts to honour the axis (a tsx game requesting a shared world, etc.) is a tracked follow-up needing the SDL build.

## Not in this PR

- **R.2** reclassified in #267 as **intended drop-in co-op** (deliberately not "fixed").
- **R.6** (RunnerMode enum + per-backend adapters) and **R.8** (script-return contract checks) remain tracked in `IDEAL_TODO.md`.

## Verification

- New self-tests: `game_fixed_step_demo.rgr` **16/16**, `game_split_world_demo.rgr` **6/6**.
- Full engine self-test suite: **8 tests, 93 assertions, 0 failing**.
- `game_runtime.rgr`, `game_sdl_runner.rgr`, `game_catalog.rgr` compile **Ranger→C++**.
- The interpreted `.as` autopeli physics demo still **runs** (car moves under control) — no regression.

SDL-only runtime paths (input edges, `.as` load, the split hosts) need the SDL/native build to exercise end-to-end, which isn't available here; the fixes are direct mirrors of working code and compile on the native target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)