### PR TITLE
docs(game-engine): extend controller ABI plan for mobile development

### DIFF
--- a/gallery/game_engine/ABI_V1.md
+++ b/gallery/game_engine/ABI_V1.md
@@ -465,12 +465,21 @@ rejects an unsatisfiable guest at load.
 | `RG_WASM_HOST_CAP_POSE_INPUT` | `0x0010` | RGP1 pose streaming + motion/speed |
 | `RG_WASM_HOST_CAP_UI_DYNAMIC` | `0x0020` | handle-based dynamic EVG UI (`rg_evg_*`) — **[RESERVED]**, API surface is PROPOSED (V2) |
 | `RG_WASM_HOST_CAP_RES_STREAM` | `0x0040` | `rg_res_*` streaming resources / workers — **[RESERVED]**, API surface is PROPOSED (V2) |
+| `RG_WASM_HOST_CAP_MOTION` | `0x0080` | RGMO device motion/orientation sensors — **[RESERVED]**, API surface is PROPOSED (`V2 §18`) |
+| `RG_WASM_HOST_CAP_NET` | `0x0100` | `rg_net_*` online services / multiplayer — **[RESERVED]**, API surface is PROPOSED (`V2 §19`) |
+| `RG_WASM_HOST_CAP_IAP` | `0x0200` | `rg_iap_*` in-app purchases / entitlements — **[RESERVED]**, API surface is PROPOSED (`V2 §20`) |
 
 Bits `0x0001`–`0x0010` gate shipped surfaces. `0x0020`/`0x0040` are **defined
 header values** whose *guest-facing APIs* (`rg_evg_*`, `rg_res_*`) are proposed —
 the bit exists so a host that later ships the provider can advertise it, but a
 guest requiring one of these bits against today's runtime is correctly rejected.
-Bits `0x0080` and up are unassigned; assign additively, never reuse a retired bit.
+`0x0080`/`0x0100`/`0x0200` are the mobile-oriented bits (device motion, networking,
+in-app purchases) reserved on the same terms — defined header values whose
+guest-facing surfaces are PROPOSED (`V2 §18`–`§20`). Mobile **haptics** does not add
+a bit: a Taptic-Engine / Core-Haptics / Android-`VibrationEffect` host advertises the
+existing `RG_WASM_HOST_CAP_RUMBLE` (`0x0002`), generalised from "gamepad rumble" to
+"haptics" (`IDEAL §2.9`). Bits `0x0400` and up are unassigned; assign additively,
+never reuse a retired bit.
 
 ---
 

