### PR TITLE
Native (host-side) 3D asset loading: GLB importer + asset/entity model

### DIFF
--- a/gallery/game_engine/IDEAL_3D.md
+++ b/gallery/game_engine/IDEAL_3D.md
@@ -383,6 +383,7 @@ The guest does **not** own:
 | `ABI_V2_PROPOSAL.md` §18–§21 | The block definitions (RGMB, RGMA, RGCM, RGLT) are useful for the *transport layer* between guest command buffer and host. But they should be internal host structures, not guest-exported memory. |
 | `IDEAL_TODO.md` Phase G | Phase G tracks the PoC slices. This document defines the architectural target those PoCs must evolve toward. |
 | `HOST_ARCHITECTURE.md` | The `GameSceneProvider` pattern aligns — the host holds the scene through an internal interface; the 3D entity registry is the generalisation. |
+| `model3d/` (`gallery/game_engine/model3d/`) | **Implements** the host-managed object model this document requires (§2, §4.3): `AssetRegistry`/`EntityRegistry`, `load_model`→`ModelAsset`→entity hierarchy→`MeshRenderer`, `instantiate_model`, `find_child`. Pure Ranger, host-owned, WASM-free. §12 below is the checklist to wire it to the §4.4 ABI imports. |
 
 ---
 
@@ -434,3 +435,122 @@ guest decision; its *engine representation* is a host resource.
 This is identical to how the 2D path works: the guest writes body positions into
 RGW1, but the *sprite* that represents the body (texture, animation, draw order)
 is a host concern through the `spriteFor` / `GameSceneProvider` interface.
+
+---
+
+## 12. ABI integration: wiring the native `model3d` loader to the host imports
+
+The `model3d/` module (`gallery/game_engine/model3d/`, see its
+[`README.md`](./model3d/README.md)) is the **host-side realisation** of §2 and
+§4.3: a Ranger-owned entity registry, transform hierarchy, asset/resource cache,
+`instantiate_model`, and `find_child` — plus a native GLB importer that turns a
+file into a `ModelAsset`. It is deliberately **host-side and WASM-free**, which
+is exactly what §10 demands: `EntityId`s, the scene graph, transform tables, and
+model instances live in the host, and the guest only ever receives opaque
+handles. It is **not** a guest-side wrapper.
+
+This section is the checklist to expose that model across the ABI (§4.4). It
+does **not** require any new guest-side scene state.
+
+### 12.1 What `model3d` already provides (host-side)
+
+| §4.3 component | `model3d` implementation |
+|----------------|--------------------------|
+| Entity Registry | `EntityRegistry` — `create`, `get`, `setParent`, `findChild`, `updateWorld` (id = registry index) |
+| Scene Graph | `Entity.children` + `TransformComponent` (local + world `Mat4`) |
+| Resource Cache | `AssetRegistry` (models by id) → `ModelAsset` → `Mesh/Material/Texture/NodeAsset` |
+| Resource loading / parse | `GlbImporter` (container + accessors) + `GltfDocument` (typed view + support gate) + `TextureDecode` (embedded PNG/JPEG → RGBA) |
+| `instantiate_model` | `ModelInstancer.instantiate(model)` → root `EntityId` (nodes → entities, TRS/matrix → transforms, mesh → `MeshRenderer`) |
+| `find_child_by_name` | `EntityRegistry.findChild(rootEntity, name)` |
+| Public API | `ModelLoader.loadFromFile / loadFromBuffer / instantiate / findChild / getEntity` |
+
+### 12.2 §4.4 import → `model3d` call
+
+Keep one `ModelLoader` instance **per WASM guest** (keyed by the guest's `wasm`
+handle) so its `AssetRegistry` + `EntityRegistry` are that guest's private,
+host-owned scene — this is what makes the lifecycle cleanup of §6 possible.
+
+| Host import (§4.4) | Backing `model3d` call |
+|--------------------|------------------------|
+| `rg_load_model(name_ptr, name_len)` → ModelHandle | read guest string → `loader.loadFromFile(dir, file)`; return model id, or `-1` (`loader.ok` / `loader.lastError` carry the reason) |
+| `rg_instantiate_model(model_handle)` → EntityId | `loader.instantiate(modelId)` → root `EntityId` |
+| `rg_find_child_by_name(parent, name_ptr, name_len)` → EntityId | read guest string → `loader.findChild(parent, name)` |
+| `rg_set_position(entity, x, y, z)` | `loader.getEntity(entity)`; convert fixed→double; `transform.setTRS(...)`; then `updateWorld(root, identity)` |
+| `rg_set_rotation(entity, qx, qy, qz, qw)` | same, Q16.16→double quaternion into `setTRS` |
+| `rg_set_scale(entity, sx, sy, sz)` | same, into `setTRS` |
+| `rg_set_parent(entity, parent)` | `EntityRegistry.setParent(entity, parent)` |
+| `rg_create_mesh_entity(mesh, material)` | `EntityRegistry.create` + set `MeshRenderer.meshAsset` (host-authored mesh/material path) |
+| `rg_load_texture(name_ptr, name_len)` → TextureHandle | `TextureDecode` on file bytes into a `TextureAsset` (standalone-texture path — **TODO**, see §12.5) |
+| `rg_create_material(desc_ptr)` → MaterialHandle | build a `MaterialAsset` from the desc block (**TODO**: define desc layout) |
+| `rg_destroy_entity(entity)` | **TODO** — needs destroy/free on the registries (see §12.5) |
+
+### 12.3 Wiring steps (concrete to this codebase)
+
+1. **Register the imports** the same way the existing 3D/resource imports are
+   registered — as `env.rg_*` functions through the C++ bridge
+   (`rg_wasm_bridge.h`; cf. `env.rg_res_load`, `env.rg_host_register_sheet` in
+   `wasm_runtime.rgr`). Add `rg_load_model`, `rg_instantiate_model`,
+   `rg_find_child_by_name`, `rg_set_position/rotation/scale`, `rg_set_parent`.
+2. **String arguments** (`name_ptr`, `name_len`): the guest passes an offset into
+   its own linear memory. Read the bytes host-side exactly as
+   `wasm3d_runner.readResName` already does (`rbyte` / `wasm_mem_i32`), build the
+   Ranger string, then call `ModelLoader`.
+3. **Handles**: model id = `AssetRegistry` index, `EntityId` = `EntityRegistry`
+   index; return as `i32`, reserve `-1` for errors. Before production, wrap these
+   with a generation counter (§4.3, §12.5) so stale handles are rejected.
+4. **Ownership**: store the per-guest `ModelLoader` in the runner (like
+   `Wasm3dRunner` holds its mesh/texture state today), so unloading a guest frees
+   exactly its models and entities (§6).
+5. **Fixed-point**: the guest sends positions `*256` and quaternion/unit
+   components as `Q16.16` (§4.4). Convert to `double` on the way in (into
+   `setTRS`) and call `EntityRegistry.updateWorld(root, identity)` to refresh
+   world matrices. Host-internal math stays in `double`.
+
+### 12.4 Render bridge
+
+The existing GPU path (`gfx_3d_*` in `gfx_sdl.rgr`, driven by `Wasm3dRunner`)
+already works in `double`. To make it the §4.3 **Render Bridge** for this model,
+replace its single guest-published-mesh read with a walk of the host scene:
+
+- for each `Entity` where `hasRenderer`, resolve its `MeshAsset` (via
+  `renderer.meshAsset` in the instance's `ModelAsset`), upload/lookup its
+  geometry, bind the material's `baseColorTexture` (`TextureAsset.rgba` replaces
+  the current PPM upload), and draw it with the entity's
+  `transform.worldMatrix`.
+
+No guest memory is read for scene data — the guest only issued handle-returning
+commands.
+
+### 12.5 What the ABI layer must still add (not in `model3d` v1)
+
+`model3d` intentionally stops at the host object model + loader. The remaining
+pieces are the ABI-surface concerns §10 says must live host-side (not as a guest
+wrapper):
+
+- per-guest ownership map + **generation counters** on `EntityId` (use-after-free
+  detection) — §4.3, §6;
+- `rg_destroy_entity` / free + refcounting on shared `ModelAsset`s — §6 (the
+  registries are currently append-only);
+- command validation / stale-handle rejection — §7 command processor;
+- `rg_create_material` desc layout and the standalone `rg_load_texture` path;
+- optionally, the §7 Option B command buffer for batching.
+
+### 12.6 Minimal end-to-end flow
+
+```
+guest:  h    = rg_load_model("models/robot.glb")     // ptr,len into guest memory
+host:        id   = loader.loadFromFile("models", "robot.glb");  return id  (or -1)
+
+guest:  root = rg_instantiate_model(h)
+host:        return loader.instantiate(id)            // root EntityId
+
+guest:  hand = rg_find_child_by_name(root, "RightHand")
+host:        return loader.findChild(root, "RightHand")
+
+guest:  rg_set_rotation(hand, qx, qy, qz, qw)         // Q16.16
+host:        e = loader.getEntity(hand);
+             e.transform.setTRS(e.transform.translation, quatFromFixed(qx,qy,qz,qw), e.transform.scale);
+             loader.entities.updateWorld(root, Mat4.identity())
+```
+
+The guest holds only opaque `i32` handles throughout — satisfying §2.2 and §10.

