### PR TITLE
docs(game_engine): split IDEAL_API into V1/V2/host per ABI review

### DIFF
--- a/gallery/game_engine/ABI_V1.md
+++ b/gallery/game_engine/ABI_V1.md
@@ -1,0 +1,545 @@
+# ABI_V1 — the shipped Ranger game-engine ABI (normative)
+
+**Status of this document: NORMATIVE.** This file describes *exactly* the byte
+contract that ships and runs today. If an implementer needs to know "what is the
+current, binding guest/host contract", it is this file and the generated headers
+under [`wasm/`](./wasm/). Nothing here is aspirational.
+
+- Rationale and motivation for these shapes live in [`IDEAL.md`](./IDEAL.md).
+- Proposed layouts, breaking changes, and everything not yet shipped live in
+  [`ABI_V2_PROPOSAL.md`](./ABI_V2_PROPOSAL.md) — **do not implement against those
+  as if they were current.**
+- Host-side Ranger interfaces that are *not* a byte-level ABI (providers, scene
+  seam, registries) live in [`HOST_ARCHITECTURE.md`](./HOST_ARCHITECTURE.md).
+- Shared conventions and the status legend are in [`IDEAL_API.md`](./IDEAL_API.md).
+
+**Source of truth precedence.** When this document and a generated header under
+[`wasm/`](./wasm/) disagree, **the header wins** and this document has a bug to
+fix. The header is machine-checkable; prose is not. `IDEAL.md` never overrides a
+shipped byte layout — it explains intent only.
+
+**Cross-reference notation.** `API §x` refers to a section of *this* file or of
+`ABI_V2_PROPOSAL.md` (stated which). `IDEAL §x` refers to `IDEAL.md`. `HOST §x`
+refers to `HOST_ARCHITECTURE.md`. A bare `§` is never used.
+
+Every symbol and field below is tagged **[SHIPPED]** (present in a `wasm/*.h`
+header and honoured by the runtime) or **[RESERVED]** (a defined slot/constant
+that ships in the header but is not yet acted on by the runtime — safe to write,
+currently ignored on read). Anything that would be **[PROPOSED]** is not in this
+file; it is in `ABI_V2_PROPOSAL.md`.
+
+---
+
+## API §1. Concurrency & ownership model (as shipped)
+
+This is the single most important section for a correct implementation, and the
+one the ABI historically under-specified. The shipped blocks do **not** share one
+uniform model; there are two, and they differ in whether a `revision` seqlock is
+present.
+
+### API §1.1 Two shipped patterns
+
+| Pattern | Blocks | Writer(s) | Reader | Synchronisation |
+|---------|--------|-----------|--------|-----------------|
+| **A — turn-based, single-threaded, no seqlock** | RGW1, RGSP1 | both host and guest write *different words of the same block*, but never at the same time | the other party | frame turn order (below); **no** `revision` word exists |
+| **B — cross-thread, single-writer, seqlock** | RGP1, RGIN, RGU1 | exactly one party writes the whole block | the other party, possibly on another thread | a `revision` seqlock word |
+
+**There is no shipped block in which two parties write concurrently.** Pattern A
+blocks are mixed-writer but strictly ordered within a frame; pattern B blocks
+have a single writer.
+
+### API §1.2 Pattern A: RGW1 / RGSP1 turn order (normative)
+
+RGW1 and RGSP1 are one linear-memory block each, driven by a single host thread
+that calls the guest synchronously. Per frame the host runs this exact order:
+
+```
+1. host writes its header words   (RGW1: dt_ms, time_ms, input, input_p2;
+                                    RGSP1: dt_ms, time_ms, char_count, input,
+                                    input_p2, view_w, view_h, catalog ids)
+2. host calls guest update()/tick() — SYNCHRONOUS, host is blocked
+3.   guest reads host words, writes its words
+       (RGW1: body_count + bodies[], impulses[], contacts[], events[], scalars;
+        RGSP1: slot_count + slots[], mode)
+4. update() returns
+5. host reads the guest words it needs (and RGSP1 host MAY write slot.frame back)
+```
+
+Because step 2 is synchronous and single-threaded, **neither party ever reads a
+word while the other is writing it**, and no seqlock is needed. A conforming host
+MUST NOT run the guest's `update()` concurrently with its own writes to the same
+block. A conforming host MUST NOT retain a guest pointer past `update()` return.
+
+Ownership per word is fixed and documented in the layout tables (API §3): a word
+is either host-owned or guest-owned; the other party treats it as read-only.
+
+> **[Known divergence — resolved in ABI_V2_PROPOSAL API §V2-1]** The shared
+> convention (`IDEAL_API` status legend, `IDEAL §2.3`) recommends offset 12 be a
+> `revision` seqlock word for *new* blocks. RGW1 and RGSP1 predate that rule and
+> use **offset 12 = `dt_ms`** (a host-written scalar). This is intentional and
+> correct for pattern A, which needs no seqlock. Do not add a seqlock read to
+> RGW1/RGSP1 — offset 12 is `dt_ms`, full stop.
+
+### API §1.3 Pattern B: RGP1 / RGIN / RGU1 seqlock (normative)
+
+These blocks have a single writer that may run on a different thread from the
+reader (pose from a camera/AI worker; input from an OS input thread; UI read by a
+render thread). They carry a `revision` word and use a **seqlock**:
+
+- **Writer**, before touching payload: `revision += 1` (now **odd** = writing).
+  After the payload is fully written: `revision += 1` (now **even** = stable).
+- **Reader**: read `revision` (r1); if odd, retry. Copy the payload. Read
+  `revision` again (r2); if `r1 != r2` or either is odd, retry.
+
+`revision` is a `u32` and wraps; readers MUST compare for equality, never
+ordering. The word offset differs by block and MUST be read from the constant,
+not assumed:
+
+| Block | `revision` offset | Writer | Reader |
+|-------|-------------------|--------|--------|
+| RGP1 | 12 (`RG_POSE_OFF_REVISION`) | host | guest |
+| RGIN | 12 (`RG_IN_OFF_REVISION`) | host | guest |
+| RGU1 | 8 (`RG_UI_OFF_REVISION`) | guest | host |
+
+RGU1's `revision` is *also* a change-token: the guest bumps it only when rendered
+content changes, so the host may skip re-parsing an unchanged document (`IDEAL
+§2.3`). Both roles are served by the same monotone bump; the odd/even seqlock read
+still applies during the bump.
+
+> The shipped memory-ordering guarantee is **"single host thread, synchronous
+> guest calls" for pattern A** and **"seqlock with full copy between matched even
+> revisions" for pattern B.** The ABI does not yet specify C11 `memory_order`
+> tags; a host that publishes pattern-B blocks across real threads MUST use at
+> least release-on-writer-second-bump / acquire-on-reader-first-read fencing. A
+> precise atomics contract is proposed in `ABI_V2_PROPOSAL API §V2-7`.
+
+---
+
+## API §2. Lifecycle & capability handshake (shipped subset)
+
+```
+load → negotiate → init → loop
+```
+
+### API §2.1 Handshake exports (guest → host) [SHIPPED]
+
+A guest MAY export these pure, side-effect-free probes. A host calls them after
+load and before the first `init()`/`update()`.
+
+| Export | Returns | Meaning |
+|--------|---------|---------|
+| `i32 rg_abi_version(void)` | RGW1 version the guest built against | absent ⇒ treat as v1 |
+| `i32 rg_ui_abi(void)` | `(RGU1_major << 16) \| RGU1_minor` | absent ⇒ guest uses no UI |
+| `i32 rg_required_caps(void)` | OR of `RG_WASM_HOST_CAP_*` the guest must have | absent ⇒ 0 |
+
+**Export-presence detection is required.** A legacy guest that omits
+`rg_abi_version` MUST read as v1, *not* as "exported and returned 0". The wasm3
+bridge provides `rg_wasm_has_export`; a host that cannot probe presence treats a
+`0` return as legacy v1 / caps 0.
+
+Recommended gate (run once, after load, before `init()`):
+
+```c
+ver  = has(rg_abi_version)   ? call(rg_abi_version)   : 1;   /* legacy = v1  */
+need = has(rg_required_caps) ? call(rg_required_caps) : 0;
+if (ver > RG_WASM_ABI_VERSION) reject("needs newer host");   /* layout gap   */
+if (need & ~RG_WASM_HOST_CAPS) reject("missing capability");  /* feature gap  */
+/* then init(): verify RGW1 magic + size, clamp every count to its MAX_*.    */
+```
+
+`RG_WASM_HOST_CAPS` (what this host advertises) is the OR of every attached
+provider's `capBit()` (`HOST §1`); it is a host-build value, not a header
+constant.
+
+### API §2.2 RGCQ typed capability query [SHIPPED]
+
+The soft-capability channel lives in the reserved RGW1 tail (`2304..2560`) so
+`RG_WASM_ABI_SIZE` is unchanged. A host that ignores it degrades to "nothing
+answered" and the guest reads its own defaults.
+
+```c
+#define RG_WASM_OFF_CAPQ         2304        /* block base                      */
+#define RG_WASM_CAPQ_MAGIC       0x51434752u /* 'RGCQ'                          */
+#define RG_WASM_CAPQ_OFF_MAGIC   0   /* u32 guest writes once declared          */
+#define RG_WASM_CAPQ_OFF_COUNT   4   /* u32 guest: number of requested keys (≤6)*/
+#define RG_WASM_CAPQ_OFF_READY   8   /* u32 host: 1 when answers are filled     */
+#define RG_WASM_CAPQ_OFF_POOL_USED 12/* u32 guest: key bytes used in the pool   */
+#define RG_WASM_CAPQ_ENTRIES     2320        /* entry[] base (CAPQ + 16)        */
+#define RG_WASM_CAPQ_MAX         6
+#define RG_WASM_CAPQ_ENTRY_SIZE  20
+#define RG_WASM_CAPQ_POOL        2440        /* string pool base, to ABI_SIZE   */
+/* entry (20 B): keyOff(u16) keyLen(u16) present(u8) type(u8) _(u16)
+ *               ival(i32) fval(f32) sLen(i32)
+ *   guest writes keyOff/keyLen (into the pool); host writes present/type/value. */
+#define RG_WASM_CAP_NONE 0u
+#define RG_WASM_CAP_BOOL 1u
+#define RG_WASM_CAP_INT  2u
+#define RG_WASM_CAP_FLOAT 3u
+#define RG_WASM_CAP_STRING 4u
+```
+
+Flow: host calls `rg_declare_queries()` → guest writes keys into the pool and sets
+`COUNT`/`POOL_USED`/`MAGIC`; host resolves each key, writes `present`/`type`/value,
+sets `READY = 1`; host calls `i32 rg_check_env()` → guest returns `0` (run) or
+`!= 0` (abort reason).
+
+> **[Known gap — resolved in ABI_V2_PROPOSAL API §V2-2]** For a **string** answer,
+> the entry carries `sLen` (byte length) but **no offset** to the value bytes. The
+> shipped runtime therefore answers `BOOL`/`INT`/`FLOAT` keys only; a `STRING`
+> answer has no defined location and MUST NOT be relied on. `type = STRING` is
+> **[RESERVED]** until V2 defines the value region.
+
+Key strings are a convention, not ABI (`"physics"`, `"screen.width"`, `"gpu"`,
+`"debugmode"`, …). Absence of `rg_declare_queries`/`rg_check_env` means the guest
+does not negotiate soft capabilities.
+
+---
+
+## API §3. Shipped blocks (byte layouts)
+
+Every block: 4-char little-endian `magic`, `version`, `size` in the first 12
+bytes; host validates magic + version + size and clamps every count to its
+`MAX_*` before trusting the block (untrusted-data discipline, `IDEAL §2.3`).
+
+### API §3.1 RGW1 — world / physics [SHIPPED]
+
+`wasm/wasm_game_abi.h`, magic `0x31574752` `'RGW1'`, **v1**, **2560 B**,
+`FP_SCALE 256`. Pattern **A** (API §1.2). Header (64 B), all `i32`:
+
+| Off | Field | Owner | Off | Field | Owner |
+|-----|-------|-------|-----|-------|-------|
+| 0 | `magic 'RGW1'` | guest | 32 | `impulse_count` | guest |
+| 4 | `version` | guest | 36 | `contact_count` | guest |
+| 8 | `size` (2560) | guest | 40 | `score` | guest |
+| **12** | **`dt_ms`** | **host** | 44 | `hits` | guest |
+| 16 | `time_ms` | host | 48 | `camera_y` | guest |
+| 20 | `input` | host | 52 | `event_count` | guest |
+| 24 | `input_p2` | host | 56 | `air_p1` *(generic guest scalar)* | guest |
+| 28 | `body_count` | guest | 60 | `air_p2` *(generic guest scalar)* | guest |
+
+Host-owned header words are exactly the four: `dt_ms`, `time_ms`, `input`,
+`input_p2`. `air_p1`/`air_p2` are **generic opaque guest scalars** the host
+transports without meaning (`IDEAL §2.1`) — the names are historical.
+
+Arrays (offsets derived from the `MAX_*`/`*_SIZE` constants in the header):
+
+| Array | Off | Count × stride | Record fields (`i32`) | Owner |
+|-------|-----|----------------|-----------------------|-------|
+| `bodies` | 64 | 32 × 24 | `x, y, angle, speed, angVel, flags` | guest |
+| `controls` | 832 | 32 × 16 | `ch0..ch3` (API §3.2) | host |
+| `impulses` | 1344 | 16 × 16 | `bodyIdx, ix, iy, _` | guest |
+| `contacts` | 1600 | 14 × 32 | API §3.3 | guest |
+| `events` | 2048 | 12 × 20 | `kind, sub, a, b, c` | guest |
+| RGCQ tail | 2304 | — | API §2.2 | mixed |
+
+`MAX_BODIES 32`, `MAX_IMPULSES 16`, `MAX_CONTACTS 14`, `MAX_EVENTS 12`. Counts are
+host-clamped to these. Event `kind`: `1 = sound` (`RG_WASM_EVENT_SOUND`),
+`2 = rumble`, `3 = particles`; `sub` and `a/b/c` are guest conventions.
+
+> `time_ms` is a **signed `i32`** in milliseconds. Wrap/overflow behaviour past
+> ~24.8 days is currently **undefined**; a widening/wrap contract is proposed in
+> `ABI_V2_PROPOSAL API §V2-9`. Guests should treat it as monotonic within a
+> session and diff it, not compare absolute values across long sessions.
+
+### API §3.2 RGW1 control record (16 B) [SHIPPED]
+
+Four opaque `i32` fixed-point channels; the guest names them in its own source.
+
+```c
+#define RG_WASM_CTRL_OFF_CH0  0
+#define RG_WASM_CTRL_OFF_CH1  4
+#define RG_WASM_CTRL_OFF_CH2  8
+#define RG_WASM_CTRL_OFF_CH3  12
+```
+
+Host side stays neutral: `readControlChannel(bodyIdx, ch)` — never
+`steer/throttle/brake/grip`.
+
+### API §3.3 RGW1 contact record (32 B) [SHIPPED]
+
+The record is **fully allocated to eight `i32` fields — there is no free slack.**
+
+```c
+#define RG_WASM_CT_OFF_BODYA    0   /* i32 body id code (guest convention)      */
+#define RG_WASM_CT_OFF_BODYB    4   /* i32 body id code                         */
+#define RG_WASM_CT_OFF_PHASE    8   /* i32 RG_WASM_CONTACT_PHASE_*              */
+#define RG_WASM_CT_OFF_IMPULSE  12  /* i32 normal impulse (fp)                  */
+#define RG_WASM_CT_OFF_X        16  /* i32 contact point x (fp)                 */
+#define RG_WASM_CT_OFF_Y        20  /* i32 contact point y (fp)                 */
+#define RG_WASM_CT_OFF_NX       24  /* i32 normal x * 1000 (milli)              */
+#define RG_WASM_CT_OFF_NY       28  /* i32 normal y * 1000 (milli)              */
+```
+
+Contact phases are defined constants:
+
+```c
+#define RG_WASM_CONTACT_PHASE_BEGIN   1
+#define RG_WASM_CONTACT_PHASE_PERSIST 2   /* [RESERVED] arcade core emits BEGIN only */
+#define RG_WASM_CONTACT_PHASE_END     3   /* [RESERVED]                              */
+```
+
+**[SHIPPED behaviour]** The shipped arcade core emits **`BEGIN` only**;
+`PERSIST`/`END` are defined constants but not yet produced. `MAX_CONTACTS` (14)
+overflow uses **drop-lowest-impulse**.
+
+> **[Known hazard — resolved in ABI_V2_PROPOSAL API §V2-3 and §V2-4]** Because the
+> record has no free field, penetration depth and tangent (friction) impulse
+> cannot be added without widening the record and bumping the block version.
+> Separately, once `PERSIST`/`END` are produced, "drop-lowest-impulse" is unsafe
+> (a low-impulse `END` could be dropped, stranding the guest in a
+> permanently-touching state). Both are addressed in V2; today, with `BEGIN`-only
+> semantics, the drop policy is acceptable but must not be carried into the
+> three-phase model unchanged.
+
+Collision **geometry is declared once (guest-owned), never streamed per frame.**
+Shape kinds are defined constants:
+
+```c
+#define RG_WASM_SHAPE_CIRCLE   1   /* a = radius (fp)            */
+#define RG_WASM_SHAPE_BOX      2   /* a = halfW, b = halfH (fp)  */
+#define RG_WASM_SHAPE_SEGMENT  3   /* a..d = x1,y1,x2,y2 (fp)    */
+#define RG_WASM_SHAPE_POLYGON  4   /* a = vertex count -> side vertex table */
+```
+
+> **[Incomplete — resolved in ABI_V2_PROPOSAL API §V2-5]** `RG_WASM_SHAPE_POLYGON`
+> references a "side vertex table" for which **no block, offset, handle, capacity,
+> or owner is defined** in the shipped ABI. Polygon shapes therefore **cannot be
+> implemented portably today**; CIRCLE/BOX/SEGMENT are the shipped shape set.
+
+`body.flags` bits (additive): `RG_WASM_BODY_ACTIVE 1`, `RG_WASM_BODY_STATIC 2`,
+`RG_WASM_BODY_SENSOR 4`.
+
+### API §3.4 RGSP1 — ready-character sprites [SHIPPED]
+
+`wasm/wasm_sprite_abi.h`, magic `0x50534752` `'RGSP'`, **v1**, **2560 B**,
+`FP_SCALE 256`. Pattern **A**. Host writes header + catalog + input; guest writes
+`slot_count` + slots + `mode`; host resolves `charId → sheet/rows`, animates, and
+MAY write the resolved `frame` back.
+
+```
+Header (64 B): MAGIC 0, VERSION 4, SIZE 8 (guest);  DT_MS 12, TIME_MS 16 (host);
+  CHAR_COUNT 20 (host), SLOT_COUNT 24 (guest), INPUT 28, INPUT_P2 32 (host),
+  VIEW_W 36, VIEW_H 40 (host), MODE 44 (guest).
+Slots @64: MAX_SLOTS 64 × SLOT_SIZE 32, i32 fields:
+  CHARID 0 (0 = empty), ANIM 4, DIR 8, FLAGS 12, XFP 16, YFP 20 (feet),
+  CLOCK 24 (anim ms), FRAME 28.
+Catalog id table (host) @2112: RG_SPR_OFF_CAT_IDS, i32[RG_SPR_MAX_CAT 32].
+```
+
+- Slot flags: `ACTIVE 1`, `FRAMEOVERRIDE 2`, `FLIP_X 4`.
+- `DIR`: `UP 0, LEFT 1, DOWN 2, RIGHT 3`.
+- Exports: `sprite_ptr/size/init/tick` (MAY also export `rg_abi_version`).
+- Note offset 12 = `dt_ms` (pattern A; see API §1.2), same as RGW1.
+
+**[SHIPPED behaviour]** `RG_SPR_ANIM_WALK 0` works; `RUN 1`/`JUMP 2` are
+**[RESERVED]** constants that currently fall back to `WALK` (+ a synthesised hop)
+until expanded art is baked. The roster is the **catalog id table**
+(`RG_SPR_OFF_CAT_IDS`), data — never a frozen `RG_SPR_CHAR_*` enum (there is none).
+
+### API §3.5 RGU1 — retained-mode UI [SHIPPED]
+
+`wasm/wasm_ui_abi.h`, magic `0x31554752` `'RGU1'`, **v1.0**, **8192 B**. Pattern
+**B** (guest writes, host reads; `revision` @8). A flat vDOM: `parent_id +
+child_order` describe structure; strings live in a table referenced by
+`(offset,len)`; colors are `0xRRGGBBAA`. The host validates the whole block as
+untrusted (magic, version, bounds, unique ids, valid/acyclic parents, utf-8) and
+rebuilds its element tree on a `revision` bump. Exports: `rg_ui_ptr/size/revision`.
+
+```
+Header (48 B): MAGIC 0, MAJOR 4(u16), MINOR 6(u16), REVISION 8, ROOT_ID 12,
+  NODE_OFFSET 16, NODE_COUNT 20, PROP_OFFSET 24, PROP_COUNT 28,
+  STRING_OFFSET 32, STRING_SIZE 36, FLAGS 40 (RG_UI_FLAG_VALID 1), RESERVED0 44.
+Node table @64: MAX_NODES 64 × NODE_SIZE 32:
+  id 0, parent_id 4, kind 8(u16), flags 10(u16), first_property 12,
+  property_count 16(u16), child_order 18(u16), event_mask 20, reserved 24/28.
+Property table @2112: MAX_PROPS 128 × PROP_SIZE 16:
+  key 0(u16), type 2(u8), flags 3(u8), value_a 4, value_b 8, value_c 12.
+String table @4160: STRING_CAP 1024.
+```
+
+- **Node kinds**: `VIEW 1, TEXT 2, IMAGE 3, PROGRESS_BAR 4, BUTTON 5, SPACER 6,
+  CUSTOM 100`.
+- **Node flags** (u16): `SELECTABLE 0x1, DISABLED 0x2, DEFAULT 0x4`.
+- **Property types**: `I32 1, F32 2, COLOR 3, STRING 4 (a=off, b=len), VEC2 5,
+  RECT 6, ENUM 7, BOOL 8`.
+- **Property keys**: `TEXT 1, BACKGROUND 2, COLOR 3, FONT_SIZE 4, FONT_FAMILY 5;
+  WIDTH 10, HEIGHT 11, PADDING 12, MARGIN 13, BORDER_RADIUS 14, BORDER_COLOR 15,
+  BORDER_WIDTH 16; FLEX 20, FLEX_DIRECTION 21, ALIGN_ITEMS 22, JUSTIFY 23,
+  TEXT_ALIGN 24; IMAGE_RESOURCE 30; VALUE 40, MAX_VALUE 41`. Enums:
+  `FlexDirection {ROW 0, COLUMN 1}`, `Align {START 0, CENTER 1, END 2,
+  SPACE_BETWEEN 3}`.
+- **Events** (`event_mask`, shipped subset): `ACTIVATE 0x1, SELECT 0x2,
+  DESELECT 0x4`. Selection state lives on the host, keyed by stable node id, and
+  survives rebuilds.
+
+### API §3.6 RGU1 event callback (host → guest) [SHIPPED]
+
+The **shipped** signature is exactly three parameters:
+
+```c
+void rg_ui_event(uint32_t node_id, uint32_t event, uint32_t value);
+/*   event = one of RG_UI_EVENT_* (ACTIVATE / SELECT / DESELECT)
+ *   value = event-specific payload (0 for ACTIVATE; reserved otherwise)        */
+```
+
+If the guest does not export `rg_ui_event`, the host still navigates and
+highlights; activation is simply not delivered.
+
+> **[Breaking change ahead — resolved in ABI_V2_PROPOSAL API §V2-6]** The target
+> pointer/text-capable UI needs a wider payload. Because the export name cannot
+> carry two signatures and export-presence does not reveal arity, the shipped
+> 3-arg `rg_ui_event` is **frozen**; the 4-arg form ships under a **new name**
+> (`rg_ui_event_v2`). Do not redefine `rg_ui_event`'s arity.
+
+### API §3.7 RGP1 — pose / body tracking [SHIPPED]
+
+`wasm/wasm_pose_abi.h`, magic `0x31504752` `'RGP1'`, **v2**, **856 B** (read
+`RG_POSE_OFF_SIZE`, never assume). Pattern **B** (host writes, guest reads;
+`revision` @12). Host→guest streaming skeleton with motion/speed as first-class
+channels.
+
+```
+Header (64 B): MAGIC 0, VERSION 4, SIZE 8, REVISION 12, PRESENT 16, GESTURE 20,
+  LM_COUNT 24, TIME_MS 28, DT_MS 32, FLAGS 36, BODY_VX 40, BODY_VY 44,
+  BODY_SPEED 48, (52..63 reserved).
+Landmark[i] @64, LM_SIZE 24: X 0, Y 4, VX 8, VY 12, SPEED 16, CONF 20.
+FP: positions [0,1]*FP_SCALE(256); velocity/speed Q16.16 (FP_VEL 65536), per sec.
+Flags: VALID 1, HAS_VEL 2, SMOOTHED 4, JUST_APPEARED 8.
+```
+
+Motion (`vx/vy`), speed (`|v|`), and aggregate body velocity/speed are
+host-provided (computed from consecutive smoothed frames), gated by
+`RG_POSE_FLAG_HAS_VEL` and `RG_WASM_HOST_CAP_POSE_INPUT`. Coordinates are
+normalized and view-independent; the guest scales into its own world. Velocity
+definition is precise in the header comment (differenced from the *smoothed*
+signal, `dt = DT_MS/1000`).
+
+> `RG_POSE_MAX_LM = 33` documents the BlazePose landmark count in the header. That
+> constant is a *capacity*, not a taxonomy the guest must obey; which landmark
+> means what stays the guest's decision. A `skeleton_schema_id + landmark_count`
+> generalisation (so 33 is one registered schema, not the only one) is proposed in
+> `ABI_V2_PROPOSAL API §V2-8`.
+
+### API §3.8 RGIN — typed per-player input [SHIPPED]
+
+`wasm/wasm_input_abi.h`, magic `0x4e494752` `'RGIN'`, **v1**. Pattern **B** (host
+writes, guest reads; `revision` @12). A 20-byte header + `record[player_count]`,
+each **40 B** (`RG_IN_STRIDE`).
+
+```
+Header (20 B): MAGIC 0, VERSION 4, SIZE 8, REVISION 12, PLAYER_COUNT 16.
+record[p] @ 20 + p*40:
+  BUTTONS 0 (u32), LSTICK_X 4, LSTICK_Y 8, RSTICK_X 12, RSTICK_Y 16,
+  TRIG_L 20, TRIG_R 24, POINTER_X 28, POINTER_Y 32, FLAGS 36 (u32).
+FP_SCALE 256 (normalized axes -FP..+FP; triggers 0..FP).
+MAX_PLAYERS 8; host clamps PLAYER_COUNT.
+```
+
+- Digital bits: `UP 1, DOWN 2, LEFT 4, RIGHT 8, ACTION 16, BACK 32`. These mirror
+  RGW1's `input`/`input_p2` (five bits × two players → `record[0]`/`record[1]`
+  `BUTTONS`).
+- Record flags: `CONNECTED 1, POINTER_DOWN 2, HAS_ANALOG 4, HAS_POINTER 8`.
+- The digital `BUTTONS` bitfield is the simple default; analog/pointer are
+  additive (a guest reading only `BUTTONS` is unaffected).
+
+> `POINTER_X/Y` are **integer view pixels** (`-1 = none`), not fixed-point. Whether
+> a pointer value fed back into game logic is deterministic across replays depends
+> on a normalization rule that the shipped ABI does not define; see
+> `ABI_V2_PROPOSAL API §V2-10`. Today, treat pointer as a presentation-space input,
+> not a replay-stable logic input.
+
+---
+
+## API §4. Capability bits (`RG_WASM_HOST_CAP_*`) [SHIPPED values]
+
+A guest ORs the bits it requires into `rg_required_caps()`. The host advertises
+the OR of its providers' `capBit()`s (`RG_WASM_HOST_CAPS`, a host-build value) and
+rejects an unsatisfiable guest at load.
+
+| Bit | Value | Gates |
+|-----|-------|-------|
+| `RG_WASM_HOST_CAP_PHYSICS` | `0x0001` | host runs `GamePhysics` for the guest |
+| `RG_WASM_HOST_CAP_RUMBLE` | `0x0002` | gamepad rumble events honoured |
+| `RG_WASM_HOST_CAP_PARTICLES` | `0x0004` | particle events honoured |
+| `RG_WASM_HOST_CAP_RGU1` | `0x0008` | retained-mode HUD (RGU1) parsed |
+| `RG_WASM_HOST_CAP_POSE_INPUT` | `0x0010` | RGP1 pose streaming + motion/speed |
+| `RG_WASM_HOST_CAP_UI_DYNAMIC` | `0x0020` | handle-based dynamic EVG UI (`rg_evg_*`) — **[RESERVED]**, API surface is PROPOSED (V2) |
+| `RG_WASM_HOST_CAP_RES_STREAM` | `0x0040` | `rg_res_*` streaming resources / workers — **[RESERVED]**, API surface is PROPOSED (V2) |
+
+Bits `0x0001`–`0x0010` gate shipped surfaces. `0x0020`/`0x0040` are **defined
+header values** whose *guest-facing APIs* (`rg_evg_*`, `rg_res_*`) are proposed —
+the bit exists so a host that later ships the provider can advertise it, but a
+guest requiring one of these bits against today's runtime is correctly rejected.
+Bits `0x0080` and up are unassigned; assign additively, never reuse a retired bit.
+
+---
+
+## API §5. Determinism — what the shipped ABI actually guarantees
+
+The shipped ABI guarantees **fixed-point transport** (positions, velocities, hit
+tests, and any logic-affecting value fed back to the guest are integers, so they
+match bit-for-bit across CPU/GPU/replay). It does **not** yet guarantee
+end-to-end deterministic replay. Honestly stated:
+
+| Channel | Shipped guarantee |
+|---------|-------------------|
+| Fixed-point world/pose values | ✅ identical across platforms |
+| RGW1 `input`/`input_p2`, RGIN buttons | deterministic *if* the host feeds identical inputs per step (the host does not yet record/replay them for you) |
+| Pose (RGP1) | values are fixed-point, but sampling cadence vs. `step` is host-dependent; no replay protocol |
+| Storage reads (none shipped) | n/a |
+| Audio / rumble / particle events | output-only; must never feed logic/RNG/step order |
+| Resize / hotplug | surfaced as events, not silent mutation |
+
+A full, testable record/replay protocol (`step_id`, per-step event ordering, pose
+resampling, storage snapshot, hotplug capture, callback delivery point, worker
+results) is **proposed** in `ABI_V2_PROPOSAL API §V2-11`. Until it lands,
+determinism is a *design goal supported by fixed-point*, not a checkable ABI
+guarantee — do not promise frame-accurate replay to a guest against V1.
+
+---
+
+## API §6. Entity identity — the shipped reality
+
+The shipped surfaces address entities **three different ways**, and an implementer
+must not assume they are interchangeable:
+
+| Surface | Identifier | Kind |
+|---------|-----------|------|
+| RGW1 `impulses[].bodyIdx` | array index into `bodies[]` | frame-local slot |
+| RGW1 `contacts[].bodyA/bodyB` | guest-defined **body id code** | guest convention |
+| RGSP1 slots | array slot + `charId` | frame-local slot + catalog id |
+
+A **body array index is valid only within one snapshot**; a **body id code** is
+whatever mapping the guest chose (`HOST §2`, `contactBodyCode`/`bodyCodeToId`).
+There is no shipped persistent `EntityId` and no generation counter on game
+entities (generation counters exist only on the *proposed* host-object handles,
+which are not shipped). A unified `EntityId` model (persistent id, local index,
+resource handle with generation, reuse rules) is proposed in
+`ABI_V2_PROPOSAL API §V2-12`.
+
+---
+
+## API §7. Conformance (shipped blocks)
+
+A host or guest claims V1 conformance for a block by passing that block's test
+vectors. The following are **required deliverables** for each shipped block
+(RGW1, RGSP1, RGU1, RGP1, RGIN); they are the machine-checkable complement to this
+prose and, together with the headers, are the real contract:
+
+1. **Golden byte fixtures** — a canonical valid block, byte-for-byte, that a
+   conforming reader parses to a known structure.
+2. **Validator vectors** — malformed blocks (bad magic, wrong version, count past
+   `MAX_*`, out-of-bounds string offset, cyclic/duplicate RGU1 parent ids,
+   non-utf8 string) each with the expected host verdict (reject / clamp).
+3. **A reference encoder + decoder** for at least one block, so two independent
+   implementations can be diffed against the same bytes.
+
+These vectors live alongside the headers (proposed location `wasm/tests/`); until
+present, treat the headers plus this document as the contract and add fixtures as
+blocks stabilise. The V2 blocks carry the same conformance requirement from day
+one (`ABI_V2_PROPOSAL API §V2-13`).
+
+---
+
+*Normative for the shipped ABI. Motivation: [`IDEAL.md`](./IDEAL.md). Target and
+breaking changes: [`ABI_V2_PROPOSAL.md`](./ABI_V2_PROPOSAL.md).*