--- a/gallery/game_engine/ABI_V2_PROPOSAL.md
+++ b/gallery/game_engine/ABI_V2_PROPOSAL.md
@@ -34,6 +34,9 @@ section of *this* file. `IDEAL §x` = `IDEAL.md`. `HOST §x` = `HOST_ARCHITECTUR
 | V2 §15 | Common result model (`RgResult`) & error taxonomy |
 | V2 §16 | Proposed blocks (camera, sound, view fields) |
 | V2 §17 | Proposed host imports (dynamic UI, resources, storage, animation, haptics, particles, views, logging) |
+| V2 §18 | RGMO — device motion / orientation block (mobile sensors) |
+| V2 §19 | Networking host imports (`rg_net_*`) — backend request/response + multiplayer sessions |
+| V2 §20 | In-app purchase host imports (`rg_iap_*`) — products & entitlements |
 
 ---
 
@@ -501,6 +504,14 @@ guest pointer.
 - **Haptics** [PROPOSED, `RG_WASM_HOST_CAP_RUMBLE`] — `RgHaptic { i32 target, low,
   high, ms }` (both motors distinct, never one `strength`); optional
   envelope/named pattern; sustained effect updated/stopped by handle; output-only.
+  One vocabulary, two back-ends: on a gamepad `low`/`high` drive the two rumble
+  motors; on a **mobile** single-actuator device the host maps `low` → Core Haptics
+  *intensity* (continuous), `high` → *sharpness* (transient), and a named pattern
+  (`bump`/`hit`/`click`) → the closest platform primitive (`UIImpactFeedbackGenerator`
+  / an AHAP pattern, or Android `VibrationEffect`); `target` collapses to "the
+  device". `RG_WASM_HOST_CAP_RUMBLE` generalises from "gamepad rumble" to "haptics"
+  and is the bit a Taptic-Engine host advertises — no separate mobile bit
+  (`IDEAL §2.9`).
 - **View navigation** [PROPOSED] — `rg_view_load/push/pop`; `push` suspends,
   `pop` resumes with a typed result; routes are registered names; deterministic
   control-flow input.
@@ -514,6 +525,184 @@ guest pointer.
 Sprite/atlas/HUD data shapes and the body→visual binding are game-declared
 structures resolved by host-side interfaces; they are documented in `HOST §3`
 because they are not byte-level guest/host ABI.
+
+---
+
+## V2 §18. RGMO — device motion / orientation block [PROPOSED, `RG_WASM_HOST_CAP_MOTION 0x0080`]
+
+**Motivation:** `IDEAL §2.19`. A host→guest streaming input block for handheld
+inertial sensors (accelerometer, gyroscope, fused attitude), on the RGP1 pattern:
+pattern-B (seqlock `revision`), host-write-only, per-frame, host-validated. The host
+runs the sensor fusion (Apple **Core Motion** `CMMotionManager`, Android
+`SensorManager`) and publishes clean, view-independent channels; the guest reads and
+scales into its own world. Nothing here is a game vocabulary — it is pure transport.
+
+**Fixed-point.** Acceleration in **g** and rotation rate in **rad/s** use `FP_VEL`
+(Q16.16); quaternion components (normalized `[-1,1]`) and roll/pitch/yaw (radians) use
+`FP_SCALE` (256) — the same "scale sized to the quantity" rule as RGP1 velocity vs
+position.
+
+```c
+/* wasm/wasm_motion_abi.h — RGMO: host->guest device motion/orientation (PROPOSED). */
+#define RG_MO_ABI_MAGIC   0x4f4d4752u /* 'RGMO' little-endian */
+#define RG_MO_ABI_VERSION 1u
+#define RG_MO_FP_SCALE    256          /* quaternion/angles: value * 256          */
+#define RG_MO_FP_ACCEL    65536        /* accel (g) & rot-rate (rad/s): Q16.16     */
+
+/* Header (32 bytes) — standard block words + timing + orientation/reference. */
+#define RG_MO_OFF_MAGIC       0   /* u32 'RGMO'                                    */
+#define RG_MO_OFF_VERSION     4   /* u32 ABI version the host wrote                */
+#define RG_MO_OFF_SIZE        8   /* u32 total block bytes                         */
+#define RG_MO_OFF_REVISION    12  /* u32 seqlock: odd=writing, even=stable         */
+#define RG_MO_OFF_FLAGS       16  /* u32 RG_MO_FLAG_*                              */
+#define RG_MO_OFF_ORIENT      20  /* u32 interface orientation (RG_MO_ORIENT_*)    */
+#define RG_MO_OFF_REFERENCE   24  /* u32 attitude reference frame (RG_MO_REF_*)    */
+#define RG_MO_OFF_TIME_MS     28  /* i32 capture timestamp, monotonic ms          */
+#define RG_MO_HEADER_SIZE     32
+
+/* Sensor channels — device (body) frame: +x right, +y top, +z out of screen,
+ * right-handed, natural(portrait) orientation. */
+#define RG_MO_OFF_ACC_X       32  /* i32 total acceleration x, g * FP_ACCEL        */
+#define RG_MO_OFF_ACC_Y       36  /* i32 (includes gravity)                        */
+#define RG_MO_OFF_ACC_Z       40
+#define RG_MO_OFF_UACC_X      44  /* i32 user acceleration x (gravity removed)     */
+#define RG_MO_OFF_UACC_Y      48
+#define RG_MO_OFF_UACC_Z      52
+#define RG_MO_OFF_GRAV_X      56  /* i32 gravity vector x, g * FP_ACCEL            */
+#define RG_MO_OFF_GRAV_Y      60
+#define RG_MO_OFF_GRAV_Z      64
+#define RG_MO_OFF_ROT_X       68  /* i32 rotation rate x (gyro), rad/s * FP_ACCEL  */
+#define RG_MO_OFF_ROT_Y       72
+#define RG_MO_OFF_ROT_Z       76
+/* Fused attitude (device -> reference frame), normalized quaternion + euler. */
+#define RG_MO_OFF_QUAT_W      80  /* i32 quaternion w, [-1,1] * FP_SCALE           */
+#define RG_MO_OFF_QUAT_X      84
+#define RG_MO_OFF_QUAT_Y      88
+#define RG_MO_OFF_QUAT_Z      92
+#define RG_MO_OFF_ROLL        96  /* i32 roll  (radians * FP_SCALE)                */
+#define RG_MO_OFF_PITCH       100 /* i32 pitch                                     */
+#define RG_MO_OFF_YAW         104 /* i32 yaw                                       */
+#define RG_MO_SIZE            108
+
+/* flags (RG_MO_OFF_FLAGS) */
+#define RG_MO_FLAG_VALID      1u /* host published a full sample this frame        */
+#define RG_MO_FLAG_HAS_ACCEL  2u /* accelerometer channels are real                */
+#define RG_MO_FLAG_HAS_GYRO   4u /* gyroscope / rotation-rate channels are real    */
+#define RG_MO_FLAG_HAS_ATT    8u /* fused attitude (quaternion/euler) is real      */
+
+/* interface orientation (RG_MO_OFF_ORIENT) — coarse; CHANGES arrive as a §2.14
+ * lifecycle event, this field is the current value. */
+#define RG_MO_ORIENT_PORTRAIT        0u
+#define RG_MO_ORIENT_PORTRAIT_DOWN   1u
+#define RG_MO_ORIENT_LANDSCAPE_LEFT  2u
+#define RG_MO_ORIENT_LANDSCAPE_RIGHT 3u
+#define RG_MO_ORIENT_FACE_UP         4u
+#define RG_MO_ORIENT_FACE_DOWN       5u
+
+/* attitude reference frame (RG_MO_OFF_REFERENCE) — which world frame the quaternion
+ * rotates the device INTO; published because it is negotiable, not universal. */
+#define RG_MO_REF_ARBITRARY_Z_VERTICAL 0u /* z up (gravity), x arbitrary          */
+#define RG_MO_REF_Z_VERTICAL_X_NORTH   1u /* z up, x toward magnetic/true north    */
+```
+
+Determinism: the sample valid at each `step_id` is recorded and re-fed on replay
+(V2 §11); the native sensor rate is decimated to the fixed step **host-side**, and a
+motion read may drive logic/RNG because it is a recorded input, not an output.
+Capability: attaches as a provider (`direction = host→guest`, `cadence = frame`,
+`capBit = RG_WASM_HOST_CAP_MOTION`); a host without an IMU advertises the bit off and a
+motion-requiring guest is rejected at load (`API §2.1`).
+
+---
+
+## V2 §19. Networking host imports (`rg_net_*`) [PROPOSED, `RG_WASM_HOST_CAP_NET 0x0100`]
+
+**Motivation:** `IDEAL §2.20`. Host-owned, **async** networking: a backend
+request/response surface and a multiplayer session/message surface. Every call is
+non-blocking, returns `RG_ERR_PENDING` + a request/session handle (V2 §15), and
+completions / incoming messages / connection-state changes arrive as **host→guest
+events at defined step boundaries** (V2 §11), so non-determinism is captured, not
+smeared into logic. All payloads are **opaque byte blobs** copied across the boundary
+(no guest pointers retained, no fixed message taxonomy — the game owns the protocol,
+`IDEAL §4`). **Data and assets only — never executable code / new game modules** (App
+Review 2.5.2; `IDEAL §2.20`, `§2.22`).
+
+```c
+/* Endpoints/sessions are named by REGISTERED id (like routes/sounds), not raw URLs
+ * baked into the guest; the host owns the connection, TLS, and destination policy. */
+
+/* Backend request/response (cloud save, leaderboard, remote config, net resources). */
+u32 rg_net_request(u32 endpoint_id, ptr reqBuf, u32 reqLen);  /* -> request handle (0=OOM) */
+/* Completion -> host->guest event carrying { request handle, RgResult, respOff, respLen }
+ * into a host-owned net-response buffer (base published like the UI-event text block). */
+
+/* Multiplayer sessions. */
+u32  rg_net_session_open (u32 config_id);                 /* create/join -> session handle  */
+void rg_net_session_close(u32 session);
+u32  rg_net_send(u32 session, u32 channel, ptr buf, u32 len, u32 flags); /* RG_NET_RELIABLE… */
+i32  rg_net_recv(u32 session, ptr outBuf, u32 outCap);    /* drain queue: bytes, -1 empty   */
+
+/* send flags */
+#define RG_NET_RELIABLE   1u   /* ordered+reliable (else best-effort datagram)     */
+#define RG_NET_BROADCAST  2u   /* to all peers in the session/room                 */
+
+/* Events (host -> guest, on the shared event channel): REQUEST_DONE, MESSAGE,
+ * PEER_JOIN, PEER_LEAVE, SESSION_STATE. Keyed to a step_id and recorded (V2 §11). */
+```
+
+- **Determinism / multiplayer.** Replies and messages enter the sim only as
+  step-keyed events (recorded, re-injected on replay). Deterministic **lockstep** is
+  built on the fixed-step + `step_id` protocol (V2 §11): peers exchange *inputs* per
+  step and each simulates identically (the fixed-point transport is what makes this
+  bit-reproducible); rollback/prediction is a guest netcode layer. Worker/streaming
+  results already sit outside the replay stream (V2 §11); network *inputs* are inside
+  it. Authority for cheat-sensitive state stays server-side.
+- **Capability.** `RG_WASM_HOST_CAP_NET`; an offline/networkless host fails requests
+  fast (`RG_ERR_UNSUPPORTED`) and a net-requiring guest is rejected at load — most
+  guests declare it optional and fall back to single-player.
+- **Relation to storage/resources.** Cloud save is the §2.11 store with a
+  `scope = cloud` backend over this transport; a network-sourced asset is a §2.7
+  resource whose staging buffer is filled from a `rg_net_request` response.
+
+---
+
+## V2 §20. In-app purchase host imports (`rg_iap_*`) [PROPOSED, `RG_WASM_HOST_CAP_IAP 0x0200`]
+
+**Motivation:** `IDEAL §2.21`. A thin, safe seam over StoreKit / Play Billing. The
+guest names **product ids** (its own vocabulary); catalog metadata (localized title/
+price, product type) lives in store/app config, not the `.wasm`. Purchases are
+**async** (user-driven, out-of-process): `RG_ERR_PENDING` + handle, outcome and later
+renewal/refund/revocation delivered as **host→guest events at step boundaries**
+(V2 §15, §11). The guest never sees payment credentials or receipts; it receives only a
+**verified entitlement** (ideally server-validated via `rg_net_*`).
+
+```c
+/* Product info is written into a host-owned buffer (base published like other event
+ * buffers); the guest reads localized title/price + kind but never a raw receipt.  */
+u32  rg_iap_list_products(ptr idsBuf, u32 idsLen);  /* registered product ids -> request handle */
+u32  rg_iap_purchase(u32 product_id);               /* -> request handle; host runs store sheet  */
+u32  rg_iap_restore(void);                          /* -> request handle (App Store requirement)  */
+i32  rg_iap_entitlements(ptr outBuf, u32 outCap);   /* current owned/active set -> bytes (or -1)  */
+
+/* product kinds (in list_products result) */
+#define RG_IAP_CONSUMABLE     0u
+#define RG_IAP_NON_CONSUMABLE 1u
+#define RG_IAP_SUBSCRIPTION   2u
+
+/* Events (host -> guest): PRODUCTS_READY, PURCHASE_OK, PURCHASE_CANCEL,
+ * PURCHASE_FAIL, ENTITLEMENT_CHANGED — each { request handle, RgResult, product_id }. */
+```
+
+- **Trust boundary.** Host owns the wallet, the sheet, the receipt, and validation;
+  the guest owns only the *request* and the *unlock logic*. A guest that merely
+  *claims* an entitlement is not believed — the host (or a server via `rg_net_*`) is
+  the source of truth (`IDEAL §2.21`).
+- **Determinism.** An entitlement *read* is a stable input like a persisted read
+  (§2.11) and replays identically; the *purchase* is an external side effect captured
+  as a recorded event (V2 §11). Entitlements gate content/presentation, not simulation
+  logic, so gameplay replay is store-independent.
+- **Capability.** `RG_WASM_HOST_CAP_IAP`; a host with no store returns empty products
+  and fails `purchase` cleanly, and the guest hides its store UI. Rarely a hard
+  requirement — degrades to "store unavailable".
 
 ---
 

--- a/gallery/game_engine/ABI_V2_PROPOSAL.md
+++ b/gallery/game_engine/ABI_V2_PROPOSAL.md
@@ -35,7 +35,7 @@ section of *this* file. `IDEAL §x` = `IDEAL.md`. `HOST §x` = `HOST_ARCHITECTUR
 | V2 §16 | Proposed blocks (camera, sound, view fields) |
 | V2 §17 | Proposed host imports (dynamic UI, resources, storage, animation, haptics, particles, views, logging) |
 | V2 §18 | RGMO — device motion / orientation block (mobile sensors) |
-| V2 §19 | Networking host imports (`rg_net_*`) — backend request/response + multiplayer sessions |
+| V2 §19 | Networking host imports (`rg_net_*`) — backend request/response + multiplayer sessions; §19.1 OpenAPI-subset backend schema validation |
 | V2 §20 | In-app purchase host imports (`rg_iap_*`) — products & entitlements |
 
 ---
