### PR TITLE
game(mathquiz): educational math quiz "Laskupeli" + spoken voice-asset (.info) support

### DIFF
--- a/gallery/game_engine/games/mathquiz/game.info
+++ b/gallery/game_engine/games/mathquiz/game.info
@@ -1,0 +1,2 @@
+name=Laskupeli
+category=Games

--- a/gallery/game_engine/games/mathquiz/index.tsx
+++ b/gallery/game_engine/games/mathquiz/index.tsx
@@ -1,0 +1,284 @@
+/// <reference path="../../scripting/game.d.ts" />
+//
+// Laskupeli — an educational math quiz for young children.
+//
+//   * Level select: "5v" (add within 5) and "8v" (+, −, × within ~20).
+//   * A question and three answer tiles; move with ←/→, pick with Space.
+//   * Right  -> cheer + a spoken "Hyvä!"   (games/mathquiz/voices/good-fi.wav)
+//   * Wrong  -> sigh  + a spoken "Yritä uudelleen" (voices/wrong-fi.wav)
+//
+// The vocal effects (cheer/sigh) are the built-in synth, so audio works out of
+// the box. The SPOKEN words come from real WAV files under voices/ (auto-loaded
+// when present, see voices/*.info); until you drop those in you just hear the
+// synth cheer/sigh. Questions are deterministic (a tiny LCG), no Math.random.
+//
+// Written in the interpreter-safe subset: no array-index writes, own input-edge
+// detection so menus don't skip. Coordinates are a 480x270 buffer.
+
+// Spoken feedback overrides — auto-loaded when the WAV exists (see voices/).
+// Missing files are ignored, so the game runs on the synth cheer/sigh alone.
+function resources() {
+  return [
+    { kind: "voice", id: "good-fi", path: "voices/good-fi.wav" },
+    { kind: "voice", id: "wrong-fi", path: "voices/wrong-fi.wav" }
+  ];
+}
+
+function sprites() {
+  return [
+    { id: "bg", kind: "rect", w: 480, h: 270, r: 18, g: 22, b: 40 }
+  ];
+}
+
+function initState() {
+  return {
+    screen: "menu",
+    level: 1,
+    sel: 0,
+    seed: 12345,
+    a: 0, b: 0, op: "+", ans: 0,
+    o0: 0, o1: 0, o2: 0,
+    correct: 0,
+    qnum: 1,
+    total: 6,
+    score: 0,
+    phase: "ask",
+    fb: 0,
+    entities: { bg: { x: 240, y: 135 } },
+    pUp: 0, pDown: 0, pLeft: 0, pRight: 0, pAct: 0
+  };
+}
+
+function nextSeed(seed) {
+  return (seed * 75 + 74) % 65537;
+}
+
+// Build a question for `level` from `seed`; returns the new seed plus the
+// question fields and three answer options (correct at index `correct`).
+function makeQuestion(level, seed) {
+  let s = seed;
+  let a = 0;
+  let b = 0;
+  let op = "+";
+  let ans = 0;
+
+  if (level == 1) {
+    s = nextSeed(s); a = s % 5;
+    s = nextSeed(s); b = s % 5;
+    op = "+"; ans = a + b;
+  } else {
+    s = nextSeed(s);
+    let kind = s % 3;
+    if (kind == 2) {
+      s = nextSeed(s); a = 1 + (s % 5);
+      s = nextSeed(s); b = 1 + (s % 5);
+      op = "x"; ans = a * b;
+    } else {
+      if (kind == 1) {
+        s = nextSeed(s); a = 5 + (s % 11);
+        s = nextSeed(s); b = s % (a + 1);
+        op = "-"; ans = a - b;
+      } else {
+        s = nextSeed(s); a = s % 13;
+        s = nextSeed(s); b = s % 13;
+        op = "+"; ans = a + b;
+      }
+    }
+  }
+
+  // Two distractors near the answer, kept distinct and non-negative.
+  let d1 = ans + 1;
+  let d2 = ans - 1;
+  if (d2 < 0) { d2 = ans + 2; }
+  if (d2 == d1) { d2 = d1 + 1; }
+
+  s = nextSeed(s);
+  let slot = s % 3;
+  let o0 = d1;
+  let o1 = d1;
+  let o2 = d1;
+  if (slot == 0) { o0 = ans; o1 = d1; o2 = d2; }
+  if (slot == 1) { o0 = d1; o1 = ans; o2 = d2; }
+  if (slot == 2) { o0 = d1; o1 = d2; o2 = ans; }
+
+  return {
+    seed: s, a: a, b: b, op: op, ans: ans,
+    o0: o0, o1: o1, o2: o2, correct: slot
+  };
+}
+
+function update(props) {
+  const s = props.state;
+
+  // Rising-edge detection so held keys don't fly through menus/answers.
+  const up = props.up && !s.pUp;
+  const down = props.down && !s.pDown;
+  const left = props.left && !s.pLeft;
+  const right = props.right && !s.pRight;
+  const act = props.action && !s.pAct;
+
+  let pUp = 0; if (props.up) { pUp = 1; }
+  let pDown = 0; if (props.down) { pDown = 1; }
+  let pLeft = 0; if (props.left) { pLeft = 1; }
+  let pRight = 0; if (props.right) { pRight = 1; }
+  let pAct = 0; if (props.action) { pAct = 1; }
+
+  // Carry state forward by default.
+  let screen = s.screen;
+  let level = s.level;
+  let sel = s.sel;
+  let seed = s.seed;
+  let a = s.a; let b = s.b; let op = s.op; let ans = s.ans;
+  let o0 = s.o0; let o1 = s.o1; let o2 = s.o2;
+  let correct = s.correct;
+  let qnum = s.qnum;
+  let score = s.score;
+  let phase = s.phase;
+  let fb = s.fb;
+  let ev = [];
+
+  if (screen == "menu") {
+    if (up || down) {
+      if (sel == 0) { sel = 1; } else { sel = 0; }
+    }
+    if (act) {
+      level = 1;
+      if (sel == 1) { level = 2; }
+      const q = makeQuestion(level, nextSeed(seed + level * 7));
+      seed = q.seed; a = q.a; b = q.b; op = q.op; ans = q.ans;
+      o0 = q.o0; o1 = q.o1; o2 = q.o2; correct = q.correct;
+      screen = "play"; phase = "ask"; sel = 0; qnum = 1; score = 0; fb = 0;
+    }
+  } else {
+    if (screen == "play") {
+      if (phase == "ask") {
+        if (left) { if (sel == 0) { sel = 2; } else { sel = sel - 1; } }
+        if (right) { if (sel == 2) { sel = 0; } else { sel = sel + 1; } }
+        if (act) {
+          if (sel == correct) {
+            score = score + 1;
+            phase = "right"; fb = 60;
+            ev = [
+              { kind: "playSound", id: "win" },
+              { kind: "playVoice", id: "cheer" },
+              { kind: "playVoice", id: "good-fi" }
+            ];
+          } else {
+            phase = "wrong"; fb = 60;
+            ev = [
+              { kind: "playSound", id: "lose" },
+              { kind: "playVoice", id: "sigh" },
+              { kind: "playVoice", id: "wrong-fi" }
+            ];
+          }
+        }
+      } else {
+        // Feedback shown; auto-advance when the timer runs out or on Space.
+        fb = fb - 1;
+        if (fb <= 0 || act) {
+          if (phase == "right") {
+            if (qnum >= s.total) {
+              screen = "done";
+            } else {
+              qnum = qnum + 1;
+              const q = makeQuestion(level, seed);
+              seed = q.seed; a = q.a; b = q.b; op = q.op; ans = q.ans;
+              o0 = q.o0; o1 = q.o1; o2 = q.o2; correct = q.correct;
+              phase = "ask"; sel = 0;
+            }
+          } else {
+            // Wrong: let them try the same question again.
+            phase = "ask";
+          }
+        }
+      }
+    } else {
+      // done
+      if (act) {
+        screen = "menu"; sel = 0;
+      }
+    }
+  }
+
+  return {
+    screen: screen,
+    level: level,
+    sel: sel,
+    seed: seed,
+    a: a, b: b, op: op, ans: ans,
+    o0: o0, o1: o1, o2: o2,
+    correct: correct,
+    qnum: qnum,
+    total: s.total,
+    score: score,
+    phase: phase,
+    fb: fb,
+    entities: { bg: { x: 240, y: 135 } },
+    pUp: pUp, pDown: pDown, pLeft: pLeft, pRight: pRight, pAct: pAct,
+    events: ev
+  };
+}
+
+function tile(value, active) {
+  let bg = "#26304e";
+  let fg = "#cbd6f2";
+  if (active == 1) { bg = "#ffd23f"; fg = "#1a1e33"; }
+  return (
+    <View backgroundColor={bg} padding="10px" margin="6px">
+      <Label color={fg}>{value}</Label>
+    </View>
+  );
+}
+
+function hud(props) {
+  const s = props.state;
+
+  if (s.screen == "menu") {
+    let a0 = 0; let a1 = 0;
+    if (s.sel == 0) { a0 = 1; } else { a1 = 1; }
+    return (
+      <View width="100%" height="100%" flexDirection="column" justifyContent="center" align="center">
+        <Label color="#8cd3ff">LASKUPELI</Label>
+        <Label color="#6a8aaa">Valitse taso — nuolet + Space</Label>
+        {tile("5v  (helppo)", a0)}
+        {tile("8v  (haastava)", a1)}
+      </View>
+    );
+  }
+
+  if (s.screen == "done") {
+    return (
+      <View width="100%" height="100%" flexDirection="column" justifyContent="center" align="center">
+        <Label color="#ffd23f">Valmis!</Label>
+        <Label color="#ffffff">Pisteet {s.score} / {s.total}</Label>
+        <Label color="#8cd3ff">Space = alkuun</Label>
+      </View>
+    );
+  }
+
+  const q = s.a + " " + s.op + " " + s.b + " = ?";
+  let msg = "";
+  let mc = "#8cd3ff";
+  if (s.phase == "right") { msg = "Hyvä!"; mc = "#7CFF9B"; }
+  if (s.phase == "wrong") { msg = "Yritä uudelleen"; mc = "#ff8899"; }
+
+  let a0 = 0; let a1 = 0; let a2 = 0;
+  if (s.phase == "ask") {
+    if (s.sel == 0) { a0 = 1; }
+    if (s.sel == 1) { a1 = 1; }
+    if (s.sel == 2) { a2 = 1; }
+  }
+
+  return (
+    <View width="100%" height="100%" flexDirection="column" justifyContent="center" align="center">
+      <Label color="#6a8aaa">Kysymys {s.qnum} / {s.total}   Pisteet {s.score}</Label>
+      <Label color="#ffffff">{q}</Label>
+      <View flexDirection="row" justifyContent="center">
+        {tile(s.o0, a0)}
+        {tile(s.o1, a1)}
+        {tile(s.o2, a2)}
+      </View>
+      <Label color={mc}>{msg}</Label>
+    </View>
+  );
+}