--- a/gallery/game_engine/ABI_V2_PROPOSAL.md
+++ b/gallery/game_engine/ABI_V2_PROPOSAL.md
@@ -1,0 +1,521 @@
+# ABI_V2_PROPOSAL — target layouts & breaking changes (proposed)
+
+**Status of this document: PROPOSED / NON-NORMATIVE.** Nothing here is the current
+contract. Implement against [`ABI_V1.md`](./ABI_V1.md) for anything shipping today.
+This file collects the *target* ABI: new blocks, breaking layout changes, and the
+cross-cutting rules (versioning, result semantics, determinism, identity) that V1
+does not yet specify. Motivation for each shape is in [`IDEAL.md`](./IDEAL.md).
+
+**Every entry is [PROPOSED] unless it says [RESERVED]** (a slot already defined in
+a shipped header for future use). When a proposal *breaks* a V1 layout it says so
+explicitly and gives the migration.
+
+**Cross-reference notation.** `API §x` = a section of `ABI_V1.md`. `V2 §x` = a
+section of *this* file. `IDEAL §x` = `IDEAL.md`. `HOST §x` = `HOST_ARCHITECTURE.md`.
+
+**Table of proposals (referenced from `ABI_V1.md`):**
+
+| Ref | Proposal |
+|-----|----------|
+| V2 §1 | Single-writer block model (retire mixed-writer RGW1) |
+| V2 §2 | RGCQ string-answer value region |
+| V2 §3 | Contact record widening (manifold: depth + tangent) |
+| V2 §4 | Contact overflow safety with three-phase lifecycle |
+| V2 §5 | Polygon side-vertex table (block/offset/owner) |
+| V2 §6 | `rg_ui_event_v2` + TEXT event buffer |
+| V2 §7 | Atomics / memory-ordering contract |
+| V2 §8 | Pose `skeleton_schema_id` generalisation |
+| V2 §9 | `time_ms` width / wrap contract |
+| V2 §10 | Pointer normalisation for replay |
+| V2 §11 | Deterministic record/replay protocol |
+| V2 §12 | Unified entity-identity model |
+| V2 §13 | Conformance for V2 blocks |
+| V2 §14 | Per-block versioning & compatibility rules |
+| V2 §15 | Common result model (`RgResult`) & error taxonomy |
+| V2 §16 | Proposed blocks (camera, sound, view fields) |
+| V2 §17 | Proposed host imports (dynamic UI, resources, storage, animation, haptics, particles, views, logging) |
+
+---
+
+## V2 §1. Single-writer block model — retire mixed-writer RGW1
+
+**Breaks:** RGW1 v1 header (`API §3.1`).
+
+The shipped RGW1 is a **mixed-writer** block: the guest owns most words, but the
+host writes `dt_ms`, `time_ms`, `input`, `input_p2` into the same block
+(`API §1.2`). That works only because the guest is called synchronously; it makes
+validation and snapshotting harder than they should be, and it blocks moving the
+host writes to another thread.
+
+**Target: one writer per block.**
+
+- **RGW1 v2** becomes **guest-write-only** (world/physics results the guest
+  publishes). It gains a `revision` word and becomes a pattern-B block
+  (`API §1.3`).
+- The host's per-frame inputs move to blocks that already exist or are added:
+  `input`/`input_p2` → **RGIN** (`API §3.8`, already the typed input surface);
+  `dt_ms`/`time_ms`/viewport → a small **host-status block** `RG_HS` (host-write-
+  only, guest-read), header + `dt_ms, time_ms, step_id (V2 §11), view_w, view_h,
+  safe_area…`.
+- A guest that only needs the five digital bits keeps reading `RGIN.record[0/1]
+  .BUTTONS`; RGW1's `input`/`input_p2` header words become **[RESERVED]** (host
+  writes 0), removing the last host write to RGW1.
+
+Migration: RGW1 v2 keeps every guest-owned offset in place, so a guest that
+already writes bodies/contacts/events is unchanged except that it now reads
+timing/input from `RG_HS`/RGIN instead of RGW1 header words, and bumps `revision`.
+Host advertises RGW1 v2 via `rg_abi_version` gating (`API §2.1`).
+
+**Viewport fields** (the "RGW1 gains view fields" note in `IDEAL §2.14`) live in
+`RG_HS`, not scattered into RGW1 — a physics guest sizes/letterboxes itself from
+`RG_HS.view_w/view_h`, mirroring RGSP1's shipped `VIEW_W/VIEW_H`.
+
+---
+
+## V2 §2. RGCQ string-answer value region
+
+**Fixes gap in `API §2.2`.** Today a `STRING` capability answer has `sLen` but no
+offset to its bytes. Proposal: split the RGCQ pool into a guest **key** pool and a
+host **value** pool, and add a value offset to the entry.
+
+```c
+/* entry grows from 20 B to 24 B (RG_WASM_CAPQ_ENTRY_SIZE 24):
+ *   keyOff(u16) keyLen(u16) present(u8) type(u8) _(u16)
+ *   ival(i32) fval(f32) sOff(u16) sLen(u16)
+ *   guest writes keyOff/keyLen; host writes present/type/ival/fval/sOff/sLen.  */
+#define RG_WASM_CAPQ_VAL_POOL  <base>  /* host-owned value bytes; sOff is relative here */
+```
+
+`sOff` is an offset into the host-owned value pool (kept separate from the guest
+key pool so the two writers never overlap, per V2 §1). Because this changes
+`ENTRY_SIZE` and adds a pool, it is a **minor RGCQ bump** gated by the RGW1
+version and negotiated so a host that only speaks the 20-byte entry still answers
+BOOL/INT/FLOAT keys. Until then, `type = STRING` stays **[RESERVED]** (`API §2.2`).
+
+---
+
+## V2 §3. Contact record widening — manifold data
+
+**Breaks:** RGW1 contact stride (`API §3.3`). The shipped 32-byte record is fully
+used by eight `i32` fields; there is **no slack** for penetration depth or tangent
+impulse. Adding them requires a new stride and a block-version bump.
+
+```c
+/* Contact record v2: 40 B (RG_WASM_CONTACT_SIZE 40). First 32 B are byte-identical
+ * to v1 so a v1 reader on a v2 block still reads the normal-impulse manifold. */
+#define RG_WASM_CT_OFF_BODYA    0
+#define RG_WASM_CT_OFF_BODYB    4
+#define RG_WASM_CT_OFF_PHASE    8
+#define RG_WASM_CT_OFF_IMPULSE  12
+#define RG_WASM_CT_OFF_X        16
+#define RG_WASM_CT_OFF_Y        20
+#define RG_WASM_CT_OFF_NX       24
+#define RG_WASM_CT_OFF_NY       28
+#define RG_WASM_CT_OFF_DEPTH    32  /* i32 penetration depth (fp)  — NEW */
+#define RG_WASM_CT_OFF_TANGENT  36  /* i32 tangent/friction impulse (fp) — NEW */
+```
+
+Because the array base and stride change, `RG_WASM_OFF_CONTACTS` and everything
+after it move; this is a **major RGW1 change** (new `RG_WASM_ABI_VERSION`, new
+`RG_WASM_ABI_SIZE`). The version gate (`API §2.1`) rejects a v1-only host for a
+v2-requiring guest. `MAX_CONTACTS` may also be renegotiated here (V2 §14 min-size
+rules).
+
+---
+
+## V2 §4. Contact overflow safety with three-phase lifecycle
+
+**Fixes hazard in `API §3.3`.** Once the core emits `PERSIST`/`END`, the shipped
+"drop-lowest-impulse" policy is unsafe: an `END` event often has near-zero
+impulse, so dropping the lowest-impulse contact can drop exactly the `END`,
+leaving the guest permanently believing two bodies still touch.
+
+Target policy when more than `MAX_CONTACTS` pairs are active in a step:
+
+1. **Never drop `END`.** Lifecycle transitions (`BEGIN`, `END`) rank above
+   `PERSIST`; among droppable contacts, prefer dropping `PERSIST` by lowest
+   impulse. An `END` is emitted even if it means dropping a `PERSIST` to make room.
+2. **Signal truncation.** Add `RG_WASM_CT_FLAG_OVERFLOW` (a header status bit in
+   RGW1, e.g. a `contact_flags` word) so the guest knows the contact set was
+   truncated this step and must not treat "absent" as "separated".
+3. **Resync path.** When overflow occurs, the next step MUST publish a **full
+   snapshot of all currently-active contacts** (or an explicit "these pairs are no
+   longer touching" resync list) so the guest's contact state machine can recover.
+
+This makes the collision state machine robust: a guest that tracks
+begin/persist/end can always reconstruct truth within one step of an overflow.
+
+---
+
+## V2 §5. Polygon side-vertex table
+
+**Fixes incomplete `API §3.3`.** `RG_WASM_SHAPE_POLYGON` references a "side vertex
+table" with no defined storage. Proposal: a **guest-owned, declare-once vertex
+block**, addressed from the shape descriptor by an index, never a pointer.
+
+```c
+struct RgShape { u32 kind; u16 layer; u16 mask; i32 a, b, c, d; };
+/* For kind = RG_WASM_SHAPE_POLYGON:
+ *   a = vertex count (2..RG_WASM_POLY_MAX_VERTS)
+ *   b = first-vertex index into the polygon vertex block (below)               */
+
+/* Guest-owned polygon vertex block (declared once, like the shape descriptor):
+ *   header: magic 'RGPV', version, size, revision (pattern B, guest writes)
+ *   verts[]: RG_WASM_POLY_MAX_VERTS_TOTAL × { i32 x_fp, i32 y_fp }             */
+#define RG_WASM_POLY_MAX_VERTS        16u   /* per polygon               */
+#define RG_WASM_POLY_MAX_VERTS_TOTAL  256u  /* pool capacity, host-clamped */
+```
+
+Vertices are convex, CCW, in body-local fixed-point coordinates; the host
+validates count and index bounds as untrusted data and clamps to the pool
+capacity. Ownership: guest writes the pool once at declare-time (`HOST §2`
+declare-once channel); the host reads it when building collision geometry. This
+makes POLYGON portable; CIRCLE/BOX/SEGMENT are unaffected.
+
+---
+
+## V2 §6. `rg_ui_event_v2` + TEXT event buffer
+
+**Fixes breaking change in `API §3.6`.** The shipped `rg_ui_event(node_id, event,
+value)` is frozen. The pointer/text-capable callback ships under a **new name and
+its own UI-event ABI minor version** so export-presence disambiguates arity:
+
+```c
+/* Guest OPTIONALLY exports one of these; the host prefers _v2 if present. */
+void rg_ui_event   (uint32_t node_id, uint32_t event, uint32_t value);        /* v1, frozen */
+void rg_ui_event_v2(uint32_t target,  uint32_t event, uint32_t a, uint32_t b);/* v2 */
+```
+
+`target` = an RGU1 node id *or* a dynamic-UI handle (V2 §17). `event` widens the
+shipped `ACTIVATE/SELECT/DESELECT` to `FOCUS / BLUR / POINTER_DOWN / POINTER_UP /
+POINTER_MOVE / POINTER_ENTER / POINTER_LEAVE / DRAG / SCROLL / TEXT /
+VALUE_CHANGED`. `a,b` is a typed payload per event: pointer `x,y`; scroll `dx,dy`;
+value `newValue,_`.
+
+**TEXT event buffer.** For `event = TEXT`, `a,b` are `(offset, len)` **into a
+host-owned UI-event string block whose base is published in `RG_HS`/the UI ABI
+header** (never a bare offset relative to nothing). The host writes the utf-8 text
+there before the callback and it is valid only for the duration of the call; the
+guest copies what it needs. Reporting arity/version: `rg_ui_abi()` gains a minor
+bump when `_v2` is offered.
+
+---
+
+## V2 §7. Atomics / memory-ordering contract
+
+**Tightens `API §1.3`.** Pattern-B blocks published across real threads need an
+explicit ordering contract, not just "seqlock". Proposal:
+
+- `revision` is accessed with atomic loads/stores.
+- **Writer:** `revision.store(odd, relaxed)` → write payload →
+  `atomic_thread_fence(release)` → `revision.store(even, relaxed)`.
+- **Reader:** `r1 = revision.load(acquire)`; if odd retry; copy payload;
+  `atomic_thread_fence(acquire)` (paired) → `r2 = revision.load(relaxed)`; accept
+  iff `r1 == r2 && even`.
+- **"Monotonic revision" and "odd/even seqlock" are the same mechanism**, not
+  alternatives: the writer's two bumps produce the odd (writing) and even (stable)
+  states, and the even values are monotone so a reader can also detect "unchanged
+  since last frame". `API §1` and this section replace the earlier text that
+  presented them as two options with different read algorithms.
+
+RGW1 v2 / RGSP1 v2 adopt pattern B under this contract (V2 §1). Pattern-A turn
+ordering remains valid for a purely single-threaded host but is no longer the only
+model a block may use.
+
+---
+
+## V2 §8. Pose `skeleton_schema_id` generalisation
+
+**Generalises `API §3.7`.** `RG_POSE_MAX_LM = 33` bakes the BlazePose landmark
+count. To keep "transport, never taxonomy" (`IDEAL §2.1`), add to the RGP1 header:
+
+```c
+#define RG_POSE_OFF_SCHEMA_ID  <n>  /* u32 registered skeleton schema id */
+/* landmark_count already exists as RG_POSE_OFF_LM_COUNT; capacity stays a
+ * compile-time max but the MEANING of each index is defined by SCHEMA_ID.     */
+```
+
+`schema_id` names a registered skeleton (BlazePose-33 is *one* schema, e.g. id 1);
+hand (21), face-mesh, or a custom rig are other ids. The guest reads `schema_id +
+landmark_count` and interprets indices per that schema, instead of assuming 33
+BlazePose joints. `RG_POSE_MAX_LM` becomes a pure capacity bound.
+
+---
+
+## V2 §9. `time_ms` width / wrap contract
+
+**Fixes note in `API §3.1`.** `time_ms` is a signed `i32` ms (wraps ~24.8 days;
+overflow currently undefined). Options, in order of preference:
+
+1. **Widen to `i64` monotonic ms** in the header (new RGW1/`RG_HS` version). Clean,
+   no wrap for practical sessions.
+2. If 32-bit is kept, define it as **unsigned monotonic ms with explicit modular
+   wrap**; guests compute deltas with `(u32)(now - prev)` and never compare
+   absolute values.
+
+The determinism protocol (V2 §11) uses `step_id`, not wall time, for ordering, so
+`time_ms` is presentation/telemetry only and its wrap never affects logic.
+
+---
+
+## V2 §10. Pointer normalisation for replay
+
+**Fixes note in `API §3.8`.** `POINTER_X/Y` are integer view pixels — resolution-
+and viewport-dependent, so not replay-stable. Proposal: alongside the pixel
+fields, transport a **normalised, fixed-point pointer** (`[0,1] * FP_SCALE`
+relative to the negotiated viewport) whenever the pointer feeds game logic, and
+declare which one is the deterministic input:
+
+- **Replay-stable logic input:** normalised fixed-point pointer (recorded in the
+  input snapshot, V2 §11).
+- **Presentation only:** the raw pixel pointer (for cursor drawing), never
+  recorded, never fed to logic.
+
+A guest picks the normalised field for anything that affects the world; the host
+records only that in the replay stream.
+
+---
+
+## V2 §11. Deterministic record/replay protocol
+
+**Fills the gap in `API §5`.** Fixed-point transport is necessary but not
+sufficient for replay. The protocol makes determinism a *checkable* property:
+
+- **`step_id`** — a monotic `u64` on every input snapshot and every event
+  (published in `RG_HS`). Replay is "feed the recorded snapshot/events for each
+  `step_id` and expect identical guest output".
+- **Intra-step event ordering** — events within a step are delivered in a defined
+  stable order (by `(kind, source_index)`), recorded and replayed in that order.
+- **Pose sampling** — pose is resampled to the fixed step: each `step_id` sees the
+  pose snapshot valid at that step (recorded), not a free-running camera rate.
+- **Storage snapshot** — a replay begins from a recorded storage snapshot (V2 §17
+  storage); reads during replay come from that snapshot, not live disk.
+- **Resize / hotplug capture** — resize and gamepad connect/disconnect are
+  recorded as events keyed to a `step_id` and re-injected at the same step.
+- **Callback delivery point** — every host→guest callback (UI events, anim events,
+  view lifecycle) is delivered at a **defined phase** of the step (proposal:
+  *before* `update()`, so `update()` sees a consistent world) and recorded there.
+- **Worker results** — streaming/loader worker outputs (V2 §17) affect only
+  rendering and resource lifetime, never logic/step order, so they are **not**
+  part of the replay stream; the protocol asserts this invariant.
+
+A conformance replay harness (V2 §13) records a session and asserts byte-identical
+guest output on replay.
+
+---
+
+## V2 §12. Unified entity-identity model
+
+**Fixes the scatter in `API §6`.** One model, three distinct concepts kept
+distinct:
+
+| Concept | Type | Lifetime | Rule |
+|---------|------|----------|------|
+| **EntityId** | `u32` (or `u64`) stable id | whole entity lifetime | the persistent identity used in contacts, visuals, events |
+| **array index** | slot in a per-frame array | one snapshot | a *location*, never stored across frames |
+| **host handle** | slot index + generation | resource lifetime | a resource lease (`rg_evg_*`, `rg_res_*`), not a game entity |
+
+- Contacts, impulses, visuals, and events all key on **EntityId**, not array
+  index (indices become a per-snapshot lookup only).
+- **EntityId reuse** requires a **generation** field so a stale id fails a
+  generation check (same discipline as host handles); an id is never silently
+  reused within a session without bumping generation.
+- `contactBodyCode`/`bodyCodeToId` (`HOST §2`) collapse into "EntityId ↔ guest
+  name", removing the parallel body-code space.
+
+---
+
+## V2 §13. Conformance for V2 blocks
+
+Every V2 block ships with the `API §7` deliverables **from day one**: golden byte
+fixtures, malformed-input validator vectors, and a reference encoder/decoder,
+plus — new for V2 — a **record/replay conformance harness** (V2 §11) that asserts
+byte-identical guest output on replay of a recorded session. A V2 block is not
+"shipped" (promoted into `ABI_V1.md`) until its vectors exist and pass.
+
+---
+
+## V2 §14. Per-block versioning & compatibility rules
+
+**Fills the gap in the shipped gate** (which only checks `guest_version >
+host_version`). Each independently-versioned block (RGW1, RGSP1, RGU1, RGP1, RGIN,
+RGCQ, RG_CAM, …) carries **major.minor** semantics:
+
+- **Major** = incompatible layout (moved/removed field, changed stride, changed
+  meaning). A reader MUST reject a block whose major it does not implement.
+- **Minor** = backward-compatible addition. **A minor bump may only append fields
+  at the end of a record/header**, never move or repurpose an existing offset. A
+  reader of an older minor reads the prefix it knows and ignores the tail.
+- **Minimum block size per version** is published (`RG_*_MIN_SIZE_Vn`); a reader
+  rejects a block smaller than the minimum for the version it claims.
+- **Unknown events / property keys / node kinds are ignored**, not errors — a
+  forward-compatible reader skips what it does not recognise (RGU1 already does
+  this for `event_mask`).
+- **Fields a writer does not set MUST be zeroed** (reserved words, unused record
+  tails), so a reader can rely on zero-means-absent.
+- **Old guest on newer host:** allowed when the host implements the guest's major
+  (the host reads the older minor's prefix). This is the common case and MUST work.
+- **New guest on older host:** allowed only via **capability degradation** — the
+  guest queries (RGCQ / env, `API §2.2`) and adapts; a *hard* requirement it
+  cannot degrade goes through `rg_required_caps` and is rejected at load
+  (`API §2.1`). A guest MUST NOT assume a newer block layout without either a
+  version check or a capability answer.
+
+---
+
+## V2 §15. Common result model & error taxonomy
+
+**Fixes the silent-no-op semantics** (`rg_store_commit`/`set`/`delete` and most
+handle ops return `void`; a bad handle is a silent no-op — safe against crashes,
+bad for debugging and reliability). Target: a shared result and a defined error
+set.
+
+```c
+typedef struct { i32 code; i32 detail; } RgResult;   /* code 0 = OK */
+
+enum RgErr {
+    RG_OK              = 0,
+    RG_ERR_UNSUPPORTED = 1,  /* capability not present                     */
+    RG_ERR_INVALID_ARG = 2,  /* malformed argument                         */
+    RG_ERR_BAD_HANDLE  = 3,  /* invalid / stale (generation-failed) handle */
+    RG_ERR_QUOTA       = 4,  /* storage/quota exceeded                     */
+    RG_ERR_POOL_FULL   = 5,  /* handle pool / arena exhausted              */
+    RG_ERR_TOO_SMALL   = 6,  /* output buffer too small (detail = needed)  */
+    RG_ERR_PENDING     = 7,  /* async op accepted, completion later        */
+    RG_ERR_IO          = 8   /* backend I/O failure                        */
+};
+```
+
+- Handle-returning creators still return `0` for null/OOM (`IDEAL §2.6`), but the
+  *reason* is retrievable via a companion `RgResult` (or an `rg_last_error()` on
+  paths that cannot widen their return).
+- **Async-shaped ops** (`rg_store_commit`, resource loads) either return
+  `RG_ERR_PENDING` with a **request handle** whose completion arrives as a
+  host→guest event, or expose an awaitable completion — the API must not *look*
+  async (`IDEAL §2.11` "awaitable commit") while returning `void`. Pick one; the
+  proposal is request-handle + completion event, which fits the existing
+  event/handle machinery.
+- A silent no-op remains the crash-safe *fallback* when a guest ignores results,
+  but the information is always available.
+
+---
+
+## V2 §16. Proposed blocks
+
+### V2 §16.1 RGW1 view fields → `RG_HS` host-status block [PROPOSED]
+
+See V2 §1. `dt_ms`, `time_ms`, `step_id`, `view_w`, `view_h`, `safe_area`, and
+`log.level` live in a host-write-only block the guest reads; RGW1 v2 stops
+carrying host words.
+
+### V2 §16.2 RG_CAM — camera + view matrix [PROPOSED]
+
+Guest declares the camera; host writes back the resolved matrix and its inverse.
+A **full block header** and an explicit **matrix fixed-point scale** are part of
+the contract (both missing from the earlier sketch):
+
+```c
+#define RG_CAM_MAGIC       0x4d434752u /* 'RGCM' */
+#define RG_CAM_VERSION     1u
+#define RG_CAM_FP_MTX      65536        /* matrix entries are Q16.16 (NOT FP_SCALE) */
+/* Header (pattern B; guest writes camera, host writes matrices): */
+#define RG_CAM_OFF_MAGIC     0
+#define RG_CAM_OFF_VERSION   4
+#define RG_CAM_OFF_SIZE      8
+#define RG_CAM_OFF_REVISION  12   /* seqlock */
+/* Guest-written camera params: */
+#define RG_CAM_OFF_X       16  /* i32 world x (* FP_SCALE)          */
+#define RG_CAM_OFF_Y       20  /* i32 world y                       */
+#define RG_CAM_OFF_ZOOM    24  /* i32 zoom (* FP_SCALE; FP = 1x)    */
+#define RG_CAM_OFF_ROT     28  /* i32 rotation (* FP_SCALE radians) */
+#define RG_CAM_OFF_FOLLOW  32  /* u32 follow EntityId (0 = free)    */
+/* Host-written matrices (3x3 affine as 6 entries a b c d e f, Q16.16): */
+#define RG_CAM_OFF_VIEW_M  40  /* 6×i32 forward: screen = view · world */
+#define RG_CAM_OFF_VIEW_INV 64 /* 6×i32 inverse: world = view⁻¹ · screen (picking) */
+#define RG_CAM_SIZE        88
+```
+
+One camera model → one affine `Mat3`, applied identically on software and GPU. The
+inverse is transported (not left for the guest to compute) for pointer/touch
+picking and world-anchored HUD. Matrix entries use `RG_CAM_FP_MTX` (Q16.16), which
+is distinct from position `FP_SCALE` (256) — stated explicitly because the earlier
+sketch omitted the matrix scale.
+
+### V2 §16.3 Sound event record — 32 B + response for handles [PROPOSED]
+
+**Reconciles two sizes.** RGW1's shipped event record is **20 B** (`kind, sub, a,
+b, c`; `API §3.1`). A richer sound record is **32 B**. These do not fit the same
+slot, so a 32-B sound event is **not** an RGW1 `events[]` entry — it is either its
+own sound block/ring or a host import, versioned separately:
+
+```c
+#define RG_SND_OFF_KIND     0   /* u32 0=sfx 1=voice 2=music-start 3=music-stop */
+#define RG_SND_OFF_ID       4   /* u32 registered sound id (HOST §3 palette)    */
+#define RG_SND_OFF_GAIN     8   /* i32 gain 0..FP (FP = unity)                  */
+#define RG_SND_OFF_PAN      12  /* i32 pan -FP..+FP (0 = centre)                */
+#define RG_SND_OFF_PITCH    16  /* i32 pitch ratio * FP                         */
+#define RG_SND_OFF_FLAGS    20  /* u32 loop, positional, ...                    */
+#define RG_SND_OFF_X        24  /* i32 world x (positional, * FP_SCALE)         */
+#define RG_SND_OFF_Y        28  /* i32 world y                                  */
+```
+
+**Handles for loops/music cannot be returned by a fire-and-forget event.** A
+one-shot is fire-and-forget by id. A loop/music/long-voice needs a handle, so it
+uses one of:
+
+1. a **host import** `u32 rg_sound_play(const RgSound* rec)` that returns the
+   handle synchronously (preferred — the guest gets the handle immediately), or
+2. a **command/response id**: the guest writes a `request_id` with the event and
+   the host returns `{request_id → handle}` on the host→guest event channel.
+
+The earlier text's "loops/music return a handle" is only realisable through (1) or
+(2), never through a bare event record; this proposal makes that explicit.
+
+---
+
+## V2 §17. Proposed host imports
+
+All handles follow the handle discipline (`IDEAL §2.6`): opaque `slot index +
+generation`, `0` = null/OOM, arena-owned and bulk-freed on guest teardown, pools
+bounded (allocation past capacity returns `0`). All results follow V2 §15. All
+string/byte pointers are copied *out of* guest memory; the host never retains a
+guest pointer.
+
+- **Dynamic UI / EVG** [PROPOSED, `RG_WASM_HOST_CAP_UI_DYNAMIC 0x0020`] —
+  `rg_evg_create/set_i32/set_color/set_str/append/remove/destroy/set_root`, the
+  *delta* counterpart to RGU1's snapshot; same kinds/keys, same "no pointers cross,
+  host validates" discipline. Callbacks via `rg_ui_event_v2` (V2 §6).
+- **Resources / streaming** [PROPOSED, `RG_WASM_HOST_CAP_RES_STREAM 0x0040`] —
+  `rg_res_begin/commit/free/lookup`; load and generate are one staging path;
+  handles refcounted and arena-owned. Blocks RGO1 (host→worker observation), RGX1
+  (host↔worker residency ring), RGLD (loader requests). Invariant `gen − freed =
+  live` (the `streaming_world` regression fixture, `IDEAL §2.7`).
+- **Storage** [PROPOSED] — `rg_store_get/set/delete/list/commit` returning
+  `RgResult` (not `void`, V2 §15). Keyed, scoped (per-game / global), atomic
+  temp-and-rename `commit`, host-enforced isolation and quota; a read is a
+  deterministic input (recorded in the replay snapshot, V2 §11).
+- **Animation** [PROPOSED] — `rg_anim_start/set/stop` → handle; one clip/tween
+  model over a UI node, sprite frame, or body-visual transform; keyframe tracks +
+  registered easings; advances on the fixed step so a replay animates identically.
+  Lifecycle events (`END/LOOP/FRAME/LABEL`) via `rg_anim_event`.
+- **Haptics** [PROPOSED, `RG_WASM_HOST_CAP_RUMBLE`] — `RgHaptic { i32 target, low,
+  high, ms }` (both motors distinct, never one `strength`); optional
+  envelope/named pattern; sustained effect updated/stopped by handle; output-only.
+- **View navigation** [PROPOSED] — `rg_view_load/push/pop`; `push` suspends,
+  `pop` resumes with a typed result; routes are registered names; deterministic
+  control-flow input.
+- **Logging** [PROPOSED] — `rg_log(level, channel, msg, len)`; per-channel
+  filtering from `log.level`; output-only sinks; `FATAL` ties into abort-with-
+  reason (`API §2.1`).
+- **Particles / effects / filters** [PROPOSED, `RG_WASM_HOST_CAP_PARTICLES`] —
+  event+handle shape like audio/animation; seeded fixed-point RNG so a burst
+  replays identically; output-only.
+
+Sprite/atlas/HUD data shapes and the body→visual binding are game-declared
+structures resolved by host-side interfaces; they are documented in `HOST §3`
+because they are not byte-level guest/host ABI.
+
+---
+
+*Proposed. None of this is the current contract — see [`ABI_V1.md`](./ABI_V1.md).
+Motivation: [`IDEAL.md`](./IDEAL.md).*

--- a/gallery/game_engine/HOST_ARCHITECTURE.md
+++ b/gallery/game_engine/HOST_ARCHITECTURE.md
@@ -1,0 +1,177 @@
+# HOST_ARCHITECTURE — host-internal Ranger interfaces (not the ABI)
+
+**Status: informative, host-internal.** Everything in this document is a **Ranger
+host-side interface** — a set of functions the engine core calls *inside one
+address space*. **None of it is a byte-level guest/host ABI.** It cannot be
+implemented across the Rust / WASM / AssemblyScript / TS boundary as written,
+because it passes function pointers and object references, not bytes at fixed
+offsets.
+
+It lives here, separate from [`ABI_V1.md`](./ABI_V1.md) and
+[`ABI_V2_PROPOSAL.md`](./ABI_V2_PROPOSAL.md), precisely so the ABI documents
+contain only what crosses the byte boundary: memory layouts, imports/exports,
+wire types, lifecycle, result/error semantics, and capability/versioning rules.
+
+**How this relates to the ABI.** These interfaces *sit behind* the ABI: a provider
+is how a host wires a capability up internally, and its `capBit()` is what the host
+then advertises over the byte-level capability bitmask (`API §4`). Registries
+are how the host resolves guest-declared vocabulary (ids, names) that the ABI
+transports opaquely. The ABI is the contract; this is one host's implementation
+shape.
+
+**Cross-reference notation.** `API §x` = `ABI_V1.md`. `V2 §x` =
+`ABI_V2_PROPOSAL.md`. `IDEAL §x` = `IDEAL.md`. `HOST §x` = this file.
+
+---
+
+## HOST §1. Providers & the capability seam — `IDEAL §6`
+
+Every host capability plugs into a **registry**, not hand-wired into the runner and
+three bridges. A provider is a host-side object:
+
+```
+class GameProvider {
+    fn id:string ()        ; "resource", "pose", "scene", …
+    fn capBit:int ()       ; RG_WASM_HOST_CAP_* it satisfies (0 = base ABI)
+    fn direction:int ()    ; 1 = guest->host, 2 = host->guest
+    fn cadence:int ()      ; 1 = setup (once), 2 = frame (per physicsStep)
+    fn onAttach / onDeclare / beforeUpdate / afterUpdate / onDetach
+}
+```
+
+The host's advertised capability set — the `RG_WASM_HOST_CAPS` value the
+byte-level gate consumes (`API §2.1`, `API §4`) — is the **OR of every attached
+provider's `capBit()`**. Adding a provider automatically widens what the host
+advertises; there is no second capability list. The gate itself (reject an
+unsatisfiable guest once, right after load, before `update()`) is ABI and lives in
+`API §2.1`; *this* interface is how the host assembles the number the gate checks.
+
+`direction` and `cadence` here are the host-internal mirror of the wire-level
+direction/cadence encoding (`IDEAL_API` shared conventions). RGP1, for example,
+plugs in as a provider (`direction = host→guest`, `cadence = frame`, `capBit =
+RG_WASM_HOST_CAP_POSE_INPUT`), and *that* is what makes the shipped RGP1 byte block
+(`API §3.7`) available to a guest.
+
+---
+
+## HOST §2. Engine-core ↔ game seam — `GameSceneProvider` (`IDEAL §3`)
+
+A generic runner obtains **everything game-specific from an interface it is
+compiled against** — never from concrete game types, imports, or constants:
+
+```
+interface GameSceneProvider {              ; provided by the game, held by the core runner
+    ; world (guest is the preferred source; a provider is the fallback)
+    fn buildScene(phys:GamePhysics bodyIds:[string]) : void   ; bodies + bounds
+    fn worldSize() : (int, int)                               ; no 6000 baked in core
+    fn playerCount() : int                                    ; no fixed 2 in core
+    ; presentation
+    fn initAssets(render:GenericRender pw:int) : void
+    fn buildStaticBg(render:GenericRender) : void
+    fn spriteFor(id:string) : string                          ; entity id -> template
+    fn drawHud(target:SoftCanvas paneIdx:int abi:WasmAbiMem) : void  ; HUD, or emit RGU1
+    ; ABI conventions this guest chose (transport, not taxonomy — IDEAL §2.1)
+    fn contactBodyCode(id:string) : int
+    fn bodyCodeToId(code:int) : string
+    fn mapEvent(kind:int sub:int) : GameEventNative           ; sound / particle ids
+    ; camera policy
+    fn cameraFor(paneIdx:int phys:GamePhysics) : int
+}
+```
+
+`contactBodyCode`/`bodyCodeToId` bridge the host's internal representation to the
+**guest-defined body id codes** the ABI transports opaquely in RGW1 contacts
+(`API §3.3`). Under the V2 identity model these collapse into a single
+`EntityId ↔ guest name` mapping (`V2 §12`), removing the parallel body-code space.
+
+`mapEvent` turns the ABI's opaque `event.kind/sub` (`API §3.1`) into a
+host-native sound/particle action — again, meaning assigned host-side, transport
+kept neutral.
+
+**Proposed — not yet in code (`IDEAL §5`).** `wasm_physics_runner.rgr` still
+imports `wasm_autopeli_setup.rgr` / `wasm_autopeli_render.rgr` and holds a concrete
+`setup:WasmAutopeliSetup`. The target ("one world, one owner"): the *guest* owns
+the world — it declares bodies, bounds, world size, camera hints, and static-bg
+through the same declare-once channel it already uses for resources, and the
+host-side `setupPhysics()` copy is deleted. The `GameSceneProvider` above is the
+fallback for hosts/paths where the guest is not the world source.
+
+---
+
+## HOST §3. Game-declared data shapes resolved host-side
+
+These are structures a game declares and a host resolves; they travel as
+guest-declared data (ids, atlas rows, registered names) that the ABI transports,
+but the *interfaces* that consume them are host-side.
+
+### HOST §3.1 Body → visual binding (`IDEAL §2.5`)
+
+One declared contract the game provides (not three code paths):
+
+```
+interface BodyVisual {                 ; provided by the game, not core
+    fn visualFor(bodyId:string) : VisualRef        ; template id | RGSP1 charId
+    fn animFor(bodyId:string st:BodyState) : (anim dir flip)  ; guest rule
+}
+; Host loop, backend-agnostic:
+;   for each active body: read (x,y,angle) from RGW1 (API §3.1),
+;     resolve BodyVisual.visualFor(id),
+;     write that transform into the sprite template OR the RGSP1 slot xFp/yFp,
+;     pick anim/dir from BodyVisual.animFor(id, {speed, vx, vy, lastContact}).
+```
+
+The *values* here cross the ABI (RGW1 body pose in, RGSP1 slot out); the
+`BodyVisual` interface that maps between them is host-side.
+
+### HOST §3.2 Sprite / atlas / HUD shapes (`IDEAL §2.8`, `IDEAL §2.15`)
+
+- **Atlas** — the runtime shape of `atlas.json` (`frameW/H`, `sheetW/H`,
+  direction rows, `animations{ id: { row, frameCount, cycle[], fps, loop } }`).
+  Animation ids/rows/cycles are **data** (LPC emits them); the roster is the RGSP1
+  catalog id table (`API §3.4`), never a frozen `RG_SPR_CHAR_*` enum.
+- **Sprite instance** — `{ visual: sheetHandle + atlas, transform: x,y,angle,
+  scale,flipX, anim: animId, clockMs|frameOverride, dir }`. `GameEntity` kinds,
+  RGSP1 slots, and the draw list all reduce to this host-side shape; sheets load
+  through the resource path (`V2 §17`).
+- **HUD** — an EVG/RGU1 document the game declares, drawn by the one EVG renderer
+  used for both HUD and menus; interactive via the typed input record delivered
+  back over `rg_ui_event`/`rg_ui_event_v2` (`API §3.6`, `V2 §6`). The document and
+  events are ABI; the renderer and layout engine are host-side.
+
+---
+
+## HOST §4. Registries — game vocabulary as data (`IDEAL §4`)
+
+Game vocabulary is **registration**, not `if (kind == "…")` in core. The
+registration table lives in the host; entries come from the game at setup. The
+*registered names/ids* are guest data the ABI transports opaquely; the registry
+that resolves them is host-side.
+
+| Registry | Call (at setup) | Replaces |
+|----------|-----------------|----------|
+| Shape drawers | `registerShape("ghost", fn)` | `kind == "wedge"` / `"ghost"` branches |
+| Sound palette | `registerSound("brick", spec)` | builtin ids `brick`/`bounce`/`wall` |
+| Animation clips / easings | `register("walk", …)` / `register("glow", …)` | `WALK/RUN/JUMP`, `glow/pulse` enums |
+| Haptic patterns | pattern-name registration | frozen rumble presets |
+| View routes | route-name registration | raw file paths |
+| Emitters / effects / filters | descriptor registration | canned particle presets |
+| Feature flags | named/typed flag registry | ad-hoc `verbose` / `useWasmHud` |
+
+`registerShape("ghost", fn)` and friends pass a **function** to the host — the
+clearest reason these are host-internal and not ABI: a byte layout cannot transport
+a drawer callback across the WASM boundary. A guest on the far side of the boundary
+instead registers *data* (an emitter descriptor, an atlas row, a sound spec) that
+the host interprets; only an in-process (TS/`.as`-interpreted) guest can hand the
+host an actual `fn`.
+
+Feature flags are named, typed values (bool/int/enum) with a defined **source
+precedence** — build default → config/`game.info` → env/CLI → persisted →
+runtime override — queryable by host *and* guest over the RGCQ / env key/value
+channel (`API §2.2`), scoped per-game or global. Flags read at init are stable
+inputs; runtime toggles arrive as events.
+
+---
+
+*Host-internal. The byte-level contract is [`ABI_V1.md`](./ABI_V1.md) (shipped) and
+[`ABI_V2_PROPOSAL.md`](./ABI_V2_PROPOSAL.md) (proposed). Rationale:
+[`IDEAL.md`](./IDEAL.md).*

--- a/gallery/game_engine/IDEAL.md
+++ b/gallery/game_engine/IDEAL.md
@@ -1856,7 +1856,8 @@ compiled against* — never from concrete game types, imports, or constants. A
 (`initAssets`, `buildStaticBg`, `spriteFor`, `drawHud`), the **ABI conventions this guest
 chose** (`contactBodyCode`/`bodyCodeToId`, `mapEvent` for sound/particle ids, §2.1), and
 **camera policy** (`cameraFor`). The full method list is in
-[`IDEAL_API.md`](./IDEAL_API.md) §7.
+[`HOST_ARCHITECTURE.md`](./HOST_ARCHITECTURE.md) §2 (`GameSceneProvider` is a
+host-side interface, not a byte-level ABI).
 
 The rule the interface encodes: the core holds `provider:GameSceneProvider`, **never**
 `setup:WasmAutopeliSetup`, and imports the interface, **never** `wasm_autopeli_setup.rgr` —

--- a/gallery/game_engine/IDEAL_API.md
+++ b/gallery/game_engine/IDEAL_API.md
@@ -1,879 +1,128 @@
-# IDEAL_API — the full game-engine ABI, consolidated
+# IDEAL_API — index & shared conventions for the game-engine ABI
 
-This is the **API reference** for the interfaces proposed in [`IDEAL.md`](./IDEAL.md).
-Where `IDEAL.md` argues *why* each interface should look the way it does, this document
-collects the *what*: every block layout, host import, guest export, event, registry, and
-capability bit in one place, so a guest or host author can implement against a single
-contract.
+This is the entry point to the Ranger game-engine ABI. It used to be a single
+document that mixed the current contract, the v2 plan, a roadmap, and host-internal
+architecture. Following review, that content is now split so an implementer can
+always tell **what is binding right now** from **what is proposed**:
 
-Everything here is a **target specification.** Some of it ships today (RGW1, RGSP1, RGU1);
-much of it is proposed. Each entry links back to the chapter of `IDEAL.md` that motivates
-it. When the two documents disagree, `IDEAL.md` is the source of intent and this file is
-the derived surface.
+| Document | Status | Contents |
+|----------|--------|----------|
+| **[`ABI_V1.md`](./ABI_V1.md)** | **NORMATIVE** | Exactly what ships and runs today: block byte-layouts (RGW1, RGSP1, RGU1, RGP1, RGIN, RGCQ), the concurrency/ownership model, handshake, capability bits, and honest current result/determinism/identity semantics. |
+| **[`ABI_V2_PROPOSAL.md`](./ABI_V2_PROPOSAL.md)** | **PROPOSED** | Target layouts and breaking changes: new blocks, widened records, `rg_ui_event_v2`, versioning rules, the `RgResult` model, the replay protocol, the identity model. **Not the current contract.** |
+| **[`HOST_ARCHITECTURE.md`](./HOST_ARCHITECTURE.md)** | Informative | Host-internal Ranger interfaces (`GameProvider`, `GameSceneProvider`, `BodyVisual`, registries). Function-passing interfaces, **not a byte-level ABI.** |
+| **[`IDEAL.md`](./IDEAL.md)** | Rationale | Why each interface should look the way it does. The source of *intent*; never overrides a shipped byte layout. |
+
+**Where to start:** implementing a guest or host against today's runtime → read
+`ABI_V1.md` and the generated headers under [`wasm/`](./wasm/). Planning the next
+version → `ABI_V2_PROPOSAL.md`. Understanding a design choice → `IDEAL.md`.
 
 ---
 
-## 0. Conventions
+## Status legend
 
-These rules hold for *every* block and import below.
+Every symbol, field, and layout in the ABI documents is tagged:
 
-### 0.1 The three-layer boundary
+- **[SHIPPED]** — present in a `wasm/*.h` header and honoured by the runtime. Bind
+  to it. (Only in `ABI_V1.md`.)
+- **[RESERVED]** — a slot or constant that exists in a shipped header for future
+  use but is **not yet acted on**. Safe to write; currently ignored on read.
+- **[PROPOSED]** — a target shape not in any shipped header. **Do not implement as
+  if current.** (Only in `ABI_V2_PROPOSAL.md`.)
+
+Tagging is **per symbol**, not per section: a shipped block may contain reserved
+fields, and a shipped constant (e.g. a capability bit) may gate a proposed API.
+
+## Source-of-truth precedence
+
+1. **Generated headers** under [`wasm/`](./wasm/) — machine-checkable, and the
+   real contract. If a doc disagrees with a header, the header wins.
+2. **`ABI_V1.md`** — normative prose for the shipped surface.
+3. **`ABI_V2_PROPOSAL.md`** — proposed, non-binding.
+4. **`IDEAL.md`** — intent/rationale. Explains, never defines a byte.
+
+Conformance is ultimately defined by **test vectors** (golden byte fixtures,
+validator vectors, a reference encoder/decoder, and — for v2 — a record/replay
+harness), not by prose. See `ABI_V1 §7` and `ABI_V2_PROPOSAL §13`.
+
+---
+
+## Cross-reference notation
+
+Section references are always prefixed with the document, so a `§` is never
+ambiguous:
+
+- **`API §x`** → a section of `ABI_V1.md`.
+- **`V2 §x`** → a section of `ABI_V2_PROPOSAL.md`.
+- **`HOST §x`** → a section of `HOST_ARCHITECTURE.md`.
+- **`IDEAL §x`** → a section of `IDEAL.md`.
+
+A bare `§x` with no prefix is a bug — report it. (The old convention, where a bare
+`§` sometimes meant `IDEAL.md` and sometimes meant a local section, is retired.)
+
+---
+
+## Shared conventions (invariant across V1 and V2)
+
+These hold for every block and import in both ABI documents.
+
+### The three-layer boundary (`IDEAL §1`)
 
 | Layer | Who | Sees |
 |-------|-----|------|
 | **Host** | engine core (`scripting/`, `gfx_sdl.rgr`, …) | owns memory, devices, rendering, simulation |
 | **ABI** | shared `wasm/*.h` byte contracts + host imports | *transport only* — bytes and structure, never game meaning |
-| **Guest** | the game (Rust / AssemblyScript `.wasm`, or interpreted `.as`, or TS) | owns *meaning* — names channels, declares its world, registers its vocabulary |
+| **Guest** | the game (Rust / AssemblyScript `.wasm`, interpreted `.as`, or TS) | owns *meaning* — names channels, declares its world, registers its vocabulary |
 
-The ABI is a **transport, never a taxonomy** (§2.1). A block defines *bytes and
-structure*; the guest assigns meaning. No game name, sound id, character kind, or control
-label belongs in a shared header.
+The ABI is a **transport, never a taxonomy** (`IDEAL §2.1`): a block defines bytes
+and structure; the guest assigns meaning. No game name, sound id, character kind,
+or control label belongs in a shared header.
 
-### 0.2 Fixed-point
+### Fixed-point (`IDEAL §0.2`)
 
 | Constant | Value | Used for |
 |----------|-------|----------|
 | `FP_SCALE` | `256` | world/screen positions, normalized `[0,1]`, gain/pan/pitch ratios (`FP = unity`) |
 | `FP_VEL` (`RG_POSE_FP_VEL`) | `65536` (Q16.16) | velocities and speeds, per second |
 
-Anything fed *back* to the guest that could affect logic (a hit test, an unprojected
-pointer, a persisted read) uses fixed-point so results match across CPU, GPU, and replays.
+Anything fed *back* to the guest that could affect logic (a hit test, an
+unprojected pointer, a persisted read) uses fixed-point so results match across
+CPU, GPU, and replays. (The camera view matrix uses its own Q16.16 scale,
+`RG_CAM_FP_MTX`, distinct from `FP_SCALE`; see `V2 §16.2`.)
 
-### 0.3 Block discipline (the RGU1 rule — §2.3)
+### Direction & cadence encoding (`IDEAL §0.5`)
 
-Every block copies RGU1's discipline:
+- **Direction:** `1 = guest→host`, `2 = host→guest`.
+- **Cadence:** `1 = setup (once)`, `2 = frame (per step)`.
 
-- **Fixed, typed layout** at documented byte offsets; no pointers ever cross the boundary.
-- **Snapshot-first**: the writer publishes a complete, self-consistent block.
-- **Host validates** the block as untrusted data (magic, version, size, counts clamped).
-- **Tear-free** cross-thread reads use a seqlock `revision` (odd = writing, even = stable)
-  or a monotonic revision bump.
+These integers appear both on the wire and on the host-side provider interface
+(`HOST §1`).
 
-Standard header words every new block should carry:
+### Determinism principle (`IDEAL §0.5`)
 
-```c
-#define RG_*_OFF_MAGIC     0   /* u32 four-char block id, little-endian */
-#define RG_*_OFF_VERSION   4   /* u32 ABI version the writer wrote      */
-#define RG_*_OFF_SIZE      8   /* u32 total block bytes                 */
-#define RG_*_OFF_REVISION  12  /* u32 seqlock: odd=writing, even=stable */
-```
+Output-only channels (audio, haptics, particles, cosmetic animation, logging)
+**must never feed logic, RNG, or step order.** Inputs (pose, controls, capability
+reads at init, gameplay-animation lifecycle events, persisted reads) are
+**deterministic**: a replay sees the same values at the same step. Genuine runtime
+changes (resize, hotplug) arrive as **events**, never silent mid-step mutations.
 
-### 0.4 Handles (§2.6)
+What the shipped ABI actually guarantees today (fixed-point transport, but no
+end-to-end replay protocol yet) is stated honestly in `API §5`; the checkable
+record/replay protocol is proposed in `V2 §11`.
 
-Host objects a guest creates and frees are addressed by an **opaque handle**, never a
-pointer:
+### Block discipline (the RGU1 rule — `IDEAL §2.3`)
 
-- A handle encodes a **slot index + a generation counter**. A handle used after free fails
-  the generation check and becomes a **safe no-op**, not a dangling access.
-- Handle **`0` is null / allocation failure**.
-- Every handle belongs to the **spawning guest's arena**; on unload/teardown/fault the host
-  **bulk-frees the arena**, so a sandboxed guest cannot leak host objects.
-- Pools are **bounded**; allocation past capacity returns `0` so the guest back-pressures.
-
-This one discipline backs dynamic UI (§2.6), streamed resources (§2.7), sprite sheets
-(§2.8), audio (§2.10), animation (§2.12), and haptics (§2.9).
-
-### 0.5 Direction, cadence, determinism
-
-- **Direction**: `1 = guest→host`, `2 = host→guest`.
-- **Cadence**: `1 = setup (once)`, `2 = frame (per step)`.
-- **Determinism**: output-only channels (audio, haptics, particles, cosmetic animation,
-  logging) **must never feed logic, RNG, or step order**. Inputs (pose, controls, capability
-  reads at init, gameplay-animation lifecycle events, persisted reads) are **deterministic**:
-  a replay sees the same values at the same step. Genuine runtime changes (resize, hotplug)
-  arrive as **events**, never silent mid-step mutations.
-
-### 0.6 Capability gating (§6, §2.14)
-
-- Hard requirements go through the `RG_WASM_HOST_CAP_*` **bitmask**: a guest declares its
-  required caps; the host rejects an unsatisfiable guest **once, right after load, before
-  the first `update()`**, with a surfaced reason.
-- Soft capabilities go through the typed **environment query** (§2.14): the guest asks, the
-  host answers, the guest **adapts or degrades** (no GPU → software; no pad → D-pad; no
-  storage → no-op writes / absent reads).
+Every block follows RGU1's discipline: a fixed, typed layout at documented byte
+offsets (no pointers ever cross the boundary); snapshot-first publication; the host
+validates the block as untrusted data (magic, version, size, counts clamped); and
+tear-free cross-thread reads use a `revision` seqlock **where the block's writer
+model requires one**. Note that the shipped RGW1/RGSP1 blocks are single-threaded
+turn-based and carry `dt_ms` (not a seqlock) at offset 12 — the seqlock rule
+applies to cross-thread blocks (RGP1, RGIN, RGU1); see `API §1` for the precise,
+per-block model.
 
 ---
 
-## 1. Lifecycle & capability handshake (§2.14, §6)
-
-The defined init lifecycle, available on **every** path (WASM / `.as` / TS):
-
-```
-load → negotiate → init → loop
-```
-
-### 1.1 Handshake exports (guest → host)
-
-| Export | Purpose |
-|--------|---------|
-| `rg_abi_version() -> u32` | ABI version the guest was built against. |
-| `rg_ui_abi() -> u32` | RGU1 version, if the guest uses UI. |
-| `rg_required_caps() -> u32` | OR of `RG_WASM_HOST_CAP_*` bits the guest *must* have. Host rejects if unmet. |
-| `rg_declare_queries(...)` | Guest declares the soft-capability keys it wants answered. |
-| `rg_check_env(...)` | Guest reads the resolved environment (see §1.3). |
-
-The host's advertised caps are the **OR of every attached provider's `capBit()`** (§6), so
-adding a provider automatically widens what the host offers — there is no second list.
-
-**Recommended gate** (run once, right after load, before `init()`):
-
-```
-ver  = has(rg_abi_version)   ? call(rg_abi_version)   : 1;   /* legacy guest = v1  */
-need = has(rg_required_caps) ? call(rg_required_caps) : 0;
-if (ver > RG_WASM_ABI_VERSION) reject("needs newer host");   /* layout mismatch    */
-if (need & ~RG_WASM_HOST_CAPS) reject("missing capability");  /* feature gap        */
-/* then init(), verify magic + size, clamp every count to its MAX_*. */
-```
-
-The `has(...)` above requires the host to detect **export presence** — a legacy guest
-that omits `rg_abi_version` must read as v1, not as "exported and returned 0". The WASM
-host therefore needs an export-existence primitive (`rg_wasm_has_export` on the wasm3
-bridge); a host that cannot probe presence treats a `0` return as legacy v1 / caps 0.
-`RG_WASM_HOST_CAPS` is the OR of the attached providers' `capBit()`s (§7), so the gate
-consumes the provider registry and needs no separate cap list.
-
-**RGCQ typed query (shipped, RGW1 tail `wasm_game_abi.h`).** The soft-capability channel
-lives in the reserved RGW1 tail so `ABI_SIZE` is unchanged; a host that ignores it degrades
-to "nothing answered" and the guest reads its own defaults.
-
-```c
-#define RG_WASM_OFF_CAPQ         2304        /* block base                             */
-#define RG_WASM_CAPQ_MAGIC       0x51434752u /* 'RGCQ'                                 */
-#define RG_WASM_CAPQ_OFF_MAGIC   0   /* u32 guest writes once declared                 */
-#define RG_WASM_CAPQ_OFF_COUNT   4   /* u32 guest: number of requested keys (≤ 6)      */
-#define RG_WASM_CAPQ_OFF_READY   8   /* u32 host: 1 when answers are filled            */
-#define RG_WASM_CAPQ_OFF_POOL_USED 12/* u32 guest: key bytes used in the pool          */
-#define RG_WASM_CAPQ_ENTRIES     2320        /* entry[] base (CAPQ + 16)               */
-#define RG_WASM_CAPQ_MAX         6
-#define RG_WASM_CAPQ_ENTRY_SIZE  20
-#define RG_WASM_CAPQ_POOL        2440        /* string pool, to ABI_SIZE               */
-/* entry: keyOff(u16) keyLen(u16) present(u8) type(u8) _(u16) ival(i32) fval(f32) sLen(i32)
- *   guest writes keyOff/keyLen; host writes present/type/value.                       */
-#define RG_WASM_CAP_NONE 0u  /* value types: */
-#define RG_WASM_CAP_BOOL 1u
-#define RG_WASM_CAP_INT  2u
-#define RG_WASM_CAP_FLOAT 3u
-#define RG_WASM_CAP_STRING 4u
-```
-
-Flow: host calls `rg_declare_queries()` → guest writes keys; host resolves each and sets
-`READY = 1`; host calls `rg_check_env()` → guest returns `0` (run) or `!= 0` (abort reason).
-The §1.2 environment descriptor is the target generalisation of this 6-key tail onto every
-path. The **v2 target** widens the tail to the full core key set (§1.2) and mirrors it on the
-`.as`/TS paths; the 6-key RGW1 form above is the shipped subset.
-
-### 1.2 Environment descriptor (host → guest, read once at init)
-
-A typed key/value block the host publishes; keys are **open and typed**, but the core set is
-documented convention (§2.14), not per-host invention:
-
-```
-screen.width / screen.height / screen.dpi / screen.refreshHz / screen.safeArea
-device.type        # 0=desktop 1=handheld 2=tv 3=phone 4=embedded
-input.keyboard / input.pointer / input.touch / input.gamepads(count) / input.pose
-audio / haptics / gpu / storage / network      # present + limits
-locale / clock.monotonic
-log.level                                       # global log level (§2.16)
-```
-
-Capabilities are **read once at init** (stable inputs). Runtime changes (resize, gamepad
-hotplug) arrive as **events**, not silent value swaps. Viewport is a first-class field on
-*every* block (RGW1 gains view fields), and a **resize** is a lifecycle event.
-
----
-
-## 2. Blocks (data layouts)
-
-Shipping blocks are marked **shipped**; proposed blocks/fields are marked **proposed**.
-
-### 2.1 Overview
-
-| Block | Header | Purpose | Size | Direction | Status |
-|-------|--------|---------|------|-----------|--------|
-| **RGW1** | `wasm/wasm_game_abi.h` | world / physics | 2560 B | mostly guest→host | shipped |
-| **RGSP1** | `wasm/wasm_sprite_abi.h` | ready-character sprites | 2560 B | host writes catalog+input, guest writes slots | shipped (§2.9) |
-| **RGU1** | `wasm/wasm_ui_abi.h` | retained-mode UI | 8192 B | guest→host (+ optional `rg_ui_event`) | shipped (§2.10) |
-| **RGP1** | `wasm/wasm_pose_abi.h` | pose / body tracking | 856 B (read `OFF_SIZE`) | host→guest | header landed (§2.4) |
-| **RGIN** | `wasm/wasm_input_abi.h` | typed per-player input | 20 + 40·players | host→guest | header landed (§2.5) |
-| **RGO1** | `wasm/*.h` | game observation snapshot | — | host→worker | proposed (§2.7) |
-| **RGX1** | `wasm/*.h` | streaming worker observation/results | 2560 B | host↔worker | proposed header (§2.7) |
-| **RGLD** | `wasm/*.h` | resource loader requests/responses | — | host↔worker | proposed header (§2.7) |
-| **RG_CAM** | `wasm/*.h` | camera + view matrix | — | guest→host (+ matrix back) | proposed (§2.17) |
-
-**RGW1 shipped layout** (`wasm_game_abi.h`, magic `0x31574752` `'RGW1'`, v1, 2560 B,
-`FP_SCALE 256`). Header (64 B), all i32:
-
-| Off | Field | Dir | Off | Field | Dir |
-|-----|-------|-----|-----|-------|-----|
-| 0 | magic `'RGW1'` | guest | 32 | impulse_count | guest |
-| 4 | version | guest | 36 | contact_count | guest |
-| 8 | size (2560) | guest | 40 | score | guest |
-| 12 | dt_ms | host→guest | 44 | hits | guest |
-| 16 | time_ms | host→guest | 48 | camera_y | guest |
-| 20 | input | host→guest | 52 | event_count | guest |
-| 24 | input_p2 | host→guest | 56 | air_p1 *(→ generic guest scalar, §2.1)* | guest |
-| 28 | body_count | guest | 60 | air_p2 *(→ generic guest scalar)* | guest |
-
-The **host→guest** channel is only the four bold words (`dt_ms`, `time_ms`, `input`,
-`input_p2`) — the target adds view fields (§1.2) and the §2.5 input record here.
-
-Arrays (offsets derived from the `MAX_*`/`*_SIZE` constants):
-
-| Array | Off | Count × stride | Record fields (i32) |
-|-------|-----|----------------|---------------------|
-| `bodies` | 64 | 32 × 24 | `x, y, angle, speed, angVel, flags` |
-| `controls` | 832 | 32 × 16 | ch0..ch3 (§2.2; shipped = steer/throttle/brake/grip) |
-| `impulses` | 1344 | 16 × 16 | `bodyIdx, ix, iy, _` |
-| `contacts` | 1600 | 14 × 32 | see §2.3 |
-| `events` | 2048 | 12 × 20 | `kind, sub, a, b, c` |
-| RGCQ tail | 2304 | — | §1.1 |
-
-Event `kind`: `1 = sound`, `2 = rumble`, `3 = particles`. Body/impulse/event *counts* are
-host-clamped to their `MAX_*`. `MAX_BODIES 32`, `MAX_IMPULSES 16`, `MAX_CONTACTS 14`,
-`MAX_EVENTS 12`.
-
-### 2.2 Control record (RGW1 `controls[]`, 16 B) — §2.2
-
-Genre-neutral: four opaque scalar channels. The **guest** names them in its own source.
-
-```c
-#define RG_WASM_CTRL_OFF_CH0    0   /* i32 fixed-point control channel 0 */
-#define RG_WASM_CTRL_OFF_CH1    4   /* i32 fixed-point control channel 1 */
-#define RG_WASM_CTRL_OFF_CH2    8   /* i32 fixed-point control channel 2 */
-#define RG_WASM_CTRL_OFF_CH3    12  /* i32 fixed-point control channel 3 */
-```
-
-Host side stays neutral: `readControlChannel(bodyIdx, ch)` / indexed `writeControl` — never
-`steer/throttle/brake/grip`.
-
-### 2.3 Physics: body, shape, contact (RGW1) — §2.5
-
-The **24-byte body record streams pose only** (`x, y, angle, speed, angVel, flags`).
-Collision **geometry is declared once** (guest-owned), not carried per frame.
-
-```c
-/* body.flags — additive, genre-neutral */
-#define RG_WASM_BODY_ACTIVE    1u
-#define RG_WASM_BODY_STATIC    2u  /* infinite mass                          */
-#define RG_WASM_BODY_SENSOR    4u  /* report overlaps, apply NO response      */
-/* + a u16 layer + u16 mask per body: "which layers am I, which do I hit"    */
-
-/* Per-body collision descriptor (declared once, guest-owned) */
-#define RG_WASM_SHAPE_CIRCLE   1   /* a = radius (fp)                         */
-#define RG_WASM_SHAPE_BOX      2   /* a = halfW, b = halfH (fp)               */
-#define RG_WASM_SHAPE_SEGMENT  3   /* a..d = x1,y1,x2,y2 (fp)                 */
-#define RG_WASM_SHAPE_POLYGON  4   /* a = vertex count -> side vertex table   */
-
-/* Contact phases (RGW1) — complete three-phase model */
-#define RG_WASM_CONTACT_PHASE_BEGIN   1   /* pair started touching this step  */
-#define RG_WASM_CONTACT_PHASE_PERSIST 2   /* still touching                   */
-#define RG_WASM_CONTACT_PHASE_END     3   /* separated this step              */
-```
-
-**Contact record (32 B).** Shipped fields (`wasm_game_abi.h`), then the proposed manifold
-additions:
-
-```c
-/* shipped (8×i32): */
-#define RG_WASM_CT_OFF_BODYA    0   /* i32 body id code (guest convention, §2.1) */
-#define RG_WASM_CT_OFF_BODYB    4   /* i32 body id code                          */
-#define RG_WASM_CT_OFF_PHASE    8   /* i32 RG_WASM_CONTACT_PHASE_* (only BEGIN today) */
-#define RG_WASM_CT_OFF_IMPULSE  12  /* i32 normal impulse (fp)                   */
-#define RG_WASM_CT_OFF_X        16  /* i32 contact point x (fp)                  */
-#define RG_WASM_CT_OFF_Y        20  /* i32 contact point y (fp)                  */
-#define RG_WASM_CT_OFF_NX       24  /* i32 normal x * 1000 (milli)               */
-#define RG_WASM_CT_OFF_NY       28  /* i32 normal y * 1000 (milli)               */
-/* proposed additions (widen the record / repurpose slack): PERSIST/END phases,
- * penetration DEPTH (fp), and TANGENT (friction) impulse (fp).                  */
-```
-
-`MAX_CONTACTS` (14) overflow policy is documented (**drop-lowest-impulse**), not a silent
-clamp.
-
-**Shape descriptor (proposed, declared once, guest-owned).** Collision geometry never streams
-per frame; the guest declares one descriptor per body through the §5/§7 declare-once channel:
-
-```c
-struct RgShape { u32 kind; u16 layer; u16 mask; i32 a, b, c, d; };
-/* kind = RG_WASM_SHAPE_*; a..d per kind (circle:a=r; box:a=hw,b=hh;
- * segment:a..d=x1,y1,x2,y2; polygon:a=vertCount -> side vertex table).           */
-```
-
-Simulation sits behind a `PhysicsWorld` interface (`addBody` / `setBounds` / `step(dt)` /
-`contacts()`) so the arcade core, the `cannon` rigid-body port, or a host-native engine are
-selectable with **no ABI change** — the ABI transports *results* (poses + contacts), never
-engine internals. World config (gravity, fixed timestep, solver iterations, bounds) is
-negotiated through the declare-once channel / RGCQ, not hard-coded.
-
-### 2.4 Pose block (RGP1 v2) — §2.4
-
-Host→guest streaming skeleton with **motion and speed as first-class channels**. Replaces
-the drifting per-host layouts with one shared `wasm/wasm_pose_abi.h`.
-
-```c
-#define RG_POSE_ABI_MAGIC   0x31504752u /* 'RGP1' little-endian */
-#define RG_POSE_ABI_VERSION 2u
-#define RG_POSE_MAX_LM      33u          /* BlazePose skeleton              */
-#define RG_POSE_FP_SCALE    256          /* positions: normalized[0,1]*256  */
-#define RG_POSE_FP_VEL      65536        /* velocity/speed: Q16.16 per sec  */
-
-/* Header */
-#define RG_POSE_OFF_MAGIC      0   /* u32 'RGP1'                                  */
-#define RG_POSE_OFF_VERSION    4   /* u32 ABI version the host wrote              */
-#define RG_POSE_OFF_SIZE       8   /* u32 total block bytes                       */
-#define RG_POSE_OFF_REVISION   12  /* u32 seqlock: odd=writing, even=stable       */
-#define RG_POSE_OFF_PRESENT    16  /* u32 1 if a pose was detected this sample    */
-#define RG_POSE_OFF_GESTURE    20  /* i32 guest-defined gesture id (0 = none)     */
-#define RG_POSE_OFF_LM_COUNT   24  /* u32 landmarks written this sample           */
-#define RG_POSE_OFF_TIME_MS    28  /* i32 capture timestamp, monotonic ms         */
-#define RG_POSE_OFF_DT_MS      32  /* i32 ms since the previous published sample   */
-#define RG_POSE_OFF_FLAGS      36  /* u32 RG_POSE_FLAG_*                           */
-#define RG_POSE_OFF_BODY_VX    40  /* i32 aggregate body velocity x (FP_VEL)      */
-#define RG_POSE_OFF_BODY_VY    44  /* i32 aggregate body velocity y (FP_VEL)      */
-#define RG_POSE_OFF_BODY_SPEED 48  /* i32 aggregate body speed |v| (FP_VEL)       */
-#define RG_POSE_HEADER_SIZE    64
-
-/* Landmark array */
-#define RG_POSE_OFF_LM0        64
-#define RG_POSE_LM_SIZE        24
-#define RG_POSE_LM_OFF_X       0   /* i32 normalized x * FP_SCALE  (+x = right)    */
-#define RG_POSE_LM_OFF_Y       4   /* i32 normalized y * FP_SCALE  (+y = down)     */
-#define RG_POSE_LM_OFF_VX      8   /* i32 velocity x, normalized/sec * FP_VEL     */
-#define RG_POSE_LM_OFF_VY      12  /* i32 velocity y, normalized/sec * FP_VEL     */
-#define RG_POSE_LM_OFF_SPEED   16  /* i32 |velocity|, normalized/sec * FP_VEL     */
-#define RG_POSE_LM_OFF_CONF    20  /* i32 visibility/confidence, 0..FP_SCALE      */
-
-/* Flags */
-#define RG_POSE_FLAG_VALID         1u /* host finished a full frame               */
-#define RG_POSE_FLAG_HAS_VEL       2u /* velocity/speed are host-provided         */
-#define RG_POSE_FLAG_SMOOTHED      4u /* landmarks passed the host filter         */
-#define RG_POSE_FLAG_JUST_APPEARED 8u /* present flipped 0->1; velocity zeroed     */
-```
-
-Motion (`vx/vy`), speed (`|v|`), and an aggregate body velocity/speed are **host-provided**
-(the host computes them from consecutive frames and smooths them), gated by
-`RG_POSE_FLAG_HAS_VEL` and `RG_WASM_HOST_CAP_POSE_INPUT`.
-
-### 2.5 Input record (host → guest) — §2.9
-
-One typed per-player input record, transported for N players. The digital
-`Buttons`/`PlayerButtons` model stays the simple default; analog/pointer are additive.
-
-```c
-#define RG_IN_OFF_BUTTONS   0   /* u32 digital bitfield (D-pad, face, start/select) */
-#define RG_IN_OFF_LSTICK_X  4   /* i32 left stick x,  -FP..+FP (normalized * FP)    */
-#define RG_IN_OFF_LSTICK_Y  8   /* i32 left stick y                                 */
-#define RG_IN_OFF_RSTICK_X  12  /* i32 right stick x                                */
-#define RG_IN_OFF_RSTICK_Y  16  /* i32 right stick y                                */
-#define RG_IN_OFF_TRIG_L    20  /* i32 left trigger,  0..FP                         */
-#define RG_IN_OFF_TRIG_R    24  /* i32 right trigger, 0..FP                         */
-#define RG_IN_OFF_POINTER_X 28  /* i32 pointer/touch x in view px (-1 = none)       */
-#define RG_IN_OFF_POINTER_Y 32  /* i32 pointer/touch y                              */
-#define RG_IN_OFF_FLAGS     36  /* u32 pointerDown, connected, ...                  */
-```
-
-The record above is **40 B/player** (`RG_IN_STRIDE`); the block is a 20-byte header
-(`magic 'RGIN'`, version, size, **`revision`** — the standard seqlock word §0.3, so a
-per-frame host→guest write reads tear-free — then `player_count`) followed by
-`record[player_count]`, and the
-host clamps `player_count` to the negotiated max (the host tracks up to **8** players; today
-RGW1 exposes only `input`/`input_p2` — five bits × 2 players — which becomes `record[0]` /
-`record[1]` `BUTTONS` fields). Shipped digital bits (`RG_WASM_IN_*` / `RG_SPR_IN_*`):
-`UP=1, DOWN=2, LEFT=4, RIGHT=8, ACTION=16` (RGSP1 adds `BACK=32`).
-
-Games declare **semantic actions** ("jump", "steer") and the host maps physical inputs →
-actions through a **remappable table** the guest (or a settings UI) supplies. Device
-connect/disconnect is surfaced as an event (hotplug). Direction: host→guest, cadence: frame.
-
-### 2.6 Sound event (guest → host) — §2.10
-
-Same record on RGW1, `.as`, and TS. The id references a **game-registered palette** (§4),
-never a frozen enum.
-
-```c
-#define RG_SND_OFF_KIND     0   /* u32 0=sfx 1=voice 2=music-start 3=music-stop */
-#define RG_SND_OFF_ID       4   /* u32 registered sound id (see §4 palette)     */
-#define RG_SND_OFF_GAIN     8   /* i32 gain 0..FP (FP = unity)                  */
-#define RG_SND_OFF_PAN      12  /* i32 pan -FP..+FP (0 = centre)                */
-#define RG_SND_OFF_PITCH    16  /* i32 pitch ratio * FP (FP = no shift)         */
-#define RG_SND_OFF_FLAGS    20  /* u32 loop, positional, ...                    */
-#define RG_SND_OFF_X        24  /* i32 world x (positional, * FP_SCALE)         */
-#define RG_SND_OFF_Y        28  /* i32 world y                                  */
-```
-
-One-shots are fire-and-forget by id; loops/music/long voices return a **handle** (§0.4) for
-gain/stop/crossfade. Music (`kind = 2/3`) may be a decoded track *or* a **soundscore**
-(§3.5). Sounds are §2.7 resources behind one decoder (WAV + a compressed format).
-
-### 2.7 Camera block (RG_CAM) — §2.17
-
-Guest declares the camera; host writes back the resolved matrix and viewport.
-
-```c
-/* Camera block (guest -> host); fixed-point per §0.2 */
-#define RG_CAM_OFF_X       0   /* i32 camera world x (* FP_SCALE)          */
-#define RG_CAM_OFF_Y       4   /* i32 camera world y                       */
-#define RG_CAM_OFF_ZOOM    8   /* i32 zoom (* FP; FP = 1x)                 */
-#define RG_CAM_OFF_ROT     12  /* i32 rotation (* FP radians)             */
-#define RG_CAM_OFF_FOLLOW  16  /* u32 follow entity id (0 = free)          */
-/* host writes back the resolved 3x3 view matrix + viewport for the guest  */
-#define RG_CAM_OFF_VIEW_M  32  /* 6×i32 affine (a b c d e f), host-written */
-```
-
-One camera model → one affine `Mat3` view matrix applied on **software and GPU**
-(`screen = view · world`). The host also exposes the **inverse** (screen ↔ world) for
-pointer/touch picking and world-anchored HUD. A shared per-object local transform
-(translation, rotation, scale, pivot, optional parent/child) generalises the stranded
-`cannon_mat3`/`cannon_transform` math into the 2D engine.
-
-### 2.8 Resource / streaming blocks — §2.7
-
-- **RGO1** (host→worker, revision-gated snapshot): header (`magic`, `version`, `size`,
-  `revision`), camera transform + view volume, world bounds/grid, `time_ms`, and an optional
-  `wishlist[]` of `(resourceKey, priority)`. Proposed header; split out of RGX1.
-- **RGX1** (host↔worker, 2560 B, proven on the wasm3 bridge with mock handles): host writes an
-  observation (camera transform, view size, world grid, entity list); the worker writes back
-  per-cell visibility flags + a request ring of `{ cell, op=load|free }`, driven by a
-  residency ring with hysteresis (`preload` < `retire`). Needs a shared `wasm/*.h`.
-- **RGLD** (host↔worker): request record `{ cell, kind = load|generate }` → the worker
-  **produces** a resource; `{ cell, op = free }` → it **releases** it; status words report
-  `live / peak / gen / freed`.
-
-Invariant (the streaming regression fixture, §5): **`gen − freed = live`** — bounded live
-memory under unbounded travel. The `streaming_world` stress test holds ~13 live from
-1143 generated / 1130 freed while roaming a 1000×1000 world.
-
-### 2.9 RGSP1 — ready-character sprites (shipped)
-
-`wasm_sprite_abi.h`, magic `0x50534752` `'RGSP'`, v1, 2560 B, `FP_SCALE 256`. Host writes the
-header + catalog + input; the guest writes `slot_count` and the slot array; the host resolves
-`charId → sheet/rows`, animates, and may write the resolved `frame` back.
-
-```c
-/* Header (64 B) */
-#define RG_SPR_OFF_MAGIC  0  /* RG_SPR_OFF_VERSION 4, OFF_SIZE 8 (guest)          */
-#define RG_SPR_OFF_DT_MS  12 /* host; TIME_MS 16 host                             */
-#define RG_SPR_OFF_CHAR_COUNT 20 /* host: catalog size                            */
-#define RG_SPR_OFF_SLOT_COUNT 24 /* guest: slots to draw                          */
-#define RG_SPR_OFF_INPUT  28 /* host; INPUT_P2 32 host                            */
-#define RG_SPR_OFF_VIEW_W 36 /* host: viewport px; VIEW_H 40 host                 */
-#define RG_SPR_OFF_MODE   44 /* guest: 0=menu 1=play                              */
-/* Slots @64: RG_SPR_MAX_SLOTS 64 × RG_SPR_SLOT_SIZE 32. Slot fields (i32): */
-#define RG_SPR_SLOT_OFF_CHARID 0  /* 0 = empty */   /* ANIM 4, DIR 8, FLAGS 12    */
-#define RG_SPR_SLOT_OFF_XFP 16    /* YFP 20 (feet), CLOCK 24 (anim ms), FRAME 28  */
-/* Catalog id table (host): RG_SPR_OFF_CAT_IDS 2112, i32[RG_SPR_MAX_CAT 32].      */
-```
-
-Slot flags: `ACTIVE=1, FRAMEOVERRIDE=2, FLIP_X=4`. `DIR`: `UP=0, LEFT=1, DOWN=2, RIGHT=3`.
-Exports: `sprite_ptr/size/init/tick`. **Target (§2.1, §2.8):** the roster is the catalog table
-(`RG_SPR_OFF_CAT_IDS`), not the shipped `RG_SPR_CHAR_HERO/KNIGHT/MAGE/ROGUE` constants; `anim`
-becomes data-driven atlas rows, not the frozen `WALK=0/RUN=1/JUMP=2` (RUN/JUMP fall back to
-WALK today). RGSP1 slots fold into the §5.2 sprite model and bind to physics bodies via §5.3.
-
-### 2.10 RGU1 — retained-mode UI (shipped; the block to imitate, §2.3-ideal)
-
-`wasm_ui_abi.h`, magic `0x31554752` `'RGU1'`, v1.0, 8192 B. A **flat** vDOM: `parent_id +
-child_order` describe structure; strings live in a table referenced by `(offset,len)`; colors
-are `0xRRGGBBAA`. The host validates the whole block as untrusted (magic, version, bounds,
-unique ids, valid/acyclic parents, utf-8) and rebuilds the `EVGElement` tree on a `revision`
-bump. Exports: `rg_ui_ptr/size/revision`.
-
-```c
-/* Header (48 B) */  RG_UI_OFF_MAGIC 0, MAJOR 4(u16), MINOR 6(u16), REVISION 8,
-/*   ROOT_ID 12, NODE_OFFSET 16, NODE_COUNT 20, PROP_OFFSET 24, PROP_COUNT 28,   */
-/*   STRING_OFFSET 32, STRING_SIZE 36, FLAGS 40 (RG_UI_FLAG_VALID 1).            */
-/* Node table @64: MAX_NODES 64 × NODE_SIZE 32. Node fields:                     */
-/*   id 0, parent_id 4, kind 8(u16), flags 10(u16), first_property 12,           */
-/*   property_count 16(u16), child_order 18(u16), event_mask 20.                 */
-/* Property table @2112: MAX_PROPS 128 × PROP_SIZE 16:                           */
-/*   key 0(u16), type 2(u8), flags 3(u8), value_a 4, value_b 8, value_c 12.      */
-/* String table @4160: STRING_CAP 1024.                                          */
-```
-
-- **Node kinds** (`RgUiNodeKind`): `VIEW=1, TEXT=2, IMAGE=3, PROGRESS_BAR=4, BUTTON=5,
-  SPACER=6, CUSTOM=100`.
-- **Node flags** (u16): `SELECTABLE=0x1, DISABLED=0x2, DEFAULT=0x4`.
-- **Property types**: `I32=1, F32=2, COLOR=3, STRING=4 (a=off,b=len), VEC2=5, RECT=6, ENUM=7,
-  BOOL=8`.
-- **Property keys**: `TEXT=1, BACKGROUND=2, COLOR=3, FONT_SIZE=4, FONT_FAMILY=5; WIDTH=10,
-  HEIGHT=11, PADDING=12, MARGIN=13, BORDER_RADIUS=14, BORDER_COLOR=15, BORDER_WIDTH=16;
-  FLEX=20, FLEX_DIRECTION=21, ALIGN_ITEMS=22, JUSTIFY=23, TEXT_ALIGN=24; IMAGE_RESOURCE=30;
-  VALUE=40, MAX_VALUE=41`. Enums: `FlexDirection {ROW=0, COLUMN=1}`, `Align {START=0, CENTER=1,
-  END=2, SPACE_BETWEEN=3}`.
-- **Events** (shipped `event_mask` subset): `ACTIVATE=0x1, SELECT=0x2, DESELECT=0x4` — widened
-  to the full interaction set by §4 / §3.1. Selection state lives on the host, keyed by stable
-  node id, and survives rebuilds.
-
-**Target:** the dynamic/delta mode (§3.1 `rg_evg_*` + command block) complements this snapshot
-mode; both keep the same kinds/keys and the "no pointers cross, host validates" discipline.
-
----
-
-## 3. Host imports (guest → host functions)
-
-All handles follow §0.4. All string/byte pointers are copied *out of* guest memory — the
-host never retains a guest pointer. Every call validates its handle; an invalid handle is a
-no-op, not a crash.
-
-### 3.1 Dynamic UI / EVG objects — §2.6
-
-```c
-/* Guest -> host. All ids are opaque handles, never pointers. */
-uint32_t rg_evg_create(uint32_t kind);                 /* RG_UI_* kind -> handle (0=OOM) */
-void     rg_evg_set_i32  (uint32_t h, uint32_t key, int32_t  v);
-void     rg_evg_set_color(uint32_t h, uint32_t key, uint32_t rgba);
-void     rg_evg_set_str  (uint32_t h, uint32_t key, uint32_t str_off, uint32_t len);
-void     rg_evg_append   (uint32_t parent, uint32_t child);  /* build the tree      */
-void     rg_evg_remove   (uint32_t h);                 /* detach, keep the object     */
-void     rg_evg_destroy  (uint32_t h);                 /* free h and its subtree      */
-void     rg_evg_set_root (uint32_t h);                 /* which handle is the root     */
-```
-
-`destroy(h)` frees `h` and its descendants and bumps each freed slot's generation (safe
-double-free / use-after-free). The same eight ops may instead be written into a shared
-**command block** and applied once per frame — the *delta* counterpart to RGU1's *snapshot*.
-Gated by `RG_WASM_HOST_CAP_UI_DYNAMIC`; snapshot RGU1 (§2.3) stays the zero-dependency
-default.
-
-### 3.2 Resources — §2.7
-
-```c
-uint32_t rg_res_begin (uint32_t kind, uint32_t w, uint32_t h, uint32_t fmt); /* -> staging buffer */
-uint64_t rg_res_commit(uint32_t staging_id, uint32_t key);  /* filled buffer -> u64 handle */
-void     rg_res_free  (uint64_t handle);                    /* refcounted release          */
-uint64_t rg_res_lookup(uint32_t key);                       /* dedup / cache by key        */
-/* kind in { texture2D, mesh, audioClip, tilemap, ... } — nothing says "2D". */
-```
-
-A file **loader** and a procedural **generator** both fill a staging buffer and call
-`rg_res_commit` — "load" and "generate" are one path. Handles are **refcounted** and
-arena-owned (bulk-freed on worker shutdown/fault). `rg_res_begin` past capacity returns null
-(back-pressure). Gated by `RG_WASM_HOST_CAP_RES_STREAM`; the declare-once manifest
-(`rg_host_register_sheet` / `rg_host_register_rect`) remains the default for small games.
-
-Worker plugin contract (a worker is "just another guest"):
-
-```c
-void rg_worker_init(...);
-void rg_worker_tick(...);
-void rg_worker_shutdown(...);
-uint32_t rg_spawn_worker(ptr, len);   /* a game guest spawns a loader from its own WASM */
-```
-
-### 3.3 Storage — §2.11
-
-```c
-/* scope: 0 = per-game, 1 = global/shared. Values are opaque byte blobs. */
-i32  rg_store_get(u32 scope, ptr keyUtf8, u32 keyLen, ptr outBuf, u32 outCap);
-                                   /* -> byte length (or -1 = absent)          */
-void rg_store_set(u32 scope, ptr keyUtf8, u32 keyLen, ptr valBuf, u32 valLen);
-void rg_store_delete(u32 scope, ptr keyUtf8, u32 keyLen);
-u32  rg_store_list(u32 scope, ptr prefix, u32 prefixLen, ptr outBuf, u32 outCap);
-void rg_store_commit(u32 scope);   /* atomically flush pending set/delete       */
-```
-
-Keyed and transactional (atomic temp-and-rename on `commit`). Scopes (per-game / global),
-optional named slots, host-enforced isolation, a format/version tag for migration, and a
-host-reported quota. Backend is pluggable (FS / `localStorage` / IndexedDB / in-memory /
-cloud) behind the same imports; the interface is **async-shaped** (awaitable `commit`).
-`loadGameData` / `saveGameData` become a thin whole-object wrapper over `get`/`set` on one
-well-known key. Gated via §6. A **read is a deterministic input**; a write must not alter
-logic mid-frame.
-
-### 3.4 Animation — §2.12
-
-```c
-/* Guest -> host; returns an opaque handle. */
-u32  rg_anim_start(u32 target, u32 clipOrTweenId, ptr paramsBuf, u32 paramsLen);
-void rg_anim_set(u32 handle, u32 key, i32 value);   /* speed, weight, seek, ... */
-void rg_anim_stop(u32 handle, u32 flags);           /* finish | cancel | hold   */
-```
-
-One model (clip or tween) drives a §2.6 UI node, a §2.8 sprite frame, or a §2.5
-`BodyVisual` transform — the difference is only the `target`. Tween
-`x/y/scale/rotation/opacity/color` (and sprite frame) over **keyframe tracks** with a
-registered **easing** set (linear, quad, cubic, elastic, …) and `loop`/`pingpong`/`reverse`.
-Clips/easings are **game-registered** (`register("glow", …)`), so `glow/pulse` and
-`WALK/RUN/JUMP` dissolve into guest data. Animations advance on the negotiated timestep so a
-replay animates identically.
-
-### 3.5 Audio (see also the sound event §2.6)
-
-Emitting a sound writes the §2.6 sound-event record. Loading a sound acquires a §2.7
-resource handle. The **built-in synth**, the **soundscore player** (text-based multi-voice
-procedural music), and the **vocal synth** become §2.7 **"generate" producers**: a score
-(inline or by resource id) → a music handle, so the same procedural-music engine serves
-every path and scores can layer (the "one score at a time" limit lifts). Loop/duck/crossfade
-are parameters; live handles adjust tempo or per-track gain.
-
-### 3.6 Haptics — §2.9
-
-Fired as an event addressing a **target** (pad index, or `-1` = all; optionally
-L/R/trigger). Both motors are honoured (`low` = heavy/low-freq, `high` = sharp/high-freq) —
-never collapsed to one `strength`.
-
-```c
-/* Base command; both motors distinct. */
-struct RgHaptic { i32 target; i32 low; i32 high; i32 ms; };
-```
-
-Optional **envelope** (attack/sustain/release) or a small named **pattern** (`bump`, `hit`,
-`engine`, `click`) with an intensity — pattern names are a per-game vocabulary the host maps
-(§4), not a frozen enum. Overlapping effects **mix or arbitrate by priority**; a sustained
-effect is updated/stopped **by handle** (§0.4). Gated by `RG_WASM_HOST_CAP_RUMBLE`;
-output-only (never feeds logic/RNG).
-
-### 3.7 View navigation — §2.13
-
-```c
-/* Guest -> host; route is a registered name (see §4). Safe end-of-frame semantics. */
-void rg_view_load(u32 route, ptr argsBuf, u32 argsLen);  /* replace, clear stack  */
-void rg_view_push(u32 route, ptr argsBuf, u32 argsLen);  /* suspend cur, open new */
-void rg_view_pop(ptr resultBuf, u32 resultLen);          /* resume caller w/ result */
-```
-
-`push` **suspends** the current view (state stays alive, paused) and overlays the new one;
-`pop` **resumes** it exactly where it left off, delivering a **typed result**. `load` is a
-full replace that clears the stack. Views can be **modal** (input captured). Routes are
-**game-registered names**, not file paths. Full-reload remains a fallback mode for
-memory-bounded hosts. Deterministic control-flow input (a replay visits the same views with
-the same args in the same order).
-
-### 3.8 Logging — §2.16
-
-```c
-/* Guest -> host; one stream shared by host and guest. */
-#define RG_LOG_TRACE 0
-#define RG_LOG_DEBUG 1
-#define RG_LOG_INFO  2
-#define RG_LOG_WARN  3
-#define RG_LOG_ERROR 4
-#define RG_LOG_FATAL 5
-void rg_log(u32 level, u32 channel, ptr msgUtf8, u32 msgLen);
-```
-
-Per-channel level filtering (`audio=WARN`, `physics=DEBUG`), set from the `log.level` env key
-(§1.2) and adjustable at runtime — filtered `TRACE`/`DEBUG` cost nothing. Pluggable
-**output-only** sinks (stdout / file / ring buffer / on-screen console / test capture).
-Errors are typed results carrying **severity + code + channel + message** (`FATAL` ties into
-the §1 abort-with-reason), propagated to the guest and surfaceable in a HUD/console.
-
-### 3.9 Particles & effects — §2.18
-
-Spawns/triggers use the same **event + handle** shape as audio (§3.5) and animation (§3.4):
-one-shot bursts are fire-and-forget by id; continuous emitters and live filters return a
-**handle** to update/stop; completion arrives on the host→guest event channel
-(`rg_ui_effect_done` generalised, §4.x). Particle textures come from §2.7/§2.8 resources.
-
-- **Emitters** are game-registered descriptors: emission rate / burst count, lifetime, spawn
-  shape, direction + spread, initial speed, gravity/forces, **size and colour curves over
-  life**, blend mode, optional textured/sprite particles.
-- **Effects** (glow / pulse / screen-wash generalised) are §2.12 animations over a target
-  (node / screen / world-region).
-- **Filters** are ordered stages in a per-frame or per-layer post chain (blur, bloom, colour
-  grade, vignette, CRT/scanline, chromatic aberration, distortion).
-
-Software/GPU parity; particle RNG uses the engine's **seeded, fixed-point** convention so a
-burst replays identically; output-only; capability-gated (`max particles`, available
-filters, GPU vs software).
-
----
-
-## 4. Events (host → guest exports)
-
-The guest optionally exports these; the host calls them. One shared host→guest event path.
-
-| Export | From | Signature / payload |
-|--------|------|---------------------|
-| `rg_ui_event` | §2.6 / §2.15 | `void rg_ui_event(u32 target, u32 event, u32 a, u32 b)` — `target` = §2.6 handle or RGU1 node id; `event` ∈ `ACTIVATE / FOCUS / BLUR / POINTER_DOWN / POINTER_UP / POINTER_MOVE / POINTER_ENTER / POINTER_LEAVE / DRAG / SCROLL / TEXT / VALUE_CHANGED / SELECT / DESELECT`; `a,b` = typed payload (pointer x/y, scroll dx/dy, text off/len). |
-| `rg_anim_event` | §2.12 | `void rg_anim_event(u32 handle, u32 event, u32 value)` — `event: 0=END 1=LOOP 2=FRAME(value=frame) 3=LABEL(value=labelId)`. |
-| view lifecycle | §2.13 | `onEnter` / `onExit` / `onPause` / `onResume` (with the returned result on resume). |
-| `rg_ui_effect_done` | §2.18 | effect/particle/filter completion (generalised across the "make it flashy" paths). |
-| resize / hotplug | §2.14 | viewport resize and gamepad connect/disconnect arrive as events, not silent mutations. |
-
-RGU1 nodes opt into events via `event_mask` (a node receives only what it subscribes to), so
-the guest is never spammed. Node flags: `RG_UI_NODEFLAG_SELECTABLE`, `RG_UI_NODEFLAG_DEFAULT`.
-
-Shipped RGU1 event constants (the minimal subset the widened taxonomy extends):
-
-```c
-#define RG_UI_EVENT_ACTIVATE  0x0001u  /* action button pressed while selected */
-#define RG_UI_EVENT_SELECT    0x0002u  /* selection cursor moved onto the node */
-#define RG_UI_EVENT_DESELECT  0x0004u  /* selection cursor left the node       */
-```
-
----
-
-## 5. Sprites, atlases, and HUD (data shapes)
-
-### 5.1 Atlas (data the guest/provider declares) — §2.8
-
-```
-Atlas (the runtime shape of today's atlas.json)
-  frameW, frameH, sheetW, sheetH
-  directions: [ up, left, down, right ]          ; row order; FLIP_X may reuse LEFT
-  animations: { <id>: { row, frameCount, cycle[], fps, loop } }
-```
-
-Animation ids, rows, and cycles are **data** (LPC emits them); a `slash`/`cast` row needs no
-new `RG_SPR_ANIM_*` constant, and the roster is the catalog table (`RG_SPR_OFF_CAT_IDS`),
-never `RG_SPR_CHAR_*`.
-
-### 5.2 Sprite instance — §2.8
-
-```
-Sprite = { visual:   sheetHandle + atlas   (or a registered shape-drawer, §6)
-           transform: x, y, angle, scale, flipX
-           anim:      animId, clockMs | frameOverride, dir }
-```
-
-`GameEntity` kinds, RGSP1 slots, and the RGS1 draw list all become *this*. Pose comes from
-the guest directly or from a physics body (§5.3). Animation is **one clock over the atlas**.
-Sheets load through the §2.7 resource path (decode PNG *and* JPEG through one decoder →
-upload → refcounted handle). Runtime LPC composition is a §2.7 "generate" producer. GPU
-(`shGpuTexId`) and software (`ImageBuffer`) resolve behind one interface, capability-gated.
-
-### 5.3 Body → visual binding — §2.5
-
-One declared contract the game provides (not three code paths):
-
-```
-interface BodyVisual {                 ; provided by the game (§7), not core
-    fn visualFor(bodyId:string) : VisualRef        ; template id | RGSP1 charId
-    fn animFor(bodyId:string st:BodyState) : (anim dir flip)  ; guest rule, §6
-}
-; Host loop, backend-agnostic:
-;   for each active body: read (x,y,angle) from RGW1,
-;     resolve BodyVisual.visualFor(id),
-;     write that transform into the sprite template OR the RGSP1 slot xFp/yFp,
-;     pick anim/dir from BodyVisual.animFor(id, {speed, vx, vy, lastContact}).
-```
-
-### 5.4 HUD — §2.15
-
-The HUD is an EVG/RGU1 document the game declares, drawn by the **one EVG renderer** (TTF
-glyph/line cache, backgrounds, borders/radius, images, clip, GPU path) used for both HUD and
-menus — the limited `GameHudBlitter` and the hand-drawn `fillRect` fallback are deleted. The
-HUD is **interactive** via the one typed input (§2.4 input record) delivered back over
-`rg_ui_event` (§4): a HUD button, an in-game slider, and a text field fire the same events on
-every path. Layout via `EVGLayout`; styling is guest-declared, host-resolved; the HUD sizes
-itself from the negotiated viewport (§1.2). HUD updates use the §2.6 handle/mutation model
-for cheap incremental changes.
-
----
-
-## 6. Registries (data the guest declares, not branches in core) — §4
-
-Game vocabulary is **registration**, not `if (kind == "…")` in core. The registration table
-lives in core; entries come from the game at load (setup).
-
-| Registry | Call (at setup) | Replaces |
-|----------|-----------------|----------|
-| Shape drawers | `registerShape("ghost", fn)` | `kind == "wedge"` / `kind == "ghost"` in `game_sprite.rgr` |
-| Sound palette | `registerSound("brick", spec)` | builtin ids `brick`/`bounce`/`wall` in `game_audio.rgr` |
-| Animation clips / easings | `register("walk", …)` / `register("glow", …)` | `WALK/RUN/JUMP`, `glow/pulse` enums |
-| Haptic patterns | pattern-name registration | frozen rumble presets |
-| View routes | route-name registration | raw file paths |
-| Emitters / effects / filters | emitter/effect/filter descriptors | four canned particle presets, `"sparkle"` |
-| Feature flags | named/typed flag registry | ad-hoc `verbose` / `useWasmHud` / `debugmode` |
-
-Feature flags are named, typed values (bool/int/enum) with a defined **source precedence** —
-build default → config / `game.info` → env / CLI → persisted (§2.11) → runtime override —
-queryable by host *and* guest over the §1.2 key/value channel, scoped per-game or global.
-Flags read at init are stable inputs; runtime toggles arrive as events.
-
----
-
-## 7. Providers & the capability seam — §6
-
-Every host capability plugs into a **registry**, not hand-wired into the runner and three
-bridges:
-
-```
-class GameProvider {
-    fn id:string ()        ; "resource", "pose", "scene", …
-    fn capBit:int ()       ; RG_WASM_HOST_CAP_* it satisfies (0 = base ABI)
-    fn direction:int ()    ; 1 = guest->host, 2 = host->guest
-    fn cadence:int ()      ; 1 = setup (once), 2 = frame (per physicsStep)
-    fn onAttach / onDeclare / beforeUpdate / afterUpdate / onDetach
-}
-```
-
-The host's advertised caps = the OR of every provider's `capBit()`; the gate runs **once,
-right after load, before `update()`**, rejecting a guest whose required caps are unmet.
-Adding a provider automatically widens what the host advertises.
-
-The engine-core ↔ game seam is `GameSceneProvider` (§3 of `IDEAL.md`): a generic runner
-obtains **everything game-specific from an interface it is compiled against** — never from
-concrete game types, imports, or constants.
-
-```
-interface GameSceneProvider {              ; provided by the game, held by the core runner
-    ; world (guest is the preferred source; a provider is the fallback)
-    fn buildScene(phys:GamePhysics bodyIds:[string]) : void   ; bodies + bounds
-    fn worldSize() : (int, int)                               ; no 6000 baked in core
-    fn playerCount() : int                                    ; no fixed 2 in core
-    ; presentation
-    fn initAssets(render:GenericRender pw:int) : void
-    fn buildStaticBg(render:GenericRender) : void
-    fn spriteFor(id:string) : string                          ; entity id -> template
-    fn drawHud(target:SoftCanvas paneIdx:int abi:WasmAbiMem) : void  ; HUD, or emit RGU1
-    ; ABI conventions this guest chose (§2.1 / §2.2)
-    fn contactBodyCode(id:string) : int
-    fn bodyCodeToId(code:int) : string
-    fn mapEvent(kind:int sub:int) : GameEventNative           ; sound / particle ids
-    ; camera policy
-    fn cameraFor(paneIdx:int phys:GamePhysics) : int
-}
-```
-
-Proposed — not yet in code: `wasm_physics_runner.rgr` still imports `wasm_autopeli_setup.rgr`/
-`wasm_autopeli_render.rgr` and holds a concrete `setup:WasmAutopeliSetup`. The **guest owns
-the world** (§5 of `IDEAL.md`): it declares bodies, bounds, world size, camera hints, and
-static-bg through the same declare-once channel it already uses for resources; the host-side
-`setupPhysics()` copy is deleted. One world, one owner.
-
----
-
-## 8. Capability bits (`RG_WASM_HOST_CAP_*`)
-
-A guest ORs the bits it requires into `rg_required_caps()`; the host advertises the OR of its
-providers' `capBit()`s and rejects an unsatisfiable guest at load (§7).
-
-| Bit (name) | Value | Gates | Chapter |
-|------------|-------|-------|---------|
-| `RG_WASM_HOST_CAP_PHYSICS` | `0x0001` | host runs `GamePhysics` for the guest | §2.3 |
-| `RG_WASM_HOST_CAP_RUMBLE` | `0x0002` | gamepad rumble events honoured (→ dual-motor, §3.6) | §2.9 |
-| `RG_WASM_HOST_CAP_PARTICLES` | `0x0004` | particle events honoured | §3.9 |
-| `RG_WASM_HOST_CAP_RGU1` | `0x0008` | retained-mode HUD (RGU1) parsed | §2.10 |
-| `RG_WASM_HOST_CAP_POSE_INPUT` | `0x0010` | RGP1 pose streaming + motion/speed | §2.4 |
-| `RG_WASM_HOST_CAP_UI_DYNAMIC` | `0x0020` | handle-based dynamic EVG UI (`rg_evg_*`) | §2.6 |
-| `RG_WASM_HOST_CAP_RES_STREAM` | `0x0040` | `rg_res_*` streaming resources / workers | §2.7 |
-| GPU sheets / GPU camera / GPU fx | *tbd* | GPU sprite/camera/effect/filter paths | §2.8, §2.7, §3.9 |
-| audio / voice / music / file-decode / positional | *tbd* | audio playback classes | §2.6, §3.5 |
-| storage (scopes / binary / size) | *tbd* | persistence classes | §3.3 |
-| animation (targets / easings / labels) | *tbd* | animation classes | §3.4 |
-| navigation (stack depth / suspend-resume / modal) | *tbd* | view-stack classes | §3.7 |
-
-Bits `0x0001`–`0x0010` are **shipped values** (`0x0001`–`0x0008` in `wasm_game_abi.h`,
-`0x0010` reserved for pose per §2.4). Bits `0x0020` and up are **reserved**: assign
-additively, never reuse a retired bit. `RG_WASM_HOST_CAPS` (what a given host advertises) is
-the OR of its providers' `capBit()`s and is defined by the host build, not the header. Soft
-capabilities that a guest can *adapt* to are answered through the typed environment query
-(§1.2 / §1.1 RGCQ) rather than the hard bitmask.
-
----
-
-## 9. Determinism summary
-
-| Channel | Kind | Rule |
-|---------|------|------|
-| Pose (§2.4), controls (§2.9), env reads at init (§1.2), persisted reads (§2.11) | input | deterministic — a replay sees the same values at the same step |
-| Gameplay animation lifecycle events (§2.12) | input | deterministic — fire at the same step every run |
-| Audio (§2.10), haptics (§2.9), particles/effects/filters (§2.18), cosmetic animation (§2.12), logging (§2.16) | output | never feed logic, RNG, or step order |
-| Streaming residency (§2.7) | output | affects only rendering + resource lifetime, never the game outcome |
-| Resize / hotplug / runtime flag toggles (§1.2, §2.14, §4) | event | arrive as events, never silent mid-step mutations |
-
----
-
-*Derived from [`IDEAL.md`](./IDEAL.md). Section numbers (§) refer to that document.*
+*Index. Shipped contract: [`ABI_V1.md`](./ABI_V1.md). Proposals:
+[`ABI_V2_PROPOSAL.md`](./ABI_V2_PROPOSAL.md). Host internals:
+[`HOST_ARCHITECTURE.md`](./HOST_ARCHITECTURE.md). Rationale:
+[`IDEAL.md`](./IDEAL.md).*

--- a/gallery/game_engine/docs/PLAN_PHYSICS_RUNNER_GENERIC.md
+++ b/gallery/game_engine/docs/PLAN_PHYSICS_RUNNER_GENERIC.md
@@ -19,7 +19,8 @@ single-world-owner (guest) handshake, the neutral ABI header, and the
 
 - [`../IDEAL.md`](../IDEAL.md) **§3** (`GameSceneProvider` seam) and **§7**
   (leak-guard grep, allow-listing, second-game regression fixture).
-- [`../IDEAL_API.md`](../IDEAL_API.md) **§7** (provider/capability registry).
+- [`../HOST_ARCHITECTURE.md`](../HOST_ARCHITECTURE.md) **§1** (provider/capability
+  registry — a host-side interface, split out of the old `IDEAL_API.md §7`).
 
 Do not restate the interface or grep here — IDEAL §7 already carries the exact
 `grep -rniE 'autopeli|…'` command and back-references this plan for phasing.


### PR DESCRIPTION
Addresses the IDEAL_API review (verdict: *request changes*) by separating the single mixed document into a normative current-ABI spec, a proposal, and a host-internal doc, and by closing the concrete layout/semantics gaps the review flagged.

Scope decisions (confirmed with the author): **separate files** (not in-place status tags) and **markdown spec only** — the generated `wasm/*.h` headers are untouched; required header changes are documented as proposals.

## New structure

| File | Status | Contents |
|------|--------|----------|
| `IDEAL_API.md` (rewritten) | index | Reading guide + shared invariant conventions, `SHIPPED/RESERVED/PROPOSED` legend, source-of-truth precedence (**generated headers win**), and a prefixed cross-ref notation (`API/V2/HOST/IDEAL §`) that retires the ambiguous bare-`§`. Preserves inbound links. |
| `ABI_V1.md` (new) | **NORMATIVE** | Exactly what ships today. |
| `ABI_V2_PROPOSAL.md` (new) | PROPOSED | Target layouts and breaking changes. |
| `HOST_ARCHITECTURE.md` (new) | informative | `GameProvider`, `GameSceneProvider`, `BodyVisual`, registries — host-side interfaces, not byte-level ABI. |

## Review points addressed

| # | Point | Resolution |
|---|-------|-----------|
| 1 | Separate current ABI vs target | File split + per-symbol status tags + header-as-source-of-truth |
| 2 | Concurrency/ownership model | `ABI_V1 §1`: two shipped patterns (turn-based RGW1/RGSP1 with `dt_ms` at offset 12, vs seqlock RGP1/RGIN/RGU1), per-word ownership; `V2 §1` single-writer target; `V2 §7` atomics + "monotonic revision == odd/even seqlock" |
| 3 | Layout gaps | RGCQ string value region `V2 §2`, sound 20-vs-32B + real handle-return path `V2 §16.3`, contact stride widening `V2 §3`, polygon vertex block `V2 §5` |
| 4 | Contact overflow breaks state machine | `V2 §4`: never drop `END`, lifecycle > telemetry, `CONTACT_OVERFLOW` flag, resync snapshot |
| 5 | `rg_ui_event` silent break | `ABI_V1 §3.6` freezes shipped 3-arg; `V2 §6` adds `rg_ui_event_v2` (4-arg) + TEXT buffer definition |
| 6 | Versioning rules | `V2 §14`: major/minor, append-only minor, min size, unknown-ignored, zeroing, compat matrix |
| 7 | Async/error semantics | `V2 §15`: `RgResult{code,detail}` + error taxonomy |
| 8 | Determinism over-promised | `V2 §11` record/replay protocol (`step_id`, event ordering, pose sampling, storage snapshot, hotplug capture, callback delivery point, workers); `ABI_V1 §5` states current guarantees honestly |
| 9 | Entity identity scattered | `V2 §12`: `EntityId` / array index / host handle with generation; `ABI_V1 §6` documents current reality |
| 10 | Host internals in ABI | Moved to `HOST_ARCHITECTURE.md` |
| inline | pose `schema_id`, `time_ms` wrap, camera header/matrix/inverse, pointer normalisation, cross-ref notation, conformance fixtures | `V2 §8/§9/§16.2/§10`, prefix notation, `ABI_V1 §7` + `V2 §13` |

Also fixes two now-stale `IDEAL_API §7` cross-refs (`IDEAL.md`, `docs/PLAN_PHYSICS_RUNNER_GENERIC.md`) to point at `HOST_ARCHITECTURE`.

## Verification
- All factual claims checked against the shipped headers: RGW1/RGSP1 offset 12 = `dt_ms` (no seqlock), `rg_ui_event` ships as 3-arg (`wasm_ui_abi.h:139`), RGCQ string entry has `sLen` but no value offset (`wasm_game_abi.h:192`).
- All `§` references verified prefixed; no bare-`§` remains in the new docs.

## Follow-up (not in this PR)
Conformance fixtures (`wasm/tests/`: golden bytes, validator vectors, reference encoder/decoder) — the one review ask documentation alone cannot satisfy. Specified as a requirement in `ABI_V1 §7` and `V2 §13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgfRSaXTK1eyDf6XHXLWFu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgfRSaXTK1eyDf6XHXLWFu)_