@@ -385,7 +385,8 @@ enum RgErr {
     RG_ERR_POOL_FULL   = 5,  /* handle pool / arena exhausted              */
     RG_ERR_TOO_SMALL   = 6,  /* output buffer too small (detail = needed)  */
     RG_ERR_PENDING     = 7,  /* async op accepted, completion later        */
-    RG_ERR_IO          = 8   /* backend I/O failure                        */
+    RG_ERR_IO          = 8,  /* backend I/O failure                        */
+    RG_ERR_SCHEMA      = 9   /* request/response failed schema validation (V2 §19) */
 };
 ```
 
@@ -630,10 +631,22 @@ Review 2.5.2; `IDEAL §2.20`, `§2.22`).
 /* Endpoints/sessions are named by REGISTERED id (like routes/sounds), not raw URLs
  * baked into the guest; the host owns the connection, TLS, and destination policy. */
 
+/* Schema declaration (declare-once, at setup). A backend endpoint is usable ONLY if
+ * the game has declared its contract as an OpenAPI (bounded subset, see below) doc;
+ * the host parses+validates the schema itself as untrusted data and refuses to call
+ * an endpoint that has none. Data, not code — the schema ships inside the reviewed
+ * app (App Review 2.5.2), it does not change behaviour at runtime.                   */
+RgResult rg_net_declare_schema(u32 endpoint_id, ptr openApiBuf, u32 len);
+
 /* Backend request/response (cloud save, leaderboard, remote config, net resources). */
 u32 rg_net_request(u32 endpoint_id, ptr reqBuf, u32 reqLen);  /* -> request handle (0=OOM) */
-/* Completion -> host->guest event carrying { request handle, RgResult, respOff, respLen }
- * into a host-owned net-response buffer (base published like the UI-event text block). */
+/* The host validates reqBuf against the endpoint's request schema BEFORE sending
+ * (RG_ERR_SCHEMA on failure, nothing leaves), and validates the response against the
+ * response schema BEFORE delivery. Completion -> host->guest event carrying
+ * { request handle, RgResult, respOff, respLen } into a host-owned net-response buffer
+ * (base published like the UI-event text block). On a schema-invalid response the guest
+ * gets RgResult.code = RG_ERR_SCHEMA and NEVER sees the malformed bytes. An endpoint
+ * with no declared schema returns RG_ERR_SCHEMA at request time.                      */
 
 /* Multiplayer sessions. */
 u32  rg_net_session_open (u32 config_id);                 /* create/join -> session handle  */
@@ -662,6 +675,63 @@ i32  rg_net_recv(u32 session, ptr outBuf, u32 outCap);    /* drain queue: bytes,
 - **Relation to storage/resources.** Cloud save is the §2.11 store with a
   `scope = cloud` backend over this transport; a network-sourced asset is a §2.7
   resource whose staging buffer is filled from a `rg_net_request` response.
+
+### V2 §19.1 Backend schema validation — the OpenAPI subset
+
+**Motivation:** `IDEAL §2.20` point 4. The backend request/response surface accepts
+**only schema-declared endpoints**, and the host validates both directions against the
+declared schema so a guest never parses an unchecked reply. This is the RGU1
+"host validates untrusted data" rule (`API §1`) applied to the network: a
+malformed/drifted/spoofed response becomes an `RG_ERR_SCHEMA` result, never bytes the
+guest must trust. It applies to **surface (a) only** — multiplayer datagrams (surface b)
+are binary, not HTTP-shaped, and get their own lightweight message schema in a later
+proposal.
+
+**Declaration format.** The game declares each endpoint's contract as an **OpenAPI 3.x**
+document; the engine consumes a **bounded subset** (a full OpenAPI + full JSON Schema
+validator is too heavy for a mobile/WASM host, and its own surface is an attack sink).
+The document is parsed and validated by the host as untrusted data; a malformed schema
+is rejected at declare time (`RG_ERR_INVALID_ARG`), never partially applied.
+
+**Supported subset (target).** From each operation the engine uses the request-body and
+response-body **JSON Schemas**; the enforced JSON-Schema keywords are:
+
+| Group | Supported | Not (initially) |
+|-------|-----------|-----------------|
+| Types | `object`, `array`, `string`, `number`, `integer`, `boolean`, `null` | — |
+| Object | `properties`, `required`, `additionalProperties` (bool) | pattern-properties, dependencies |
+| Array | `items` (single schema), `minItems`, `maxItems` | tuple `items[]`, `contains` |
+| Scalars | `enum`, `minimum`/`maximum`, `minLength`/`maxLength`, `nullable` | `pattern` (regex), `multipleOf` |
+| Composition | intra-document `$ref` (acyclic) | `allOf`/`anyOf`/`oneOf`/`not`, external `$ref` |
+| `format` | advisory only (not enforced) | — |
+
+The subset is chosen so a validator is **bounded and terminating** (no regex engine, no
+combinator blow-up, no remote `$ref` fetch — which would also violate the "no runtime
+fetch" rule). Anything outside the subset is a declare-time rejection, so a game cannot
+believe it declared a constraint the host does not enforce.
+
+**Validation semantics.**
+
+- **Request:** `rg_net_request` validates `reqBuf` against the operation's request
+  schema *before* sending; failure → `RG_ERR_SCHEMA`, nothing leaves the device.
+- **Response:** the host validates the response body against the response schema *before*
+  the completion event; failure → the event's `RgResult.code = RG_ERR_SCHEMA` and the
+  guest receives **no response bytes**.
+- **No schema:** an endpoint id with no `rg_net_declare_schema` returns `RG_ERR_SCHEMA`
+  at request time — schema-less endpoints are simply not callable.
+- **Drift:** `additionalProperties: true` tolerates additive backend fields (the
+  forward-compat rule of V2 §14); a breaking change fails validation and surfaces as a
+  handled `RG_ERR_SCHEMA`, not a crash.
+- **Limits (stated honestly):** validation is **structural** — it cannot catch a
+  schema-valid but semantically-wrong response (e.g. a negative score where the game
+  assumed non-negative). It is defence in depth, not a correctness proof.
+
+**Implementation & determinism.** Validation is **host-side** and MAY reuse an existing
+C++ JSON-Schema validator or a Ranger-native implementation — the ABI contract is
+validator-agnostic. But the verdict MUST be **deterministic and validator-versioned**:
+the validator identity/version is recorded with the step event (V2 §11) so a replay
+re-derives the same accept/reject, and a validated response is therefore a replay-stable
+input, not a source of divergence across engine versions.
 
 ---
 

--- a/gallery/game_engine/IDEAL.md
+++ b/gallery/game_engine/IDEAL.md
@@ -92,7 +92,7 @@ without re-widening the leaks above.
 | **Streaming (`RGX1`) and loader (`RGLD`)** | Unheadered | Referenced as siblings of RGW1 but have no canonical `wasm/*.h`, so their offsets are not a stable contract. | §2 |
 | **Save-state / persistence, networking, clock/RNG seed, config negotiation** | Partial | Persistence **does** exist — `saveGameData`/`loadGameData`/`resetGameData` (whole-file `gamedata.json`) — but only as a TS-path native bridge, not over the binary ABI; and beyond `dt_ms`/`time_ms` there is no deterministic seed, no networking, and no negotiated timestep/config. | §2.11, §2.1 (RGCQ), §6 |
 | **Device motion & orientation** (accelerometer, gyroscope, fused attitude) | Missing | Nothing streams a phone/tablet's linear acceleration, rotation rate, gravity vector, or orientation quaternion to a guest; there is no motion block and no `HOST_CAP_MOTION`. A tilt-controlled game has no channel at all. | §2.19, §6 |
-| **Online services & multiplayer** (game backend, state/resource sync, sessions) | Missing | The row above lists networking as absent over the ABI; there is no request/response to a game's own backend (cloud saves, leaderboards, remote *data/assets*), and no session/message channel for real-time or turn-based multiplayer. | §2.20, §2.11, §2.7, §6 |
+| **Online services & multiplayer** (game backend, state/resource sync, sessions) | Missing | The row above lists networking as absent over the ABI; there is no request/response to a game's own backend (cloud saves, leaderboards, remote *data/assets*), no session/message channel for real-time or turn-based multiplayer, and no way to **validate a backend response against a declared schema** — a guest would have to trust raw bytes and can crash on a malformed/​drifted reply. | §2.20, §2.11, §2.7, §6 |
 | **In-app purchases & entitlements** | Missing | No interface to list store products, run a purchase/restore flow, or read verified entitlements (StoreKit / Play Billing); a game cannot gate content on a purchase through the engine. | §2.21, §6 |
 | **Mobile host packaging** (Apple/Xcode, AOT vs interpret, store constraints) | Missing | Nothing describes how one Ranger host runs local `.wasm` games on iOS/iPadOS — bundled+interpreted vs AOT-compiled to a native lib/XCFramework — or how App Review's "no runtime code download" rule shapes what the network channel may carry. | §2.22, §2.14, §2.20 |
 | **RGU1 interactivity / UI events** | Optional & minimal | The document is guest→host; the only host→guest path is an optional `rg_ui_event` export limited to `ACTIVATE/SELECT/DESELECT` driven by a **D-pad selection cursor** (no pointer/hover/drag/scroll/text/focus events, reserved `value` payload), and selection state lives on the host. | §2.6, §2.15, §2.3 |
@@ -1982,8 +1982,10 @@ Ranger game shippable.
      takes an endpoint id + an opaque request blob and returns a **request handle**; the
      response (or failure) arrives later on the host→guest event channel. This backs
      cloud saves (the §2.11 store with `scope = cloud`), leaderboards, remote config, and
-     network-sourced §2.7 resources. The *protocol and schema are the game's* (JSON,
-     protobuf, whatever) — the ABI transports bytes, never a fixed message taxonomy (§4).
+     network-sourced §2.7 resources. The *protocol is the game's*, but a backend endpoint
+     is accepted **only if the game declares its schema** (point 4) — the ABI transports
+     bytes, never a fixed message taxonomy (§4), yet the host still validates their
+     *shape* against that declared contract before anything crosses to the guest.
    - **Sessions & messages for multiplayer** — a session lifecycle (`create` / `join` /
      `leave`, matchmaking delegated to the host: Apple **Game Center** `GKMatch`, or a
      game server) plus reliable/unreliable **send** and a **receive** queue keyed to a
@@ -2004,23 +2006,57 @@ Ranger game shippable.
    identically (the write-once/fixed-point invariant is what makes lockstep possible);
    rollback/prediction is a guest netcode layer above it. Authority for
    cheat-sensitive state stays server-side.
-4. **Security and privacy are host-enforced.** The guest names endpoints/sessions by
+4. **Only schema-declared backends are accepted, and the host validates every message
+   against that schema.** This is the reliability-and-security core of the chapter. A
+   game **declares its backend contract once at setup** — an **OpenAPI document (a
+   bounded subset, `V2 §19`)** describing each endpoint's request and response shapes —
+   through the declare-once channel (§5), so the schema is *data shipped inside the
+   reviewed app*, not runtime-fetched behaviour (App-Review-safe: a passive contract,
+   like an atlas or a level description, never code). The host then:
+   - **refuses any endpoint with no declared schema** — "only schema'd services are a
+     backend interface", so a free-form or undeclared endpoint simply cannot be called;
+   - **validates the request body** against the endpoint's schema *before* it leaves —
+     catching guest bugs and protecting the backend;
+   - **validates the response** against the schema *before* handing anything to the
+     guest; a response that violates the contract (wrong type, missing required field,
+     out-of-range, unexpected shape) becomes a **typed `RgResult` error (`RG_ERR_SCHEMA`,
+     `V2 §15`)** and the guest **never sees the malformed bytes**.
+
+   So a drifting, buggy, spoofed, or compromised backend cannot crash the game or feed
+   its parser garbage — the worst case is a clean, handled error. This is exactly the
+   RGU1 *"host validates untrusted data at the boundary"* rule (§2.3) applied to the
+   network, and it is the missing piece that makes the "opaque blob" surface (point 1)
+   safe. Two honest limits keep the promise realistic: (a) validation catches
+   **structural** violations (shape/type/contract), **not** semantically-wrong-but-valid
+   data — it is defence in depth, not a correctness proof (as you'd expect, it "filters
+   out the worst"); (b) it covers the **backend request/response** surface only —
+   multiplayer datagrams (surface b) are binary, not HTTP-shaped, so OpenAPI does not fit
+   them and they get their own lightweight message schema later. Interface drift is
+   handled by design: *additive* backend changes are tolerated per the schema (mirroring
+   the ABI's own "unknown fields ignored", V2 §14), while a *breaking* change is
+   **correctly rejected** as `RG_ERR_SCHEMA` instead of crashing. Validation runs
+   **host-side** — it may reuse an existing C++ JSON-Schema validator or a Ranger-native
+   one — and its verdict is **deterministic and validator-versioned**, so a validated
+   response is a replay-stable input (point 3), not a source of divergence.
+5. **Security and privacy are host-enforced.** The guest names endpoints/sessions by
    **registered id** (like routes and sounds), not raw URLs baked into `.wasm`; the host
    owns the actual connection, applies TLS, and can scope/allow-list destinations — a
    sandboxed guest cannot open arbitrary sockets. Payloads are opaque bytes copied across
    the boundary (no guest pointers retained). This mirrors §2.11's "host owns the medium".
-5. **Capability-gated and degrades cleanly.** `RG_WASM_HOST_CAP_NET` advertises presence;
+6. **Capability-gated and degrades cleanly.** `RG_WASM_HOST_CAP_NET` advertises presence;
    a guest queries reach/latency-class/multiplayer via §2.14 and adapts — an offline or
    networkless host makes every request fail fast (`RG_ERR_UNSUPPORTED`) or surfaces a
    clear "no connection" so the game runs single-player. A game that *requires* networking
    is rejected at load; most declare it optional.
 
-The result: talking to the world becomes *"send this blob to a named endpoint or peer and
-hand me the reply as an event,"* — one async, handle-based transport for backend
-request/response and multiplayer sessions alike, carrying **data, never code**,
-non-determinism quarantined into recorded step events, game-defined in protocol and
-host-owned in the connection (§2.7, §2.11, §2.14, §4, §6, §7). Proposed imports:
-`ABI_V2_PROPOSAL.md V2 §19`.
+The result: talking to the world becomes *"declare my backend's schema, then send a blob
+to a named endpoint or peer and get the reply — validated — as an event,"* — one async,
+handle-based transport for backend request/response and multiplayer sessions alike,
+carrying **data, never code**, accepting only **schema-validated** backend services so a
+bad response is a handled error and never a crash, non-determinism quarantined into
+recorded step events, game-defined in protocol and host-owned in the connection and its
+validation (§2.3, §2.7, §2.11, §2.14, §4, §6, §7). Proposed imports and the OpenAPI
+subset: `ABI_V2_PROPOSAL.md V2 §19`.
 
 ### 2.21 In-app purchases and entitlements
 

--- a/gallery/game_engine/IDEAL.md
+++ b/gallery/game_engine/IDEAL.md
@@ -76,7 +76,7 @@ without re-widening the leaks above.
 | Know the **viewport / screen size** in a physics guest | Missing | RGSP1 has `VIEW_W`/`VIEW_H`, but RGW1 has no view fields, so a physics guest cannot size or letterbox itself. | §2.14, §2.1 |
 | **Init handshake & host-capability negotiation** | Dead | The header specs a version/caps handshake (`rg_abi_version`/`rg_required_caps`) and a typed query (RGCQ, `rg_declare_queries`/`rg_check_env`), but no host calls them — runners only `verifyMagic()`. No device-type/screen/input environment is answered, and only the WASM path has any query at all. | §2.14, §6 |
 | **Richer input** (analog sticks, pointer/touch, text, per-player remap) | Minimal | Only two i32 bitfields (`input`, `input_p2`); no analog axes, no pointer, no text entry. The host tracks 8 players × 12 buttons but the ABI carries 2 players × ~5 bits. | §2.1, §2.9 |
-| **Haptic feedback** (rumble) | Partial | Rumble flows as an RGW1 event `{ pad, low, high, ms }`, but the two motors are collapsed at `gfx_rumble_pad` (single strength) and `high` is dropped; no envelope/pattern, priority/mixing, cancel, or trigger haptics, and `HOST_CAP_RUMBLE` is never negotiated. | §2.9, §6 |
+| **Haptic feedback** (rumble / mobile taptics) | Partial | Rumble flows as an RGW1 event `{ pad, low, high, ms }`, but the two motors are collapsed at `gfx_rumble_pad` (single strength) and `high` is dropped; no envelope/pattern, priority/mixing, cancel, or trigger haptics, and `HOST_CAP_RUMBLE` is never negotiated. Nothing maps the effect onto a **mobile** Taptic Engine / Core Haptics / Android `VibrationEffect` (intensity/sharpness, transient vs continuous). | §2.9, §6 |
 | **Pose / body-tracking input** | Shared | `RGP1` v2 has one shared header (`wasm/wasm_pose_abi.h`): magic/version/size/seqlock, normalized positions + per-landmark & body motion/speed, capability-gated. All producers (native, MediaPipe, `.as`) and both consumer paths (`.as` bridge, `ranger_game::pose`) conform; first WASM game is `games/pose_arena`. | §2.4, §6 |
 | **Game-defined sound palette** | Rigid | A fixed enum (`RG_WASM_SOUND_WALL/BOUNCE/WIN`) in the header; the `.as` path bolts on an integer `playSound` queue instead. No way to register a per-game palette through the ABI. | §4, §2.10 |
 | **Voice & music over the binary ABI** | Missing | `playVoice`/`playMusic`/`stopMusic` exist only on the TS/EvalValue path; WASM and `.as` guests have no encoding for vocal or music events. | §2.10 |
@@ -91,6 +91,10 @@ without re-widening the leaks above.
 | **Guest draw list / resource manifest / sound queue as first-class ABI** | Path-specific | `RGS1`, the resource manifest, and the sound queue are native-array APIs on the interpreted `.as` path only — not a shared byte block, so compiled-WASM guests cannot use them uniformly. | §2, §5 |
 | **Streaming (`RGX1`) and loader (`RGLD`)** | Unheadered | Referenced as siblings of RGW1 but have no canonical `wasm/*.h`, so their offsets are not a stable contract. | §2 |
 | **Save-state / persistence, networking, clock/RNG seed, config negotiation** | Partial | Persistence **does** exist — `saveGameData`/`loadGameData`/`resetGameData` (whole-file `gamedata.json`) — but only as a TS-path native bridge, not over the binary ABI; and beyond `dt_ms`/`time_ms` there is no deterministic seed, no networking, and no negotiated timestep/config. | §2.11, §2.1 (RGCQ), §6 |
+| **Device motion & orientation** (accelerometer, gyroscope, fused attitude) | Missing | Nothing streams a phone/tablet's linear acceleration, rotation rate, gravity vector, or orientation quaternion to a guest; there is no motion block and no `HOST_CAP_MOTION`. A tilt-controlled game has no channel at all. | §2.19, §6 |
+| **Online services & multiplayer** (game backend, state/resource sync, sessions) | Missing | The row above lists networking as absent over the ABI; there is no request/response to a game's own backend (cloud saves, leaderboards, remote *data/assets*), and no session/message channel for real-time or turn-based multiplayer. | §2.20, §2.11, §2.7, §6 |
+| **In-app purchases & entitlements** | Missing | No interface to list store products, run a purchase/restore flow, or read verified entitlements (StoreKit / Play Billing); a game cannot gate content on a purchase through the engine. | §2.21, §6 |
+| **Mobile host packaging** (Apple/Xcode, AOT vs interpret, store constraints) | Missing | Nothing describes how one Ranger host runs local `.wasm` games on iOS/iPadOS — bundled+interpreted vs AOT-compiled to a native lib/XCFramework — or how App Review's "no runtime code download" rule shapes what the network channel may carry. | §2.22, §2.14, §2.20 |
 | **RGU1 interactivity / UI events** | Optional & minimal | The document is guest→host; the only host→guest path is an optional `rg_ui_event` export limited to `ACTIVATE/SELECT/DESELECT` driven by a **D-pad selection cursor** (no pointer/hover/drag/scroll/text/focus events, reserved `value` payload), and selection state lives on the host. | §2.6, §2.15, §2.3 |
 | **Animation system & lifecycle events** | Fragmented | Three unrelated timing systems (host-only `UIAnimator` glow/pulse, RGSP1 sprite clock, RGU1 full-tree re-emit); no general tweening/easing, frozen effect + anim enums, and the only completion hook (`UIAnimator.after`) is a host closure — no `onAnimationEnd`/`onLoop`/`onFrame` over the ABI. | §2.12 |
 | **Screen navigation / view stack** | Partial | `loadGame`/`pushGame`/`popGame` exist only on the TS path; every transition is a full teardown + `initState()` reload (no suspend/resume), routes are file paths, and there are no typed args, no result on pop, and no `onEnter`/`onExit`/`onPause`/`onResume` hooks. | §2.13 |
@@ -1032,36 +1036,61 @@ player↔game channel.
    present and the guest **adapts** (synthesize a stick from the D-pad, a pointer from
    a cursor) or aborts cleanly — and device connect/disconnect is surfaced so "press
    START on player 2's pad to join" works without a fixed slot table.
+4. **On mobile, the device *is* a controller.** A phone or tablet has no gamepad but
+   a rich sensor suite — accelerometer, gyroscope, fused attitude, and a
+   multi-touch surface. Touch already lands in the pointer/touch fields above (a
+   guest reads `POINTER_*` + `HAS_POINTER`); **device tilt and motion** are a
+   separate streaming input with their own block, specified in **§2.19**, and a
+   guest maps them onto the *same* semantic actions ("steer" ← tilt, "aim" ←
+   attitude) it declares for a stick. The action/binding indirection (point 2) is
+   what lets one game read "steer" from a gamepad stick on desktop and from
+   accelerometer tilt on a phone with no change to its logic.
 
 **Ideal — haptic feedback.**
 
-4. **Address both motors independently (and stop flattening them).** The transport
+5. **Address both motors independently (and stop flattening them).** The transport
    already carries `low`/`high`; the host must drive each motor with its own value —
    low-frequency (heavy) and high-frequency (sharp) are distinct feelings — instead of
    collapsing them to a single `max(low, high)` strength.
    The event addresses a *target* (pad index, or `-1` = all; optionally L/R/trigger).
-5. **A richer command than (strength, ms), with the simple case intact.** Beyond the
+6. **A richer command than (strength, ms), with the simple case intact.** Beyond the
    base `{ target, low, high, ms }`, an optional **envelope** (attack / sustain /
    release) or a small named **pattern** (`bump`, `hit`, `engine`, `click`) with an
    intensity lets "a soft tap" and "a long engine rumble" be different effects — the
    haptic analogue of §4's registered sound palette, so pattern *names* are a per-game
    vocabulary the host maps, not a frozen enum.
-6. **Priority, mixing, and cancel.** Overlapping effects **mix or arbitrate by
+7. **Priority, mixing, and cancel.** Overlapping effects **mix or arbitrate by
    priority** rather than last-write-wins clobber, and a sustained effect (engine
    rumble while accelerating) can be **updated and stopped** by handle — not just fired
    and forgotten. This is the §2.6 handle discipline applied to a time-extended output.
-7. **Capability-gated with graceful fallback.** The host advertises rumble (and finer
-   trigger/waveform caps) via `RG_WASM_HOST_CAP_RUMBLE` (§6); a guest queries and
-   degrades — a device with no motors simply ignores haptics, and a host *may*
+8. **The same command drives a mobile Taptic Engine — one vocabulary, two back-ends.**
+   A phone has no dual-motor pad; it has a single high-fidelity actuator addressed by
+   **intensity + sharpness** (Apple **Core Haptics** `CHHapticEngine`, or the semantic
+   `UIImpactFeedbackGenerator`/`UINotificationFeedbackGenerator` families), and Android
+   exposes `VibrationEffect` waveforms/predefined effects. The engine keeps *one*
+   game-facing vocabulary — target + `low`/`high` + optional envelope/named pattern —
+   and the host maps it per platform: the **low-frequency** channel drives Core Haptics
+   *intensity* (a `HapticContinuous` rumble), the **high-frequency** channel drives
+   *sharpness* (a crisp `HapticTransient` tap), and a named pattern (`bump`/`hit`/
+   `click`) resolves to the closest platform primitive (an impact generator, or an AHAP
+   pattern). `target` collapses to "the device" on a single-actuator phone. So a game
+   that fires `pattern("hit")` feels right on a gamepad, a DualSense, and a Taptic
+   Engine without knowing which it landed on — the §4 transport-not-taxonomy rule, in
+   the haptic dimension.
+9. **Capability-gated with graceful fallback.** The host advertises rumble/haptics (and
+   finer trigger/waveform/Core-Haptics caps) via `RG_WASM_HOST_CAP_RUMBLE` (§6) — the
+   one bit now spanning gamepad motors *and* mobile taptics; a guest queries and
+   degrades — a device with no actuator simply ignores haptics, and a host *may*
    substitute (a brief screen shake) as policy. Like pose and audio, haptics is
    **output-only and must never feed back into logic/RNG or step order**, so
    determinism holds whether or not a device buzzes.
 
 The result: controls become *"read the actions I declared, from whatever device the
-host bound,"* and haptics becomes *"play a named/enveloped effect on a target, mix it,
-and stop it when done"* — both carried at full fidelity over the ABI on every guest
+host bound — gamepad, touch, or device tilt,"* and haptics becomes *"play a
+named/enveloped effect on a target, mix it, and stop it when done — on a rumble motor
+or a Taptic Engine alike"* — both carried at full fidelity over the ABI on every guest
 path, both capability-negotiated, and both game-defined in meaning while the host owns
-the devices (§2.1, §4, §6, §7).
+the devices (§2.1, §2.19, §4, §6, §7).
 
 ### 2.10 The sound system — sound events, vocal events, and audio resources
 
@@ -1847,6 +1876,273 @@ The result: juice becomes *"register an emitter or a filter, spawn or trigger it
 a handle if it lives,"* — one particle-and-effects model shared by the software and GPU
 backends and by every guest path, game-declared in vocabulary and host-owned in rendering
 (§2.7, §2.8, §2.9, §2.10, §2.12, §4, §5, §6).
+
+### 2.19 Device motion and orientation (mobile sensors)
+
+§2.9 made controls genre-neutral and noted that *on a phone the device is the
+controller*. This chapter specifies that input. A handheld has no gamepad but a rich
+inertial suite — accelerometer, gyroscope, magnetometer, and a fused **attitude** — that
+a tilt-steered racer, a bubble-level, an AR-style aiming game, or a "shake to reroll"
+mechanic reads every frame. It is a host→guest **streaming input**, exactly the shape of
+pose (§2.4): the host owns the sensors and the fusion, the guest reads clean typed
+channels, and the block copies the RGU1 discipline.
+
+**Current state.** Nothing. RGW1 carries `input`/`input_p2`; RGIN (§2.9) adds sticks,
+triggers, and pointer/touch — but there is **no channel for acceleration, rotation rate,
+gravity, or orientation**, no motion block, and no `HOST_CAP_MOTION`. A tilt-controlled
+game cannot be written against the ABI at all; the sensors exist on every iOS/Android
+device (Apple **Core Motion** `CMMotionManager`, Android `SensorManager`) and reach the
+engine nowhere.
+
+**Ideal — the principles** (the pose rules, §2.4, applied to inertial sensors).
+
+1. **One shared block, RGU1-discipline, seqlock-published.** Define **RGMO**
+   (`'RGMO'`) with `magic` / `version` / `size` / `revision`, host-validated, a
+   host→guest per-frame block like RGP1. One layout for every host and both guest
+   paths (§ parity).
+2. **The frames are defined precisely — this is the whole contract.** Motion is
+   meaningless without a fixed coordinate convention, so the transport *fixes* it:
+   - **Sensor (device body) frame.** A right-handed frame fixed to the device in its
+     natural (portrait) orientation: `+x` = right edge, `+y` = top edge, `+z` = out of
+     the screen toward the user. Accelerometer, gyroscope, gravity, and user
+     acceleration are all reported in this frame.
+   - **Reference frame.** A gravity-and-heading world frame the **attitude quaternion**
+     rotates the device *into* (device→reference). The host publishes which reference it
+     used (`xArbitraryZVertical` / true-north-aligned / …) as a small enum, because it
+     is negotiable, not universal.
+   - The guest scales/rotates into *its* world exactly as pose does — the block never
+     bakes a screen size or a game's up-axis.
+3. **Both cooked and raw acceleration ship, so the guest never guesses.** Raw
+   accelerometer output includes gravity; a game usually wants one *or* the other, never
+   to subtract them itself. The host — which runs the sensor fusion — publishes **user
+   acceleration** (gravity removed) *and* the **gravity vector** *and* raw total
+   acceleration, plus **rotation rate** (gyroscope) and the **attitude quaternion** with
+   its convenience roll/pitch/yaw. Computed once, correctly, host-side (cf. pose's
+   host-computed velocity).
+4. **Fixed-point sized to the quantity.** Acceleration is in **g** (1 g = gravity) at
+   Q16.16 (`FP_VEL`); rotation rate is **rad/s** at Q16.16; the quaternion components are
+   normalized `[-1,1] × FP_SCALE`; roll/pitch/yaw are **radians** × `FP_SCALE`. A
+   resolution choice, documented in the header, not a taxonomy.
+5. **Interface orientation is discrete and event-driven.** Continuous attitude lives in
+   RGMO; the *coarse* interface orientation (portrait / landscape-left / landscape-right
+   / face-up) and its **changes** arrive as a lifecycle event (§2.14 resize/orientation),
+   never as a silent value swap mid-step — the same rule as gamepad hotplug.
+6. **Capability-gated like any provider.** RGMO plugs in as a `GameProvider` (direction
+   host→guest, cadence per-frame, `capBit = RG_WASM_HOST_CAP_MOTION`). A host with no
+   IMU advertises the bit off; a guest that *requires* motion is rejected at load (§6),
+   and a guest that can *optionally* use it (tilt as an alternative to a stick) adapts.
+7. **Motion is a deterministic input, resampled to the step.** Like pose and controls,
+   the sensor sample valid at each `step_id` is what a replay re-feeds (§2.4 timing rules;
+   V2 replay protocol) — a *read*, never an output, so it may drive logic/RNG and still
+   replay identically. The high native sensor rate (often 100 Hz) is decimated to the
+   fixed step by the host, not the guest.
+
+The block carries the sensor channels as typed bytes — acceleration, gravity, rotation
+rate, attitude — while *what a tilt means* ("lean left = steer left", "sharp shake =
+reroll") stays the guest's decision, mapped through the §2.9 action table so the same
+"steer" action reads a stick on a gamepad and tilt on a phone. Proposed byte layout:
+`ABI_V2_PROPOSAL.md V2 §18` (RGMO).
+
+The result: motion becomes *"read the device's acceleration and orientation in a fixed
+frame, and turn it into my own actions,"* — one streaming block shared by every guest
+path, host-fused and host-owned in the devices, game-defined in meaning
+(§2.4, §2.9, §2.14, §6, §7).
+
+### 2.20 Networking — talking to a game backend, and multiplayer
+
+A mobile game rarely lives alone: it syncs progress to the player's cloud, reads a
+remote config or a seasonal content drop, posts a score to a leaderboard, and — for many
+genres — plays against other people in real time or by turns. All of that is **network
+I/O**, and the engine has none of it over the ABI (the top-level gap row lists networking
+as absent). This chapter adds it as a **host-owned, async, capability-gated** service, on
+the same handle/result discipline as the rest of the ABI, and with one hard constraint
+the mobile stores impose baked into the design.
+
+**Current state.** No networking crosses the ABI. Persistence (§2.11) is a local
+`gamedata.json` on the TS path only; there is no request/response to a remote endpoint,
+no session or message channel, and no `HOST_CAP_NET`. Multiplayer does not exist in any
+form. (`PLAN_HTTP.md`/`TODO_HTTP.md` exist elsewhere in the tree, but nothing wires a
+network capability into the game-engine guest surface.)
+
+**The store constraint that shapes everything.** Apple's App Review Guideline 2.5.2 (and
+the emulator/mini-app carve-outs of 4.7) forbid an app from **downloading, installing, or
+executing code that changes its behaviour** at runtime. So the networking interface is
+deliberately a **data-and-assets transport, never a code transport**: it moves save
+blobs, config, leaderboard rows, matchmaking tickets, and §2.7 resource *bytes* (a PNG,
+an audio bank, a level description) — it **cannot** fetch and run a new `.wasm` game
+module or new game logic. The game shipped to the store is the game Apple reviewed; the
+network changes its *data*, not its *code* (§2.22 makes the packaging side of this rule
+concrete). This is not a limitation the engine adds — it is the guardrail that keeps a
+Ranger game shippable.
+
+**Ideal.**
+
+1. **Two surfaces, both async, both host-owned.**
+   - **Request/response to the game's own backend** — a generic `rg_net_request` that
+     takes an endpoint id + an opaque request blob and returns a **request handle**; the
+     response (or failure) arrives later on the host→guest event channel. This backs
+     cloud saves (the §2.11 store with `scope = cloud`), leaderboards, remote config, and
+     network-sourced §2.7 resources. The *protocol and schema are the game's* (JSON,
+     protobuf, whatever) — the ABI transports bytes, never a fixed message taxonomy (§4).
+   - **Sessions & messages for multiplayer** — a session lifecycle (`create` / `join` /
+     `leave`, matchmaking delegated to the host: Apple **Game Center** `GKMatch`, or a
+     game server) plus reliable/unreliable **send** and a **receive** queue keyed to a
+     peer/room. Datagrams are opaque blobs; the netcode (state sync, prediction) is the
+     game's.
+2. **Async by construction — the frame never blocks.** Networking is I/O, so every call
+   is non-blocking and returns `RG_ERR_PENDING` + a request handle (V2 §15); completion,
+   incoming messages, and connection state changes are delivered as **host→guest events
+   at defined step boundaries** — the same machinery as UI/anim/view events. A guest polls
+   a receive queue or reacts to an event; it never spins waiting on a socket.
+3. **Non-determinism is contained, not smeared through logic.** A network reply is
+   inherently non-deterministic (latency, ordering, loss), so — exactly like resize and
+   hotplug (§2.14, V2 §11) — it enters the simulation **only as an event captured to a
+   `step_id`**, recorded and re-injected on replay. Logic/RNG/step order never depend on
+   *when* a packet happened to arrive; they depend on the event as delivered at its step.
+   For **deterministic lockstep** multiplayer, the engine's fixed-step + `step_id`
+   protocol is the substrate: peers exchange *inputs* per step and each simulates
+   identically (the write-once/fixed-point invariant is what makes lockstep possible);
+   rollback/prediction is a guest netcode layer above it. Authority for
+   cheat-sensitive state stays server-side.
+4. **Security and privacy are host-enforced.** The guest names endpoints/sessions by
+   **registered id** (like routes and sounds), not raw URLs baked into `.wasm`; the host
+   owns the actual connection, applies TLS, and can scope/allow-list destinations — a
+   sandboxed guest cannot open arbitrary sockets. Payloads are opaque bytes copied across
+   the boundary (no guest pointers retained). This mirrors §2.11's "host owns the medium".
+5. **Capability-gated and degrades cleanly.** `RG_WASM_HOST_CAP_NET` advertises presence;
+   a guest queries reach/latency-class/multiplayer via §2.14 and adapts — an offline or
+   networkless host makes every request fail fast (`RG_ERR_UNSUPPORTED`) or surfaces a
+   clear "no connection" so the game runs single-player. A game that *requires* networking
+   is rejected at load; most declare it optional.
+
+The result: talking to the world becomes *"send this blob to a named endpoint or peer and
+hand me the reply as an event,"* — one async, handle-based transport for backend
+request/response and multiplayer sessions alike, carrying **data, never code**,
+non-determinism quarantined into recorded step events, game-defined in protocol and
+host-owned in the connection (§2.7, §2.11, §2.14, §4, §6, §7). Proposed imports:
+`ABI_V2_PROPOSAL.md V2 §19`.
+
+### 2.21 In-app purchases and entitlements
+
+The commercial counterpart to networking: a mobile game sells things — remove-ads,
+a cosmetic pack, a coin bundle, a season pass — and reads back **entitlements** to
+unlock content. The platform owns the money (Apple **StoreKit**, Google **Play
+Billing**); the engine's job is a thin, safe seam that lets a guest *offer* a product and
+*learn* whether the player owns it, without ever touching payment credentials.
+
+**Current state.** Nothing over the ABI: no product listing, no purchase flow, no
+entitlement read, no `HOST_CAP_IAP`. A game cannot monetise through the engine at all.
+
+**Ideal.**
+
+1. **Products and entitlements are the vocabulary; the store owns the transaction.** The
+   guest declares **product ids** (its own vocabulary, transport-not-taxonomy §4) and the
+   host resolves them against the store's configured catalog — StoreKit product metadata
+   (localized title, **localized price**, type) lives in the app/store config, not in the
+   `.wasm`. Imports:
+   - `rg_iap_list_products(ids…)` → localized product info (title, price string,
+     kind: consumable / non-consumable / subscription).
+   - `rg_iap_purchase(productId)` → a **request handle**; the host runs the platform
+     purchase sheet; success / cancel / failure arrives as a host→guest event.
+   - `rg_iap_restore()` → re-establish non-consumable/subscription entitlements (an
+     App Store requirement).
+   - `rg_iap_entitlements()` → the current owned/active set the guest gates content on.
+2. **Async and event-delivered, like networking.** A purchase is a user-driven,
+   out-of-process flow that can take seconds and be interrupted; it is `RG_ERR_PENDING` +
+   handle, with the outcome and any later renewal/refund/revocation arriving as **events
+   at step boundaries** (V2 §15, §2.20). The guest never blocks on a purchase.
+3. **The guest never sees money, and the host never trusts the guest.** Payment details,
+   receipts, and signatures stay host-side; the guest receives only a **verified
+   entitlement** (a boolean/token), ideally validated **server-side** (via §2.20) rather
+   than trusting the device — a sandboxed guest that *claims* an entitlement it did not
+   buy is not believed. This is the §2.6 "host owns memory / guest owns intent" rule
+   applied to money: the host owns the wallet, the guest owns the *request*.
+4. **Entitlement reads are deterministic inputs; purchase events are external.** Reading
+   "does the player own no-ads" is a stable input like a persisted read (§2.11) — the same
+   answer replays the same. The *purchase* itself is an external side effect captured as a
+   recorded event (§2.20/V2 §11). Entitlements should gate **content/presentation**, not
+   simulation logic, so a replay of gameplay is independent of the store.
+5. **Capability-gated and optional by default.** `RG_WASM_HOST_CAP_IAP` advertises a store
+   backend; a host without one (a desktop dev build, a sideloaded runner) makes
+   `list_products` return empty and `purchase` fail cleanly, and the guest hides its store
+   UI. A game almost never *requires* IAP at load — it degrades to "everything unlocked" or
+   "store unavailable".
+
+The result: monetising becomes *"list my product ids, ask the host to sell one, and read
+back a verified entitlement,"* — one async, handle-based store seam where the guest owns
+the product vocabulary and the unlock logic while the host owns the transaction, the
+receipt, and the money (§2.6, §2.11, §2.20, §4, §6). Proposed imports:
+`ABI_V2_PROPOSAL.md V2 §20`.
+
+### 2.22 The mobile host — one Ranger host, many local WASM games
+
+The previous four chapters (§2.9 haptics/touch, §2.19 motion, §2.20 networking, §2.21
+IAP) are the *capabilities* a mobile game needs; this chapter is the *host* that provides
+them and the *packaging* that ships them. On Apple platforms one Xcode project is the
+Ranger host, and the games it runs are local `.wasm` modules — bundled at build time,
+never fetched at runtime. The shape below is the concrete home for every "capability-gated
+via §6" the document leans on, on iOS/iPadOS/macOS.
+
+**The host is layered, and each layer maps to a provider (§6).** A single workspace:
+
+```
+Ranger.xcworkspace
+├─ RangerCore          C++17 engine: physics, rendering, audio (the host, scripting/ analog)
+├─ RangerWasmRuntime   WASM loader + the Ranger ABI (interpreter on iOS — no JIT)
+├─ RangerAppleHost     Swift/ObjC++ lifecycle, StoreKit, Game Center, Core Motion, Core Haptics
+│
+├─ DevRunner target    picks a local game_*.wasm from a menu / Xcode scheme
+├─ GameA target        GameA.wasm + assets (own bundle id, icon, StoreKit products)
+└─ GameB target        GameB.wasm + assets
+```
+
+`RangerAppleHost` is where the platform frameworks become **capability providers**: Core
+Motion → the RGMO motion provider (§2.19, `capBit = MOTION`); Core Haptics → the haptics
+provider (§2.9, generalised `RUMBLE`); Game Center / URLSession → the networking provider
+(§2.20, `capBit = NET`); StoreKit → the IAP provider (§2.21, `capBit = IAP`). Each
+attaches through the §6 registry, so the host's advertised `RG_WASM_HOST_CAPS` is exactly
+the OR of what this device build wired in — a phone build lights up MOTION/NET/IAP/haptics;
+a headless CI build advertises none, and the same guest degrades through the same gate.
+
+**Development: fast local iteration.** A `DevRunner.app` lists the local games and launches
+the selected module; on macOS it can read `game.wasm` straight from the build directory, on
+device Xcode copies the chosen `.wasm` into the app bundle / sandbox. An Xcode **scheme**
+selects the module (`RANGER_GAME_MODULE = games/pong/game.wasm`), so "Run Pong" / "Run
+Platformer" is a scheme switch over one runner — the WASM fast-iteration loop the whole
+engine is built around (§0), now on a phone.
+
+**Store build: two shippable shapes, both static.**
+
+1. **Bundled + interpreted.** The chosen `game.wasm` ships inside the app bundle and the
+   `RangerWasmRuntime` **interprets** it (no JIT — iOS forbids runtime-generated native
+   code). Straightforward, one WASM runs on iOS/Android/desktop, and App Review sees the
+   whole delivered app.
+2. **AOT-compiled to native.** A build step ahead-of-time compiles `game.wasm` → a native
+   static library / **XCFramework** (per-arch: device `arm64`, simulator, macOS), linked
+   into the app with **no WASM runtime present** — better performance, smaller footprint,
+   native-symbol debugging, dead-code stripping, and no interpreted-code ambiguity for
+   review.
+
+**The invariant that makes both shapes legal *and* correct.** Because the game shipped to
+the store is the game Apple reviewed, **no game logic is ever downloaded at runtime** — the
+network channel (§2.20) carries data and assets only. And because interpret and AOT are two
+executions of the *same* `.wasm` against the *same* fixed-point ABI, they **must produce
+identical results** — the write-once / determinism invariant (§0, §2.4, V2 §11) is exactly
+what guarantees an AOT store build behaves like the interpreted dev build. Capability
+negotiation (§2.14) is identical on both: the guest reads the device it landed on and adapts,
+whether its code is interpreted or native.
+
+One target per store game (its own bundle id, icons, StoreKit products, Game Center config,
+privacy strings) or one parameterised target that a CI script fills per game are both fine;
+every target links the same `RangerCore`, and only the game, its assets, and its metadata
+change. Android mirrors the model (one host `Activity`, bundled `.wasm`, `SensorManager` /
+`VibrationEffect` / Play Billing / sockets as the same providers).
+
+The result: the mobile host is *"one reviewed, static app = one Ranger host + one local
+game, its platform frameworks wired in as capability providers,"* — dev iterates on fast
+interpreted WASM, the store ships the same WASM bundled-and-interpreted or AOT-compiled to
+native, no code crosses the wire, and the fixed-point ABI keeps every shape identical
+(§0, §2.9, §2.14, §2.19, §2.20, §2.21, §6, §7).
 
 ---
 

--- a/gallery/game_engine/IDEAL_API.md
+++ b/gallery/game_engine/IDEAL_API.md
@@ -15,9 +15,10 @@ always tell **what is binding right now** from **what is proposed**:
 **Where to start:** implementing a guest or host against today's runtime → read
 `ABI_V1.md` and the generated headers under [`wasm/`](./wasm/). Planning the next
 version → `ABI_V2_PROPOSAL.md`. Understanding a design choice → `IDEAL.md`.
-Targeting **mobile** (device motion/orientation, haptics, networking/multiplayer,
-in-app purchases, and the Apple/Xcode host packaging) → `IDEAL §2.9`, `§2.19`–`§2.22`
-for rationale and `ABI_V2_PROPOSAL.md §18`–`§20` for the proposed byte/import surfaces.
+Targeting **mobile** (device motion/orientation, haptics, networking/multiplayer with
+OpenAPI-subset backend schema validation, in-app purchases, and the Apple/Xcode host
+packaging) → `IDEAL §2.9`, `§2.19`–`§2.22` for rationale and `ABI_V2_PROPOSAL.md §18`–`§20`
+(schema validation in `§19.1`) for the proposed byte/import surfaces.
 
 ---
 

--- a/gallery/game_engine/IDEAL_API.md
+++ b/gallery/game_engine/IDEAL_API.md
@@ -8,13 +8,16 @@ always tell **what is binding right now** from **what is proposed**:
 | Document | Status | Contents |
 |----------|--------|----------|
 | **[`ABI_V1.md`](./ABI_V1.md)** | **NORMATIVE** | Exactly what ships and runs today: block byte-layouts (RGW1, RGSP1, RGU1, RGP1, RGIN, RGCQ), the concurrency/ownership model, handshake, capability bits, and honest current result/determinism/identity semantics. |
-| **[`ABI_V2_PROPOSAL.md`](./ABI_V2_PROPOSAL.md)** | **PROPOSED** | Target layouts and breaking changes: new blocks, widened records, `rg_ui_event_v2`, versioning rules, the `RgResult` model, the replay protocol, the identity model. **Not the current contract.** |
+| **[`ABI_V2_PROPOSAL.md`](./ABI_V2_PROPOSAL.md)** | **PROPOSED** | Target layouts and breaking changes: new blocks, widened records, `rg_ui_event_v2`, versioning rules, the `RgResult` model, the replay protocol, the identity model, and the **mobile** surfaces (RGMO device motion `V2 §18`, networking `rg_net_*` `V2 §19`, in-app purchases `rg_iap_*` `V2 §20`). **Not the current contract.** |
 | **[`HOST_ARCHITECTURE.md`](./HOST_ARCHITECTURE.md)** | Informative | Host-internal Ranger interfaces (`GameProvider`, `GameSceneProvider`, `BodyVisual`, registries). Function-passing interfaces, **not a byte-level ABI.** |
 | **[`IDEAL.md`](./IDEAL.md)** | Rationale | Why each interface should look the way it does. The source of *intent*; never overrides a shipped byte layout. |
 
 **Where to start:** implementing a guest or host against today's runtime → read
 `ABI_V1.md` and the generated headers under [`wasm/`](./wasm/). Planning the next
 version → `ABI_V2_PROPOSAL.md`. Understanding a design choice → `IDEAL.md`.
+Targeting **mobile** (device motion/orientation, haptics, networking/multiplayer,
+in-app purchases, and the Apple/Xcode host packaging) → `IDEAL §2.9`, `§2.19`–`§2.22`
+for rationale and `ABI_V2_PROPOSAL.md §18`–`§20` for the proposed byte/import surfaces.
 
 ---
 

--- a/gallery/game_engine/wasm/README.md
+++ b/gallery/game_engine/wasm/README.md
@@ -37,7 +37,9 @@ surface in [`../IDEAL_API.md`](../IDEAL_API.md); the migration plan in
 Networking (`rg_net_*`, §2.20), in-app purchases (`rg_iap_*`, §2.21), and the mobile
 host packaging model (§2.22) are **host imports + completion-event channels**, not
 fixed byte blocks; their proposed shapes live in [`../ABI_V2_PROPOSAL.md`](../ABI_V2_PROPOSAL.md)
-`V2 §19`–`§20`.
+`V2 §19`–`§20`. Backend endpoints are accepted **only with a declared OpenAPI-subset
+schema**, which the host validates in both directions so a malformed reply is a typed
+error, never a guest crash (`V2 §19.1`).
 
 ## Discipline every block copies (the RGU1 rule, §2.3 / IDEAL_API §0.3)
 

--- a/gallery/game_engine/wasm/README.md
+++ b/gallery/game_engine/wasm/README.md
@@ -32,6 +32,12 @@ surface in [`../IDEAL_API.md`](../IDEAL_API.md); the migration plan in
 | **RGX1** streaming worker | *proposed* | `'RGX1'` | — | 2560 B | host↔worker | frame | proven (mock handles) (§2.7) |
 | **RGLD** resource loader | *proposed* | `'RGLD'` | — | — | host↔worker | frame | planned (§2.7) |
 | **RG_CAM** camera + view matrix | *proposed* | — | — | — | guest→host (+ matrix back) | frame | planned (§2.17) |
+| **RGMO** device motion / orientation | *proposed* | `'RGMO'` `0x4f4d4752` | — | header + sensors | host→guest | frame | planned (§2.19) |
+
+Networking (`rg_net_*`, §2.20), in-app purchases (`rg_iap_*`, §2.21), and the mobile
+host packaging model (§2.22) are **host imports + completion-event channels**, not
+fixed byte blocks; their proposed shapes live in [`../ABI_V2_PROPOSAL.md`](../ABI_V2_PROPOSAL.md)
+`V2 §19`–`§20`.
 
 ## Discipline every block copies (the RGU1 rule, §2.3 / IDEAL_API §0.3)
 
@@ -72,8 +78,13 @@ OR of its providers' `capBit()`s and rejects an unsatisfiable guest at load.
 | `POSE_INPUT` | `0x0010` | RGP1 pose streaming + motion/speed |
 | `UI_DYNAMIC` | `0x0020` | handle-based dynamic EVG UI (`rg_evg_*`) — reserved |
 | `RES_STREAM` | `0x0040` | `rg_res_*` streaming resources / workers — reserved |
+| `MOTION` | `0x0080` | RGMO device motion / orientation sensors (§2.19) — reserved |
+| `NET` | `0x0100` | `rg_net_*` online services / multiplayer (§2.20) — reserved |
+| `IAP` | `0x0200` | `rg_iap_*` in-app purchases / entitlements (§2.21) — reserved |
 
-Bits `0x0080` and up are reserved; assign additively, never reuse a retired bit.
+Mobile **haptics** reuses `RUMBLE` (`0x0002`), generalised from "gamepad rumble" to
+"haptics" (Taptic Engine / Core Haptics / Android `VibrationEffect`, §2.9). Bits
+`0x0400` and up are reserved; assign additively, never reuse a retired bit.
 
 ## Guest paths
 

--- a/gallery/game_engine/wasm/wasm_game_abi.h
+++ b/gallery/game_engine/wasm/wasm_game_abi.h
@@ -154,7 +154,14 @@
 #define RG_WASM_HOST_CAP_POSE_INPUT 0x0010u /* RGP1 pose streaming + motion/speed   */
 #define RG_WASM_HOST_CAP_UI_DYNAMIC 0x0020u /* handle-based dynamic EVG UI (rg_evg_*) */
 #define RG_WASM_HOST_CAP_RES_STREAM 0x0040u /* rg_res_* streaming resources / workers */