--- a/gallery/game_engine/games/mathquiz/voices/README.md
+++ b/gallery/game_engine/games/mathquiz/voices/README.md
@@ -1,0 +1,40 @@
+# Spoken voice assets for Laskupeli
+
+Drop **real** spoken recordings here to give the quiz a human voice. Until you
+do, the game just plays the built-in synth cheer/sigh — everything still works.
+
+## Convention: `<id>[-<lang>].wav` + a sibling `<id>[-<lang>].info`
+
+- `good-fi.wav` — the audio (played when the answer is right).
+- `good-fi.info` — key=value metadata:
+  ```
+  lang=fi
+  text=Hyvä!
+  ```
+
+The engine auto-loads the WAV (declared in `index.tsx` `resources()`) and reads
+the `.info` (`GameVocalFx.textFor(id)` → subtitle / accessibility / future TTS
+or language switching — `lang=` is stored now, though there is no runtime
+language switch yet).
+
+## Needed for this game
+
+| id         | says (fi)            | when              |
+| ---------- | -------------------- | ----------------- |
+| `good-fi`  | "Hyvä!"              | correct answer    |
+| `wrong-fi` | "Yritä uudelleen"    | wrong answer      |
+
+(English versions would be `good-en.wav` + `good-en.info` with `lang=en`,
+`text=Well done!` — the game would need to pick the id per its language.)
+
+## Audio format
+
+**16-bit mono PCM WAV @ 44100 Hz.** Stereo is auto-downmixed; other rates play
+at the wrong speed. Convert anything with:
+
+```bash
+ffmpeg -i recording.wav -ac 1 -ar 44100 -sample_fmt s16 good-fi.wav
+```
+
+You can record these yourself, or generate them (e.g. with the Voicebox app /
+any TTS) on a machine with the models available.

