### PR TITLE
compiler: emit .has_value for optional int/double if/else (clang C++)

### DIFF
--- a/compiler/Lang.rgr
+++ b/compiler/Lang.rgr
@@ -1739,7 +1739,22 @@ fn r_read_file(path: &str, filename: &str) -> Option<String> {
             templates {
                 cpp ( "if ( " (e 1) ".has_value ) {" nl I (block 2) i nl "}" nl )
             }
-        }        
+        }
+
+        ; typed optional int/double with an else branch: r_optional_primitive is
+        ; a value type (has_value field), not a pointer, so the generic :T
+        ; `!= NULL` form below does not compile under clang. Emit `.has_value`.
+        if              cmdIf:void              ( condition@(optional):int then_block:block else_block )  {
+            templates {
+                cpp ( "if ( " (e 1) ".has_value ) {" I nl (block 2) i nl "} else {" nl I (block 3) i "}" nl )
+            }
+        }
+
+        if              cmdIf:void              ( condition@(optional):double then_block:block else_block )  {
+            templates {
+                cpp ( "if ( " (e 1) ".has_value ) {" I nl (block 2) i nl "} else {" nl I (block 3) i "}" nl )
+            }
+        }
 
         if              cmdIf:void              ( condition@(optional):T then_block:block )  {
             templates {


### PR DESCRIPTION
The typed single-branch `if <optional:int|double>` already emits `.has_value` for the cpp target, but the two-branch (if/else) form had only the generic `:T` overload, which emits `!= NULL`. That is correct for pointer/shared_ptr optionals but not for r_optional_primitive<int|double> — a value type with a `has_value` field and no operator!=/NULL conversion. g++ accepts it with a -Wnull-arithmetic warning; clang (macOS) rejects it:

  error: invalid operands to binary expression
         ('r_optional_primitive<double>' and 'long')
  if ( d != NULL ) { ...

This surfaced building the SDL launcher, which now compiles model3d (its GLB JSON parser does `if (str2double sub) { ... } { ... }`) to C++.

Add typed two-branch overloads for int/double optionals emitting `.has_value`, mirroring the existing single-branch ones. Object optionals keep the generic `:T` `!= NULL`. cpp-only templates; other targets fall back to the generic overload (model3d ES6 suite still 112/112).


Claude-Session: https://claude.ai/code/session_01DQjZpX48DV71VRA5SqRYNs