-/* Bits 0x0080.. are reserved for future host features. Assign additively and
+#define RG_WASM_HOST_CAP_MOTION     0x0080u /* RGMO device motion/orientation sensors */
+#define RG_WASM_HOST_CAP_NET        0x0100u /* rg_net_* online services / multiplayer */
+#define RG_WASM_HOST_CAP_IAP        0x0200u /* rg_iap_* in-app purchases / entitlements */
+/* RG_WASM_HOST_CAP_MOTION / NET / IAP name the mobile-oriented capabilities the
+ * plan reserves (§2.19–§2.22 / V2 §18–§20); the byte layouts and imports they gate
+ * are PROPOSED, not yet acted on. RG_WASM_HOST_CAP_RUMBLE (0x0002) generalises to
+ * "haptics" and is what a mobile Taptic/Core-Haptics host advertises (§2.9).
+ * Bits 0x0400.. are reserved for future host features. Assign additively and
  * never reuse a retired bit. RG_WASM_HOST_CAPS is what a given host advertises
  * (the OR of every attached provider's capBit, §6); it is defined by the host
  * build, not here. */


### PR DESCRIPTION
> **Status: suunnitelma / proposal.** Kaikki lisätyt ABI-pinnat ovat `[PROPOSED]`/`[RESERVED]` — ei mikään näistä ole vielä nykyinen sopimus (`ABI_V1.md`). Tämä on tarkoitettu myöhemmin reviewattavaksi, ei sellaisenaan toteutettavaksi.

