### PR TITLE
model3d: rename Json.rgr -> GltfJson.rgr (case-insensitive filename c…

### DIFF
--- a/gallery/game_engine/model3d/GltfDocument.rgr
+++ b/gallery/game_engine/model3d/GltfDocument.rgr
@@ -9,7 +9,7 @@
 ; tukitaso".
 ; ==============================================================================
 
-Import "Json.rgr"
+Import "GltfJson.rgr"
 Import "GltfMath.rgr"
 
 class GltfBufferView {

--- a/gallery/game_engine/model3d/GltfJson.rgr
+++ b/gallery/game_engine/model3d/GltfJson.rgr
@@ -1,5 +1,7 @@
 ; ==============================================================================
-; Json.rgr — a compact, self-contained JSON parser for the 3D asset loader.
+; GltfJson.rgr — a compact, self-contained JSON parser for the 3D asset loader.
+; (Named GltfJson, not Json, to avoid a case-insensitive filename clash with
+;  lib/JSON.rgr on macOS/Windows filesystems when built to a native target.)
 ; ==============================================================================
 ; Pure Ranger, no host JSON and no compiler-internal parser: a small recursive
 ; descent parser that produces a typed JsonValue tree. Scoped to what glTF 2.0

--- a/gallery/game_engine/model3d/README.md
+++ b/gallery/game_engine/model3d/README.md
@@ -44,7 +44,7 @@ On failure `loader.ok` is `false` and `loader.lastError` explains why.
 
 | File | Role |
 | --- | --- |
-| `Json.rgr` | Self-contained JSON parser → `JsonValue` tree |
+| `GltfJson.rgr` | Self-contained JSON parser → `JsonValue` tree |
 | `ByteReader.rgr` | Little-endian byte reads + IEEE-754 float32 decode/encode |
 | `GltfMath.rgr` | `Vec2/Vec3/Vec4/Quat/Mat4` (TRS → matrix, matrix multiply) |
 | `AssetModel.rgr` | `TextureAsset/MaterialAsset/MeshAsset/NodeAsset/ModelAsset` + `AssetRegistry` |


### PR DESCRIPTION
…lash)

On case-insensitive filesystems (macOS/Windows) `Import "Json.rgr"` in GltfDocument resolves to the already-registered lib/JSON.rgr / compiler/JSON.rgr (a systemunion-based parser that cannot target C++), so building the SDL launcher — which now compiles model3d to C++ via the Wasm3dRunner GLB preload — failed with "Only system classes can be systemunions". Linux (case-sensitive) was unaffected, which is why it compiled in CI here but not on the user's Mac.

Give the loader's JSON parser a unique basename so it can never clash. Class names (JsonValue etc.) are unchanged; only the file and its single import move.

Verified: model3d suite 112/112 pass, launcher compiles Ranger->C++.


Claude-Session: https://claude.ai/code/session_01DQjZpX48DV71VRA5SqRYNs