--- a/gallery/game_engine/games/mathquiz/voices/good-fi.info
+++ b/gallery/game_engine/games/mathquiz/voices/good-fi.info
@@ -1,0 +1,2 @@
+lang=fi
+text=Hyvä!

--- a/gallery/game_engine/games/mathquiz/voices/wrong-fi.info
+++ b/gallery/game_engine/games/mathquiz/voices/wrong-fi.info
@@ -1,0 +1,2 @@
+lang=fi
+text=Yritä uudelleen

--- a/gallery/game_engine/scripting/game_vocal_fx.rgr
+++ b/gallery/game_engine/scripting/game_vocal_fx.rgr
@@ -58,6 +58,10 @@ class GameVocalFx {
     ; under the C++ backend (empty map), which wrongly sent every effect down the
     ; empty-asset path -> 0 bytes -> silent voices in the SDL host.
     def assetIds:[string]
+    ; Optional per-asset metadata from a sibling <id>.info file (key=value):
+    ; text = what the clip says (subtitles / accessibility), lang = fi | en | ...
+    def assetText:[string:string]
+    def assetLang:[string:string]
 
     fn init:void () {
         synth.init()
@@ -566,6 +570,65 @@ class GameVocalFx {
             fi = (fi + 1)
         }
         this.registerAsset(id pcm frames)
+        return true
+    }
+
+    ; --- .info metadata (subtitles / language / accessibility) ---------------
+
+    fn registerAssetInfo:void (id:string lang:string text:string) {
+        set assetLang id lang
+        set assetText id text
+    }
+
+    fn textFor:string (id:string) {
+        def v@(optional):string (get assetText id)
+        if (!null? v) {
+            return (unwrap v)
+        }
+        return ""
+    }
+
+    fn langFor:string (id:string) {
+        def v@(optional):string (get assetLang id)
+        if (!null? v) {
+            return (unwrap v)
+        }
+        return ""
+    }
+
+    ; Parse a sibling `<id>.info` file: key=value lines, `lang=` and `text=`.
+    ; A line without `=` is ignored; everything after the first `=` is the value.
+    fn loadAssetInfo:boolean (id:string dir:string file:string) {
+        def raw:buffer (buffer_read_file dir file)
+        def txt:string (buffer_to_string raw)
+        def lang:string ""
+        def text:string ""
+        def line:string ""
+        def i 0
+        def n:int (strlen txt)
+        while (i <= n) {
+            def atEnd:boolean (i == n)
+            def ch:string ""
+            if (false == atEnd) {
+                ch = (substring txt i (i + 1))
+            }
+            if (atEnd || (ch == "\n")) {
+                def eq:int (indexOf line "=")
+                if (eq > 0) {
+                    def key:string (substring line 0 eq)
+                    def val:string (substring line (eq + 1) (strlen line))
+                    if (key == "lang") { lang = val }
+                    if (key == "text") { text = val }
+                }
+                line = ""
+            } {
+                if (ch != "\r") {
+                    line = (line + ch)
+                }
+            }
+            i = (i + 1)
+        }
+        this.registerAssetInfo(id lang text)
         return true
     }
 

--- a/gallery/ts_to_ranger/game_host.rgr
+++ b/gallery/ts_to_ranger/game_host.rgr
@@ -226,7 +226,23 @@ class GameHost {
         if (false == (file_exists dir file)) {
             return false
         }
-        return (vocalFx.registerAssetWav(id dir file))
+        def ok:boolean (vocalFx.registerAssetWav(id dir file))
+        ; Optional sibling <base>.info (key=value: lang, text) for subtitles.
+        def dot:int -1
+        def di 0
+        while (di < (strlen file)) {
+            if ((substring file di (di + 1)) == ".") {
+                dot = di
+            }
+            di = (di + 1)
+        }
+        if (dot > 0) {
+            def infoFile:string ((substring file 0 dot) + ".info")
+            if (file_exists dir infoFile) {
+                vocalFx.loadAssetInfo(id dir infoFile)
+            }
+        }
+        return ok
     }
 
     fn registerResources:void (list:[ResourceDefNative]) {
@@ -266,7 +282,9 @@ class GameHost {
                 ; synth has its own GameAudio, so mirror the rate or the PCM
                 ; plays back at the wrong speed and sounds like crackle.
                 vocalFx.synth.sampleRate = a.sampleRate
-                if (vocalFx.has(e.id)) {
+                ; Play a built-in synth effect OR any registered WAV override —
+                ; the latter lets a game use custom spoken ids (e.g. "good-fi").
+                if ((vocalFx.has(e.id)) || (vocalFx.hasAsset(e.id))) {
                     vocalFx.play(e.id a.sink)
                 } {
                     if verbose { print ("[host] playVoice (unknown effect) " + e.id) }


### PR DESCRIPTION
Pinottu #263:n päälle (base = `claude/vocal-fx-real-voices`), koska tämä käyttää sen WAV-auto-load-putkea. Diff on vain uusi työ. Kun #263 mergautuu masteriin, tämä rebasetaan.

## Uusi esimerkkipeli: `games/mathquiz/` — "Laskupeli"
Opetuspeli lapsille (ylos2:n rinnalle):
- **Tasovalinta:** *5v* (yhteenlasku ≤ 5) ja *8v* (+/−/× ~20 asti).
- Kysymys + **3 vastausruutua**, ←/→ liikkuu, **Space** valitsee. Kysymykset deterministisiä (pieni LCG, ei Math.random), oma input-edge-tunnistus. Tulkkiturvallinen osajoukko.
- **Oikein →** cheer-synth + puhuttu **"Hyvä!"**; **väärin →** sigh-synth + **"Yritä uudelleen"**. Synth-palaute toimii heti; puhutut sanat tulevat oikeista WAV:eista `voices/`-kansiosta kun ne on tiputettu sisään.

## Ihmisäänen `.info`-metadata (suunnittelemasi konvention mukaan)
- `game_host.handleEvent playVoice` soittaa nyt sisäänrakennetun efektin **TAI minkä tahansa rekisteröidyn WAV-overriden** → mukautetut puhutut id:t (`good-fi`/`wrong-fi`) toimivat, ei vain 11 synth-efektiä.
- `GameVocalFx`: `loadAssetInfo()` lukee sisaruksen `<id>.info` (`lang=`, `text=`); `textFor(id)`/`langFor(id)` tarjoavat sen tekstityksiin/saavutettavuuteen/tulevaan kielivalintaan. `loadVoiceAsset` lataa `.info`:n automaattisesti WAV:n rinnalta.

## Konventio: `games/mathquiz/voices/`
`<id>[-<lang>].wav` + `<id>[-<lang>].info` (esim. `good-fi.info`: `lang=fi`, `text=Hyvä!`). Mukana placeholder-`.info`:t + README, jotka kertovat tarkalleen mitä äänittää (**16-bit mono PCM WAV @ 44100 Hz**, `ffmpeg`-komento annettu).

## Testattu (headless es6 + C++ gen)
- Peli: valikko → taso → vastaus etenee (score/qnum kasvaa), `play*`-eventit lähtevät.
- Katalogi listaa "Laskupeli" Games-kategoriaan.
- `.info`-parseri palauttaa `lang=fi` / `text=Hyvä!` (mono+stereo WAV lataa).
- SDL-ketju generoi puhtaan C++:n.

## Näin lisäät ihmisäänet
Äänitä/generoi omalla koneellasi → `ffmpeg -i in.wav -ac 1 -ar 44100 -sample_fmt s16 voices/good-fi.wav` → peli soittaa ne automaattisesti (kuvattu `voices/README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQRL14bKRzDnGKGcuS8A8Q)_