## Mitä tämä tekee

Laajentaa pelimoottorin rajapintasuunnitelman **kontrolleri-osaa mobiilikehityksen** tueksi. Kattaa neljä pyydettyä capability-aluetta sekä Apple/Xcode-hostin paketointimallin, johdonmukaisesti läpi koko dokumenttiketjun (rationale → ehdotettu API → capability-bitit → indeksit).

## Piirteet

| Piirre | Rationale (`IDEAL.md`) | Ehdotettu API (`ABI_V2_PROPOSAL.md`) | Capability |
|--------|------------------------|--------------------------------------|------------|
| Devicen asento & acceleration | §2.19 (uusi) + §2.9 (tilt kontrollerina) | `V2 §18` — `RGMO`-lohko (accel/gyro/gravity/attitude) | `HOST_CAP_MOTION 0x0080` |
| Mobiilin haptiikka | §2.9 (kohdat 8–9) | `V2 §17` — Core Haptics / VibrationEffect -mappaus | yleistetty `RUMBLE 0x0002` |
| Verkkoliikenne (backend + moninpeli) | §2.20 (uusi) | `V2 §19` — `rg_net_*` async imports | `HOST_CAP_NET 0x0100` |
| In-app purchases | §2.21 (uusi) | `V2 §20` — `rg_iap_*` imports | `HOST_CAP_IAP 0x0200` |
| Mobiili-host / Xcode-paketointi | §2.22 (uusi) | — (providerit, ei tavutason ABI) | — |