--- a/gallery/game_engine/lpc/src/png_decoder.rgr
+++ b/gallery/game_engine/lpc/src/png_decoder.rgr
@@ -442,15 +442,32 @@ class PNGDecoder {
         def fail:ImageBuffer (new ImageBuffer())
         fail.init(1 1)
 
-        fileData = (buffer_read_file dir fileName)
+        def bytes:buffer (buffer_read_file dir fileName)
+        if ((buffer_length bytes) < 24) {
+            print ("[png_decoder] file too small: " + dir + fileName)
+            return fail
+        }
+        return (this.decodeBytes(bytes))
+    }
+
+    ; decode a PNG already held in memory (e.g. a glTF embedded image slice).
+    fn decodeBytes:ImageBuffer (bytes:buffer) {
+        def fail:ImageBuffer (new ImageBuffer())
+        fail.init(1 1)
+
+        ; reset per-decode state so one instance can decode many buffers
+        pos = 0
+        idatData = (new GrowableBuffer())
+        this.clearPalette()
+        fileData = bytes
         fileLen = (buffer_length fileData)
         if (fileLen < 24) {
-            print ("[png_decoder] file too small: " + dir + fileName)
+            print "[png_decoder] buffer too small"
             return fail
         }
 
         if ((this.parseChunks()) == false) {
-            print ("[png_decoder] chunk parse failed: " + fileName)
+            print "[png_decoder] chunk parse failed"
             return fail
         }
 

--- a/gallery/game_engine/model3d/AssetModel.rgr
+++ b/gallery/game_engine/model3d/AssetModel.rgr
@@ -1,0 +1,159 @@
+; ==============================================================================
+; AssetModel.rgr — host-side asset model + registry for loaded 3D models.
+; ==============================================================================
+; These are the "resources the host owns" side of the load_model() pipeline:
+;
+;   ModelAsset
+;   ├─ NodeAsset[]       scene graph description (TRS or matrix, mesh ref, kids)
+;   ├─ MeshAsset[]       ├─ MeshPrimitiveAsset[]  (geometry + material ref)
+;   ├─ MaterialAsset[]   base colour factor + optional base colour texture
+;   └─ TextureAsset[]    decoded RGBA pixels (+ original bytes / mime type)
+;
+; A GLB importer fills these; the AssetRegistry hands back a ModelHandle (id).
+; Nothing here references WASM memory — the host owns every resource.
+; ==============================================================================
+
+Import "GltfMath.rgr"
+
+class TextureAsset {
+    def id:int 0
+    def name:string ""
+    def width:int 0
+    def height:int 0
+    def mimeType:string ""
+    ; original encoded bytes (PNG/JPEG) as they appeared in the file
+    def sourceBytes:buffer (buffer_alloc 0)
+    ; decoded, tightly packed RGBA8 (width*height*4); empty until decoded
+    def rgba:buffer (buffer_alloc 0)
+    def decoded:boolean false
+}
+
+class MaterialAsset {
+    def id:int 0
+    def name:string ""
+    def baseColorR:double 1.0
+    def baseColorG:double 1.0
+    def baseColorB:double 1.0
+    def baseColorA:double 1.0
+    ; index into ModelAsset.textures, or -1 for none
+    def baseColorTexture:int (0 - 1)
+    ; TEXCOORD set index for the base colour texture (usually 0)
+    def baseColorTexCoord:int 0
+    def metallic:double 1.0
+    def roughness:double 1.0
+    def doubleSided:boolean false
+    def unlit:boolean false
+}
+
+class MeshPrimitiveAsset {
+    def positions:[Vec3]
+    def normals:[Vec3]
+    def uvs:[Vec2]
+    def indices:[int]
+    ; index into ModelAsset.materials, or -1 for none
+    def material:int (0 - 1)
+    ; glTF primitive mode; only 4 (TRIANGLES) is supported in v1
+    def mode:int 4
+
+    fn vertexCount:int () {
+        return (array_length positions)
+    }
+    fn indexCount:int () {
+        return (array_length indices)
+    }
+    fn hasNormals:boolean () {
+        return ((array_length normals) > 0)
+    }
+    fn hasUvs:boolean () {
+        return ((array_length uvs) > 0)
+    }
+}
+
+class MeshAsset {
+    def id:int 0
+    def name:string ""
+    def primitives:[MeshPrimitiveAsset]
+
+    fn primitiveCount:int () {
+        return (array_length primitives)
+    }
+}
+
+; A node in the model's scene graph. Transform is either an explicit
+; column-major matrix (hasMatrix = true) or separate T/R/S.
+class NodeAsset {
+    def id:int 0
+    def name:string ""
+    def children:[int]
+    def hasMatrix:boolean false
+    def matrix:Mat4 (Mat4.identity())
+    def translation:Vec3 (Vec3.of(0.0 0.0 0.0))
+    def rotation:Quat (Quat.identity())
+    def scale:Vec3 (Vec3.of(1.0 1.0 1.0))
+    ; index into ModelAsset.meshes, or -1 for none
+    def mesh:int (0 - 1)
+
+    ; local transform of this node as a column-major matrix
+    fn localMatrix:Mat4 () {
+        if hasMatrix {
+            def out:Mat4 (new Mat4)
+            out.copyFrom(matrix)
+            return out
+        }
+        return (Mat4.fromTRS(translation rotation scale))
+    }
+}
+
+class ModelAsset {
+    def id:int 0
+    def name:string ""
+    def nodes:[NodeAsset]
+    def meshes:[MeshAsset]
+    def materials:[MaterialAsset]
+    def textures:[TextureAsset]
+    ; node indices that are roots of the default scene
+    def rootNodes:[int]
+
+    fn nodeCount:int () {
+        return (array_length nodes)
+    }
+    fn meshCount:int () {
+        return (array_length meshes)
+    }
+    fn materialCount:int () {
+        return (array_length materials)
+    }
+    fn textureCount:int () {
+        return (array_length textures)
+    }
+    fn getNode:NodeAsset (index:int) {
+        return (itemAt nodes index)
+    }
+    fn getMesh:MeshAsset (index:int) {
+        return (itemAt meshes index)
+    }
+    fn getMaterial:MaterialAsset (index:int) {
+        return (itemAt materials index)
+    }
+    fn getTexture:TextureAsset (index:int) {
+        return (itemAt textures index)
+    }
+}
+
+; Owns loaded models; the model id is its index in the registry.
+class AssetRegistry {
+    def models:[ModelAsset]
+
+    fn addModel:int (model:ModelAsset) {
+        def newId:int (array_length models)
+        model.id = newId
+        push models model
+        return newId
+    }
+    fn modelCount:int () {
+        return (array_length models)
+    }
+    fn getModel:ModelAsset (id:int) {
+        return (itemAt models id)
+    }
+}

--- a/gallery/game_engine/model3d/ByteReader.rgr
+++ b/gallery/game_engine/model3d/ByteReader.rgr
@@ -1,0 +1,174 @@
+; ==============================================================================
+; ByteReader.rgr — little-endian reads over a byte buffer (GLB/glTF BIN data).
+; ==============================================================================
+; glTF stores all multi-byte values little-endian. This wraps a `buffer` and
+; offers positional and absolute reads for the scalar types accessors use:
+; u8/u16/u32 (indices) and IEEE-754 float32 (positions, normals, uv, TRS).
+; float32 is decoded from raw bytes so the loader never depends on a host codec.
+; ==============================================================================
+
+class ByteReader {
+    def buf:buffer (buffer_alloc 0)
+    def pos:int 0
+    def len:int 0
+
+    fn init:void (b:buffer) {
+        buf = b
+        pos = 0
+        len = (buffer_length b)
+    }
+    fn seek:void (p:int) {
+        pos = p
+    }
+    fn tell:int () {
+        return pos
+    }
+    fn remaining:int () {
+        return (len - pos)
+    }
+
+    ; ---- absolute reads -----------------------------------------------------
+    fn u8at:int (off:int) {
+        return (buffer_get buf off)
+    }
+    fn i8at:int (off:int) {
+        def v:int (buffer_get buf off)
+        if (v >= 128) {
+            return (v - 256)
+        }
+        return v
+    }
+    fn u16at:int (off:int) {
+        def b0:int (buffer_get buf off)
+        def b1:int (buffer_get buf (off + 1))
+        return (b0 + (b1 * 256))
+    }
+    fn i16at:int (off:int) {
+        def v:int (this.u16at(off))
+        if (v >= 32768) {
+            return (v - 65536)
+        }
+        return v
+    }
+    ; multiply (not shift) so the high byte never trips 32-bit sign in JS/ES6.
+    fn u32at:int (off:int) {
+        def b0:int (buffer_get buf off)
+        def b1:int (buffer_get buf (off + 1))
+        def b2:int (buffer_get buf (off + 2))
+        def b3:int (buffer_get buf (off + 3))
+        return (b0 + ((b1 * 256) + ((b2 * 65536) + (b3 * 16777216))))
+    }
+    fn f32at:double (off:int) {
+        def b0:int (buffer_get buf off)
+        def b1:int (buffer_get buf (off + 1))
+        def b2:int (buffer_get buf (off + 2))
+        def b3:int (buffer_get buf (off + 3))
+        return (ByteReader.decodeF32(b0 b1 b2 b3))
+    }
+
+    ; ---- positional reads (advance pos) -------------------------------------
+    fn u8:int () {
+        def v:int (this.u8at(pos))
+        pos = (pos + 1)
+        return v
+    }
+    fn u16:int () {
+        def v:int (this.u16at(pos))
+        pos = (pos + 2)
+        return v
+    }
+    fn u32:int () {
+        def v:int (this.u32at(pos))
+        pos = (pos + 4)
+        return v
+    }
+    fn f32:double () {
+        def v:double (this.f32at(pos))
+        pos = (pos + 4)
+        return v
+    }
+
+    ; ---- float32 bit decoding ----------------------------------------------
+    sfn pow2:double (e:int) {
+        def r:double 1.0
+        def k:int 0
+        if (e >= 0) {
+            while (k < e) {
+                r = (r * 2.0)
+                k = (k + 1)
+            }
+        } {
+            def nn:int (0 - e)
+            while (k < nn) {
+                r = (r / 2.0)
+                k = (k + 1)
+            }
+        }
+        return r
+    }
+    sfn decodeF32:double (b0:int b1:int b2:int b3:int) {
+        def sign:double 1.0
+        if ((bit_and b3 128) != 0) {
+            sign = -1.0
+        }
+        def exp:int (bit_or (bit_shl (bit_and b3 127) 1) (bit_shr b2 7))
+        def mant:int (bit_or (bit_or (bit_shl (bit_and b2 127) 16) (bit_shl b1 8)) b0)
+        if (exp == 0) {
+            return (sign * ((to_double mant) * (ByteReader.pow2(0 - 149))))
+        }
+        if (exp == 255) {
+            ; inf / nan are not valid glTF geometry values; clamp to 0
+            return 0.0
+        }
+        def frac:double (1.0 + ((to_double mant) / 8388608.0))
+        return (sign * (frac * (ByteReader.pow2(exp - 127))))
+    }
+
+    ; ---- float32 encoding (for building fixtures / round-trips) -------------
+    sfn encodeF32:void (dst:buffer off:int value:double) {
+        def sign:int 0
+        def v:double value
+        if (v < 0.0) {
+            sign = 128
+            v = (0.0 - v)
+        }
+        if (v == 0.0) {
+            buffer_set dst off 0
+            buffer_set dst (off + 1) 0
+            buffer_set dst (off + 2) 0
+            buffer_set dst (off + 3) sign
+            return
+        }
+        ; normalise into [1,2) tracking the exponent
+        def e:int 0
+        while (v >= 2.0) {
+            v = (v / 2.0)
+            e = (e + 1)
+        }
+        while (v < 1.0) {
+            v = (v * 2.0)
+            e = (e - 1)
+        }
+        def biased:int (e + 127)
+        def frac:double (v - 1.0)
+        def mant:int (to_int (frac * 8388608.0))
+        def b0:int (bit_and mant 255)
+        def b1:int (bit_and (bit_shr mant 8) 255)
+        def b2:int (bit_or (bit_and (bit_shr mant 16) 127) (bit_shl (bit_and biased 1) 7))
+        def b3:int (bit_or sign (bit_and (bit_shr biased 1) 127))
+        buffer_set dst off b0
+        buffer_set dst (off + 1) b1
+        buffer_set dst (off + 2) b2
+        buffer_set dst (off + 3) b3
+    }
+    sfn encodeU16:void (dst:buffer off:int value:int) {
+        buffer_set dst off (bit_and value 255)
+        buffer_set dst (off + 1) (bit_and (bit_shr value 8) 255)
+    }
+    sfn encodeU32:void (dst:buffer off:int value:int) {
+        buffer_set dst off (bit_and value 255)
+        buffer_set dst (off + 1) (bit_and (bit_shr value 8) 255)
+        buffer_set dst (off + 2) (bit_and (bit_shr value 16) 255)
+        buffer_set dst (off + 3) (bit_and (bit_shr value 24) 255)
+    }
+}

--- a/gallery/game_engine/model3d/EntityModel.rgr
+++ b/gallery/game_engine/model3d/EntityModel.rgr
@@ -1,0 +1,162 @@
+; ==============================================================================
+; EntityModel.rgr — host-side entity / transform / mesh-renderer scene model.
+; ==============================================================================
+; The instantiate_model() half of the pipeline. A ModelAsset describes a scene
+; graph; instantiating it allocates a host EntityId per node, wires parent/child
+; links, copies each node's transform into a TransformComponent, and attaches a
+; MeshRenderer wherever a node references a mesh. The guest normally only gets
+; the root EntityId back and can find children by name through the host:
+;
+;   let robot = instantiate_model(model)   // -> root EntityId
+;   let hand  = find_child(robot, "RightHand")
+;
+; EntityIds are allocated and owned by the host, exactly because a GLB's nodes
+; are born from the file's hierarchy, not one-at-a-time from game code.
+; ==============================================================================
+
+Import "AssetModel.rgr"
+
+class TransformComponent {
+    def hasMatrix:boolean false
+    def translation:Vec3 (Vec3.of(0.0 0.0 0.0))
+    def rotation:Quat (Quat.identity())
+    def scale:Vec3 (Vec3.of(1.0 1.0 1.0))
+    def localMatrix:Mat4 (Mat4.identity())
+    def worldMatrix:Mat4 (Mat4.identity())
+
+    fn setTRS:void (t:Vec3 r:Quat s:Vec3) {
+        hasMatrix = false
+        translation = t
+        rotation = r
+        scale = s
+        localMatrix = (Mat4.fromTRS(t r s))
+    }
+    fn setMatrix:void (m:Mat4) {
+        hasMatrix = true
+        localMatrix = m
+    }
+}
+
+class MeshRenderer {
+    ; index into the source ModelAsset.meshes
+    def meshAsset:int (0 - 1)
+    ; kept for convenience so a renderer is self-describing
+    def meshName:string ""
+}
+
+class Entity {
+    def id:int 0
+    def name:string ""
+    def parent:int (0 - 1)
+    def children:[int]
+    def transform:TransformComponent (new TransformComponent)
+    def hasRenderer:boolean false
+    def renderer:MeshRenderer (new MeshRenderer)
+
+    fn childCount:int () {
+        return (array_length children)
+    }
+}
+
+class EntityRegistry {
+    def entities:[Entity]
+
+    fn create:int (name:string) {
+        def e:Entity (new Entity)
+        e.id = (array_length entities)
+        e.name = name
+        push entities e
+        return e.id
+    }
+    fn count:int () {
+        return (array_length entities)
+    }
+    fn get:Entity (id:int) {
+        return (itemAt entities id)
+    }
+    fn setParent:void (childId:int parentId:int) {
+        def child:Entity (itemAt entities childId)
+        child.parent = parentId
+        if (parentId >= 0) {
+            def parent:Entity (itemAt entities parentId)
+            push parent.children childId
+        }
+    }
+    ; depth-first search for a descendant entity by exact name; -1 if not found
+    fn findChild:int (rootId:int name:string) {
+        def root:Entity (itemAt entities rootId)
+        def n:int (array_length root.children)
+        def i:int 0
+        while (i < n) {
+            def cid:int (itemAt root.children i)
+            def child:Entity (itemAt entities cid)
+            if (child.name == name) {
+                return cid
+            }
+            def deep:int (this.findChild(cid name))
+            if (deep >= 0) {
+                return deep
+            }
+            i = (i + 1)
+        }
+        return (0 - 1)
+    }
+    ; recompute world matrices from a root down, given a parent world matrix
+    fn updateWorld:void (rootId:int parentWorld:Mat4) {
+        def e:Entity (itemAt entities rootId)
+        def world:Mat4 (Mat4.mul(parentWorld e.transform.localMatrix))
+        e.transform.worldMatrix = world
+        def n:int (array_length e.children)
+        def i:int 0
+        while (i < n) {
+            def cid:int (itemAt e.children i)
+            this.updateWorld(cid world)
+            i = (i + 1)
+        }
+    }
+}
+
+; Turns a ModelAsset into a live entity subtree; returns the root EntityId.
+class ModelInstancer {
+    ; instantiate one NodeAsset (and its descendants) under parentEntity
+    sfn instantiateNode:int (registry:EntityRegistry model:ModelAsset nodeIndex:int parentEntity:int) {
+        def node:NodeAsset (model.getNode(nodeIndex))
+        def eid:int (registry.create(node.name))
+        registry.setParent(eid parentEntity)
+        def e:Entity (registry.get(eid))
+        if node.hasMatrix {
+            def m:Mat4 (node.localMatrix())
+            e.transform.setMatrix(m)
+        } {
+            e.transform.setTRS(node.translation node.rotation node.scale)
+        }
+        if (node.mesh >= 0) {
+            e.hasRenderer = true
+            e.renderer.meshAsset = node.mesh
+            def mesh:MeshAsset (model.getMesh(node.mesh))
+            e.renderer.meshName = mesh.name
+        }
+        def kids:int (array_length node.children)
+        def i:int 0
+        while (i < kids) {
+            def childNodeIndex:int (itemAt node.children i)
+            ModelInstancer.instantiateNode(registry model childNodeIndex eid)
+            i = (i + 1)
+        }
+        return eid
+    }
+    ; instantiate the whole model; a single root entity wraps the scene roots
+    sfn instantiate:int (registry:EntityRegistry model:ModelAsset) {
+        def rootId:int (registry.create(model.name))
+        def roots:int (array_length model.rootNodes)
+        def i:int 0
+        while (i < roots) {
+            def nodeIndex:int (itemAt model.rootNodes i)
+            ModelInstancer.instantiateNode(registry model nodeIndex rootId)
+            i = (i + 1)
+        }
+        def identity:Mat4 (Mat4.identity())
+        registry.updateWorld(rootId identity)
+        return rootId
+    }
+}

--- a/gallery/game_engine/model3d/GlbImporter.rgr
+++ b/gallery/game_engine/model3d/GlbImporter.rgr
@@ -1,0 +1,345 @@
+; ==============================================================================
+; GlbImporter.rgr — GLB 2.0 container + accessor reader -> host ModelAsset.
+; ==============================================================================
+; The native (no-WASM) importer. Reads the GLB container (12-byte header, JSON
+; chunk, BIN chunk), parses the JSON with GltfDocument, then materialises a
+; host ModelAsset: accessor/bufferView data becomes real Vec3/Vec2/index arrays,
+; nodes become a NodeAsset hierarchy, materials/textures are resolved. Embedded
+; image bytes are sliced out of the BIN chunk into TextureAsset.sourceBytes with
+; their mime type; pixel decoding is layered on top in ModelLoader.
+;
+; Supported (v1): single JSON + single BIN chunk, scenes/nodes, matrix or TRS,
+; multiple meshes/primitives, TRIANGLES, POSITION/NORMAL/TEXCOORD_0, u8/u16/u32
+; indices, interleaved byteStride, baseColorFactor + baseColorTexture, embedded
+; PNG/JPEG, multiple materials. Anything else is rejected with a clear error.
+; ==============================================================================
+
+Import "ByteReader.rgr"
+Import "GltfDocument.rgr"
+Import "AssetModel.rgr"
+
+class GlbImporter {
+    def ok:boolean true
+    def error:string ""
+    def glb:buffer (buffer_alloc 0)
+    def reader:ByteReader (new ByteReader)
+    def binOffset:int 0
+    def binLength:int 0
+    def jsonText:string ""
+    def doc:GltfDocument (new GltfDocument)
+
+    fn fail:void (msg:string) {
+        if ok {
+            ok = false
+            error = msg
+        }
+    }
+
+    ; ---- container ----------------------------------------------------------
+    fn readContainer:void (bytes:buffer) {
+        glb = bytes
+        reader.init(bytes)
+        def total:int (buffer_length bytes)
+        if (total < 12) {
+            this.fail("not a GLB file: shorter than 12-byte header")
+            return
+        }
+        def magic:int (reader.u32at(0))
+        if (magic != 1179937895) {
+            this.fail("not a GLB file: bad magic")
+            return
+        }
+        def version:int (reader.u32at(4))
+        if (version != 2) {
+            this.fail("unsupported GLB container version " + (to_string version))
+            return
+        }
+        ; walk chunks from offset 12
+        def pos:int 12
+        def haveJson:boolean false
+        def haveBin:boolean false
+        def go:boolean true
+        while go {
+            if ((pos + 8) > total) {
+                go = false
+            } {
+                def clen:int (reader.u32at(pos))
+                def ctype:int (reader.u32at(pos + 4))
+                def cdata:int (pos + 8)
+                if (ctype == 1313821514) {
+                    ; 'JSON'
+                    def slice:buffer (buffer_slice glb cdata (cdata + clen))
+                    jsonText = (buffer_to_string slice)
+                    haveJson = true
+                } {
+                    if (ctype == 5130562) {
+                        ; 'BIN\0'
+                        binOffset = cdata
+                        binLength = clen
+                        haveBin = true
+                    }
+                }
+                pos = ((cdata + clen))
+            }
+        }
+        if (haveJson == false) {
+            this.fail("GLB has no JSON chunk")
+            return
+        }
+        ; BIN is optional in general, but our geometry needs it
+        if (haveBin == false) {
+            binOffset = 0
+            binLength = 0
+        }
+    }
+
+    ; ---- accessor reads -----------------------------------------------------
+    fn accessorStride:int (a:GltfAccessor) {
+        if (a.bufferView < 0) {
+            return (a.elementSize())
+        }
+        def bv:GltfBufferView (itemAt doc.bufferViews a.bufferView)
+        if (bv.byteStride > 0) {
+            return bv.byteStride
+        }
+        return (a.elementSize())
+    }
+    fn accessorBase:int (a:GltfAccessor) {
+        if (a.bufferView < 0) {
+            return (binOffset + a.byteOffset)
+        }
+        def bv:GltfBufferView (itemAt doc.bufferViews a.bufferView)
+        return ((binOffset + bv.byteOffset) + a.byteOffset)
+    }
+
+    fn readVec3:[Vec3] (accessorIndex:int) {
+        def out:[Vec3]
+        def a:GltfAccessor (itemAt doc.accessors accessorIndex)
+        def stride:int (this.accessorStride(a))
+        def base:int (this.accessorBase(a))
+        def i:int 0
+        while (i < a.count) {
+            def off:int (base + (i * stride))
+            def x:double (reader.f32at(off))
+            def y:double (reader.f32at(off + 4))
+            def z:double (reader.f32at(off + 8))
+            def v:Vec3 (Vec3.of(x y z))
+            push out v
+            i = (i + 1)
+        }
+        return out
+    }
+
+    fn readVec2:[Vec2] (accessorIndex:int) {
+        def out:[Vec2]
+        def a:GltfAccessor (itemAt doc.accessors accessorIndex)
+        def stride:int (this.accessorStride(a))
+        def base:int (this.accessorBase(a))
+        def i:int 0
+        while (i < a.count) {
+            def off:int (base + (i * stride))
+            def u:double 0.0
+            def v:double 0.0
+            if (a.componentType == 5126) {
+                u = (reader.f32at(off))
+                v = (reader.f32at(off + 4))
+            } {
+                if (a.componentType == 5121) {
+                    u = ((to_double (reader.u8at(off))) / 255.0)
+                    v = ((to_double (reader.u8at(off + 1))) / 255.0)
+                } {
+                    if (a.componentType == 5123) {
+                        u = ((to_double (reader.u16at(off))) / 65535.0)
+                        v = ((to_double (reader.u16at(off + 2))) / 65535.0)
+                    }
+                }
+            }
+            def uv:Vec2 (Vec2.of(u v))
+            push out uv
+            i = (i + 1)
+        }
+        return out
+    }
+
+    fn readIndices:[int] (accessorIndex:int) {
+        def out:[int]
+        def a:GltfAccessor (itemAt doc.accessors accessorIndex)
+        def size:int (a.componentSize())
+        def base:int (this.accessorBase(a))
+        def i:int 0
+        while (i < a.count) {
+            def off:int (base + (i * size))
+            def val:int 0
+            if (a.componentType == 5121) {
+                val = (reader.u8at(off))
+            } {
+                if (a.componentType == 5123) {
+                    val = (reader.u16at(off))
+                } {
+                    if (a.componentType == 5125) {
+                        val = (reader.u32at(off))
+                    }
+                }
+            }
+            push out val
+            i = (i + 1)
+        }
+        return out
+    }
+
+    ; ---- build the host ModelAsset -----------------------------------------
+    fn buildTextures:void (model:ModelAsset) {
+        def n:int (array_length doc.textures)
+        def i:int 0
+        while (i < n) {
+            def tref:GltfTextureRef (itemAt doc.textures i)
+            def tex:TextureAsset (new TextureAsset)
+            tex.id = i
+            if (tref.source >= 0) {
+                def img:GltfImage (itemAt doc.images tref.source)
+                tex.mimeType = img.mimeType
+                tex.name = img.uri
+                if (img.bufferView >= 0) {
+                    def bv:GltfBufferView (itemAt doc.bufferViews img.bufferView)
+                    def start:int (binOffset + bv.byteOffset)
+                    def endp:int (start + bv.byteLength)
+                    tex.sourceBytes = (buffer_slice glb start endp)
+                    if ((strlen tex.mimeType) == 0) {
+                        tex.mimeType = (this.sniffMime(tex.sourceBytes))
+                    }
+                }
+            }
+            push model.textures tex
+            i = (i + 1)
+        }
+    }
+
+    fn sniffMime:string (bytes:buffer) {
+        if ((buffer_length bytes) >= 4) {
+            def b0:int (buffer_get bytes 0)
+            def b1:int (buffer_get bytes 1)
+            if (b0 == 137) {
+                if (b1 == 80) {
+                    return "image/png"
+                }
+            }
+            if (b0 == 255) {
+                if (b1 == 216) {
+                    return "image/jpeg"
+                }
+            }
+        }
+        return ""
+    }
+
+    fn buildMaterials:void (model:ModelAsset) {
+        def n:int (array_length doc.materials)
+        def i:int 0
+        while (i < n) {
+            def gm:GltfMaterial (itemAt doc.materials i)
+            def m:MaterialAsset (new MaterialAsset)
+            m.id = i
+            m.name = gm.name
+            m.baseColorR = gm.baseColorR
+            m.baseColorG = gm.baseColorG
+            m.baseColorB = gm.baseColorB
+            m.baseColorA = gm.baseColorA
+            m.baseColorTexture = gm.baseColorTexture
+            m.baseColorTexCoord = gm.baseColorTexCoord
+            m.metallic = gm.metallic
+            m.roughness = gm.roughness
+            m.doubleSided = gm.doubleSided
+            push model.materials m
+            i = (i + 1)
+        }
+    }
+
+    fn buildMeshes:void (model:ModelAsset) {
+        def n:int (array_length doc.meshes)
+        def i:int 0
+        while (i < n) {
+            def gmesh:GltfMesh (itemAt doc.meshes i)
+            def mesh:MeshAsset (new MeshAsset)
+            mesh.id = i
+            mesh.name = gmesh.name
+            def pn:int (array_length gmesh.primitives)
+            def j:int 0
+            while (j < pn) {
+                def gp:GltfPrimitive (itemAt gmesh.primitives j)
+                def prim:MeshPrimitiveAsset (new MeshPrimitiveAsset)
+                prim.mode = gp.mode
+                prim.material = gp.material
+                prim.positions = (this.readVec3(gp.posAccessor))
+                if (gp.normalAccessor >= 0) {
+                    prim.normals = (this.readVec3(gp.normalAccessor))
+                }
+                if (gp.uvAccessor >= 0) {
+                    prim.uvs = (this.readVec2(gp.uvAccessor))
+                }
+                if (gp.indicesAccessor >= 0) {
+                    prim.indices = (this.readIndices(gp.indicesAccessor))
+                }
+                push mesh.primitives prim
+                j = (j + 1)
+            }
+            push model.meshes mesh
+            i = (i + 1)
+        }
+    }
+
+    fn buildNodes:void (model:ModelAsset) {
+        def n:int (array_length doc.nodes)
+        def i:int 0
+        while (i < n) {
+            def gn:GltfNode (itemAt doc.nodes i)
+            def nd:NodeAsset (new NodeAsset)
+            nd.id = i
+            nd.name = gn.name
+            nd.mesh = gn.mesh
+            nd.children = gn.children
+            if gn.hasMatrix {
+                nd.hasMatrix = true
+                nd.matrix = (Mat4.fromColumnMajor(gn.matrix))
+            } {
+                nd.hasMatrix = false
+                nd.translation = gn.translation
+                nd.rotation = gn.rotation
+                nd.scale = gn.scale
+            }
+            push model.nodes nd
+            i = (i + 1)
+        }
+        ; default scene roots
+        if ((array_length doc.scenes) > 0) {
+            def sc:GltfScene (itemAt doc.scenes doc.defaultScene)
+            model.rootNodes = sc.nodes
+        }
+    }
+
+    ; ---- top level ----------------------------------------------------------
+    fn importModel:ModelAsset (bytes:buffer) {
+        ok = true
+        error = ""
+        def model:ModelAsset (new ModelAsset)
+        this.readContainer(bytes)
+        if (ok == false) {
+            return model
+        }
+        def parser:JsonParser (new JsonParser)
+        def root:JsonValue (parser.parse(jsonText))
+        if (parser.ok == false) {
+            this.fail("invalid glTF JSON: " + parser.err)
+            return model
+        }
+        doc.parse(root)
+        if (doc.ok == false) {
+            this.fail(doc.error)
+            return model
+        }
+        this.buildTextures(model)
+        this.buildMaterials(model)
+        this.buildMeshes(model)
+        this.buildNodes(model)
+        return model
+    }
+}

--- a/gallery/game_engine/model3d/GltfDocument.rgr
+++ b/gallery/game_engine/model3d/GltfDocument.rgr
@@ -1,0 +1,468 @@
+; ==============================================================================
+; GltfDocument.rgr — typed view of a glTF 2.0 JSON document + support gating.
+; ==============================================================================
+; Walks the parsed JSON tree into small typed structs the importer can consume
+; without repeating fragile key/offset code. This is also where the first
+; support level draws its line: anything outside the supported subset is
+; rejected up front with a clear message rather than producing a silently
+; wrong model. Supported / rejected sets follow the plan's "hyvä ensimmäinen
+; tukitaso".
+; ==============================================================================
+
+Import "Json.rgr"
+Import "GltfMath.rgr"
+
+class GltfBufferView {
+    def buffer:int 0
+    def byteOffset:int 0
+    def byteLength:int 0
+    def byteStride:int 0
+}
+
+class GltfAccessor {
+    def bufferView:int (0 - 1)
+    def byteOffset:int 0
+    def componentType:int 0
+    def count:int 0
+    def type:string "SCALAR"
+    def normalized:boolean false
+
+    fn componentCount:int () {
+        if (type == "SCALAR") {
+            return 1
+        }
+        if (type == "VEC2") {
+            return 2
+        }
+        if (type == "VEC3") {
+            return 3
+        }
+        if (type == "VEC4") {
+            return 4
+        }
+        if (type == "MAT2") {
+            return 4
+        }
+        if (type == "MAT3") {
+            return 9
+        }
+        if (type == "MAT4") {
+            return 16
+        }
+        return 1
+    }
+    ; bytes per component from the glTF componentType enum
+    fn componentSize:int () {
+        if (componentType == 5120) {
+            return 1
+        }
+        if (componentType == 5121) {
+            return 1
+        }
+        if (componentType == 5122) {
+            return 2
+        }
+        if (componentType == 5123) {
+            return 2
+        }
+        if (componentType == 5125) {
+            return 4
+        }
+        if (componentType == 5126) {
+            return 4
+        }
+        return 0
+    }
+    fn elementSize:int () {
+        return ((this.componentCount()) * (this.componentSize()))
+    }
+}
+
+class GltfImage {
+    def bufferView:int (0 - 1)
+    def mimeType:string ""
+    def uri:string ""
+}
+
+class GltfTextureRef {
+    def source:int (0 - 1)
+}
+
+class GltfMaterial {
+    def name:string ""
+    def baseColorR:double 1.0
+    def baseColorG:double 1.0
+    def baseColorB:double 1.0
+    def baseColorA:double 1.0
+    def baseColorTexture:int (0 - 1)
+    def baseColorTexCoord:int 0
+    def metallic:double 1.0
+    def roughness:double 1.0
+    def doubleSided:boolean false
+}
+
+class GltfPrimitive {
+    def posAccessor:int (0 - 1)
+    def normalAccessor:int (0 - 1)
+    def uvAccessor:int (0 - 1)
+    def indicesAccessor:int (0 - 1)
+    def material:int (0 - 1)
+    def mode:int 4
+}
+
+class GltfMesh {
+    def name:string ""
+    def primitives:[GltfPrimitive]
+}
+
+class GltfNode {
+    def name:string ""
+    def children:[int]
+    def mesh:int (0 - 1)
+    def hasMatrix:boolean false
+    def matrix:[double]
+    def translation:Vec3 (Vec3.of(0.0 0.0 0.0))
+    def rotation:Quat (Quat.identity())
+    def scale:Vec3 (Vec3.of(1.0 1.0 1.0))
+}
+
+class GltfScene {
+    def nodes:[int]
+}
+
+class GltfDocument {
+    def version:string ""
+    def ok:boolean true
+    def error:string ""
+    def bufferViews:[GltfBufferView]
+    def accessors:[GltfAccessor]
+    def images:[GltfImage]
+    def textures:[GltfTextureRef]
+    def materials:[GltfMaterial]
+    def meshes:[GltfMesh]
+    def nodes:[GltfNode]
+    def scenes:[GltfScene]
+    def defaultScene:int 0
+
+    fn fail:void (msg:string) {
+        if ok {
+            ok = false
+            error = msg
+        }
+    }
+
+    ; read one numeric element of an array JsonValue as a double
+    fn jd:double (arr:JsonValue index:int) {
+        def v:JsonValue (arr.at(index))
+        return (v.asDouble())
+    }
+
+    ; read an array-of-ints JsonValue into an [int]
+    fn readIntArray:[int] (arr:JsonValue) {
+        def out:[int]
+        def n:int (arr.count())
+        def i:int 0
+        while (i < n) {
+            def v:JsonValue (arr.at(i))
+            push out (v.asInt())
+            i = (i + 1)
+        }
+        return out
+    }
+
+    fn parse:void (root:JsonValue) {
+        ; ---- asset.version ----
+        if (root.has("asset")) {
+            def asset:JsonValue (root.get("asset"))
+            version = (asset.stringOr("version" ""))
+        }
+        def vok:boolean false
+        if ((strlen version) >= 2) {
+            if ((substring version 0 2) == "2.") {
+                vok = true
+            }
+        }
+        if (vok == false) {
+            this.fail("unsupported glTF version '" + version + "' (need 2.x)")
+            return
+        }
+        ; ---- required-extension gate ----
+        this.gateExtensions(root)
+        if (ok == false) {
+            return
+        }
+        ; ---- feature gate: skins / animations ----
+        if (root.has("skins")) {
+            def sk:JsonValue (root.get("skins"))
+            if ((sk.count()) > 0) {
+                this.fail("unsupported feature: skins")
+                return
+            }
+        }
+        if (root.has("animations")) {
+            def an:JsonValue (root.get("animations"))
+            if ((an.count()) > 0) {
+                this.fail("unsupported feature: animations")
+                return
+            }
+        }
+        this.parseBufferViews(root)
+        this.parseAccessors(root)
+        if (ok == false) {
+            return
+        }
+        this.parseImages(root)
+        this.parseTextures(root)
+        this.parseMaterials(root)
+        this.parseMeshes(root)
+        if (ok == false) {
+            return
+        }
+        this.parseNodes(root)
+        this.parseScenes(root)
+        if (root.has("scene")) {
+            defaultScene = (root.intOr("scene" 0))
+        }
+    }
+
+    fn gateExtensions:void (root:JsonValue) {
+        if (root.has("extensionsRequired")) {
+            def req:JsonValue (root.get("extensionsRequired"))
+            def n:int (req.count())
+            def i:int 0
+            while (i < n) {
+                def ext:JsonValue (req.at(i))
+                def name:string (ext.asString())
+                this.fail("unsupported feature " + name)
+                i = (i + 1)
+            }
+        }
+    }
+
+    fn parseBufferViews:void (root:JsonValue) {
+        if (root.has("bufferViews")) {
+            def arr:JsonValue (root.get("bufferViews"))
+            def n:int (arr.count())
+            def i:int 0
+            while (i < n) {
+                def o:JsonValue (arr.at(i))
+                def bv:GltfBufferView (new GltfBufferView)
+                bv.buffer = (o.intOr("buffer" 0))
+                bv.byteOffset = (o.intOr("byteOffset" 0))
+                bv.byteLength = (o.intOr("byteLength" 0))
+                bv.byteStride = (o.intOr("byteStride" 0))
+                push bufferViews bv
+                i = (i + 1)
+            }
+        }
+    }
+
+    fn parseAccessors:void (root:JsonValue) {
+        if (root.has("accessors")) {
+            def arr:JsonValue (root.get("accessors"))
+            def n:int (arr.count())
+            def i:int 0
+            while (i < n) {
+                def o:JsonValue (arr.at(i))
+                if (o.has("sparse")) {
+                    this.fail("unsupported feature: sparse accessors")
+                    return
+                }
+                def a:GltfAccessor (new GltfAccessor)
+                a.bufferView = (o.intOr("bufferView" (0 - 1)))
+                a.byteOffset = (o.intOr("byteOffset" 0))
+                a.componentType = (o.intOr("componentType" 0))
+                a.count = (o.intOr("count" 0))
+                a.type = (o.stringOr("type" "SCALAR"))
+                a.normalized = (o.boolOr("normalized" false))
+                push accessors a
+                i = (i + 1)
+            }
+        }
+    }
+
+    fn parseImages:void (root:JsonValue) {
+        if (root.has("images")) {
+            def arr:JsonValue (root.get("images"))
+            def n:int (arr.count())
+            def i:int 0
+            while (i < n) {
+                def o:JsonValue (arr.at(i))
+                def img:GltfImage (new GltfImage)
+                img.bufferView = (o.intOr("bufferView" (0 - 1)))
+                img.mimeType = (o.stringOr("mimeType" ""))
+                img.uri = (o.stringOr("uri" ""))
+                push images img
+                i = (i + 1)
+            }
+        }
+    }
+
+    fn parseTextures:void (root:JsonValue) {
+        if (root.has("textures")) {
+            def arr:JsonValue (root.get("textures"))
+            def n:int (arr.count())
+            def i:int 0
+            while (i < n) {
+                def o:JsonValue (arr.at(i))
+                def t:GltfTextureRef (new GltfTextureRef)
+                t.source = (o.intOr("source" (0 - 1)))
+                push textures t
+                i = (i + 1)
+            }
+        }
+    }
+
+    fn parseMaterials:void (root:JsonValue) {
+        if (root.has("materials")) {
+            def arr:JsonValue (root.get("materials"))
+            def n:int (arr.count())
+            def i:int 0
+            while (i < n) {
+                def o:JsonValue (arr.at(i))
+                def m:GltfMaterial (new GltfMaterial)
+                m.name = (o.stringOr("name" ""))
+                m.doubleSided = (o.boolOr("doubleSided" false))
+                if (o.has("pbrMetallicRoughness")) {
+                    def pbr:JsonValue (o.get("pbrMetallicRoughness"))
+                    m.metallic = (pbr.doubleOr("metallicFactor" 1.0))
+                    m.roughness = (pbr.doubleOr("roughnessFactor" 1.0))
+                    if (pbr.has("baseColorFactor")) {
+                        def bc:JsonValue (pbr.get("baseColorFactor"))
+                        m.baseColorR = (this.jd(bc 0))
+                        m.baseColorG = (this.jd(bc 1))
+                        m.baseColorB = (this.jd(bc 2))
+                        m.baseColorA = (this.jd(bc 3))
+                    }
+                    if (pbr.has("baseColorTexture")) {
+                        def bt:JsonValue (pbr.get("baseColorTexture"))
+                        m.baseColorTexture = (bt.intOr("index" (0 - 1)))
+                        m.baseColorTexCoord = (bt.intOr("texCoord" 0))
+                    }
+                }
+                push materials m
+                i = (i + 1)
+            }
+        }
+    }
+
+    fn parseMeshes:void (root:JsonValue) {
+        if (root.has("meshes")) {
+            def arr:JsonValue (root.get("meshes"))
+            def n:int (arr.count())
+            def i:int 0
+            while (i < n) {
+                def o:JsonValue (arr.at(i))
+                def mesh:GltfMesh (new GltfMesh)
+                mesh.name = (o.stringOr("name" ""))
+                def prims:JsonValue (o.get("primitives"))
+                def pn:int (prims.count())
+                def j:int 0
+                while (j < pn) {
+                    def po:JsonValue (prims.at(j))
+                    if (po.has("targets")) {
+                        this.fail("unsupported feature: morph targets")
+                        return
+                    }
+                    def prim:GltfPrimitive (new GltfPrimitive)
+                    prim.mode = (po.intOr("mode" 4))
+                    if (prim.mode != 4) {
+                        this.fail("unsupported primitive mode " + (to_string prim.mode) + " (only TRIANGLES)")
+                        return
+                    }
+                    prim.indicesAccessor = (po.intOr("indices" (0 - 1)))
+                    prim.material = (po.intOr("material" (0 - 1)))
+                    def attrs:JsonValue (po.get("attributes"))
+                    prim.posAccessor = (attrs.intOr("POSITION" (0 - 1)))
+                    prim.normalAccessor = (attrs.intOr("NORMAL" (0 - 1)))
+                    prim.uvAccessor = (attrs.intOr("TEXCOORD_0" (0 - 1)))
+                    if (prim.posAccessor < 0) {
+                        this.fail("primitive is missing POSITION attribute")
+                        return
+                    }
+                    push mesh.primitives prim
+                    j = (j + 1)
+                }
+                push meshes mesh
+                i = (i + 1)
+            }
+        }
+    }
+
+    fn parseNodes:void (root:JsonValue) {
+        if (root.has("nodes")) {
+            def arr:JsonValue (root.get("nodes"))
+            def n:int (arr.count())
+            def i:int 0
+            while (i < n) {
+                def o:JsonValue (arr.at(i))
+                if (o.has("skin")) {
+                    this.fail("unsupported feature: skins")
+                    return
+                }
+                def nd:GltfNode (new GltfNode)
+                nd.name = (o.stringOr("name" ""))
+                nd.mesh = (o.intOr("mesh" (0 - 1)))
+                if (o.has("children")) {
+                    def ch:JsonValue (o.get("children"))
+                    nd.children = (this.readIntArray(ch))
+                }
+                if (o.has("matrix")) {
+                    def mx:JsonValue (o.get("matrix"))
+                    def vals:[double]
+                    def k:int 0
+                    while (k < 16) {
+                        def mv:double (this.jd(mx k))
+                        push vals mv
+                        k = (k + 1)
+                    }
+                    nd.matrix = vals
+                    nd.hasMatrix = true
+                } {
+                    if (o.has("translation")) {
+                        def tr:JsonValue (o.get("translation"))
+                        def tx:double (this.jd(tr 0))
+                        def ty:double (this.jd(tr 1))
+                        def tz:double (this.jd(tr 2))
+                        nd.translation = (Vec3.of(tx ty tz))
+                    }
+                    if (o.has("rotation")) {
+                        def ro:JsonValue (o.get("rotation"))
+                        def rx:double (this.jd(ro 0))
+                        def ry:double (this.jd(ro 1))
+                        def rz:double (this.jd(ro 2))
+                        def rw:double (this.jd(ro 3))
+                        nd.rotation = (Quat.of(rx ry rz rw))
+                    }
+                    if (o.has("scale")) {
+                        def sc:JsonValue (o.get("scale"))
+                        def sx:double (this.jd(sc 0))
+                        def sy:double (this.jd(sc 1))
+                        def sz:double (this.jd(sc 2))
+                        nd.scale = (Vec3.of(sx sy sz))
+                    }
+                }
+                push nodes nd
+                i = (i + 1)
+            }
+        }
+    }
+
+    fn parseScenes:void (root:JsonValue) {
+        if (root.has("scenes")) {
+            def arr:JsonValue (root.get("scenes"))
+            def n:int (arr.count())
+            def i:int 0
+            while (i < n) {
+                def o:JsonValue (arr.at(i))
+                def sc:GltfScene (new GltfScene)
+                if (o.has("nodes")) {
+                    def nn:JsonValue (o.get("nodes"))
+                    sc.nodes = (this.readIntArray(nn))
+                }
+                push scenes sc
+                i = (i + 1)
+            }
+        }
+    }
+}

--- a/gallery/game_engine/model3d/GltfMath.rgr
+++ b/gallery/game_engine/model3d/GltfMath.rgr
@@ -1,0 +1,177 @@
+; ==============================================================================
+; GltfMath.rgr — minimal vector / quaternion / 4x4 matrix math for the loader.
+; ==============================================================================
+; Just enough linear algebra to turn a glTF node's transform (either a 16-value
+; column-major matrix, or separate translation / rotation / scale) into a local
+; matrix, and to compose parent * child into a world matrix. Column-major
+; storage (m[col*4 + row]) matches the glTF matrix layout directly.
+; ==============================================================================
+
+class Vec2 {
+    def x:double 0.0
+    def y:double 0.0
+    sfn of:Vec2 (x:double y:double) {
+        def v:Vec2 (new Vec2)
+        v.x = x
+        v.y = y
+        return v
+    }
+}
+
+class Vec3 {
+    def x:double 0.0
+    def y:double 0.0
+    def z:double 0.0
+    sfn of:Vec3 (x:double y:double z:double) {
+        def v:Vec3 (new Vec3)
+        v.x = x
+        v.y = y
+        v.z = z
+        return v
+    }
+}
+
+class Vec4 {
+    def x:double 0.0
+    def y:double 0.0
+    def z:double 0.0
+    def w:double 0.0
+    sfn of:Vec4 (x:double y:double z:double w:double) {
+        def v:Vec4 (new Vec4)
+        v.x = x
+        v.y = y
+        v.z = z
+        v.w = w
+        return v
+    }
+}
+
+; unit quaternion (x, y, z, w); identity is (0,0,0,1)
+class Quat {
+    def x:double 0.0
+    def y:double 0.0
+    def z:double 0.0
+    def w:double 1.0
+    sfn of:Quat (x:double y:double z:double w:double) {
+        def q:Quat (new Quat)
+        q.x = x
+        q.y = y
+        q.z = z
+        q.w = w
+        return q
+    }
+    sfn identity:Quat () {
+        def q:Quat (new Quat)
+        return q
+    }
+}
+
+; 4x4 matrix, column-major: m[col*4 + row].
+class Mat4 {
+    def m:double_buffer (double_buffer_alloc 16)
+
+    fn setAll:void (vals:[double]) {
+        def k:int 0
+        while (k < 16) {
+            double_buffer_set m k (itemAt vals k)
+            k = (k + 1)
+        }
+    }
+    fn setIdentity:void () {
+        def k:int 0
+        while (k < 16) {
+            double_buffer_set m k 0.0
+            k = (k + 1)
+        }
+        double_buffer_set m 0 1.0
+        double_buffer_set m 5 1.0
+        double_buffer_set m 10 1.0
+        double_buffer_set m 15 1.0
+    }
+    ; row/col accessor (row and col both 0..3)
+    fn at:double (row:int col:int) {
+        return (double_buffer_get m ((col * 4) + row))
+    }
+    fn put:void (row:int col:int value:double) {
+        double_buffer_set m ((col * 4) + row) value
+    }
+    fn copyFrom:void (other:Mat4) {
+        def k:int 0
+        while (k < 16) {
+            double_buffer_set m k (double_buffer_get other.m k)
+            k = (k + 1)
+        }
+    }
+
+    sfn identity:Mat4 () {
+        def r:Mat4 (new Mat4)
+        r.setIdentity()
+        return r
+    }
+    ; glTF node.matrix is already column-major, 16 values
+    sfn fromColumnMajor:Mat4 (vals:[double]) {
+        def r:Mat4 (new Mat4)
+        r.setAll(vals)
+        return r
+    }
+    ; compose M = T * R * S from translation / rotation / scale
+    sfn fromTRS:Mat4 (t:Vec3 q:Quat s:Vec3) {
+        def r:Mat4 (new Mat4)
+        def xx:double (q.x * q.x)
+        def yy:double (q.y * q.y)
+        def zz:double (q.z * q.z)
+        def xy:double (q.x * q.y)
+        def xz:double (q.x * q.z)
+        def yz:double (q.y * q.z)
+        def wx:double (q.w * q.x)
+        def wy:double (q.w * q.y)
+        def wz:double (q.w * q.z)
+        ; rotation basis (row, col), then scale each column
+        def r00:double (1.0 - (2.0 * (yy + zz)))
+        def r01:double (2.0 * (xy - wz))
+        def r02:double (2.0 * (xz + wy))
+        def r10:double (2.0 * (xy + wz))
+        def r11:double (1.0 - (2.0 * (xx + zz)))
+        def r12:double (2.0 * (yz - wx))
+        def r20:double (2.0 * (xz - wy))
+        def r21:double (2.0 * (yz + wx))
+        def r22:double (1.0 - (2.0 * (xx + yy)))
+        r.put(0 0 (r00 * s.x))
+        r.put(1 0 (r10 * s.x))
+        r.put(2 0 (r20 * s.x))
+        r.put(3 0 0.0)
+        r.put(0 1 (r01 * s.y))
+        r.put(1 1 (r11 * s.y))
+        r.put(2 1 (r21 * s.y))
+        r.put(3 1 0.0)
+        r.put(0 2 (r02 * s.z))
+        r.put(1 2 (r12 * s.z))
+        r.put(2 2 (r22 * s.z))
+        r.put(3 2 0.0)
+        r.put(0 3 t.x)
+        r.put(1 3 t.y)
+        r.put(2 3 t.z)
+        r.put(3 3 1.0)
+        return r
+    }
+    ; C = A * B (both column-major)
+    sfn mul:Mat4 (a:Mat4 b:Mat4) {
+        def c:Mat4 (new Mat4)
+        def col:int 0
+        while (col < 4) {
+            def row:int 0
+            while (row < 4) {
+                def sum:double 0.0
+                def k:int 0
+                while (k < 4) {
+                    sum = (sum + ((a.at(row k)) * (b.at(k col))))
+                    k = (k + 1)
+                }
+                c.put(row col sum)
+                row = (row + 1)
+            }
+            col = (col + 1)
+        }
+        return c
+    }
+}

