### PR TITLE
Optimize game launcher startup timing on Raspberry Pi

### DIFF
--- a/gallery/game_engine/scripts/deploy-pi.sh
+++ b/gallery/game_engine/scripts/deploy-pi.sh
@@ -206,18 +206,19 @@ wait_x() {
   if xdpyinfo >/dev/null 2>&1; then
     return 0
   fi
+  # poll fast (0.2s) so the game launches as soon as X is up; ~120s total
   local i=0
-  while [[ $i -lt 120 ]]; do
+  while [[ $i -lt 600 ]]; do
     if [[ -S /tmp/.X11-unix/X0 ]]; then
       export DISPLAY=:0
       if xdpyinfo -display :0 >/dev/null 2>&1; then
         return 0
       fi
     fi
-    sleep 1
+    sleep 0.2
     i=$((i + 1))
   done
-  echo "start.sh: X display :0 not ready after ${i}s" >&2
+  echo "start.sh: X display :0 not ready after $((i / 5))s" >&2
   return 1
 }
 
@@ -253,8 +254,10 @@ ssh "$TARGET" "cat > ~/initservice.sh" <<'INITEOF'
 set -euo pipefail
 
 START="$HOME/start.sh"
-BOOT_DELAY="sleep 8 && $START"
-CRON_BOOT="@reboot sleep 12 && $START"
+# No fixed boot delay: start.sh itself waits for X (wait_x) and audio
+# (wait_audio), and flock prevents duplicate launches. Launching immediately
+# gets the console up as soon as the session is ready instead of sleep N late.
+CRON_BOOT="@reboot $START"
 
 echo "==> Ranger autostart setup"
 echo "    game launcher: $START"
@@ -271,17 +274,17 @@ cat > "$HOME/.config/autostart/ranger-game.desktop" <<EOF
 Type=Application
 Name=Ranger Game
 Comment=Ranger SDL game launcher
-Exec=/bin/bash -c "$BOOT_DELAY"
+Exec=/bin/bash -c "$START"
 Terminal=false
 X-GNOME-Autostart-enabled=true
 EOF
 
 grep -v 'ranger-game\|start\.sh' "$HOME/.config/lxsession/LXDE-pi/autostart" 2>/dev/null > /tmp/lxas.tmp || true
-echo "@/bin/bash -c \"$BOOT_DELAY\"" >> /tmp/lxas.tmp
+echo "@/bin/bash -c \"$START\"" >> /tmp/lxas.tmp
 mv /tmp/lxas.tmp "$HOME/.config/lxsession/LXDE-pi/autostart"
 
 grep -v 'ranger-game\|start\.sh' "$HOME/.config/labwc/autostart" 2>/dev/null > /tmp/labas.tmp || true
-echo "/bin/bash -c \"$BOOT_DELAY\" &" >> /tmp/labas.tmp
+echo "/bin/bash -c \"$START\" &" >> /tmp/labas.tmp
 mv /tmp/labas.tmp "$HOME/.config/labwc/autostart"
 
 ( crontab -l 2>/dev/null | grep -v 'start\.sh\|ranger-game' || true


### PR DESCRIPTION
## Summary
This change improves the game launcher startup experience on Raspberry Pi by removing fixed boot delays and instead implementing dynamic waiting for system readiness. The launcher now starts as soon as the X display server and audio system are available, rather than waiting arbitrary fixed durations.

## Key Changes
- **Faster X display polling**: Changed `wait_x()` function to poll every 0.2 seconds instead of 1 second, reducing perceived startup latency while maintaining the same ~120 second timeout window (600 iterations × 0.2s)
- **Removed fixed boot delays**: Eliminated hardcoded `sleep 8` and `sleep 12` delays from autostart configurations
- **Simplified autostart scripts**: Updated GNOME, LXDE, and labwc autostart configurations to launch `start.sh` directly without wrapper delays
- **Improved cron boot**: Changed `@reboot` cron job to launch immediately, relying on `start.sh`'s internal `wait_x()` and `wait_audio()` functions for proper synchronization
- **Better error reporting**: Updated timeout error message to correctly report elapsed time in seconds (dividing iteration count by 5 to account for 0.2s intervals)

## Implementation Details
The changes leverage the existing `wait_x()` and `wait_audio()` functions in `start.sh` to handle system readiness checks, eliminating the need for fixed delays in the autostart configurations. The `flock` mechanism prevents duplicate launches if the script is triggered multiple times. This approach gets the console up as soon as the session is actually ready rather than waiting for arbitrary sleep durations.

https://claude.ai/code/session_01KWg88rgBQhS1iPD1zeJCUU