## Suunnittelun kantavat periaatatteet (säilytetty läpi lisäysten)

- **Transport, not taxonomy** — lohkot kantavat tavuja; peli antaa merkityksen (tuote-id:t, endpointit, tilt→action mappautuvat pelin omaan vokabulaariin).
- **Determinismi** — motion & verkkoinput ovat step-avaimellisia, tallennettavia inputteja (replay-yhteensopivia); haptiikka on output-only. Verkon epädeterminismi eristetty step-tapahtumiin; lockstep-moninpeli rakentuu fixed-step-protokollan päälle.
- **Capability-gated** — jokainen kyky neuvotellaan §6 handshaken kautta; puuttuva laite → guest degradoituu siististi tai hylätään latauksessa.
- **App Review 2.5.2** — verkkokanava kuljettaa vain dataa/asseteja, ei ajonaikaista koodia; store-buildi = Applen tarkastama peli.

## Mobiili-host-malli (§2.22)

Kokoaa PR-keskustelun Xcode-rakenteen: yksi Ranger-host ajaa lokaaleja `.wasm`-pelejä, platform-frameworkit (Core Motion/Haptics, StoreKit, Game Center) kytkeytyvät capability-providereina. Dev = nopea tulkittu WASM; store = bundlattu-tulkittu **tai** AOT-natiivi (XCFramework). Fixed-point-invariantti takaa että tulkattu ja AOT-buildi käyttäytyvät identtisesti.

## Muutetut tiedostot

- `IDEAL.md` — §2.9 laajennus + uudet §2.19–§2.22 + gap-taulukon rivit
- `ABI_V2_PROPOSAL.md` — `V2 §18`–`§20` + §17 haptiikka-mappaus
- `ABI_V1.md`, `wasm/README.md`, `wasm/wasm_game_abi.h` — capability-bitit (reserved, additiivinen)
- `IDEAL_API.md` — indeksi osoittamaan mobiilipinnoille

Tarkistettu: lohko- ja listanumerointi ehjä, code-fencet tasapainossa, ABI:n oma §7 leak-guard ei saastu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8L8f4npaTWsLqb1pStit7

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8L8f4npaTWsLqb1pStit7)_