--- a/gallery/game_engine/model3d/Json.rgr
+++ b/gallery/game_engine/model3d/Json.rgr
@@ -1,0 +1,468 @@
+; ==============================================================================
+; Json.rgr — a compact, self-contained JSON parser for the 3D asset loader.
+; ==============================================================================
+; Pure Ranger, no host JSON and no compiler-internal parser: a small recursive
+; descent parser that produces a typed JsonValue tree. Scoped to what glTF 2.0
+; JSON needs (objects, arrays, numbers with sign/decimal/exponent, strings with
+; escapes, booleans, null). Object members keep insertion order in `keys`.
+; ==============================================================================
+
+class JsonValue {
+    ; kind: 0 null, 1 bool, 2 number, 3 string, 4 array, 5 object
+    def kind:int 0
+    def num:double 0.0
+    def b:boolean false
+    def str:string ""
+    def arr:[JsonValue]
+    def keys:[string]
+    def members:[string:JsonValue]
+
+    fn isNull:boolean () {
+        return (kind == 0)
+    }
+    fn isNumber:boolean () {
+        return (kind == 2)
+    }
+    fn isString:boolean () {
+        return (kind == 3)
+    }
+    fn isArray:boolean () {
+        return (kind == 4)
+    }
+    fn isObject:boolean () {
+        return (kind == 5)
+    }
+    fn asInt:int () {
+        return (to_int num)
+    }
+    fn asDouble:double () {
+        return num
+    }
+    fn asString:string () {
+        return str
+    }
+    fn asBool:boolean () {
+        return b
+    }
+    ; --- array access ---
+    fn count:int () {
+        return (array_length arr)
+    }
+    fn at:JsonValue (index:int) {
+        return (itemAt arr index)
+    }
+    ; --- object access ---
+    fn has:boolean (key:string) {
+        return (has members key)
+    }
+    fn get:JsonValue (key:string) {
+        if (has members key) {
+            return (unwrap (get members key))
+        }
+        def nil:JsonValue (new JsonValue)
+        return nil
+    }
+    fn intOr:int (key:string dflt:int) {
+        if (has members key) {
+            def v:JsonValue (unwrap (get members key))
+            return (to_int v.num)
+        }
+        return dflt
+    }
+    fn doubleOr:double (key:string dflt:double) {
+        if (has members key) {
+            def v:JsonValue (unwrap (get members key))
+            return v.num
+        }
+        return dflt
+    }
+    fn stringOr:string (key:string dflt:string) {
+        if (has members key) {
+            def v:JsonValue (unwrap (get members key))
+            return v.str
+        }
+        return dflt
+    }
+    fn boolOr:boolean (key:string dflt:boolean) {
+        if (has members key) {
+            def v:JsonValue (unwrap (get members key))
+            return v.b
+        }
+        return dflt
+    }
+}
+
+class JsonParser {
+    def s:string ""
+    def i:int 0
+    def n:int 0
+    def ok:boolean true
+    def err:string ""
+
+    fn parse:JsonValue (text:string) {
+        s = text
+        i = 0
+        n = (strlen text)
+        ok = true
+        err = ""
+        def v:JsonValue (this.parseValue())
+        return v
+    }
+
+    fn isWs:boolean (c:int) {
+        if (c == 32) {
+            return true
+        }
+        if (c == 9) {
+            return true
+        }
+        if (c == 10) {
+            return true
+        }
+        if (c == 13) {
+            return true
+        }
+        return false
+    }
+
+    fn skipWs:void () {
+        def go:boolean true
+        while go {
+            if (i >= n) {
+                go = false
+            } {
+                def c:int (charAt s i)
+                if (this.isWs(c)) {
+                    i = (i + 1)
+                } {
+                    go = false
+                }
+            }
+        }
+    }
+
+    fn isNumChar:boolean (c:int) {
+        if (c == 45) {
+            return true
+        }
+        if (c == 43) {
+            return true
+        }
+        if (c == 46) {
+            return true
+        }
+        if (c == 101) {
+            return true
+        }
+        if (c == 69) {
+            return true
+        }
+        if (c >= 48) {
+            if (c <= 57) {
+                return true
+            }
+        }
+        return false
+    }
+
+    fn fail:void (msg:string) {
+        if ok {
+            ok = false
+            err = msg
+        }
+    }
+
+    fn parseValue:JsonValue () {
+        this.skipWs()
+        if (i >= n) {
+            this.fail("unexpected end of input")
+            def v:JsonValue (new JsonValue)
+            return v
+        }
+        def c:int (charAt s i)
+        if (c == 123) {
+            return (this.parseObject())
+        }
+        if (c == 91) {
+            return (this.parseArray())
+        }
+        if (c == 34) {
+            return (this.parseString())
+        }
+        if (c == 116) {
+            return (this.parseKeyword("true" 1 true))
+        }
+        if (c == 102) {
+            return (this.parseKeyword("false" 1 false))
+        }
+        if (c == 110) {
+            return (this.parseKeyword("null" 0 false))
+        }
+        return (this.parseNumber())
+    }
+
+    fn parseKeyword:JsonValue (word:string kind:int bval:boolean) {
+        def wl:int (strlen word)
+        def matched:boolean true
+        def k:int 0
+        while (k < wl) {
+            if ((i + k) >= n) {
+                matched = false
+                k = wl
+            } {
+                if ((charAt s (i + k)) != (charAt word k)) {
+                    matched = false
+                    k = wl
+                } {
+                    k = (k + 1)
+                }
+            }
+        }
+        def v:JsonValue (new JsonValue)
+        if matched {
+            i = (i + wl)
+            v.kind = kind
+            v.b = bval
+        } {
+            this.fail("invalid literal, expected " + word)
+        }
+        return v
+    }
+
+    fn parseNumber:JsonValue () {
+        def start:int i
+        def go:boolean true
+        while go {
+            if (i >= n) {
+                go = false
+            } {
+                def c:int (charAt s i)
+                if (this.isNumChar(c)) {
+                    i = (i + 1)
+                } {
+                    go = false
+                }
+            }
+        }
+        def v:JsonValue (new JsonValue)
+        if (i > start) {
+            def sub:string (substring s start i)
+            def d@(optional):double (str2double sub)
+            v.kind = 2
+            if d {
+                v.num = (unwrap d)
+            } {
+                this.fail("invalid number: " + sub)
+            }
+        } {
+            this.fail("expected value")
+        }
+        return v
+    }
+
+    fn hexDigit:int (c:int) {
+        if (c >= 48) {
+            if (c <= 57) {
+                return (c - 48)
+            }
+        }
+        if (c >= 97) {
+            if (c <= 102) {
+                return ((c - 97) + 10)
+            }
+        }
+        if (c >= 65) {
+            if (c <= 70) {
+                return ((c - 65) + 10)
+            }
+        }
+        return 0
+    }
+
+    fn readRawString:string () {
+        ; assumes current char is the opening quote
+        i = (i + 1)
+        def out:string ""
+        def go:boolean true
+        while go {
+            if (i >= n) {
+                this.fail("unterminated string")
+                go = false
+            } {
+                def c:int (charAt s i)
+                if (c == 34) {
+                    i = (i + 1)
+                    go = false
+                } {
+                    if (c == 92) {
+                        i = (i + 1)
+                        if (i >= n) {
+                            this.fail("unterminated escape")
+                            go = false
+                        } {
+                            def e:int (charAt s i)
+                            out = (out + (this.decodeEscape(e)))
+                            i = (i + 1)
+                        }
+                    } {
+                        out = (out + (substring s i (i + 1)))
+                        i = (i + 1)
+                    }
+                }
+            }
+        }
+        return out
+    }
+
+    fn decodeEscape:string (e:int) {
+        if (e == 34) {
+            return (strfromcode 34)
+        }
+        if (e == 92) {
+            return (strfromcode 92)
+        }
+        if (e == 47) {
+            return (strfromcode 47)
+        }
+        if (e == 98) {
+            return (strfromcode 8)
+        }
+        if (e == 102) {
+            return (strfromcode 12)
+        }
+        if (e == 110) {
+            return (strfromcode 10)
+        }
+        if (e == 114) {
+            return (strfromcode 13)
+        }
+        if (e == 116) {
+            return (strfromcode 9)
+        }
+        if (e == 117) {
+            def cp:int 0
+            def k:int 0
+            while (k < 4) {
+                def hc:int (charAt s (i + 1 + k))
+                cp = ((cp * 16) + (this.hexDigit(hc)))
+                k = (k + 1)
+            }
+            i = (i + 4)
+            return (strfromcode cp)
+        }
+        return (strfromcode e)
+    }
+
+    fn parseString:JsonValue () {
+        def v:JsonValue (new JsonValue)
+        v.kind = 3
+        v.str = (this.readRawString())
+        return v
+    }
+
+    fn parseArray:JsonValue () {
+        def v:JsonValue (new JsonValue)
+        v.kind = 4
+        i = (i + 1)
+        this.skipWs()
+        if (i < n) {
+            if ((charAt s i) == 93) {
+                i = (i + 1)
+                return v
+            }
+        }
+        def go:boolean true
+        while go {
+            def item:JsonValue (this.parseValue())
+            push v.arr item
+            this.skipWs()
+            if (i >= n) {
+                this.fail("unterminated array")
+                go = false
+            } {
+                def c:int (charAt s i)
+                if (c == 44) {
+                    i = (i + 1)
+                    this.skipWs()
+                } {
+                    if (c == 93) {
+                        i = (i + 1)
+                        go = false
+                    } {
+                        this.fail("expected ',' or ']' in array")
+                        go = false
+                    }
+                }
+            }
+            if (ok == false) {
+                go = false
+            }
+        }
+        return v
+    }
+
+    fn parseObject:JsonValue () {
+        def v:JsonValue (new JsonValue)
+        v.kind = 5
+        i = (i + 1)
+        this.skipWs()
+        if (i < n) {
+            if ((charAt s i) == 125) {
+                i = (i + 1)
+                return v
+            }
+        }
+        def go:boolean true
+        while go {
+            this.skipWs()
+            if (i >= n) {
+                this.fail("unterminated object")
+                go = false
+            } {
+                if ((charAt s i) != 34) {
+                    this.fail("expected string key in object")
+                    go = false
+                } {
+                    def key:string (this.readRawString())
+                    this.skipWs()
+                    if (i >= n) {
+                        this.fail("expected ':' in object")
+                        go = false
+                    } {
+                        if ((charAt s i) != 58) {
+                            this.fail("expected ':' in object")
+                            go = false
+                        } {
+                            i = (i + 1)
+                            def val:JsonValue (this.parseValue())
+                            set v.members key val
+                            push v.keys key
+                            this.skipWs()
+                            if (i >= n) {
+                                this.fail("unterminated object")
+                                go = false
+                            } {
+                                def c:int (charAt s i)
+                                if (c == 44) {
+                                    i = (i + 1)
+                                } {
+                                    if (c == 125) {
+                                        i = (i + 1)
+                                        go = false
+                                    } {
+                                        this.fail("expected ',' or '}' in object")
+                                        go = false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (ok == false) {
+                go = false
+            }
+        }
+        return v
+    }
+}

--- a/gallery/game_engine/model3d/ModelLoader.rgr
+++ b/gallery/game_engine/model3d/ModelLoader.rgr
@@ -1,0 +1,68 @@
+; ==============================================================================
+; ModelLoader.rgr — public host API tying the 3D asset pipeline together.
+; ==============================================================================
+; This is the load_model() / instantiate_model() / find_child() surface the plan
+; describes, host-side and WASM-free:
+;
+;   let model = loader.loadFromFile("models" "robot.glb")   // -> ModelHandle id
+;   let robot = loader.instantiate(model)                   // -> root EntityId
+;   let hand  = loader.findChild(robot "RightHand")         // -> EntityId
+;
+; loadFromBuffer runs the GLB importer, decodes embedded PNG/JPEG textures into
+; RGBA, and registers the resulting ModelAsset in the AssetRegistry. instantiate
+; expands a model into the host EntityRegistry. Errors surface via ok/lastError.
+; ==============================================================================
+
+Import "GlbImporter.rgr"
+Import "EntityModel.rgr"
+Import "TextureDecode.rgr"
+
+class ModelLoader {
+    def registry:AssetRegistry (new AssetRegistry)
+    def entities:EntityRegistry (new EntityRegistry)
+    def ok:boolean true
+    def lastError:string ""
+    def decodeTextures:boolean true
+
+    ; load + register a model from GLB bytes; returns a model id, or -1 on error
+    fn loadFromBuffer:int (bytes:buffer) {
+        def imp:GlbImporter (new GlbImporter)
+        def model:ModelAsset (imp.importModel(bytes))
+        if (imp.ok == false) {
+            ok = false
+            lastError = imp.error
+            return (0 - 1)
+        }
+        if decodeTextures {
+            def n:int (model.textureCount())
+            def i:int 0
+            while (i < n) {
+                def tex:TextureAsset (model.getTexture(i))
+                TextureDecode.decodeInto(tex)
+                i = (i + 1)
+            }
+        }
+        ok = true
+        lastError = ""
+        return (registry.addModel(model))
+    }
+    fn loadFromFile:int (dir:string file:string) {
+        def bytes:buffer (buffer_read_file dir file)
+        return (this.loadFromBuffer(bytes))
+    }
+
+    fn getModel:ModelAsset (modelId:int) {
+        return (registry.getModel(modelId))
+    }
+    ; expand a loaded model into the entity scene; returns the root EntityId
+    fn instantiate:int (modelId:int) {
+        def model:ModelAsset (registry.getModel(modelId))
+        return (ModelInstancer.instantiate(entities model))
+    }
+    fn findChild:int (rootEntity:int name:string) {
+        return (entities.findChild(rootEntity name))
+    }
+    fn getEntity:Entity (entityId:int) {
+        return (entities.get(entityId))
+    }
+}

--- a/gallery/game_engine/model3d/README.md
+++ b/gallery/game_engine/model3d/README.md
@@ -1,0 +1,117 @@
+# model3d — native 3D asset loading for Ranger
+
+Host-side (no WASM) reading of 3D model assets, built **before** any WASM ABI
+integration. This is the `load_model → ModelAsset → Entity hierarchy →
+MeshRenderer` path the engine needs so a GLB's node hierarchy, meshes,
+materials and textures land as **host-owned** resources — not as a new block
+written into WASM guest memory.
+
+The hard part of "GLB support" is not reading the container bytes; it is having
+a host object model for models, assets and entities. That model is the bulk of
+what lives here, with a static GLB importer on top.
+
+## Pipeline
+
+```
+GLB bytes
+  → GlbImporter        (container: 12-byte header, JSON chunk, BIN chunk)
+      → JsonParser     (compact recursive-descent JSON → JsonValue tree)
+      → GltfDocument   (typed glTF view + support gate)
+      → accessors      (bufferView + byteStride + BIN → Vec3/Vec2/index arrays)
+  → ModelAsset         (NodeAsset / MeshAsset / MaterialAsset / TextureAsset)
+  → TextureDecode      (embedded PNG/JPEG bytes → RGBA, reusing native decoders)
+  → AssetRegistry      (owns models; hands back a model id)
+
+ModelInstancer.instantiate(model)
+  → EntityRegistry     (one EntityId per node, parent/child links)
+      → TransformComponent (TRS or matrix → local + world matrix)
+      → MeshRenderer   (attached wherever a node references a mesh)
+  → root EntityId      (find_child(root, "RightHand") resolves through the host)
+```
+
+Public surface is `ModelLoader`:
+
+```
+def loader:ModelLoader (new ModelLoader)
+def model:int (loader.loadFromFile("models" "robot.glb"))   ; -> model id (-1 on error)
+def robot:int (loader.instantiate(model))                   ; -> root EntityId
+def hand:int (loader.findChild(robot "RightHand"))          ; -> EntityId
+```
+
+On failure `loader.ok` is `false` and `loader.lastError` explains why.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `Json.rgr` | Self-contained JSON parser → `JsonValue` tree |
+| `ByteReader.rgr` | Little-endian byte reads + IEEE-754 float32 decode/encode |
+| `GltfMath.rgr` | `Vec2/Vec3/Vec4/Quat/Mat4` (TRS → matrix, matrix multiply) |
+| `AssetModel.rgr` | `TextureAsset/MaterialAsset/MeshAsset/NodeAsset/ModelAsset` + `AssetRegistry` |
+| `EntityModel.rgr` | `Entity/TransformComponent/MeshRenderer` + `EntityRegistry` + `ModelInstancer` |
+| `GltfDocument.rgr` | Typed glTF 2.0 view + **support gate** (rejects unsupported features) |
+| `GlbImporter.rgr` | GLB container + accessor reader → `ModelAsset` |
+| `TextureDecode.rgr` | Decodes embedded PNG/JPEG bytes to RGBA (reuses repo decoders) |
+| `ModelLoader.rgr` | Public `loadFromFile/loadFromBuffer/instantiate/findChild` API |
+
+## First support level
+
+Supported:
+
+- GLB 2.0, one JSON chunk + one BIN chunk
+- scenes and nodes; node `matrix` **or** TRS (translation/rotation/scale)
+- multiple meshes, multiple primitives per mesh
+- `TRIANGLES`; `POSITION`, `NORMAL`, `TEXCOORD_0`
+- `u16` and `u32` (and `u8`) indices
+- interleaved `byteStride`
+- `baseColorFactor` + `baseColorTexture`, multiple materials
+- embedded PNG / JPEG textures (decoded to RGBA)
+
+Explicitly rejected (with a clear error, never a silently-wrong model):
+
+- skins, animations, morph targets
+- sparse accessors
+- Draco / Meshopt / KTX2 (any `extensionsRequired`)
+- non-`TRIANGLES` primitive modes
+
+Example rejection message:
+
+```
+robot.glb cannot be loaded: unsupported feature EXT_meshopt_compression
+```
+
+## Texture decoders (decode-from-buffer)
+
+Embedded glTF images are bytes inside the BIN chunk, not files on disk. The
+repo's existing native decoders were extended with an in-memory entry point
+(the file-based `decode(dir, file)` API is unchanged and still delegates to it):
+
+- `gallery/game_engine/lpc/src/png_decoder.rgr` → `decodeBytes(bytes:buffer)`
+- `gallery/pdf_writer/src/jpeg/JPEGDecoder.rgr` → `decodeBytes(bytes:buffer)`
+
+## Tests
+
+Hermetic — the fixture builds a valid GLB entirely in memory (`tests/GlbFixture.rgr`),
+including a real 2×2 RGBA PNG, so no external assets or toolchain are needed.
+
+```sh
+bash gallery/game_engine/model3d/tests/run.sh
+```
+
+or individually (compile to ES6, run under Node, grep for `ALL PASS`):
+
+```sh
+node bin/output.js -es6 gallery/game_engine/model3d/tests/Model3dTest.rgr -d=/tmp -o=m3d.js && node /tmp/m3d.js
+node bin/output.js -es6 gallery/game_engine/model3d/tests/TextureDecodeTest.rgr -d=/tmp -o=td.js && node /tmp/td.js
+```
+
+- `Model3dTest.rgr` — container, document, accessors, materials, embedded PNG
+  bytes, node hierarchy, instantiation (find_child, world transforms), and the
+  support gate.
+- `TextureDecodeTest.rgr` — end-to-end load + embedded PNG decoded to the
+  expected RGBA pixels through `ModelLoader`.
+
+## Not in scope yet
+
+WASM ABI integration; skinning/animation; validating against the Khronos glTF
+Sample Assets + glTF Validator (recommended next once real `.glb` inputs land).

--- a/gallery/game_engine/model3d/TextureDecode.rgr
+++ b/gallery/game_engine/model3d/TextureDecode.rgr
@@ -1,0 +1,43 @@
+; ==============================================================================
+; TextureDecode.rgr — decode a TextureAsset's embedded bytes to RGBA pixels.
+; ==============================================================================
+; Bridges the GLB importer (which extracts raw PNG/JPEG bytes out of the BIN
+; chunk into TextureAsset.sourceBytes) to the existing native image decoders in
+; the repo, reused through their new decode-from-buffer entry points:
+;   * PNG  -> gallery/game_engine/lpc/src/png_decoder.rgr  (decodeBytes)
+;   * JPEG -> gallery/pdf_writer/src/jpeg/JPEGDecoder.rgr   (decodeBytes)
+; Fills width/height and tightly packed RGBA8 into the asset. No file I/O.
+; ==============================================================================
+
+Import "../lpc/src/png_decoder.rgr"
+Import "../../pdf_writer/src/jpeg/JPEGDecoder.rgr"
+Import "AssetModel.rgr"
+
+class TextureDecode {
+    ; decode tex.sourceBytes (per tex.mimeType) into tex.rgba; returns success
+    sfn decodeInto:boolean (tex:TextureAsset) {
+        if ((buffer_length tex.sourceBytes) == 0) {
+            return false
+        }
+        def img:ImageBuffer (new ImageBuffer())
+        def done:boolean false
+        if (tex.mimeType == "image/png") {
+            def dec:PNGDecoder (new PNGDecoder)
+            img = (dec.decodeBytes(tex.sourceBytes))
+            done = true
+        }
+        if (tex.mimeType == "image/jpeg") {
+            def dec2:JPEGDecoder (new JPEGDecoder)
+            img = (dec2.decodeBytes(tex.sourceBytes))
+            done = true
+        }
+        if (done == false) {
+            return false
+        }
+        tex.width = img.width
+        tex.height = img.height
+        tex.rgba = (img.getRawBuffer())
+        tex.decoded = true
+        return true
+    }
+}

--- a/gallery/game_engine/model3d/tests/GlbFixture.rgr
+++ b/gallery/game_engine/model3d/tests/GlbFixture.rgr
@@ -1,0 +1,235 @@
+; ==============================================================================
+; GlbFixture.rgr — builds a known-good GLB byte buffer entirely in memory.
+; ==============================================================================
+; Hermetic test input: no external asset files, no toolchain. Produces a valid
+; GLB 2.0 container describing a single-triangle mesh, a small node hierarchy
+; (Root -> Body(mesh), Root -> Arm -> Hand), one PBR material with a base colour
+; factor + base colour texture, and one embedded 2x2 RGBA PNG. Byte offsets in
+; buildJson() match the layout written by buildBin() exactly.
+;
+;   BIN layout (180 bytes):
+;     [  0.. 36) positions  3 * VEC3 f32
+;     [ 36.. 72) normals    3 * VEC3 f32
+;     [ 72.. 96) uv         3 * VEC2 f32
+;     [ 96..102) indices    3 * u16   (102..104 zero pad)
+;     [104..180) image      76-byte PNG
+; ==============================================================================
+
+Import "../ByteReader.rgr"
+
+class GlbFixture {
+    ; a real, minimal 2x2 RGBA PNG: pixels red, green / blue, white
+    sfn pngBytes:buffer () {
+        def b:buffer (buffer_alloc 76)
+        buffer_set b 0 137
+        buffer_set b 1 80
+        buffer_set b 2 78
+        buffer_set b 3 71
+        buffer_set b 4 13
+        buffer_set b 5 10
+        buffer_set b 6 26
+        buffer_set b 7 10
+        buffer_set b 8 0
+        buffer_set b 9 0
+        buffer_set b 10 0
+        buffer_set b 11 13
+        buffer_set b 12 73
+        buffer_set b 13 72
+        buffer_set b 14 68
+        buffer_set b 15 82
+        buffer_set b 16 0
+        buffer_set b 17 0
+        buffer_set b 18 0
+        buffer_set b 19 2
+        buffer_set b 20 0
+        buffer_set b 21 0
+        buffer_set b 22 0
+        buffer_set b 23 2
+        buffer_set b 24 8
+        buffer_set b 25 6
+        buffer_set b 26 0
+        buffer_set b 27 0
+        buffer_set b 28 0
+        buffer_set b 29 114
+        buffer_set b 30 182
+        buffer_set b 31 13
+        buffer_set b 32 36
+        buffer_set b 33 0
+        buffer_set b 34 0
+        buffer_set b 35 0
+        buffer_set b 36 19
+        buffer_set b 37 73
+        buffer_set b 38 68
+        buffer_set b 39 65
+        buffer_set b 40 84
+        buffer_set b 41 120
+        buffer_set b 42 156
+        buffer_set b 43 99
+        buffer_set b 44 248
+        buffer_set b 45 207
+        buffer_set b 46 192
+        buffer_set b 47 240
+        buffer_set b 48 31
+        buffer_set b 49 12
+        buffer_set b 50 25
+        buffer_set b 51 24
+        buffer_set b 52 254
+        buffer_set b 53 131
+        buffer_set b 54 1
+        buffer_set b 55 0
+        buffer_set b 56 73
+        buffer_set b 57 200
+        buffer_set b 58 9
+        buffer_set b 59 247
+        buffer_set b 60 20
+        buffer_set b 61 99
+        buffer_set b 62 50
+        buffer_set b 63 157
+        buffer_set b 64 0
+        buffer_set b 65 0
+        buffer_set b 66 0
+        buffer_set b 67 0
+        buffer_set b 68 73
+        buffer_set b 69 69
+        buffer_set b 70 78
+        buffer_set b 71 68
+        buffer_set b 72 174
+        buffer_set b 73 66
+        buffer_set b 74 96
+        buffer_set b 75 130
+        return b
+    }
+
+    sfn buildBin:buffer () {
+        def b:buffer (buffer_alloc 180)
+        ; positions: (0,0,0) (1,0,0) (0,1,0)
+        ByteReader.encodeF32(b 0 0.0)
+        ByteReader.encodeF32(b 4 0.0)
+        ByteReader.encodeF32(b 8 0.0)
+        ByteReader.encodeF32(b 12 1.0)
+        ByteReader.encodeF32(b 16 0.0)
+        ByteReader.encodeF32(b 20 0.0)
+        ByteReader.encodeF32(b 24 0.0)
+        ByteReader.encodeF32(b 28 1.0)
+        ByteReader.encodeF32(b 32 0.0)
+        ; normals: (0,0,1) x3
+        ByteReader.encodeF32(b 36 0.0)
+        ByteReader.encodeF32(b 40 0.0)
+        ByteReader.encodeF32(b 44 1.0)
+        ByteReader.encodeF32(b 48 0.0)
+        ByteReader.encodeF32(b 52 0.0)
+        ByteReader.encodeF32(b 56 1.0)
+        ByteReader.encodeF32(b 60 0.0)
+        ByteReader.encodeF32(b 64 0.0)
+        ByteReader.encodeF32(b 68 1.0)
+        ; uv: (0,0) (1,0) (0,1)
+        ByteReader.encodeF32(b 72 0.0)
+        ByteReader.encodeF32(b 76 0.0)
+        ByteReader.encodeF32(b 80 1.0)
+        ByteReader.encodeF32(b 84 0.0)
+        ByteReader.encodeF32(b 88 0.0)
+        ByteReader.encodeF32(b 92 1.0)
+        ; indices u16: 0,1,2 at offset 96
+        ByteReader.encodeU16(b 96 0)
+        ByteReader.encodeU16(b 98 1)
+        ByteReader.encodeU16(b 100 2)
+        ; 102..104 zero pad (already zero)
+        def png:buffer (GlbFixture.pngBytes())
+        buffer_copy b 104 png 0 76
+        return b
+    }
+
+    sfn buildJson:string () {
+        def s:string "{"
+        s = (s + "\"asset\":{\"version\":\"2.0\"},")
+        s = (s + "\"scene\":0,")
+        s = (s + "\"scenes\":[{\"nodes\":[0]}],")
+        s = (s + "\"nodes\":[")
+        s = (s + "{\"name\":\"Root\",\"children\":[1,2],\"translation\":[0,0,5]},")
+        s = (s + "{\"name\":\"Body\",\"mesh\":0,\"translation\":[1,0,0]},")
+        s = (s + "{\"name\":\"Arm\",\"children\":[3],\"translation\":[0,2,0]},")
+        s = (s + "{\"name\":\"Hand\",\"translation\":[0,1,0]}")
+        s = (s + "],")
+        s = (s + "\"meshes\":[{\"name\":\"Tri\",\"primitives\":[{\"attributes\":{\"POSITION\":0,\"NORMAL\":1,\"TEXCOORD_0\":2},\"indices\":3,\"material\":0,\"mode\":4}]}],")
+        s = (s + "\"materials\":[{\"name\":\"Mat\",\"doubleSided\":true,\"pbrMetallicRoughness\":{\"baseColorFactor\":[0.8,0.4,0.2,1.0],\"baseColorTexture\":{\"index\":0},\"metallicFactor\":0.0,\"roughnessFactor\":0.5}}],")
+        s = (s + "\"textures\":[{\"source\":0}],")
+        s = (s + "\"images\":[{\"mimeType\":\"image/png\",\"bufferView\":4}],")
+        s = (s + "\"accessors\":[")
+        s = (s + "{\"bufferView\":0,\"componentType\":5126,\"count\":3,\"type\":\"VEC3\"},")
+        s = (s + "{\"bufferView\":1,\"componentType\":5126,\"count\":3,\"type\":\"VEC3\"},")
+        s = (s + "{\"bufferView\":2,\"componentType\":5126,\"count\":3,\"type\":\"VEC2\"},")
+        s = (s + "{\"bufferView\":3,\"componentType\":5123,\"count\":3,\"type\":\"SCALAR\"}")
+        s = (s + "],")
+        s = (s + "\"bufferViews\":[")
+        s = (s + "{\"buffer\":0,\"byteOffset\":0,\"byteLength\":36},")
+        s = (s + "{\"buffer\":0,\"byteOffset\":36,\"byteLength\":36},")
+        s = (s + "{\"buffer\":0,\"byteOffset\":72,\"byteLength\":24},")
+        s = (s + "{\"buffer\":0,\"byteOffset\":96,\"byteLength\":6},")
+        s = (s + "{\"buffer\":0,\"byteOffset\":104,\"byteLength\":76}")
+        s = (s + "],")
+        s = (s + "\"buffers\":[{\"byteLength\":180}]")
+        s = (s + "}")
+        return s
+    }
+
+    sfn pad4:int (n:int) {
+        def r:int (n - ((idiv n 4) * 4))
+        if (r == 0) {
+            return 0
+        }
+        return (4 - r)
+    }
+
+    ; wrap an arbitrary glTF JSON string into a GLB with no BIN chunk; used to
+    ; exercise the support gate (rejection of unsupported features).
+    sfn glbFromJson:buffer (json:string) {
+        def jbuf:buffer (buffer_from_string json)
+        def jlen:int (buffer_length jbuf)
+        def jpad:int (GlbFixture.pad4(jlen))
+        def jtotal:int (jlen + jpad)
+        def total:int (12 + (8 + jtotal))
+        def out:buffer (buffer_alloc total)
+        ByteReader.encodeU32(out 0 1179937895)
+        ByteReader.encodeU32(out 4 2)
+        ByteReader.encodeU32(out 8 total)
+        ByteReader.encodeU32(out 12 jtotal)
+        ByteReader.encodeU32(out 16 1313821514)
+        buffer_copy out 20 jbuf 0 jlen
+        def p:int 0
+        while (p < jpad) {
+            buffer_set out ((20 + jlen) + p) 32
+            p = (p + 1)
+        }
+        return out
+    }
+
+    sfn build:buffer () {
+        def json:string (GlbFixture.buildJson())
+        def bin:buffer (GlbFixture.buildBin())
+        def jbuf:buffer (buffer_from_string json)
+        def jlen:int (buffer_length jbuf)
+        def jpad:int (GlbFixture.pad4(jlen))
+        def jtotal:int (jlen + jpad)
+        def blen:int (buffer_length bin)
+        def bpad:int (GlbFixture.pad4(blen))
+        def btotal:int (blen + bpad)
+        def total:int ((12 + (8 + jtotal)) + (8 + btotal))
+        def out:buffer (buffer_alloc total)
+        ByteReader.encodeU32(out 0 1179937895)
+        ByteReader.encodeU32(out 4 2)
+        ByteReader.encodeU32(out 8 total)
+        ByteReader.encodeU32(out 12 jtotal)
+        ByteReader.encodeU32(out 16 1313821514)
+        buffer_copy out 20 jbuf 0 jlen
+        def p:int 0
+        while (p < jpad) {
+            buffer_set out ((20 + jlen) + p) 32
+            p = (p + 1)
+        }
+        def binChunkStart:int (20 + jtotal)
+        ByteReader.encodeU32(out binChunkStart btotal)
+        ByteReader.encodeU32(out (binChunkStart + 4) 5130562)
+        buffer_copy out (binChunkStart + 8) bin 0 blen
+        return out
+    }
+}

--- a/gallery/game_engine/model3d/tests/Model3dTest.rgr
+++ b/gallery/game_engine/model3d/tests/Model3dTest.rgr
@@ -1,0 +1,172 @@
+; ==============================================================================
+; Model3dTest.rgr — self-checking tests for the native 3D asset loader.
+; ==============================================================================
+; Compile to ES6 and run under Node; prints per-check PASS/FAIL and a final
+; "ALL PASS" line (grep-able for CI). Covers, against an in-memory GLB fixture:
+; container/header parse, glTF document counts, accessor geometry (positions,
+; normals, uv, u16 indices), PBR material (base colour factor + texture),
+; embedded PNG bytes, node hierarchy + transforms, model instantiation into a
+; host entity graph (find_child, world transforms, mesh renderers), and the
+; support gate rejecting unsupported features with a clear message.
+; ==============================================================================
+
+Import "../GlbImporter.rgr"
+Import "../EntityModel.rgr"
+Import "GlbFixture.rgr"
+
+class Checker {
+    def passed:int 0
+    def failed:int 0
+
+    fn ok:void (name:string cond:boolean) {
+        if cond {
+            passed = (passed + 1)
+            print ("  PASS " + name)
+        } {
+            failed = (failed + 1)
+            print ("  FAIL " + name)
+        }
+    }
+    fn eqInt:void (name:string got:int want:int) {
+        def c:boolean (got == want)
+        this.ok((name + " (got " + (to_string got) + " want " + (to_string want) + ")") c)
+    }
+    fn eqStr:void (name:string got:string want:string) {
+        def c:boolean (got == want)
+        this.ok((name + " (got '" + got + "' want '" + want + "')") c)
+    }
+    fn eqD:void (name:string got:double want:double) {
+        def d:double (got - want)
+        if (d < 0.0) {
+            d = (0.0 - d)
+        }
+        def c:boolean (d < 0.0001)
+        this.ok((name + " (got " + (to_string got) + " want " + (to_string want) + ")") c)
+    }
+}
+
+class Model3dTest {
+    sfn checkReject:void (ck:Checker label:string json:string wantErr:string) {
+        def glb:buffer (GlbFixture.glbFromJson(json))
+        def imp:GlbImporter (new GlbImporter)
+        def model:ModelAsset (imp.importModel(glb))
+        ck.ok((label + " rejected") (imp.ok == false))
+        ck.eqStr((label + " message") imp.error wantErr)
+    }
+
+    sfn m@(main):void () {
+        def ck:Checker (new Checker)
+        print "== container + document =="
+        def glb:buffer (GlbFixture.build())
+        def imp:GlbImporter (new GlbImporter)
+        def model:ModelAsset (imp.importModel(glb))
+        ck.ok("import ok" imp.ok)
+        ck.eqStr("no error" imp.error "")
+        ck.eqStr("glTF version" imp.doc.version "2.0")
+        ck.eqInt("node count" (model.nodeCount()) 4)
+        ck.eqInt("mesh count" (model.meshCount()) 1)
+        ck.eqInt("material count" (model.materialCount()) 1)
+        ck.eqInt("texture count" (model.textureCount()) 1)
+        ck.eqInt("root node count" (array_length model.rootNodes) 1)
+        ck.eqInt("root node index" (itemAt model.rootNodes 0) 0)
+
+        print "== mesh geometry =="
+        def mesh:MeshAsset (model.getMesh(0))
+        ck.eqStr("mesh name" mesh.name "Tri")
+        ck.eqInt("primitive count" (mesh.primitiveCount()) 1)
+        def prim:MeshPrimitiveAsset (itemAt mesh.primitives 0)
+        ck.eqInt("vertex count" (prim.vertexCount()) 3)
+        ck.eqInt("index count" (prim.indexCount()) 3)
+        ck.ok("has normals" (prim.hasNormals()))
+        ck.ok("has uvs" (prim.hasUvs()))
+        ck.eqInt("primitive material" prim.material 0)
+        ck.eqInt("primitive mode" prim.mode 4)
+        def p1:Vec3 (itemAt prim.positions 1)
+        ck.eqD("pos[1].x" p1.x 1.0)
+        ck.eqD("pos[1].y" p1.y 0.0)
+        def p2:Vec3 (itemAt prim.positions 2)
+        ck.eqD("pos[2].y" p2.y 1.0)
+        def nrm0:Vec3 (itemAt prim.normals 0)
+        ck.eqD("normal[0].z" nrm0.z 1.0)
+        def uv1:Vec2 (itemAt prim.uvs 1)
+        ck.eqD("uv[1].u" uv1.x 1.0)
+        ck.eqD("uv[1].v" uv1.y 0.0)
+        ck.eqInt("index[0]" (itemAt prim.indices 0) 0)
+        ck.eqInt("index[1]" (itemAt prim.indices 1) 1)
+        ck.eqInt("index[2]" (itemAt prim.indices 2) 2)
+
+        print "== material + texture =="
+        def mat:MaterialAsset (model.getMaterial(0))
+        ck.eqStr("material name" mat.name "Mat")
+        ck.eqD("baseColor R" mat.baseColorR 0.8)
+        ck.eqD("baseColor G" mat.baseColorG 0.4)
+        ck.eqD("baseColor B" mat.baseColorB 0.2)
+        ck.eqD("baseColor A" mat.baseColorA 1.0)
+        ck.eqInt("baseColorTexture" mat.baseColorTexture 0)
+        ck.eqD("roughness" mat.roughness 0.5)
+        ck.eqD("metallic" mat.metallic 0.0)
+        ck.ok("doubleSided" mat.doubleSided)
+        def tex:TextureAsset (model.getTexture(0))
+        ck.eqStr("texture mime" tex.mimeType "image/png")
+        ck.eqInt("texture bytes length" (buffer_length tex.sourceBytes) 76)
+        ck.eqInt("PNG signature byte0" (buffer_get tex.sourceBytes 0) 137)
+        ck.eqInt("PNG signature byte1" (buffer_get tex.sourceBytes 1) 80)
+
+        print "== node hierarchy =="
+        def n0:NodeAsset (model.getNode(0))
+        ck.eqStr("node0 name" n0.name "Root")
+        ck.eqInt("node0 child count" (array_length n0.children) 2)
+        ck.eqInt("node0 mesh" n0.mesh (0 - 1))
+        ck.eqD("node0 tz" n0.translation.z 5.0)
+        def n1:NodeAsset (model.getNode(1))
+        ck.eqStr("node1 name" n1.name "Body")
+        ck.eqInt("node1 mesh" n1.mesh 0)
+        ck.eqD("node1 tx" n1.translation.x 1.0)
+        def n3:NodeAsset (model.getNode(3))
+        ck.eqStr("node3 name" n3.name "Hand")
+
+        print "== instantiation =="
+        def reg:EntityRegistry (new EntityRegistry)
+        def rootE:int (ModelInstancer.instantiate(reg model))
+        def rootEnt:Entity (reg.get(rootE))
+        ck.eqStr("root entity name" rootEnt.name "")
+        ck.eqInt("root entity parent" rootEnt.parent (0 - 1))
+        ck.eqInt("root child count" (rootEnt.childCount()) 1)
+        def handId:int (reg.findChild(rootE "Hand"))
+        ck.ok("found Hand" (handId >= 0))
+        def bodyId:int (reg.findChild(rootE "Body"))
+        ck.ok("found Body" (bodyId >= 0))
+        def body:Entity (reg.get(bodyId))
+        ck.ok("Body has renderer" body.hasRenderer)
+        ck.eqInt("Body mesh asset" body.renderer.meshAsset 0)
+        ck.eqStr("Body mesh name" body.renderer.meshName "Tri")
+        def hand:Entity (reg.get(handId))
+        ck.ok("Hand has no renderer" (hand.hasRenderer == false))
+        ; world position of Hand: Root(0,0,5) * Arm(0,2,0) * Hand(0,1,0) = (0,3,5)
+        def wx:double (hand.transform.worldMatrix.at(0 3))
+        def wy:double (hand.transform.worldMatrix.at(1 3))
+        def wz:double (hand.transform.worldMatrix.at(2 3))
+        ck.eqD("Hand world x" wx 0.0)
+        ck.eqD("Hand world y" wy 3.0)
+        ck.eqD("Hand world z" wz 5.0)
+        ; Body world position: Root(0,0,5) * Body(1,0,0) = (1,0,5)
+        def bx:double (body.transform.worldMatrix.at(0 3))
+        def bz:double (body.transform.worldMatrix.at(2 3))
+        ck.eqD("Body world x" bx 1.0)
+        ck.eqD("Body world z" bz 5.0)
+
+        print "== support gate =="
+        Model3dTest.checkReject(ck "meshopt" "{\"asset\":{\"version\":\"2.0\"},\"extensionsRequired\":[\"EXT_meshopt_compression\"]}" "unsupported feature EXT_meshopt_compression")
+        Model3dTest.checkReject(ck "animation" "{\"asset\":{\"version\":\"2.0\"},\"animations\":[{\"channels\":[]}]}" "unsupported feature: animations")
+        Model3dTest.checkReject(ck "skins" "{\"asset\":{\"version\":\"2.0\"},\"skins\":[{\"joints\":[0]}]}" "unsupported feature: skins")
+        Model3dTest.checkReject(ck "version" "{\"asset\":{\"version\":\"1.0\"}}" "unsupported glTF version '1.0' (need 2.x)")
+
+        print "== summary =="
+        print ("passed=" + (to_string ck.passed) + " failed=" + (to_string ck.failed))
+        if (ck.failed == 0) {
+            print "ALL PASS"
+        } {
+            print "SOME FAILED"
+        }
+    }
+}

--- a/gallery/game_engine/model3d/tests/TextureDecodeTest.rgr
+++ b/gallery/game_engine/model3d/tests/TextureDecodeTest.rgr
@@ -1,0 +1,77 @@
+; ==============================================================================
+; TextureDecodeTest.rgr — end-to-end load + embedded PNG decode via ModelLoader.
+; ==============================================================================
+; Loads the in-memory GLB fixture through the full public ModelLoader path and
+; verifies its embedded 2x2 PNG is actually decoded to RGBA pixels (red, green /
+; blue, white). This exercises the decode-from-buffer refactor of the reused
+; native PNG decoder, wired into the loader. Prints "ALL PASS" on success.
+; ==============================================================================
+
+Import "../ModelLoader.rgr"
+Import "GlbFixture.rgr"
+
+class Checker {
+    def passed:int 0
+    def failed:int 0
+    fn ok:void (name:string cond:boolean) {
+        if cond {
+            passed = (passed + 1)
+            print ("  PASS " + name)
+        } {
+            failed = (failed + 1)
+            print ("  FAIL " + name)
+        }
+    }
+    fn eqInt:void (name:string got:int want:int) {
+        def c:boolean (got == want)
+        this.ok((name + " (got " + (to_string got) + " want " + (to_string want) + ")") c)
+    }
+}
+
+class TextureDecodeTest {
+    sfn m@(main):void () {
+        def ck:Checker (new Checker)
+        print "== load + decode embedded PNG =="
+        def glb:buffer (GlbFixture.build())
+        def loader:ModelLoader (new ModelLoader)
+        def modelId:int (loader.loadFromBuffer(glb))
+        ck.ok("load ok" loader.ok)
+        ck.ok("model id valid" (modelId >= 0))
+        def model:ModelAsset (loader.getModel(modelId))
+        def tex:TextureAsset (model.getTexture(0))
+        ck.ok("texture decoded" tex.decoded)
+        ck.eqInt("texture width" tex.width 2)
+        ck.eqInt("texture height" tex.height 2)
+        ck.eqInt("rgba length" (buffer_length tex.rgba) 16)
+        ; pixel (0,0) red
+        ck.eqInt("px00 R" (buffer_get tex.rgba 0) 255)
+        ck.eqInt("px00 G" (buffer_get tex.rgba 1) 0)
+        ck.eqInt("px00 B" (buffer_get tex.rgba 2) 0)
+        ck.eqInt("px00 A" (buffer_get tex.rgba 3) 255)
+        ; pixel (1,0) green
+        ck.eqInt("px10 R" (buffer_get tex.rgba 4) 0)
+        ck.eqInt("px10 G" (buffer_get tex.rgba 5) 255)
+        ck.eqInt("px10 B" (buffer_get tex.rgba 6) 0)
+        ; pixel (0,1) blue
+        ck.eqInt("px01 R" (buffer_get tex.rgba 8) 0)
+        ck.eqInt("px01 G" (buffer_get tex.rgba 9) 0)
+        ck.eqInt("px01 B" (buffer_get tex.rgba 10) 255)
+        ; pixel (1,1) white
+        ck.eqInt("px11 R" (buffer_get tex.rgba 12) 255)
+        ck.eqInt("px11 G" (buffer_get tex.rgba 13) 255)
+        ck.eqInt("px11 B" (buffer_get tex.rgba 14) 255)
+
+        print "== instantiate via loader =="
+        def robot:int (loader.instantiate(modelId))
+        def hand:int (loader.findChild(robot "Hand"))
+        ck.ok("find Hand via loader" (hand >= 0))
+
+        print "== summary =="
+        print ("passed=" + (to_string ck.passed) + " failed=" + (to_string ck.failed))
+        if (ck.failed == 0) {
+            print "ALL PASS"
+        } {
+            print "SOME FAILED"
+        }
+    }
+}

--- a/gallery/game_engine/model3d/tests/run.sh
+++ b/gallery/game_engine/model3d/tests/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Compile the model3d test suites to ES6 and run them under Node.
+# Grep-able: prints "ALL PASS" per suite on success. Run from the repo root.
+set -e
+
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+cd "$ROOT"
+# The compiler resolves -d relative to the cwd, so use a repo-relative out dir.
+OUT=".model3d_test_out"
+mkdir -p "$OUT"
+trap 'rm -rf "$OUT"' EXIT
+RGRC="node bin/output.js -es6"
+
+run_suite() {
+  local name="$1"
+  local src="gallery/game_engine/model3d/tests/${name}.rgr"
+  echo "### ${name}"
+  $RGRC "$src" -d="$OUT" -o="${name}.js" >/dev/null 2>&1
+  node "$OUT/${name}.js" | grep -E "PASS |FAIL |ALL PASS|SOME FAILED|passed="
+  echo
+}
+
+run_suite Model3dTest
+run_suite TextureDecodeTest
+
+echo "done."

--- a/gallery/pdf_writer/src/jpeg/JPEGDecoder.rgr
+++ b/gallery/pdf_writer/src/jpeg/JPEGDecoder.rgr
@@ -432,14 +432,20 @@ class JPEGDecoder {
     }
     
     fn decode:ImageBuffer (dirPath:string fileName:string) {
+        def bytes:buffer (buffer_read_file dirPath fileName)
+        return (this.decodeBytes(bytes))
+    }
+
+    ; decode a JPEG already held in memory (e.g. a glTF embedded image slice).
+    fn decodeBytes:ImageBuffer (bytes:buffer) {
         ; Main decode function
         ; Reset all state before decoding new image
         this.reset()
-        
-        data = (buffer_read_file dirPath fileName)
+
+        data = bytes
         dataLen = (buffer_length data)
-        
-        print ("Decoding JPEG: " + fileName + " (" + (to_string dataLen) + " bytes)")
+
+        print ("Decoding JPEG in-memory (" + (to_string dataLen) + " bytes)")
         
         ; Parse markers
         def ok:boolean (this.parseMarkers())


### PR DESCRIPTION
## Summary

Builds the host-side `load_model → ModelAsset → Entity hierarchy → MeshRenderer` pipeline the engine needs **before** any WASM ABI integration. This is the hard part of "GLB support": not reading the container bytes, but having a host object model for models, assets, and entities so a GLB's node hierarchy, meshes, materials, and textures land as **host-owned** resources — not as a block written into WASM guest memory.

Standalone work: a new `gallery/game_engine/model3d/` module plus two small additive changes to existing image decoders. No other games, no WASM, and no ABI code are touched. It is the host-side realisation of `IDEAL_3D.md` §2/§4.3 (which explicitly requires the entity registry / scene graph / resource cache to live host-side, not as a guest wrapper).

## New module `gallery/game_engine/model3d/`

| File | Role |
| --- | --- |
| `Json.rgr` | Compact recursive-descent JSON parser → `JsonValue` tree (the compiler-internal `ng_jsonParser` doesn't compile standalone under ES6) |
| `ByteReader.rgr` | Little-endian reads + IEEE-754 float32 decode/encode |
| `GltfMath.rgr` | `Vec2/Vec3/Vec4/Quat/Mat4` (TRS → matrix, matrix multiply) |
| `AssetModel.rgr` | `Texture/Material/Mesh/Node/ModelAsset` + `AssetRegistry` |
| `EntityModel.rgr` | `Entity/TransformComponent/MeshRenderer` + `EntityRegistry` + `ModelInstancer` (`instantiate` → root EntityId, `findChild`) |
| `GltfDocument.rgr` | Typed glTF 2.0 view + **support gate** (rejects unsupported features with clear errors) |
| `GlbImporter.rgr` | GLB container (header/JSON/BIN) + accessor reader → `ModelAsset` |
| `TextureDecode.rgr` | Decode embedded PNG/JPEG bytes → RGBA (reuses the repo's native decoders) |
| `ModelLoader.rgr` | Public `loadFromFile / loadFromBuffer / instantiate / findChild` API |

## First support level

**Supported:** GLB 2.0 (one JSON + one BIN chunk), scenes/nodes, node `matrix` or TRS, multiple meshes/primitives, `TRIANGLES`, `POSITION`/`NORMAL`/`TEXCOORD_0`, `u8`/`u16`/`u32` indices, interleaved `byteStride`, `baseColorFactor` + `baseColorTexture`, multiple materials, embedded PNG/JPEG (decoded to RGBA).

**Rejected with a clear error (never a silently-wrong model):** skins, animations, morph targets, sparse accessors, Draco/Meshopt/KTX2 (any `extensionsRequired`), non-`TRIANGLES` modes. Example: `unsupported feature EXT_meshopt_compression`.

## Texture decoders (decode-from-buffer)

Embedded glTF images are bytes inside the BIN chunk, not files on disk. Both native decoders gained an in-memory entry point so embedded images decode for real; the file-based `decode(dir, file)` API is unchanged and now delegates to it:

- `gallery/game_engine/lpc/src/png_decoder.rgr` → `decodeBytes(bytes)`
- `gallery/pdf_writer/src/jpeg/JPEGDecoder.rgr` → `decodeBytes(bytes)`

Verified the file-based path still works (real `Canon_40D.jpg` → 100×68).

## Tests

Hermetic — the fixture builds a valid GLB entirely in memory (`tests/GlbFixture.rgr`), including a real 2×2 RGBA PNG, so no external assets or toolchain are needed. Compile to ES6, run under Node, grep for `ALL PASS`:

```sh
bash gallery/game_engine/model3d/tests/run.sh
```

- `Model3dTest.rgr` — **69/69 PASS**: container, document, accessors (f32 positions/normals/uv, u16 indices), material, embedded PNG bytes, node hierarchy, instantiation (find_child, world transforms), support gate.
- `TextureDecodeTest.rgr` — **20/20 PASS**: end-to-end load + embedded PNG decoded to the expected RGBA pixels through `ModelLoader`.

## Docs

`IDEAL_3D.md` gains **§12 — ABI integration checklist** mapping each §4.4 host import (`rg_load_model`, `rg_instantiate_model`, `rg_find_child_by_name`, `rg_set_*`) to its `model3d` call, with concrete wiring steps for this codebase (the `env.rg_*` bridge, reading guest strings like `wasm3d_runner.readResName`, per-guest `ModelLoader` ownership, fixed-point conversion), the render-bridge change, and the ABI-surface pieces still to add (generation counters, destroy/refcount, command validation).

## Not in scope

WASM ABI wiring itself; skinning/animation; validating against the Khronos glTF Sample Assets + glTF Validator — the recommended next steps once real `.glb` inputs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Umert9tBqHgs1UJVVBG4R

---
_Generated by [Claude Code](https://claude.ai/code/session_012Umert9tBqHgs1UJVVBG4R)_