### PR TITLE
docs: add PLAN_WASM_MEMORY.md — RAII vs GC feasibility for the WASM backend

### DIFF
--- a/PLAN_WASM_MEMORY.md
+++ b/PLAN_WASM_MEMORY.md
@@ -34,7 +34,7 @@ RC — a major multi-phase subsystem, not a small add-on to the object work.
 General-purpose programs (parser, tools, the in-browser compiler) need it;
 object-based game/logic code does not.
 
-- **Phase 3 — string runtime + RC** 🟩 *mostly done*
+- **Phase 3 — string runtime + RC** ✅ *done*
   - 3.1–3.2 ✅ freestanding WASM string runtime (`ranger_str_*` in
     `runtime/wasm/ranger_obj.rgr`: len/concat/dup/from_int/cmp/release; literals
     in a data segment written by `ng_WATWriter.rgr`; `Mem.loadU8/storeU8` →
@@ -48,12 +48,22 @@ object-based game/logic code does not.
     fresh nested-concat operands). Reassignment frees the old buffer first. A
     per-frame `"HITS " + n` loop stays heap-flat to 100 000 iterations
     (`str_rc_test` 9/9). Gated on `-wasmrc`; the libc path is byte-unchanged.
-  - 3.3 ⬜ *remaining:* string `==`/`!=` → `ranger_str_cmp`; char access
-    (`charAt`/`substring`/`strfromcode`) routing; and inline fresh-string
-    temporaries passed as call arguments (e.g. `host.drawText("S " + n)`) —
-    needs a statement-scoped temp arena or per-call arg release, deferred because
-    an arbitrary callee's retain/borrow contract for a string arg is unproven.
-  - owned **string-field** release still needs Phase 4 typedesc emission.
+  - 3.5 ✅ **statement-scoped fresh-string arena.** Fresh strings built
+    mid-expression but never bound to a local — the dominant game pattern
+    `host.drawText("SCORE " + n)` — are tracked in `pendingStringTemps` and freed
+    at statement end (per iteration in loops, per branch in conditions). Owners
+    (assigned local / returned value) *claim* their temp out of the arena so it
+    is not double-freed. `churnInline` (concat as a bare call argument) stays
+    heap-flat to 10 000 iterations.
+  - 3.3 ✅ **comparison + char access.** `==`/`!=` route to `ranger_str_cmp`;
+    `charAt`/`substring`/`strfromcode`/`rawbytechar` route to
+    `ranger_char_at`/`ranger_substring`/`ranger_str_fromcode`/`ranger_str_frombyte`
+    (added to the `ranger` runtime class; substring/fromcode results join the
+    arena). `str_rc_test` 25/25. libc path verified byte-unchanged (a `==`
+    snippet still emits `strcmp`, not `ranger_str_cmp`).
+  - owned **string-field** release still needs Phase 4 typedesc emission; a
+    string-returning *call* result is dup'd (own a private copy) rather than
+    move-owned, since the callee's return is a borrow by convention (getters).
 - **Phase 4 — typedesc emission + array runtime + RC** ⬜ serialize typedescs to
   a data segment so owned object/string fields free recursively; port the
   ptr-array/map runtime to the free-list heap with element ownership. Large.

--- a/PLAN_WASM_MEMORY.md
+++ b/PLAN_WASM_MEMORY.md
@@ -114,8 +114,19 @@ object-based game/logic code does not.
       (new `Mem.memSize`/`Mem.memGrow` → `memory.size`/`memory.grow`). Collections
       and objects scale past the initial 64 KiB page (maps of 20 000+ entries
       grow memory to megabytes); OOM only at the host/module maximum, returning 0.
-    - ⬜ *remaining:* `[string]` array element release (libc releases elements via
-      `obj_release` only, so string elements need a per-element kind).
+    - **`[string]` arrays** own a dup'd private copy of each element and free
+      them on release. The descriptor's flag word now encodes an element *kind*
+      (0 = plain int, 1 = owned object → `obj_release`, 2 = owned string →
+      `str_release`); `ranger_ptrarray_release` dispatches on it. `[string]` is
+      detected before the general object-array case at creation. Pushing a fresh
+      `new T()` directly is now *moved* (rc stays 1) instead of retained — that
+      retain left rc=1 after the array released, a latent object-array leak, now
+      fixed on the WASM path. `strarr_rc_test` 7/7 (content survives the dup,
+      build/drop loops heap-flat, zero live blocks); `coll_rc_test` 14/14
+      (adds direct-`new`-push).
+    - Collection RC on freestanding WASM is now complete: `[int]`, `[T]`,
+      `[string]`, and `[K:V]` all allocate on the free-list heap, grow, and free
+      (with element RC where owned). No remaining collection gaps.
 - **Phase 5 — per-frame arena** ⬜ *optional optimisation, not required for
   correctness* — checkpoint/reset the frontier for frame-scoped temporaries.
 

--- a/PLAN_WASM_MEMORY.md
+++ b/PLAN_WASM_MEMORY.md
@@ -61,12 +61,26 @@ object-based game/logic code does not.
     (added to the `ranger` runtime class; substring/fromcode results join the
     arena). `str_rc_test` 25/25. libc path verified byte-unchanged (a `==`
     snippet still emits `strcmp`, not `ranger_str_cmp`).
-  - owned **string-field** release still needs Phase 4 typedesc emission; a
-    string-returning *call* result is dup'd (own a private copy) rather than
+  - a string-returning *call* result is dup'd (own a private copy) rather than
     move-owned, since the callee's return is a borrow by convention (getters).
-- **Phase 4 — typedesc emission + array runtime + RC** ⬜ serialize typedescs to
-  a data segment so owned object/string fields free recursively; port the
-  ptr-array/map runtime to the free-list heap with element ownership. Large.
+- **Phase 4 — typedesc emission + array runtime + RC** 🟩 *4a done*
+  - 4a ✅ **typedesc emission + owned string-field release.** The type
+    descriptors already built for all targets are now serialised into the WASM
+    static data segment (`ng_WATWriter.emitStaticData`: field arrays + 12-byte
+    headers `[size|fieldCount|fieldsPtr]`, after the string literals, below the
+    heap base). `lowerNewObject` passes the descriptor address to
+    `ranger_obj_new` for classes with owned (string) fields, so
+    `obj_release → obj_destroyFields` frees each string field (runtime now
+    handles kind 0 → `str_release`). String fields carry a dup'd private copy;
+    reassignment frees the old buffer first (release-before-overwrite now active
+    on the WASM path, not just libc). Fixed a latent `ptr_to_int` gap in the WAT
+    writer (identity on wasm) surfaced by the first string-field store. A
+    create/destroy loop of an Entity with a `name` field stays heap-flat to
+    50 000 iterations, zero live blocks (`field_rc_test` 9/9). Object/ptr-array
+    fields stay borrow (owned=0) — no descriptor recursion — to avoid double-free
+    of shared/cyclic graphs until borrow analysis promotes true owners.
+  - 4b ⬜ **array/collection runtime + RC** — port the ptr-array/map runtime to
+    the free-list heap with element ownership. Large; next.
 - **Phase 5 — per-frame arena** ⬜ *optional optimisation, not required for
   correctness* — checkpoint/reset the frontier for frame-scoped temporaries.
 

--- a/PLAN_WASM_MEMORY.md
+++ b/PLAN_WASM_MEMORY.md
@@ -95,15 +95,27 @@ object-based game/logic code does not.
       heap. `coll_rc_test` 11/11 — int and object arrays correct (incl. multiple
       backing grows), and build/use/drop loops stay heap-flat with zero live
       blocks. libc path byte-unchanged (`realloc`, not `Heap_realloc`).
-    - `[K:V]` maps already allocate their descriptor/keys/vals from the free-list
-      heap (the same `emitHeapAlloc` unification), so a map-using program no
-      longer corrupts the heap. They work up to the fixed bucket capacity;
-      *overflow beyond capacity recurses infinitely in the open-addressing probe*
-      — a pre-existing `RtMap` limitation on ALL targets (libc included), a
-      map-growth issue, not a memory one. ⬜ *remaining:* map descriptor/bucket
-      release (maps aren't in the owned-release path on any target yet) + growth;
-      `[string]` array element release (libc releases elements via `obj_release`
-      only, so string elements need a per-element kind in the descriptor).
+    - **`[K:V]` maps** allocate descriptor/keys/vals from the free-list heap,
+      **grow** (double + rehash) when the load factor passes 50% so a full table
+      never probes forever (was infinite recursion), and are **freed** at scope
+      end / per loop iteration (`RtMap_free` frees descriptor + key/value arrays;
+      dispatched from the owned-collection release path by collection kind).
+      `map_rc_test` 8/8 — correctness across many doublings, updates in place,
+      missing-key lookups, and build/drop loops heap-flat with zero live blocks.
+      Two `RtMap` bugs surfaced and fixed on the way: (a) `RtMap_putAt`/`getAt`
+      emitted their early-`return` blocks LAST, and the structured WAT
+      reconstruction assumes a `br_if`'s true-target precedes its false-target —
+      so the update and missing-key paths became empty `then`-blocks and were
+      silently dropped (`mapSum` never exercised them). Reordered the blocks so
+      each early return follows its guard (transparent to LLVM). (b) added an
+      `RtMap_put` guard rejecting the reserved `-1` empty sentinel as a key.
+    - **`memory.grow`**: the heap ceiling (`Heap.limit()`) is now the current
+      linear-memory size, and `Heap.alloc` grows memory by whole pages on demand
+      (new `Mem.memSize`/`Mem.memGrow` → `memory.size`/`memory.grow`). Collections
+      and objects scale past the initial 64 KiB page (maps of 20 000+ entries
+      grow memory to megabytes); OOM only at the host/module maximum, returning 0.
+    - ⬜ *remaining:* `[string]` array element release (libc releases elements via
+      `obj_release` only, so string elements need a per-element kind).
 - **Phase 5 — per-frame arena** ⬜ *optional optimisation, not required for
   correctness* — checkpoint/reset the frontier for frame-scoped temporaries.
 

--- a/PLAN_WASM_MEMORY.md
+++ b/PLAN_WASM_MEMORY.md
@@ -79,8 +79,25 @@ object-based game/logic code does not.
     50 000 iterations, zero live blocks (`field_rc_test` 9/9). Object/ptr-array
     fields stay borrow (owned=0) — no descriptor recursion — to avoid double-free
     of shared/cyclic graphs until borrow analysis promotes true owners.
-  - 4b ⬜ **array/collection runtime + RC** — port the ptr-array/map runtime to
-    the free-list heap with element ownership. Large; next.
+  - 4b 🟩 **collections on the free-list heap + RC** (ptr-arrays done; maps next)
+    - **Allocator unified.** `emitHeapAlloc` routes to the free-list `Heap`
+      (`Heap_calloc`) under `-wasmrc`, so collections stop using the leak-forever
+      bump pointer — which also *collided* with the free-list control words at
+      Mem[0]/Mem[4] whenever a program mixed objects and collections (a latent
+      corruption bug, now fixed). `Heap_realloc` (alloc+copy+free) replaces libc
+      `realloc` in the push-grow path.
+    - **`[int]` and `[T]` arrays are freed** at scope end and per loop iteration
+      (`ranger_ptrarray_release`: frees backing store + descriptor; for
+      element-owned object arrays, `obj_release`s each element). Pushing an owned
+      object local *moves* it into the array (escaped, released once by the
+      array); a fresh/borrowed element is retained by `ranger_ptrarray_push_owned`
+      to balance. Built as `ranger.ptrarray_*` runtime methods on the free-list
+      heap. `coll_rc_test` 11/11 — int and object arrays correct (incl. multiple
+      backing grows), and build/use/drop loops stay heap-flat with zero live
+      blocks. libc path byte-unchanged (`realloc`, not `Heap_realloc`).
+    - ⬜ *remaining:* `[K:V]` maps (RtMap runtime) on the free-list heap with
+      key/value RC; `[string]` array elements (libc releases array elements via
+      obj_release only — string elements would need a per-element kind).
 - **Phase 5 — per-frame arena** ⬜ *optional optimisation, not required for
   correctness* — checkpoint/reset the frontier for frame-scoped temporaries.
 

--- a/PLAN_WASM_MEMORY.md
+++ b/PLAN_WASM_MEMORY.md
@@ -1,0 +1,273 @@
+# Ranger WASM memory management — plan & feasibility (RAII vs GC)
+
+This document evaluates how Ranger's classes and the `new` operator should be
+handled when compiling to WebAssembly, and whether the answer is **RAII**,
+**reference counting**, or a **garbage collector**. It builds directly on the
+existing native/LLVM design in [`PLAN_LLVM_MEMORY.md`](./PLAN_LLVM_MEMORY.md)
+and the WAT backend in [`PLAN_WASM_BACKEND.md`](./PLAN_WASM_BACKEND.md).
+
+## Tiivistelmä (FI)
+
+Kysymys oli: RAII vai GC? **Vastaus: kumpaakaan ei tarvitse keksiä uutena.**
+Ranger on jo *valinnut* muistimallinsa manuaalisille targeteille — kevyt
+viitelaskenta (RC) + staattinen scope-siivous, joka on käytännössä RAII
+(deterministinen vapautus lohkon lopussa, ei GC-taukoja). Tämä on toteutettu ja
+testattu LLVM/libc-targeteille. **WASM-polkua ei vain ole vielä nostettu
+"freestanding/bump"-luokasta** — se allokoi `new`:llä bump-osoittimella eikä
+vapauta mitään.
+
+Ratkaisu on **laajentaa olemassa oleva RC + static cleanup WASM:iin**, ei tehdä
+GC:tä. Toteutuskelpoisuus on **korkea**, koska omistajuusanalyysi ja
+retain/release-lisäys ovat jo *target-riippumattomia* (`ng_LowIRBuilder.rgr`),
+pelkästään `usesLibc`-lipulla pois päältä. Puuttuva osa on WASM-natiivi runtime:
+vapautuslistallokaattori + `ranger_obj_new/release/retain` + typedesc-taulukot
+lineaarimuistiin. Lisänä pelisilmukoille **per-frame areena** (bump + reset),
+joka on halvin voitto. Sykliset viittaukset vuotavat (RC:n rajoite) — sama kuin
+natiivilla; ne hoidetaan borrow-by-defaultilla ja heikoilla viittauksilla.
+
+---
+
+## 1. Where WASM stands today
+
+The WAT backend allocates objects with a monotonic bump pointer and never frees:
+
+- `lowerNewObject` (`compiler/ng_LowIRBuilder.rgr:2555`) branches on the target:
+  libc → `ranger_obj_new(size, typeDesc)`; **freestanding (WASM) → `emitHeapAlloc`
+  (bump)**.
+- `heap_alloc` in WAT (`compiler/ng_WATWriter.rgr:439`) is just
+  `global.get $heap_ptr` / `i32.add` / `global.set $heap_ptr`. No object header,
+  no free, ever.
+
+Consequences for real programs:
+
+- A game `update()` that does any `new` per frame grows `$heap_ptr` unbounded;
+  over a few thousand frames it exhausts the one 64 KiB page and traps. This is
+  exactly why `ranger_pong` and `ranger_autopeli` were written with **static
+  classes + fixed `Mem` slots** — a procedural workaround for the missing heap
+  discipline, not an idiomatic use of Ranger's object model.
+- No destructors run, so any owned string/array/object field also leaks.
+
+## 2. What already exists (and is reusable)
+
+Ranger already has a complete, deliberate memory model for **manual** targets
+(LLVM + libc), documented in `PLAN_LLVM_MEMORY.md` and implemented in
+`runtime/ranger_mem.c`:
+
+- **Object header** in front of the body: `{ u32 rc; u32 size; TypeDesc* type; u32 pad }`
+  (`ranger_mem.c:28`). The Ranger-level pointer is the body; the header sits at
+  `body - HEADER_SIZE`.
+- **Type descriptors** drive recursive field release:
+  `RangerFieldDesc { u32 offset; u8 kind; u8 owned; ... }`,
+  `RangerTypeDesc { u32 struct_size; u16 field_count; ...; FieldDesc* fields }`
+  (`ranger_mem.c:10-26`). `kind` ∈ {STRING, OBJECT, PTR_ARRAY}; `owned` gates
+  whether release recurses (`ranger_destroy_field:53`, honours `!owned → return`).
+- **Runtime API** (`ranger_mem.c`): `ranger_obj_new`, `ranger_obj_retain`,
+  `ranger_obj_release` (recursive), `ranger_str_release`, `ranger_strdup`,
+  `ranger_ptrarray_release`, `ranger_ptrarray_push_owned`,
+  `ranger_mem_live_objects` (test hook).
+- **Insertion is target-agnostic.** All retain/release/obj_new/cleanup is emitted
+  in `ng_LowIRBuilder.rgr` — the LLVM writer is a dumb instruction printer with
+  no RC knowledge. Sites: `lowerNewObject:2568`, `emitReleaseOwnedLocals:2865`
+  (function/scope end), `releaseOwnedLocal:2812`, `emitFieldStoreOn:2236`,
+  `lowerPush:1304` (move vs push_owned), `lowerReturn:3261` (escape → no release),
+  loop-reassignment release (`lowerVarDef:3130`).
+- **The gate.** Every one of those sites is guarded by `target.usesLibc` /
+  `memEnabled()` (`ng_LowIRBuilder.rgr:391`) / `isManualMemory()`. The default
+  WASM target `wasm32-hosted-debug` has `usesLibc=false`
+  (`ng_LowIRTarget.rgr:142`), so the RC ops are **never emitted** for WAT — the
+  WAT writer isn't ignoring them, they don't exist in its LowIR.
+- **Type descriptors are already built for every struct regardless of target**
+  (`lowerTypeDesc:1832`, stored in `LowIRModule.typeDescs`); only the *LLVM
+  writer* serialises them (`ng_LLVMIRWriter.rgr:188`). The WAT writer never
+  touches `module.typeDescs`.
+- The ownership analysis defaults object/ptr-array fields to `owned=0`
+  (**borrow-by-default**, `ng_LowIRBuilder.rgr:1854-1867`) to avoid double-free
+  on aliased graphs; only string fields are owned by default.
+
+**Reusability verdict: high.** The hard, language-level work — deciding what is
+owned/borrowed/escaped and where to release — is done and target-independent.
+Routing it into WAT is ~90% plumbing: provide the runtime functions + the
+descriptor data in linear memory, and flip the target's memory model. (As
+evidence: `wasm32-wasi` already sets `usesLibc=true` (`ng_LowIRTarget.rgr:151`),
+so compiling with it *already* emits `call $ranger_obj_new` into WAT — it just
+fails because nothing defines those functions or places a typedesc table in
+memory.)
+
+## 3. The question, reframed: RAII or GC?
+
+The project already answered this for manual targets, and the answer applies to
+WASM: **light RC + static scope-cleanup, not a tracing GC.** Concretely:
+
+- **"RAII"** in Ranger *is* the static-cleanup layer: an owned local that does
+  not escape is released deterministically at scope/function end
+  (`emitReleaseOwnedLocals`). No runtime, no pauses, freed exactly when it dies.
+- **RC** covers the cases RAII alone can't — shared ownership across fields,
+  pushes, and returns — with `retain`/`release`.
+- A **tracing GC** was explicitly rejected (`PLAN_LLVM_MEMORY.md` "Älä tee
+  täyttä GC:tä"). For a real-time game loop this is the *right* call: RC/RAII
+  free deterministically with no stop-the-world pauses, whereas a GC introduces
+  jitter that is poison for a 60 Hz frame budget.
+
+So the WASM plan is not "add RAII" *or* "add a GC" — it is **promote the WASM
+target from the freestanding class into the managed/manual class by giving it
+the RC+cleanup runtime**, which delivers RAII-style determinism.
+
+## 4. Options evaluated
+
+### Option A — Port light-RC + static cleanup to WASM  ★ recommended (primary)
+
+Give the WASM target the same memory model as native, backed by a self-contained
+linear-memory runtime instead of libc.
+
+New components (all additive; no change to the ownership analysis):
+
+1. **A free-list allocator in linear memory** (`malloc`/`free`) to replace the
+   bump allocator: a small size-classed free list or a TLSF-lite. Reserve a heap
+   region; objects get the same `[header][body]` shape as native.
+2. **`ranger_obj_new` / `ranger_obj_release` / `ranger_obj_retain` / str /
+   ptrarray** emitted as WAT (or a tiny `ranger_mem_wasm.c` compiled to
+   `wasm32-unknown-unknown` and linked). `release` walks the typedesc exactly as
+   `ranger_destroy_field` does. The existing `ng_LowIRRuntime.rgr` already shows
+   the pattern of emitting runtime functions as target-agnostic LowIR — the same
+   mechanism can emit these so they flow through the WAT writer unchanged.
+3. **Typedesc emission into a WASM data segment**: serialise each
+   `LowIRTypeDesc`/`LowIRTypeFieldDesc` into linear memory with intra-memory
+   pointer fixups for the `fields` array, and pass the descriptor address to
+   `ranger_obj_new` (mirroring `@Class_typeDesc` on LLVM). Offsets in the
+   descriptor are already flat-memory byte offsets.
+4. **Target wiring**: decouple "emit RC" from "libc". Today `memEnabled ==
+   usesLibc`. Introduce a memory-model value (e.g. `manual-wasm`) so the WASM
+   target enables RC but selects the wasm allocator primitives instead of libc
+   `malloc`/`free`. The WAT writer already emits `call` ops, so once the runtime
+   functions exist the RC calls "just work."
+
+Pros: deterministic, pause-free; reuses the entire analysis; identical semantics
+to native (one model to reason about); runs on **both** hosts (wasm3 native +
+browser V8) because it is plain i32 linear-memory code.
+Cons: reference **cycles leak** (RC's inherent limitation). Effort: medium.
+
+### Option B — Per-frame arena / region  ★ recommended (complement)
+
+The current bump allocator *is* an arena minus the reset. Expose a checkpoint at
+frame start (save `$heap_ptr`) and a bulk reset at frame end (restore it). All
+per-frame temporaries vanish for free — zero per-object cost, ideal for games.
+
+Add an `@(arena)` / scoped-region API so transient allocations target the frame
+arena while persistent state uses the RC heap (Option A) or fixed slots. Valid as
+long as no live reference survives the reset boundary — enforced by the same
+escape analysis.
+
+Pros: the cheapest possible win, perfectly matched to a frame loop; no headers,
+no RC traffic. Cons: only for strictly frame-scoped lifetimes; needs escape
+analysis to be safe. Effort: low–medium.
+
+### Option C — Full tracing GC (mark-sweep)  ✗ not now
+
+A precise GC needs stack maps to find roots; a conservative GC must scan wasm
+locals (not directly addressable inside the module without a shadow stack) plus
+linear memory. It handles cycles (RC's weakness) but reintroduces pauses.
+Verdict: against the project principle and wrong for real-time loops; revisit
+only if cyclic object graphs become common *and* RC leaks prove painful in
+practice.
+
+### Option D — WASM GC proposal (engine-managed heap)  ✗ parked (browser-only future)
+
+Use the wasm-gc `struct`/`array` heap types and let V8's GC manage lifetimes.
+Blockers: (i) it requires a fundamentally different codegen — typed managed
+objects instead of linear-memory structs — which is incompatible with the
+fixed-offset **linear-memory ABI** the engine's games use (RGW1/RGU1 blocks live
+at byte offsets); objects and ABI blocks would occupy two disjoint worlds. (ii)
+**wasm3, the engine's native host, does not support wasm-gc** — only browsers do.
+Adopting it would split the target and break the "runs identically on wasm3 and
+in the browser" property this project relies on. Verdict: possible *future
+browser-only* variant, not a primary path.
+
+## 5. Recommendation
+
+1. **Primary: Option A** — port the existing RC + static-cleanup model to WASM,
+   promoting the WASM target into the managed/manual memory class. This is the
+   direct, reuse-heavy answer to "how do Ranger classes + `new` survive WASM,"
+   and it gives RAII-grade determinism with no GC.
+2. **Complement: Option B** — a per-frame arena for game-loop temporaries, which
+   is nearly free in this design and the best fit for the frame budget.
+3. **Not** Option C (full GC), consistent with the project's stated principle.
+4. **Park** Option D (wasm-gc) as a potential browser-only future once/if a
+   managed-heap codegen path is ever desired — explicitly out of scope while the
+   dual wasm3+browser host and the linear-memory ABI stand.
+
+RAII vs GC, one line: **extend the existing RC + static cleanup — that already
+*is* RAII where it can be and RC where it must be; a GC is neither needed nor
+wanted for a real-time frame loop.**
+
+## 6. Design specifics
+
+- **Object layout (unify with native):** allocate `HEADER + body`; header
+  `{ u32 rc; u32 size; u32 typeDescPtr; u32 pad }` (32-bit pointers on wasm32, so
+  16 bytes — smaller than the 24-byte 64-bit native header). Body pointer =
+  `alloc + 16`. `release` reads the header at `ptr - 16`.
+- **Allocator:** reserve a heap base **above** the fixed ABI region. For the
+  games, the RGW1/RGU1 blocks and the private state sit at fixed low offsets; the
+  object heap must start past them (configurable `heapBase`). Programs that use
+  only fixed slots (like today's games) pay nothing. Free list keyed by size
+  class; coalescing optional in v1.
+- **Typedesc data:** one data segment; `ranger_obj_release` walks
+  `field_count`, and for each field switches on `kind` and checks `owned`, using
+  `*(i32*)(body + offset)` — a direct transliteration of `ranger_destroy_field`
+  into i32 loads.
+- **WAT writer changes:** minimal — emit the typedesc data segment and the
+  runtime functions (or accept them from the LowIR runtime emitter). RC calls are
+  already `call` ops. f64 and nested control flow (both landed) are unaffected.
+- **Coexistence with the linear-memory ABI:** unchanged. `Mem.storeI32` fixed
+  slots and RC-managed objects live in the same page at disjoint ranges; a guest
+  can use both (e.g. RC objects for transient game entities, fixed slots for the
+  host-facing ABI blocks).
+
+## 7. Phasing
+
+- **Phase 0 — allocator.** Free-list `malloc`/`free` in linear memory + tests
+  (alloc/free/reuse, alignment, exhaustion). Reserve `heapBase`. Cheapest
+  standalone value: makes repeated `new` non-leaking even before RC.
+- **Phase 1 — obj runtime + typedescs.** Emit typedescs to a data segment; emit
+  `ranger_obj_new/release/retain` (+ str/ptrarray) walking them. Header layout.
+- **Phase 2 — flip the target.** Add `manual-wasm` memory model; decouple
+  `memEnabled` from `usesLibc`; route `lowerNewObject` and all cleanup sites to
+  the wasm allocator primitives. Now owned locals release at scope end.
+- **Phase 3 — frame arena.** `$heap_ptr` checkpoint/reset + `@(arena)` scope;
+  escape analysis guards cross-frame survivors.
+- **Phase 4 — optimisation & cycles.** Share the escape/borrow pass
+  (`PLAN_LLVM_MEMORY.md` Phase 3) with WASM to cut redundant retain/release;
+  weak references for known cycles; promote provably-owned object/array fields
+  back to `owned=1`.
+- **Testing:** port the `tests/fixtures/llvm_mem_*.rgr` suite to a WASM harness
+  that asserts `ranger_mem_live_objects() == 0` after scopes, run under V8 (and
+  wasm3). Rewrite one game (e.g. an autopeli entity pool) using real `new`
+  objects to validate end-to-end and measure module-size/perf cost.
+
+## 8. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Allocator bugs (fragmentation, alignment, double-free) | Size classes + a focused test suite; start without coalescing; reuse native semantics. |
+| Reference **cycles leak** (RC) | borrow-by-default for object/array fields (already the default); weak refs; document — a leak is far better than a real-time GC pause. |
+| Heap vs fixed-ABI-region collision | Configurable `heapBase` above the reserved ABI blocks; games using only fixed slots are unaffected. |
+| Module-size / per-alloc cost | Runtime is small; RC only where ownership is non-trivial; arena bypasses RC for per-frame temporaries. |
+| wasm3 compatibility | All plain i32 linear-memory ops — wasm3 runs them (this is precisely why wasm-gc/Option D is rejected). |
+| Analysis conservatism (borrow-by-default over-leaks true owners) | Same known interim state as native; Phase 4 borrow analysis promotes them back. |
+
+## 9. Feasibility verdict & effort
+
+**Feasible, and mostly reuse.** The intellectually hard part — target-agnostic
+ownership/escape analysis and RC-insertion — already exists and already runs; it
+is merely gated off for WASM. The remaining work is a **self-contained WASM
+runtime** (allocator + a handful of typedesc-walking functions) plus **data-
+segment emission** and a **target-model flag**, none of which touch the language
+or the analysis.
+
+- **Effort:** Option A ≈ a medium compiler project (Phases 0–2 are the core;
+  each is self-contained and independently testable). Option B is a small add-on.
+- **Highest-leverage first step:** Phase 0 (free-list allocator) alone stops the
+  unbounded-bump leak for any repeated `new`, and Phase 1 makes `new` + owned
+  locals fully safe — at which point the games can drop the static-class / fixed-
+  slot workaround and use idiomatic Ranger objects.
+- **Not recommended:** a tracing GC (Option C) or wasm-gc (Option D) as the
+  primary path, for the determinism and dual-host reasons above.

--- a/PLAN_WASM_MEMORY.md
+++ b/PLAN_WASM_MEMORY.md
@@ -34,10 +34,26 @@ RC — a major multi-phase subsystem, not a small add-on to the object work.
 General-purpose programs (parser, tools, the in-browser compiler) need it;
 object-based game/logic code does not.
 
-- **Phase 3 — string runtime + RC** ⬜ implement freestanding WASM strings
-  (linear-memory buffers, literals in a data segment, concat/length/index), then
-  owned-string-local release + owned string-field release (needs Phase 4 typedesc
-  emission). Large.
+- **Phase 3 — string runtime + RC** 🟩 *mostly done*
+  - 3.1–3.2 ✅ freestanding WASM string runtime (`ranger_str_*` in
+    `runtime/wasm/ranger_obj.rgr`: len/concat/dup/from_int/cmp/release; literals
+    in a data segment written by `ng_WATWriter.rgr`; `Mem.loadU8/storeU8` →
+    `i32.load8_u/store8`). Concat/to_string/strlen all functional (`str_test` 5/5).
+  - 3.4 ✅ **owned-string-local RC.** The compiler tracks owned string locals
+    (`ownedStringLocals`) and releases them at scope end and per loop iteration
+    via `ranger_str_release` (a no-op for static-literal pointers). Fresh strings
+    (concat/to_string/string-call) are owned directly; borrowed initializers
+    (literal/VRef/field) are dup'd so the local owns a private copy.
+    `lowerStringConcat` also frees its own intermediates (int→string temps and
+    fresh nested-concat operands). Reassignment frees the old buffer first. A
+    per-frame `"HITS " + n` loop stays heap-flat to 100 000 iterations
+    (`str_rc_test` 9/9). Gated on `-wasmrc`; the libc path is byte-unchanged.
+  - 3.3 ⬜ *remaining:* string `==`/`!=` → `ranger_str_cmp`; char access
+    (`charAt`/`substring`/`strfromcode`) routing; and inline fresh-string
+    temporaries passed as call arguments (e.g. `host.drawText("S " + n)`) —
+    needs a statement-scoped temp arena or per-call arg release, deferred because
+    an arbitrary callee's retain/borrow contract for a string arg is unproven.
+  - owned **string-field** release still needs Phase 4 typedesc emission.
 - **Phase 4 — typedesc emission + array runtime + RC** ⬜ serialize typedescs to
   a data segment so owned object/string fields free recursively; port the
   ptr-array/map runtime to the free-list heap with element ownership. Large.

--- a/PLAN_WASM_MEMORY.md
+++ b/PLAN_WASM_MEMORY.md
@@ -6,6 +6,47 @@ handled when compiling to WebAssembly, and whether the answer is **RAII**,
 existing native/LLVM design in [`PLAN_LLVM_MEMORY.md`](./PLAN_LLVM_MEMORY.md)
 and the WAT backend in [`PLAN_WASM_BACKEND.md`](./PLAN_WASM_BACKEND.md).
 
+## Implementation progress (branch: claude/ranger-wasm-memory-rc)
+
+- **Phase 0 — free-list allocator** ✅ `runtime/wasm/ranger_heap.rgr`. malloc/free
+  in linear memory (first-fit, split, coalesce, tail-reclaim, OOM-safe). 16/16
+  tests.
+- **Phase 1 — RC objects** ✅ `runtime/wasm/ranger_obj.rgr`. `[rc|size|type|pad]`
+  header, `ranger_obj_new/retain/release`, typedesc-driven recursive field
+  release. 10/10 tests.
+- **Phase 2 — codegen wiring** ✅ `-wasmrc` flag; `objRcEnabled` gates the object
+  path; `lowerNewObject` emits `ranger_obj_new`; owned locals release at scope
+  end AND per loop iteration (`releaseLoopBodyOwned`); `x = new` reassignment
+  releases the old value. Objects allocated in loops are leak-free (validated to
+  50 000 iterations). 7/7 e2e tests. No regressions; native path untouched.
+
+**Usable today:** object-oriented code — `new` of classes with primitive fields,
+in loops and nested loops, with automatic deterministic cleanup. This covers
+games, entity systems, and object-graph logic.
+
+**Not yet — and the key scoping finding:** strings and arrays/collections are
+**not implemented for freestanding WASM at all** — they currently lower to libc
+calls (`sprintf`, `strlen`, `ranger_ptrarray_*`) that do not exist in a
+freestanding module (wat2wasm rejects `undefined function $sprintf`). So "string
+/array RC on WASM" is really *implement the string + collection runtime for
+freestanding WASM* (allocation, literals, concat, length, indexing) and *then*
+RC — a major multi-phase subsystem, not a small add-on to the object work.
+General-purpose programs (parser, tools, the in-browser compiler) need it;
+object-based game/logic code does not.
+
+- **Phase 3 — string runtime + RC** ⬜ implement freestanding WASM strings
+  (linear-memory buffers, literals in a data segment, concat/length/index), then
+  owned-string-local release + owned string-field release (needs Phase 4 typedesc
+  emission). Large.
+- **Phase 4 — typedesc emission + array runtime + RC** ⬜ serialize typedescs to
+  a data segment so owned object/string fields free recursively; port the
+  ptr-array/map runtime to the free-list heap with element ownership. Large.
+- **Phase 5 — per-frame arena** ⬜ *optional optimisation, not required for
+  correctness* — checkpoint/reset the frontier for frame-scoped temporaries.
+
+Recommended order if continued: Phase 3 (strings) → Phase 4 (typedesc + arrays);
+Phase 5 only if profiling shows RC overhead matters in a frame loop.
+
 ## Tiivistelmä (FI)
 
 Kysymys oli: RAII vai GC? **Vastaus: kumpaakaan ei tarvitse keksiä uutena.**

--- a/PLAN_WASM_MEMORY.md
+++ b/PLAN_WASM_MEMORY.md
@@ -95,9 +95,15 @@ object-based game/logic code does not.
       heap. `coll_rc_test` 11/11 — int and object arrays correct (incl. multiple
       backing grows), and build/use/drop loops stay heap-flat with zero live
       blocks. libc path byte-unchanged (`realloc`, not `Heap_realloc`).
-    - ⬜ *remaining:* `[K:V]` maps (RtMap runtime) on the free-list heap with
-      key/value RC; `[string]` array elements (libc releases array elements via
-      obj_release only — string elements would need a per-element kind).
+    - `[K:V]` maps already allocate their descriptor/keys/vals from the free-list
+      heap (the same `emitHeapAlloc` unification), so a map-using program no
+      longer corrupts the heap. They work up to the fixed bucket capacity;
+      *overflow beyond capacity recurses infinitely in the open-addressing probe*
+      — a pre-existing `RtMap` limitation on ALL targets (libc included), a
+      map-growth issue, not a memory one. ⬜ *remaining:* map descriptor/bucket
+      release (maps aren't in the owned-release path on any target yet) + growth;
+      `[string]` array element release (libc releases elements via `obj_release`
+      only, so string elements need a per-element kind in the descriptor).
 - **Phase 5 — per-frame arena** ⬜ *optional optimisation, not required for
   correctness* — checkpoint/reset the frontier for frame-scoped temporaries.
 

--- a/bin/output.js
+++ b/bin/output.js
@@ -30224,6 +30224,26 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       ins.arg3 = this.irModule.ptrType;
       this.emit(ins);
     };
+    emitPtrLoad8 (ptr) {
+      const dest = this.freshTemp("m");
+      const ins = new LowIRInstr();
+      ins.op = "ptr_load8";
+      ins.dest = dest;
+      ins.irType = "i32";
+      ins.arg1 = ptr;
+      this.emit(ins);
+      return dest;
+    };
+    emitPtrStore8 (ptr, value) {
+      const n = this.tempCounter;
+      this.tempCounter = n + 1;
+      const ins = new LowIRInstr();
+      ins.op = "ptr_store8";
+      ins.dest = "ps" + ("" + n);
+      ins.arg1 = ptr;
+      ins.arg2 = value;
+      this.emit(ins);
+    };
     emitI32At (base, byteOff) {
       const pt = this.irModule.ptrType;
       const off = this.emitConst(pt, ("" + byteOff));
@@ -31455,6 +31475,14 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       const ctx = lctx.ctx;
       return ctx.hasCompilerFlag("wasmrc");
     };
+    wasmStrEnabled (lctx) {
+      const memTarget = LowIRTarget.resolve((lctx.ctx));
+      if ( memTarget.usesLibc ) {
+        return false;
+      }
+      const ctx = lctx.ctx;
+      return ctx.hasCompilerFlag("wasmrc");
+    };
     isLowerableParamType (typeName) {
       if ( LowIRUtil.isSupportedParam(typeName) ) {
         return true;
@@ -31620,7 +31648,11 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       let dupArgTypes = [];
       dupArgs.push(strPtr);
       dupArgTypes.push("i8*");
-      return lctx.builder.emitCall("ranger_strdup", "i8*", dupArgs, dupArgTypes);
+      let dupFn = "ranger_strdup";
+      if ( this.wasmStrEnabled(lctx) ) {
+        dupFn = "ranger_str_dup";
+      }
+      return lctx.builder.emitCall(dupFn, "i8*", dupArgs, dupArgTypes);
     };
     lowerStringConcat (aNode, bNode, lctx) {
       const builder = lctx.builder;
@@ -31631,6 +31663,33 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       }
       if ( this.exprIsString(bNode) ) {
         bStr = true;
+      }
+      if ( this.wasmStrEnabled(lctx) ) {
+        const aV = this.lowerConcatOperand(aNode, aStr, lctx);
+        let sa = aV;
+        if ( aStr == false ) {
+          let a1 = [];
+          let a1t = [];
+          a1.push(aV);
+          a1t.push("i32");
+          sa = builder.emitCall("ranger_str_from_int", "i8*", a1, a1t);
+        }
+        const bV = this.lowerConcatOperand(bNode, bStr, lctx);
+        let sb = bV;
+        if ( bStr == false ) {
+          let b1 = [];
+          let b1t = [];
+          b1.push(bV);
+          b1t.push("i32");
+          sb = builder.emitCall("ranger_str_from_int", "i8*", b1, b1t);
+        }
+        let cargs = [];
+        let cargTypes = [];
+        cargs.push(sa);
+        cargTypes.push("i8*");
+        cargs.push(sb);
+        cargTypes.push("i8*");
+        return builder.emitCall("ranger_str_concat", "i8*", cargs, cargTypes);
       }
       const sz = builder.emitConst("i32", "4096");
       const raw = builder.emitHeapAlloc(sz);
@@ -32392,6 +32451,17 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       const valNode = node.getSecond();
       const isF64 = this.exprIsF64(valNode);
       const val = this.lowerExpr(valNode, lctx);
+      if ( this.wasmStrEnabled(lctx) ) {
+        let iv = val;
+        if ( isF64 ) {
+          iv = builder.emitCast("fptosi", "i32", "f64", val);
+        }
+        let sargs = [];
+        let sargTypes = [];
+        sargs.push(iv);
+        sargTypes.push("i32");
+        return builder.emitCall("ranger_str_from_int", "i8*", sargs, sargTypes);
+      }
       const sz = builder.emitConst("i32", "64");
       const raw = builder.emitHeapAlloc(sz);
       const buf = builder.emitIntToI8Ptr(raw, lctx.ptrType);
@@ -32447,7 +32517,11 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       let argTypes = [];
       args.push(strPtr);
       argTypes.push("i8*");
-      return builder.emitCall("strlen", "i32", args, argTypes);
+      let lenFn = "strlen";
+      if ( this.wasmStrEnabled(lctx) ) {
+        lenFn = "ranger_str_len";
+      }
+      return builder.emitCall(lenFn, "i32", args, argTypes);
     };
     isIntArrayTypeNode (node) {
       if ( node.value_type == 6 ) {
@@ -34871,6 +34945,22 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         }
         return notIntrinsic;
       }
+      if ( fnName == "Mem_loadU8" ) {
+        if ( (argsNode.children.length) > 0 ) {
+          const ptr_2 = this.lowerExpr((argsNode.children[0]), lctx);
+          return builder.emitPtrLoad8(ptr_2);
+        }
+        return notIntrinsic;
+      }
+      if ( fnName == "Mem_storeU8" ) {
+        if ( (argsNode.children.length) > 1 ) {
+          const ptr_3 = this.lowerExpr((argsNode.children[0]), lctx);
+          const val_1 = this.lowerExpr((argsNode.children[1]), lctx);
+          builder.emitPtrStore8(ptr_3, val_1);
+          return handledVoid;
+        }
+        return notIntrinsic;
+      }
       if ( fnName == "RangerMem_liveObjects" ) {
         this.usedMemRuntime = true;
         this.ensureMemExtern(LowIRTarget.resolve((lctx.ctx)));
@@ -36116,6 +36206,16 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           this.writeGet(ins.arg1, wr);
           this.writeGet(ins.arg2, wr);
           wr.out("      i32.store", true);
+          break;
+        case "ptr_load8" : 
+          this.writeGet(ins.arg1, wr);
+          wr.out("      i32.load8_u", true);
+          wr.out("      local.set " + this.wasmName(ins.dest), true);
+          break;
+        case "ptr_store8" : 
+          this.writeGet(ins.arg1, wr);
+          this.writeGet(ins.arg2, wr);
+          wr.out("      i32.store8", true);
           break;
         case "inttoptr_struct" : 
           this.writeGet(ins.arg1, wr);

--- a/bin/output.js
+++ b/bin/output.js
@@ -31091,6 +31091,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       this.ownedObjectLocals = [];
       this.ownedCollectionLocals = [];
       this.ownedStringLocals = [];
+      this.pendingStringTemps = [];
       this.escapedLocals = {};
       this.currentRetType = "i32";
       this.llvmRetType = "i32";
@@ -31691,24 +31692,13 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         cargs.push(sb);
         cargTypes.push("i8*");
         const cres = builder.emitCall("ranger_str_concat", "i8*", cargs, cargTypes);
-        let freeA = aStr == false;
-        if ( aStr ) {
-          if ( this.exprIsFreshString(aNode, lctx) ) {
-            freeA = true;
-          }
+        if ( aStr == false ) {
+          this.registerFreshStringTemp(sa, lctx);
         }
-        if ( freeA ) {
-          this.emitStrReleasePtr(sa, lctx);
+        if ( bStr == false ) {
+          this.registerFreshStringTemp(sb, lctx);
         }
-        let freeB = bStr == false;
-        if ( bStr ) {
-          if ( this.exprIsFreshString(bNode, lctx) ) {
-            freeB = true;
-          }
-        }
-        if ( freeB ) {
-          this.emitStrReleasePtr(sb, lctx);
-        }
+        this.registerFreshStringTemp(cres, lctx);
         return cres;
       }
       const sz = builder.emitConst("i32", "4096");
@@ -32480,7 +32470,9 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         let sargTypes = [];
         sargs.push(iv);
         sargTypes.push("i32");
-        return builder.emitCall("ranger_str_from_int", "i8*", sargs, sargTypes);
+        const sres = builder.emitCall("ranger_str_from_int", "i8*", sargs, sargTypes);
+        this.registerFreshStringTemp(sres, lctx);
+        return sres;
       }
       const sz = builder.emitConst("i32", "64");
       const raw = builder.emitHeapAlloc(sz);
@@ -33684,6 +33676,8 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       lctx.ownedCollectionLocals = emptyColl;
       let emptyStr = [];
       lctx.ownedStringLocals = emptyStr;
+      let emptyPending = [];
+      lctx.pendingStringTemps = emptyPending;
       let emptyEscaped = {};
       lctx.escapedLocals = emptyEscaped;
       if ( isInstance ) {
@@ -33836,6 +33830,46 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       };
       return false;
     };
+    registerFreshStringTemp (tmp, lctx) {
+      if ( this.wasmStrEnabled(lctx) == false ) {
+        return;
+      }
+      lctx.pendingStringTemps.push(tmp);
+    };
+    claimStringTemp (tmp, lctx) {
+      if ( this.wasmStrEnabled(lctx) == false ) {
+        return;
+      }
+      let kept = [];
+      for ( let i = 0; i < lctx.pendingStringTemps.length; i++) {
+        var t = lctx.pendingStringTemps[i];
+        if ( t != tmp ) {
+          kept.push(t);
+        }
+      };
+      lctx.pendingStringTemps = kept;
+    };
+    flushStringTempsFrom (mark, lctx) {
+      if ( this.wasmStrEnabled(lctx) == false ) {
+        return;
+      }
+      const n = lctx.pendingStringTemps.length;
+      if ( n <= mark ) {
+        return;
+      }
+      let k = mark;
+      while (k < n) {
+        this.emitStrReleasePtr(lctx.pendingStringTemps[k], lctx);
+        k = k + 1;
+      };
+      let kept = [];
+      let j = 0;
+      while (j < mark) {
+        kept.push(lctx.pendingStringTemps[j]);
+        j = j + 1;
+      };
+      lctx.pendingStringTemps = kept;
+    };
     emitStrReleasePtr (ptr, lctx) {
       let args = [];
       let argTypes = [];
@@ -33869,6 +33903,8 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       let owned = strPtr;
       if ( this.exprIsFreshString(valNode, lctx) == false ) {
         owned = this.emitStrdupExpr(strPtr, lctx);
+      } else {
+        this.claimStringTemp(strPtr, lctx);
       }
       if ( this.isOwnedStringLocal(varName, lctx) == false ) {
         lctx.ownedStringLocals.push(varName);
@@ -33885,6 +33921,8 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       let owned = strPtr;
       if ( this.exprIsFreshString(valNode, lctx) == false ) {
         owned = this.emitStrdupExpr(strPtr, lctx);
+      } else {
+        this.claimStringTemp(strPtr, lctx);
       }
       if ( this.isOwnedStringLocal(varName, lctx) == false ) {
         lctx.ownedStringLocals.push(varName);
@@ -34002,6 +34040,23 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       return fc.vref == "=";
     };
     lowerStmt (node, lctx) {
+      if ( node.disabled_node ) {
+        return;
+      }
+      if ( this.wasmStrEnabled(lctx) == false ) {
+        this.lowerStmtDispatch(node, lctx);
+        return;
+      }
+      const strMark = lctx.pendingStringTemps.length;
+      this.lowerStmtDispatch(node, lctx);
+      if ( (typeof(lctx.builder.currentBlock) !== "undefined" && lctx.builder.currentBlock != null )  ) {
+        const curBlock = lctx.builder.currentBlock;
+        if ( curBlock.termKind == "" ) {
+          this.flushStringTempsFrom(strMark, lctx);
+        }
+      }
+    };
+    lowerStmtDispatch (node, lctx) {
       if ( node.disabled_node ) {
         return;
       }
@@ -34333,6 +34388,8 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         } else {
           tmp = this.lowerExpr(valNode, lctx);
         }
+        this.claimStringTemp(tmp, lctx);
+        this.flushStringTempsFrom(0, lctx);
         this.emitReleaseOwnedLocals(lctx);
         builder.terminateRet(retType, tmp);
       } else {
@@ -34492,7 +34549,9 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       const builder = lctx.builder;
       const condNode = node.getSecond();
       const thenNode = node.getThird();
+      const condMark = lctx.pendingStringTemps.length;
       const cond = this.lowerCond(condNode, lctx);
+      this.flushStringTempsFrom(condMark, lctx);
       const thenTag = "then";
       const elseTag = "else";
       const mergeTag = "merge";
@@ -34542,7 +34601,9 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       const exitLabel = builder.freshLabel(exitTag);
       builder.terminateBr(condLabel);
       builder.startBlock(condLabel);
+      const condMark = lctx.pendingStringTemps.length;
       const cond = this.lowerCond(condNode, lctx);
+      this.flushStringTempsFrom(condMark, lctx);
       builder.terminateBrIf(cond, bodyLabel, exitLabel);
       const ownedBefore = lctx.ownedObjectLocals.length;
       const ownedStrBefore = lctx.ownedStringLocals.length;
@@ -34848,11 +34909,6 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           if ( this.exprMightBeString(aNode, lctx) || this.exprMightBeString(bNode, lctx) ) {
             return true;
           }
-        }
-      }
-      if ( (exprNode.has_call || exprNode.is_direct_method_call) || exprNode.hasFnCall ) {
-        if ( this.exprIsStringish(exprNode, lctx) ) {
-          return true;
         }
       }
       return false;

--- a/bin/output.js
+++ b/bin/output.js
@@ -30274,6 +30274,17 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       this.emit(ins);
       return dest;
     };
+    emitTypeDescPtr (className) {
+      const tag = "td";
+      const dest = this.freshTemp(tag);
+      const ins = new LowIRInstr();
+      ins.op = "typedesc_ptr";
+      ins.dest = dest;
+      ins.irType = "i32";
+      ins.arg1 = className;
+      this.emit(ins);
+      return dest;
+    };
     terminateRet (retType, value) {
       const cur = this.currentBlock;
       cur.termKind = "ret";
@@ -33230,18 +33241,20 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       return raw;
     };
     emitReleaseFieldValue (className, fieldName, rawVal, lctx) {
-      if ( this.memEnabled(lctx) == false ) {
-        return;
-      }
       const builder = lctx.builder;
       const voidType = "void";
       let args = [];
       let argTypes = [];
       if ( this.fieldIsStringSlot(className, fieldName) ) {
-        const i8p = builder.emitIntToI8Ptr(rawVal, lctx.ptrType);
-        args.push(i8p);
-        argTypes.push("i8*");
-        builder.emitCall("ranger_str_release", voidType, args, argTypes);
+        if ( this.memEnabled(lctx) || this.wasmStrEnabled(lctx) ) {
+          const i8p = builder.emitIntToI8Ptr(rawVal, lctx.ptrType);
+          args.push(i8p);
+          argTypes.push("i8*");
+          builder.emitCall("ranger_str_release", voidType, args, argTypes);
+        }
+        return;
+      }
+      if ( this.memEnabled(lctx) == false ) {
         return;
       }
       if ( this.fieldIsBufferSlot(className, fieldName) ) {
@@ -33259,6 +33272,13 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       if ( this.memEnabled(lctx) ) {
         const oldRaw = builder.emitLoad(ftype, fieldPtr);
         this.emitReleaseFieldValue(className, fieldName, oldRaw, lctx);
+      } else {
+        if ( this.wasmStrEnabled(lctx) ) {
+          if ( this.fieldIsStringSlot(className, fieldName) ) {
+            const oldRawW = builder.emitLoad(ftype, fieldPtr);
+            this.emitReleaseFieldValue(className, fieldName, oldRawW, lctx);
+          }
+        }
       }
       let storeVal = value;
       if ( this.fieldIsStringSlot(className, fieldName) ) {
@@ -33542,6 +33562,20 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       };
       return 0;
     };
+    classHasOwnedFields (className) {
+      for ( let i = 0; i < this.irModule.typeDescs.length; i++) {
+        var td = this.irModule.typeDescs[i];
+        if ( td.className == className ) {
+          for ( let j = 0; j < td.fields.length; j++) {
+            var fd = td.fields[j];
+            if ( fd.owned == 1 ) {
+              return true;
+            }
+          };
+        }
+      };
+      return false;
+    };
     lowerNewObject (className, argsNode, lctx) {
       const builder = lctx.builder;
       let byteCnt = this.structByteSize(className, this.irModule);
@@ -33570,12 +33604,17 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         heapAddr = builder.emitCallWithSig("ranger_obj_new", lctx.ptrType, newSig, newArgs, newArgTypes);
       } else {
         if ( this.objRcEnabled(lctx) ) {
-          const zeroTd = builder.emitConst("i32", "0");
+          let tdArg = "";
+          if ( this.classHasOwnedFields(className) ) {
+            tdArg = builder.emitTypeDescPtr(className);
+          } else {
+            tdArg = builder.emitConst("i32", "0");
+          }
           let wArgs = [];
           let wArgTypes = [];
           wArgs.push(bytes);
           wArgTypes.push("i32");
-          wArgs.push(zeroTd);
+          wArgs.push(tdArg);
           wArgTypes.push("i32");
           heapAddr = builder.emitCall("ranger_obj_new", lctx.ptrType, wArgs, wArgTypes);
         } else {
@@ -34330,13 +34369,6 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             if ( this.fieldIsObjectSlot(cls, fld) ) {
               if ( rhs.value_type == 11 ) {
                 if ( this.isOwnedObjectLocal(rhs.vref, lctx) ) {
-                  lctx.escapedLocals[rhs.vref] = "1";
-                }
-              }
-            }
-            if ( this.fieldIsStringSlot(cls, fld) ) {
-              if ( rhs.value_type == 11 ) {
-                if ( this.isOwnedStringLocal(rhs.vref, lctx) ) {
                   lctx.escapedLocals[rhs.vref] = "1";
                 }
               }
@@ -35949,6 +35981,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
   class WATWriter  {
     constructor() {
       this.strAddrs = {};
+      this.typeDescAddrs = {};
     }
     utf8Encode (text) {
       let bytes = [];
@@ -35997,7 +36030,28 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       s = s + this.hexByte(((((v >> 24)) & 255)));
       return s;
     };
-    emitStringData (module, wr) {
+    align4 (a) {
+      return ((a + 3) & ((-1 ^ 3)));
+    };
+    descHasOwned (td) {
+      for ( let i = 0; i < td.fields.length; i++) {
+        var fd = td.fields[i];
+        if ( fd.owned == 1 ) {
+          return true;
+        }
+      };
+      return false;
+    };
+    moduleHasOwnedTypeDescs (module) {
+      for ( let i = 0; i < module.typeDescs.length; i++) {
+        var td = module.typeDescs[i];
+        if ( this.descHasOwned(td) ) {
+          return true;
+        }
+      };
+      return false;
+    };
+    emitStaticData (module, wr) {
       let addr = 16;
       for ( let i = 0; i < module.stringGlobals.length; i++) {
         var g = module.stringGlobals[i];
@@ -36008,6 +36062,30 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         this.strAddrs[g.name] = addr;
         wr.out("  (data (i32.const " + (("" + addr) + (") \"" + (this.dataEscape(bytes) + "\\00\")"))), true);
         addr = addr + ((bytes.length) + 1);
+      };
+      for ( let i_1 = 0; i_1 < module.typeDescs.length; i_1++) {
+        var td = module.typeDescs[i_1];
+        if ( this.descHasOwned(td) ) {
+          addr = this.align4(addr);
+          const fieldsPtr = addr;
+          for ( let j = 0; j < td.fields.length; j++) {
+            var fd = td.fields[j];
+            let fw = "";
+            fw = fw + this.leWord(fd.offset);
+            fw = fw + this.leWord(fd.kind);
+            fw = fw + this.leWord(fd.owned);
+            wr.out("  (data (i32.const " + (("" + addr) + (") \"" + (fw + "\")"))), true);
+            addr = addr + 12;
+          };
+          const hdrPtr = addr;
+          let hw = "";
+          hw = hw + this.leWord(td.size);
+          hw = hw + this.leWord((td.fields.length));
+          hw = hw + this.leWord(fieldsPtr);
+          wr.out("  (data (i32.const " + (("" + addr) + (") \"" + (hw + "\")"))), true);
+          this.typeDescAddrs[td.className] = hdrPtr;
+          addr = addr + 12;
+        }
       };
       const base = ((addr + 15) & ((-1 ^ 15)));
       wr.out("  (data (i32.const 4) \"" + (this.leWord(base) + "\")"), true);
@@ -36066,12 +36144,14 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     writeModule (module, wr) {
       wr.out("(module", true);
       const hasLiterals = (module.stringGlobals.length) > 0;
-      if ( this.moduleUsesHeap(module) || hasLiterals ) {
+      const hasTypeDescs = this.moduleHasOwnedTypeDescs(module);
+      const hasStatic = hasLiterals || hasTypeDescs;
+      if ( this.moduleUsesHeap(module) || hasStatic ) {
         wr.out("  (memory (export \"memory\") 1)", true);
         wr.out("  (global $heap_ptr (mut i32) (i32.const 0))", true);
       }
-      if ( hasLiterals ) {
-        this.emitStringData(module, wr);
+      if ( hasStatic ) {
+        this.emitStaticData(module, wr);
       }
       for ( let i = 0; i < module.functions.length; i++) {
         var fn = module.functions[i];
@@ -36426,6 +36506,10 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           this.writeGet(ins.arg1, wr);
           wr.out("      local.set " + this.wasmName(ins.dest), true);
           break;
+        case "ptr_to_int" : 
+          this.writeGet(ins.arg1, wr);
+          wr.out("      local.set " + this.wasmName(ins.dest), true);
+          break;
         case "zext" : 
           this.writeGet(ins.arg1, wr);
           wr.out("      local.set " + this.wasmName(ins.dest), true);
@@ -36440,6 +36524,14 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             addr = (( this.strAddrs.hasOwnProperty(ins.arg1) ? this.strAddrs[ins.arg1] : undefined ));
           }
           wr.out("      i32.const " + ("" + addr), true);
+          wr.out("      local.set " + this.wasmName(ins.dest), true);
+          break;
+        case "typedesc_ptr" : 
+          let tdAddr = 0;
+          if ( ( typeof(this.typeDescAddrs[ins.arg1] ) != "undefined" && this.typeDescAddrs.hasOwnProperty(ins.arg1) ) ) {
+            tdAddr = (( this.typeDescAddrs.hasOwnProperty(ins.arg1) ? this.typeDescAddrs[ins.arg1] : undefined ));
+          }
+          wr.out("      i32.const " + ("" + tdAddr), true);
           wr.out("      local.set " + this.wasmName(ins.dest), true);
           break;
         case "icmp" : 

--- a/bin/output.js
+++ b/bin/output.js
@@ -31447,6 +31447,14 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       }
       return this.usedMemRuntime;
     };
+    objRcEnabled (lctx) {
+      const memTarget = LowIRTarget.resolve((lctx.ctx));
+      if ( memTarget.usesLibc ) {
+        return true;
+      }
+      const ctx = lctx.ctx;
+      return ctx.hasCompilerFlag("wasmrc");
+    };
     isLowerableParamType (typeName) {
       if ( LowIRUtil.isSupportedParam(typeName) ) {
         return true;
@@ -33471,7 +33479,18 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         const newSig = "i32, ptr";
         heapAddr = builder.emitCallWithSig("ranger_obj_new", lctx.ptrType, newSig, newArgs, newArgTypes);
       } else {
-        heapAddr = builder.emitHeapAlloc(bytes);
+        if ( this.objRcEnabled(lctx) ) {
+          const zeroTd = builder.emitConst("i32", "0");
+          let wArgs = [];
+          let wArgTypes = [];
+          wArgs.push(bytes);
+          wArgTypes.push("i32");
+          wArgs.push(zeroTd);
+          wArgTypes.push("i32");
+          heapAddr = builder.emitCall("ranger_obj_new", lctx.ptrType, wArgs, wArgTypes);
+        } else {
+          heapAddr = builder.emitHeapAlloc(bytes);
+        }
       }
       const objSlot = builder.emitIntToStructPtr(className, heapAddr);
       this.initFieldDefaultsInObject(className, objSlot, lctx);
@@ -33694,8 +33713,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       return false;
     };
     releaseOwnedLocal (varName, lctx) {
-      const memTarget = LowIRTarget.resolve((lctx.ctx));
-      if ( memTarget.usesLibc == false ) {
+      if ( this.objRcEnabled(lctx) == false ) {
         return;
       }
       if ( ( typeof(lctx.escapedLocals[varName] ) != "undefined" && lctx.escapedLocals.hasOwnProperty(varName) ) ) {
@@ -33744,7 +33762,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     };
     emitReleaseOwnedLocals (lctx) {
       const memTarget = LowIRTarget.resolve((lctx.ctx));
-      if ( memTarget.isManualMemory() == false ) {
+      if ( this.objRcEnabled(lctx) == false ) {
         return;
       }
       if ( this.strictOwnershipEnabled(lctx) ) {
@@ -33754,6 +33772,9 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         var name = lctx.ownedObjectLocals[i];
         this.releaseOwnedLocal(name, lctx);
       };
+      if ( memTarget.usesLibc == false ) {
+        return;
+      }
       const builder = lctx.builder;
       const voidType = "void";
       for ( let i_1 = 0; i_1 < lctx.ownedCollectionLocals.length; i_1++) {
@@ -34345,13 +34366,37 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       builder.startBlock(condLabel);
       const cond = this.lowerCond(condNode, lctx);
       builder.terminateBrIf(cond, bodyLabel, exitLabel);
+      const ownedBefore = lctx.ownedObjectLocals.length;
       builder.startBlock(bodyLabel);
       this.lowerBlock(bodyNode, lctx);
       const bodyBlock = builder.currentBlock;
       if ( bodyBlock.termKind == "" ) {
+        this.releaseLoopBodyOwned(ownedBefore, lctx);
         builder.terminateBr(condLabel);
       }
       builder.startBlock(exitLabel);
+    };
+    releaseLoopBodyOwned (ownedBefore, lctx) {
+      const ctx = lctx.ctx;
+      if ( ctx.hasCompilerFlag("wasmrc") == false ) {
+        return;
+      }
+      const n = lctx.ownedObjectLocals.length;
+      if ( n <= ownedBefore ) {
+        return;
+      }
+      let k = ownedBefore;
+      while (k < n) {
+        this.releaseOwnedLocal(lctx.ownedObjectLocals[k], lctx);
+        k = k + 1;
+      };
+      let kept = [];
+      let j = 0;
+      while (j < ownedBefore) {
+        kept.push(lctx.ownedObjectLocals[j]);
+        j = j + 1;
+      };
+      lctx.ownedObjectLocals = kept;
     };
     lowerExpr (node, lctx) {
       const builder = lctx.builder;

--- a/bin/output.js
+++ b/bin/output.js
@@ -32244,7 +32244,9 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       argTypes.push("i32");
       args.push(end);
       argTypes.push("i32");
-      return lctx.builder.emitCall("ranger_substring", "i8*", args, argTypes);
+      const subRes = lctx.builder.emitCall("ranger_substring", "i8*", args, argTypes);
+      this.registerFreshStringTemp(subRes, lctx);
+      return subRes;
     };
     lowerAtArgs (textNode, posNode, lctx) {
       const text = this.lowerExpr(textNode, lctx);
@@ -32513,7 +32515,9 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       let argTypes = [];
       args.push(code);
       argTypes.push("i32");
-      return builder.emitCall(fnName, "i8*", args, argTypes);
+      const codeRes = builder.emitCall(fnName, "i8*", args, argTypes);
+      this.registerFreshStringTemp(codeRes, lctx);
+      return codeRes;
     };
     lowerStrlen (node, lctx) {
       const irI32 = "i32";
@@ -34984,7 +34988,11 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       argTypes.push("i8*");
       args.push(rhs);
       argTypes.push("i8*");
-      const sc = builder.emitCall("strcmp", "i32", args, argTypes);
+      let cmpFn = "strcmp";
+      if ( this.wasmStrEnabled(lctx) ) {
+        cmpFn = "ranger_str_cmp";
+      }
+      const sc = builder.emitCall(cmpFn, "i32", args, argTypes);
       const zero = builder.emitConst("i32", "0");
       return builder.emitIcmp(pred, sc, zero);
     };

--- a/bin/output.js
+++ b/bin/output.js
@@ -35657,7 +35657,70 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
   }
   class WATWriter  {
     constructor() {
+      this.strAddrs = {};
     }
+    utf8Encode (text) {
+      let bytes = [];
+      let i = 0;
+      const n = text.length;
+      while (i < n) {
+        const c = text.charCodeAt(i );
+        if ( c < 128 ) {
+          bytes.push(c);
+        } else {
+          if ( c < 2048 ) {
+            bytes.push((192 | ((c >> 6))));
+            bytes.push((128 | ((c & 63))));
+          } else {
+            bytes.push((224 | ((c >> 12))));
+            bytes.push((128 | ((((c >> 6)) & 63))));
+            bytes.push((128 | ((c & 63))));
+          }
+        }
+        i = i + 1;
+      };
+      return bytes;
+    };
+    hexDigit (d) {
+      if ( d < 10 ) {
+        return "" + d;
+      }
+      return String.fromCharCode((97 + (d - 10)));
+    };
+    hexByte (b) {
+      return "\\" + (this.hexDigit(((((b >> 4)) & 15))) + this.hexDigit(((b & 15))));
+    };
+    dataEscape (bytes) {
+      let s = "";
+      for ( let i = 0; i < bytes.length; i++) {
+        var b = bytes[i];
+        s = s + this.hexByte(b);
+      };
+      return s;
+    };
+    leWord (v) {
+      let s = "";
+      s = s + this.hexByte(((v & 255)));
+      s = s + this.hexByte(((((v >> 8)) & 255)));
+      s = s + this.hexByte(((((v >> 16)) & 255)));
+      s = s + this.hexByte(((((v >> 24)) & 255)));
+      return s;
+    };
+    emitStringData (module, wr) {
+      let addr = 16;
+      for ( let i = 0; i < module.stringGlobals.length; i++) {
+        var g = module.stringGlobals[i];
+        let bytes = this.utf8Encode(g.text);
+        if ( g.withNewline ) {
+          bytes.push(10);
+        }
+        this.strAddrs[g.name] = addr;
+        wr.out("  (data (i32.const " + (("" + addr) + (") \"" + (this.dataEscape(bytes) + "\\00\")"))), true);
+        addr = addr + ((bytes.length) + 1);
+      };
+      const base = ((addr + 15) & ((-1 ^ 15)));
+      wr.out("  (data (i32.const 4) \"" + (this.leWord(base) + "\")"), true);
+    };
     wasmName (llvmName) {
       if ( (llvmName.length) == 0 ) {
         return "";
@@ -35711,9 +35774,13 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     };
     writeModule (module, wr) {
       wr.out("(module", true);
-      if ( this.moduleUsesHeap(module) ) {
+      const hasLiterals = (module.stringGlobals.length) > 0;
+      if ( this.moduleUsesHeap(module) || hasLiterals ) {
         wr.out("  (memory (export \"memory\") 1)", true);
         wr.out("  (global $heap_ptr (mut i32) (i32.const 0))", true);
+      }
+      if ( hasLiterals ) {
+        this.emitStringData(module, wr);
       }
       for ( let i = 0; i < module.functions.length; i++) {
         var fn = module.functions[i];
@@ -36067,7 +36134,11 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           wr.out("      local.set " + this.wasmName(ins.dest), true);
           break;
         case "str_ptr" : 
-          wr.out("      i32.const 0", true);
+          let addr = 0;
+          if ( ( typeof(this.strAddrs[ins.arg1] ) != "undefined" && this.strAddrs.hasOwnProperty(ins.arg1) ) ) {
+            addr = (( this.strAddrs.hasOwnProperty(ins.arg1) ? this.strAddrs[ins.arg1] : undefined ));
+          }
+          wr.out("      i32.const " + ("" + addr), true);
           wr.out("      local.set " + this.wasmName(ins.dest), true);
           break;
         case "icmp" : 

--- a/bin/output.js
+++ b/bin/output.js
@@ -31090,6 +31090,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       this.ptrArrayElemTypes = {};
       this.ownedObjectLocals = [];
       this.ownedCollectionLocals = [];
+      this.ownedStringLocals = [];
       this.escapedLocals = {};
       this.currentRetType = "i32";
       this.llvmRetType = "i32";
@@ -31689,7 +31690,26 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         cargTypes.push("i8*");
         cargs.push(sb);
         cargTypes.push("i8*");
-        return builder.emitCall("ranger_str_concat", "i8*", cargs, cargTypes);
+        const cres = builder.emitCall("ranger_str_concat", "i8*", cargs, cargTypes);
+        let freeA = aStr == false;
+        if ( aStr ) {
+          if ( this.exprIsFreshString(aNode, lctx) ) {
+            freeA = true;
+          }
+        }
+        if ( freeA ) {
+          this.emitStrReleasePtr(sa, lctx);
+        }
+        let freeB = bStr == false;
+        if ( bStr ) {
+          if ( this.exprIsFreshString(bNode, lctx) ) {
+            freeB = true;
+          }
+        }
+        if ( freeB ) {
+          this.emitStrReleasePtr(sb, lctx);
+        }
+        return cres;
       }
       const sz = builder.emitConst("i32", "4096");
       const raw = builder.emitHeapAlloc(sz);
@@ -33662,6 +33682,8 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       lctx.ownedObjectLocals = emptyOwned;
       let emptyColl = [];
       lctx.ownedCollectionLocals = emptyColl;
+      let emptyStr = [];
+      lctx.ownedStringLocals = emptyStr;
       let emptyEscaped = {};
       lctx.escapedLocals = emptyEscaped;
       if ( isInstance ) {
@@ -33805,6 +33827,70 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       argTypes.push(lctx.ptrType);
       builder.emitCall("ranger_obj_release", voidType, args, argTypes);
     };
+    isOwnedStringLocal (varName, lctx) {
+      for ( let i = 0; i < lctx.ownedStringLocals.length; i++) {
+        var n = lctx.ownedStringLocals[i];
+        if ( n == varName ) {
+          return true;
+        }
+      };
+      return false;
+    };
+    emitStrReleasePtr (ptr, lctx) {
+      let args = [];
+      let argTypes = [];
+      args.push(ptr);
+      argTypes.push("i8*");
+      lctx.builder.emitCall("ranger_str_release", "void", args, argTypes);
+    };
+    releaseOwnedString (varName, lctx) {
+      if ( this.wasmStrEnabled(lctx) == false ) {
+        return;
+      }
+      if ( ( typeof(lctx.escapedLocals[varName] ) != "undefined" && lctx.escapedLocals.hasOwnProperty(varName) ) ) {
+        return;
+      }
+      if ( false == (( typeof(lctx.slots[varName] ) != "undefined" && lctx.slots.hasOwnProperty(varName) )) ) {
+        return;
+      }
+      const builder = lctx.builder;
+      const voidType = "void";
+      const val = this.loadSlot(varName, "i8*", lctx);
+      let args = [];
+      let argTypes = [];
+      args.push(val);
+      argTypes.push("i8*");
+      builder.emitCall("ranger_str_release", voidType, args, argTypes);
+    };
+    emitOwnedStringInit (varName, valNode, strPtr, lctx) {
+      if ( this.wasmStrEnabled(lctx) == false ) {
+        return this.emitStrdupExpr(strPtr, lctx);
+      }
+      let owned = strPtr;
+      if ( this.exprIsFreshString(valNode, lctx) == false ) {
+        owned = this.emitStrdupExpr(strPtr, lctx);
+      }
+      if ( this.isOwnedStringLocal(varName, lctx) == false ) {
+        lctx.ownedStringLocals.push(varName);
+      }
+      return owned;
+    };
+    emitOwnedStringReassign (varName, valNode, strPtr, lctx) {
+      if ( this.wasmStrEnabled(lctx) == false ) {
+        return this.emitStrdupExpr(strPtr, lctx);
+      }
+      if ( this.isOwnedStringLocal(varName, lctx) ) {
+        this.releaseOwnedString(varName, lctx);
+      }
+      let owned = strPtr;
+      if ( this.exprIsFreshString(valNode, lctx) == false ) {
+        owned = this.emitStrdupExpr(strPtr, lctx);
+      }
+      if ( this.isOwnedStringLocal(varName, lctx) == false ) {
+        lctx.ownedStringLocals.push(varName);
+      }
+      return owned;
+    };
     strictOwnershipEnabled (lctx) {
       const ctx = lctx.ctx;
       return ctx.hasCompilerFlag("strict-ownership");
@@ -33845,6 +33931,10 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       for ( let i = 0; i < lctx.ownedObjectLocals.length; i++) {
         var name = lctx.ownedObjectLocals[i];
         this.releaseOwnedLocal(name, lctx);
+      };
+      for ( let si = 0; si < lctx.ownedStringLocals.length; si++) {
+        var sname = lctx.ownedStringLocals[si];
+        this.releaseOwnedString(sname, lctx);
       };
       if ( memTarget.usesLibc == false ) {
         return;
@@ -34124,7 +34214,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         lctx.objectSlots[varName] = typeName_1;
       }
       if ( irType == "i8*" ) {
-        tmp = this.emitStrdupExpr(tmp, lctx);
+        tmp = this.emitOwnedStringInit(varName, val, tmp, lctx);
       }
       if ( irType == "f64" ) {
         if ( this.exprIsF64(val) == false ) {
@@ -34185,6 +34275,13 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
                 }
               }
             }
+            if ( this.fieldIsStringSlot(cls, fld) ) {
+              if ( rhs.value_type == 11 ) {
+                if ( this.isOwnedStringLocal(rhs.vref, lctx) ) {
+                  lctx.escapedLocals[rhs.vref] = "1";
+                }
+              }
+            }
             this.emitFieldStoreOn(cls, sptr, fld, tmp, lctx);
             return;
           }
@@ -34214,7 +34311,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           }
         }
         if ( storeType == "i8*" ) {
-          tmp = this.emitStrdupExpr(tmp, lctx);
+          tmp = this.emitOwnedStringReassign(varName, rhs, tmp, lctx);
         }
         builder.emitStore(storeType, tmp, slot);
         return;
@@ -34448,36 +34545,51 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       const cond = this.lowerCond(condNode, lctx);
       builder.terminateBrIf(cond, bodyLabel, exitLabel);
       const ownedBefore = lctx.ownedObjectLocals.length;
+      const ownedStrBefore = lctx.ownedStringLocals.length;
       builder.startBlock(bodyLabel);
       this.lowerBlock(bodyNode, lctx);
       const bodyBlock = builder.currentBlock;
       if ( bodyBlock.termKind == "" ) {
-        this.releaseLoopBodyOwned(ownedBefore, lctx);
+        this.releaseLoopBodyOwned(ownedBefore, ownedStrBefore, lctx);
         builder.terminateBr(condLabel);
       }
       builder.startBlock(exitLabel);
     };
-    releaseLoopBodyOwned (ownedBefore, lctx) {
+    releaseLoopBodyOwned (ownedBefore, ownedStrBefore, lctx) {
       const ctx = lctx.ctx;
       if ( ctx.hasCompilerFlag("wasmrc") == false ) {
         return;
       }
       const n = lctx.ownedObjectLocals.length;
-      if ( n <= ownedBefore ) {
-        return;
+      if ( n > ownedBefore ) {
+        let k = ownedBefore;
+        while (k < n) {
+          this.releaseOwnedLocal(lctx.ownedObjectLocals[k], lctx);
+          k = k + 1;
+        };
+        let kept = [];
+        let j = 0;
+        while (j < ownedBefore) {
+          kept.push(lctx.ownedObjectLocals[j]);
+          j = j + 1;
+        };
+        lctx.ownedObjectLocals = kept;
       }
-      let k = ownedBefore;
-      while (k < n) {
-        this.releaseOwnedLocal(lctx.ownedObjectLocals[k], lctx);
-        k = k + 1;
-      };
-      let kept = [];
-      let j = 0;
-      while (j < ownedBefore) {
-        kept.push(lctx.ownedObjectLocals[j]);
-        j = j + 1;
-      };
-      lctx.ownedObjectLocals = kept;
+      const sn = lctx.ownedStringLocals.length;
+      if ( sn > ownedStrBefore ) {
+        let sk = ownedStrBefore;
+        while (sk < sn) {
+          this.releaseOwnedString(lctx.ownedStringLocals[sk], lctx);
+          sk = sk + 1;
+        };
+        let keptS = [];
+        let sj = 0;
+        while (sj < ownedStrBefore) {
+          keptS.push(lctx.ownedStringLocals[sj]);
+          sj = sj + 1;
+        };
+        lctx.ownedStringLocals = keptS;
+      }
     };
     lowerExpr (node, lctx) {
       const builder = lctx.builder;
@@ -34717,6 +34829,31 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       }
       if ( op == "substring" ) {
         return true;
+      }
+      return false;
+    };
+    exprIsFreshString (node, lctx) {
+      if ( this.wasmStrEnabled(lctx) == false ) {
+        return false;
+      }
+      const exprNode = this.unwrapCondExpr(node);
+      if ( exprNode.has_operator ) {
+        const op = exprNode.getOperator();
+        if ( this.operatorReturnsString(op) ) {
+          return true;
+        }
+        if ( op == "+" ) {
+          const aNode = exprNode.getSecond();
+          const bNode = exprNode.getThird();
+          if ( this.exprMightBeString(aNode, lctx) || this.exprMightBeString(bNode, lctx) ) {
+            return true;
+          }
+        }
+      }
+      if ( (exprNode.has_call || exprNode.is_direct_method_call) || exprNode.hasFnCall ) {
+        if ( this.exprIsStringish(exprNode, lctx) ) {
+          return true;
+        }
       }
       return false;
     };

--- a/bin/output.js
+++ b/bin/output.js
@@ -34122,6 +34122,13 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       }
       if ( ( typeof(lctx.slots[varName] ) != "undefined" && lctx.slots.hasOwnProperty(varName) ) ) {
         const slot = (( lctx.slots.hasOwnProperty(varName) ? lctx.slots[varName] : undefined ));
+        if ( rhs.hasNewOper ) {
+          if ( ( typeof(lctx.objectSlots[varName] ) != "undefined" && lctx.objectSlots.hasOwnProperty(varName) ) ) {
+            if ( this.isOwnedObjectLocal(varName, lctx) ) {
+              this.releaseOwnedLocal(varName, lctx);
+            }
+          }
+        }
         let storeType = irType;
         if ( ( typeof(lctx.slotTypes[varName] ) != "undefined" && lctx.slotTypes.hasOwnProperty(varName) ) ) {
           storeType = (( lctx.slotTypes.hasOwnProperty(varName) ? lctx.slotTypes[varName] : undefined ));

--- a/bin/output.js
+++ b/bin/output.js
@@ -29884,6 +29884,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       this.triple = "unknown-unknown-unknown";
       this.ptrType = "i32";
       this.useLibcHeap = false;
+      this.useFreeListHeap = false;
       this.structs = [];
       this.typeDescs = [];
       this.functions = [];
@@ -30121,6 +30122,13 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         args.push(sizeArg);
         argTypes.push(ptrType);
         return this.emitCall("calloc", ptrType, args, argTypes);
+      }
+      if ( this.irModule.useFreeListHeap ) {
+        let hargs = [];
+        let hargTypes = [];
+        hargs.push(sizeArg);
+        hargTypes.push("i32");
+        return this.emitCall("Heap_calloc", ptrType, hargs, hargTypes);
       }
       const tag = "h";
       const dest = this.freshTemp(tag);
@@ -30925,7 +30933,11 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     rat.push(pt);
     ra.push(newBytes);
     rat.push(pt);
-    const newData = builder.emitCall("realloc", pt, ra, rat);
+    let reallocFn = "realloc";
+    if ( module.useFreeListHeap ) {
+      reallocFn = "Heap_realloc";
+    }
+    const newData = builder.emitCall(reallocFn, pt, ra, rat);
     builder.emitPtrStore("%desc", newData);
     builder.emitStoreI32At("%desc", capOff, newCap);
     builder.terminateBr(cont);
@@ -31226,6 +31238,10 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       this.irModule.useLibcHeap = target.usesLibc;
       if ( target.usesLibc ) {
         this.ensureLibcExtern(target);
+      } else {
+        if ( appCtx.hasCompilerFlag("wasmrc") ) {
+          this.irModule.useFreeListHeap = true;
+        }
       }
       for ( let i = 0; i < appCtx.definedClassList.length; i++) {
         var cName = appCtx.definedClassList[i];
@@ -32380,7 +32396,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       argTypes.push(lctx.ptrType);
       const voidType = "void";
       if ( this.exprIsObjectPtr(itemNode, lctx) ) {
-        if ( this.memEnabled(lctx) ) {
+        if ( this.memEnabled(lctx) || this.wasmCollectionRcEnabled(lctx) ) {
           let isMove = false;
           if ( itemNode.value_type == 11 ) {
             if ( this.isOwnedObjectLocal(itemNode.vref, lctx) ) {
@@ -32393,8 +32409,10 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             lctx.builder.emitCall("RtPtrArray_push", voidType, args, argTypes);
             return;
           }
-          this.usedMemRuntime = true;
-          this.ensureMemExtern(LowIRTarget.resolve((lctx.ctx)));
+          if ( this.memEnabled(lctx) ) {
+            this.usedMemRuntime = true;
+            this.ensureMemExtern(LowIRTarget.resolve((lctx.ctx)));
+          }
           lctx.builder.emitCall("ranger_ptrarray_push_owned", voidType, args, argTypes);
           return;
         }
@@ -32594,7 +32612,19 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       lctx.collectionSlots[varName] = "ptr_array";
       if ( owned ) {
         lctx.ownedCollectionLocals.push(varName);
+      } else {
+        if ( this.wasmCollectionRcEnabled(lctx) ) {
+          lctx.ownedCollectionLocals.push(varName);
+        }
       }
+    };
+    wasmCollectionRcEnabled (lctx) {
+      const memTarget = LowIRTarget.resolve((lctx.ctx));
+      if ( memTarget.usesLibc ) {
+        return false;
+      }
+      const ctx = lctx.ctx;
+      return ctx.hasCompilerFlag("wasmrc");
     };
     collectionKind (varName, lctx) {
       if ( ( typeof(lctx.collectionSlots[varName] ) != "undefined" && lctx.collectionSlots.hasOwnProperty(varName) ) ) {
@@ -33939,6 +33969,20 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       argTypes.push("i8*");
       builder.emitCall("ranger_str_release", voidType, args, argTypes);
     };
+    releaseOwnedCollectionLocal (varName, lctx) {
+      if ( ( typeof(lctx.escapedLocals[varName] ) != "undefined" && lctx.escapedLocals.hasOwnProperty(varName) ) ) {
+        return;
+      }
+      if ( false == (( typeof(lctx.slots[varName] ) != "undefined" && lctx.slots.hasOwnProperty(varName) )) ) {
+        return;
+      }
+      const desc = this.loadSlot(varName, lctx.ptrType, lctx);
+      let args = [];
+      let argTypes = [];
+      args.push(desc);
+      argTypes.push(lctx.ptrType);
+      lctx.builder.emitCall("ranger_ptrarray_release", "void", args, argTypes);
+    };
     emitOwnedStringInit (varName, valNode, strPtr, lctx) {
       if ( this.wasmStrEnabled(lctx) == false ) {
         return this.emitStrdupExpr(strPtr, lctx);
@@ -34018,24 +34062,13 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         this.releaseOwnedString(sname, lctx);
       };
       if ( memTarget.usesLibc == false ) {
-        return;
+        if ( this.wasmCollectionRcEnabled(lctx) == false ) {
+          return;
+        }
       }
-      const builder = lctx.builder;
-      const voidType = "void";
       for ( let i_1 = 0; i_1 < lctx.ownedCollectionLocals.length; i_1++) {
         var name_1 = lctx.ownedCollectionLocals[i_1];
-        if ( ( typeof(lctx.escapedLocals[name_1] ) != "undefined" && lctx.escapedLocals.hasOwnProperty(name_1) ) ) {
-          continue;
-        }
-        if ( false == (( typeof(lctx.slots[name_1] ) != "undefined" && lctx.slots.hasOwnProperty(name_1) )) ) {
-          continue;
-        }
-        const desc = this.loadSlot(name_1, lctx.ptrType, lctx);
-        let args = [];
-        let argTypes = [];
-        args.push(desc);
-        argTypes.push(lctx.ptrType);
-        builder.emitCall("ranger_ptrarray_release", voidType, args, argTypes);
+        this.releaseOwnedCollectionLocal(name_1, lctx);
       };
     };
     lowerBlock (block, lctx) {
@@ -34643,16 +34676,17 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       builder.terminateBrIf(cond, bodyLabel, exitLabel);
       const ownedBefore = lctx.ownedObjectLocals.length;
       const ownedStrBefore = lctx.ownedStringLocals.length;
+      const ownedCollBefore = lctx.ownedCollectionLocals.length;
       builder.startBlock(bodyLabel);
       this.lowerBlock(bodyNode, lctx);
       const bodyBlock = builder.currentBlock;
       if ( bodyBlock.termKind == "" ) {
-        this.releaseLoopBodyOwned(ownedBefore, ownedStrBefore, lctx);
+        this.releaseLoopBodyOwned(ownedBefore, ownedStrBefore, ownedCollBefore, lctx);
         builder.terminateBr(condLabel);
       }
       builder.startBlock(exitLabel);
     };
-    releaseLoopBodyOwned (ownedBefore, ownedStrBefore, lctx) {
+    releaseLoopBodyOwned (ownedBefore, ownedStrBefore, ownedCollBefore, lctx) {
       const ctx = lctx.ctx;
       if ( ctx.hasCompilerFlag("wasmrc") == false ) {
         return;
@@ -34686,6 +34720,21 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           sj = sj + 1;
         };
         lctx.ownedStringLocals = keptS;
+      }
+      const cn = lctx.ownedCollectionLocals.length;
+      if ( cn > ownedCollBefore ) {
+        let ck = ownedCollBefore;
+        while (ck < cn) {
+          this.releaseOwnedCollectionLocal(lctx.ownedCollectionLocals[ck], lctx);
+          ck = ck + 1;
+        };
+        let keptC = [];
+        let cj = 0;
+        while (cj < ownedCollBefore) {
+          keptC.push(lctx.ownedCollectionLocals[cj]);
+          cj = cj + 1;
+        };
+        lctx.ownedCollectionLocals = keptC;
       }
     };
     lowerExpr (node, lctx) {

--- a/bin/output.js
+++ b/bin/output.js
@@ -32573,6 +32573,20 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           itemAddr = lctx.builder.emitCast("zext", "i64", "i32", itemAddr);
         }
       }
+      if ( this.wasmStrEnabled(lctx) ) {
+        if ( LowIRUtil.isStringType(this.arrayElemTypeName(arrNode, lctx)) ) {
+          const dupStr = this.emitStrdupExpr(itemAddr, lctx);
+          let sArgs = [];
+          let sArgTypes = [];
+          sArgs.push(desc);
+          sArgTypes.push(lctx.ptrType);
+          sArgs.push(dupStr);
+          sArgTypes.push(lctx.ptrType);
+          this.usedPtrArrayRuntime = true;
+          lctx.builder.emitCall("RtPtrArray_push", "void", sArgs, sArgTypes);
+          return;
+        }
+      }
       let args = [];
       let argTypes = [];
       args.push(desc);
@@ -32588,8 +32602,16 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
               isMove = true;
             }
           }
-          if ( isMove ) {
-            lctx.escapedLocals[itemNode.vref] = "1";
+          let freshNew = false;
+          if ( itemNode.hasNewOper ) {
+            if ( this.wasmCollectionRcEnabled(lctx) ) {
+              freshNew = true;
+            }
+          }
+          if ( isMove || freshNew ) {
+            if ( itemNode.value_type == 11 ) {
+              lctx.escapedLocals[itemNode.vref] = "1";
+            }
             this.usedPtrArrayRuntime = true;
             lctx.builder.emitCall("RtPtrArray_push", voidType, args, argTypes);
             return;
@@ -32777,7 +32799,13 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       }
       return false;
     };
-    emitPtrArrayNewEmpty (lctx, owned) {
+    isStringArrayTypeNode (node) {
+      if ( node.value_type == 6 ) {
+        return LowIRUtil.isStringType(node.array_type);
+      }
+      return false;
+    };
+    emitPtrArrayNewEmpty (lctx, elemKind) {
       this.usedPtrArrayRuntime = true;
       const builder = lctx.builder;
       const cap = builder.emitConst("i32", "256");
@@ -32786,9 +32814,9 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       args.push(cap);
       argTypes.push("i32");
       const desc = builder.emitCall("RtPtrArray_new", lctx.ptrType, args, argTypes);
-      if ( owned ) {
-        const one = builder.emitConst("i32", "1");
-        builder.emitStoreI32At(desc, this.ptrArrayOwnedOff(lctx), one);
+      if ( elemKind > 0 ) {
+        const kindC = builder.emitConst("i32", ("" + elemKind));
+        builder.emitStoreI32At(desc, this.ptrArrayOwnedOff(lctx), kindC);
       }
       return desc;
     };
@@ -34445,13 +34473,19 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       }
       if ( typeof(valNode) === "undefined" ) {
         if ( this.isIntArrayTypeNode(nameNode) ) {
-          const emptyArr = this.emitPtrArrayNewEmpty(lctx, false);
+          const emptyArr = this.emitPtrArrayNewEmpty(lctx, 0);
           this.bindPtrArraySlot(varName, emptyArr, lctx, false);
           lctx.ptrArrayElemTypes[varName] = "int";
           return;
         }
+        if ( this.isStringArrayTypeNode(nameNode) ) {
+          const emptyStrArr = this.emitPtrArrayNewEmpty(lctx, 2);
+          this.bindPtrArraySlot(varName, emptyStrArr, lctx, true);
+          lctx.ptrArrayElemTypes[varName] = "string";
+          return;
+        }
         if ( this.isObjectPtrArrayTypeNode(nameNode) ) {
-          const emptyPtrArr = this.emitPtrArrayNewEmpty(lctx, true);
+          const emptyPtrArr = this.emitPtrArrayNewEmpty(lctx, 1);
           this.bindPtrArraySlot(varName, emptyPtrArr, lctx, true);
           return;
         }

--- a/bin/output.js
+++ b/bin/output.js
@@ -30252,6 +30252,25 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       ins.arg2 = value;
       this.emit(ins);
     };
+    emitMemSize () {
+      const dest = this.freshTemp("m");
+      const ins = new LowIRInstr();
+      ins.op = "mem_size";
+      ins.dest = dest;
+      ins.irType = "i32";
+      this.emit(ins);
+      return dest;
+    };
+    emitMemGrow (pages) {
+      const dest = this.freshTemp("m");
+      const ins = new LowIRInstr();
+      ins.op = "mem_grow";
+      ins.dest = dest;
+      ins.irType = "i32";
+      ins.arg1 = pages;
+      this.emit(ins);
+      return dest;
+    };
     emitI32At (base, byteOff) {
       const pt = this.irModule.ptrType;
       const off = this.emitConst(pt, ("" + byteOff));
@@ -30358,6 +30377,10 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       return;
     }
     LowIRRuntimeGen.buildRtMapNew(module);
+    if ( module.useFreeListHeap ) {
+      LowIRRuntimeGen.buildRtMapGrow(module);
+      LowIRRuntimeGen.buildRtMapFree(module);
+    }
     LowIRRuntimeGen.buildRtMapHashSlot(module);
     LowIRRuntimeGen.buildRtMapPutAt(module);
     LowIRRuntimeGen.buildRtMapPut(module);
@@ -30456,6 +30479,20 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     const off = builder.emitZextI32ToPtr(offI32);
     return builder.emitBin("add", pt, base, off);
   };
+  LowIRRuntimeGen.emitFreePtr = function(builder, module, ptr) {
+    const pt = module.ptrType;
+    let args = [];
+    let argTypes = [];
+    args.push(ptr);
+    argTypes.push(pt);
+    if ( module.useLibcHeap ) {
+      builder.emitCall("free", "void", args, argTypes);
+      return;
+    }
+    if ( module.useFreeListHeap ) {
+      builder.emitCall("Heap_free", "void", args, argTypes);
+    }
+  };
   LowIRRuntimeGen.buildRtMapNew = function(module) {
     const builder = new LowIRBuilder(module);
     builder.reset();
@@ -30505,6 +30542,123 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     builder.startBlock(doneLabel);
     builder.terminateRet(pt, desc);
     LowIRRuntimeGen.finishFn(builder, module, "RtMap_new", pt, params, false);
+  };
+  LowIRRuntimeGen.buildRtMapGrow = function(module) {
+    const builder = new LowIRBuilder(module);
+    builder.reset();
+    const pt = module.ptrType;
+    const valsOff = LowIRRuntimeGen.mapValsOff(module);
+    const capOff = LowIRRuntimeGen.mapCapOff(module);
+    const sizeOff = LowIRRuntimeGen.mapSizeOff(module);
+    let params = [];
+    const descP = new LowIRParam();
+    descP.name = "desc";
+    descP.irType = pt;
+    params.push(descP);
+    builder.startBlock("entry");
+    const oldCap = LowIRRuntimeGen.emitCap(builder, module, "%desc");
+    const oldKeys = LowIRRuntimeGen.emitKeysPtr(builder, module, "%desc");
+    const oldVals = LowIRRuntimeGen.emitValsPtr(builder, module, "%desc");
+    const two = builder.emitConst("i32", "2");
+    const newCap = builder.emitBin("mul", "i32", oldCap, two);
+    const four = builder.emitConst("i32", "4");
+    const nbytes = builder.emitBin("mul", "i32", newCap, four);
+    const newKeys = builder.emitHeapAlloc(nbytes);
+    const newVals = builder.emitHeapAlloc(nbytes);
+    const zero = builder.emitConst("i32", "0");
+    const negOne = builder.emitConst("i32", "-1");
+    const iSlot = builder.freshTemp("i");
+    builder.emitAlloca("i32", iSlot);
+    builder.emitStore("i32", zero, iSlot);
+    const ic = builder.freshLabel("grow_init_cond");
+    const ib = builder.freshLabel("grow_init_body");
+    const idn = builder.freshLabel("grow_init_done");
+    builder.terminateBr(ic);
+    builder.startBlock(ic);
+    const iV = builder.emitLoad("i32", iSlot);
+    const iLt = builder.emitIcmp("slt", iV, newCap);
+    builder.terminateBrIf(iLt, ib, idn);
+    builder.startBlock(ib);
+    const nkp = LowIRRuntimeGen.emitSlotAddr(builder, module, newKeys, iV);
+    builder.emitPtrStoreTyped(nkp, negOne, "i32");
+    const one = builder.emitConst("i32", "1");
+    const iN = builder.emitBin("add", "i32", iV, one);
+    builder.emitStore("i32", iN, iSlot);
+    builder.terminateBr(ic);
+    builder.startBlock(idn);
+    builder.emitPtrStore("%desc", newKeys);
+    const valsFld = builder.emitConst(pt, ("" + valsOff));
+    const valsAddr = builder.emitBin("add", pt, "%desc", valsFld);
+    builder.emitPtrStore(valsAddr, newVals);
+    builder.emitStoreI32At("%desc", capOff, newCap);
+    builder.emitStoreI32At("%desc", sizeOff, zero);
+    const jSlot = builder.freshTemp("j");
+    builder.emitAlloca("i32", jSlot);
+    builder.emitStore("i32", zero, jSlot);
+    const rc = builder.freshLabel("grow_rehash_cond");
+    const rb = builder.freshLabel("grow_rehash_body");
+    const rd = builder.freshLabel("grow_rehash_done");
+    const rput = builder.freshLabel("grow_rehash_put");
+    const rinc = builder.freshLabel("grow_rehash_inc");
+    builder.terminateBr(rc);
+    builder.startBlock(rc);
+    const jV = builder.emitLoad("i32", jSlot);
+    const jLt = builder.emitIcmp("slt", jV, oldCap);
+    builder.terminateBrIf(jLt, rb, rd);
+    builder.startBlock(rb);
+    const okp = LowIRRuntimeGen.emitSlotAddr(builder, module, oldKeys, jV);
+    const k = builder.emitPtrLoadTyped(okp, "i32");
+    const notEmpty = builder.emitIcmp("ne", k, negOne);
+    builder.terminateBrIf(notEmpty, rput, rinc);
+    builder.startBlock(rput);
+    const ovp = LowIRRuntimeGen.emitSlotAddr(builder, module, oldVals, jV);
+    const v = builder.emitPtrLoadTyped(ovp, "i32");
+    let pargs = [];
+    let ptypes = [];
+    pargs.push("%desc");
+    ptypes.push(pt);
+    pargs.push(k);
+    ptypes.push("i32");
+    pargs.push(v);
+    ptypes.push("i32");
+    builder.emitCall("RtMap_put", "void", pargs, ptypes);
+    builder.terminateBr(rinc);
+    builder.startBlock(rinc);
+    const jOne = builder.emitConst("i32", "1");
+    const jN = builder.emitBin("add", "i32", jV, jOne);
+    builder.emitStore("i32", jN, jSlot);
+    builder.terminateBr(rc);
+    builder.startBlock(rd);
+    LowIRRuntimeGen.emitFreePtr(builder, module, oldKeys);
+    LowIRRuntimeGen.emitFreePtr(builder, module, oldVals);
+    builder.terminateRet("void", "");
+    LowIRRuntimeGen.finishFn(builder, module, "RtMap_grow", "void", params, false);
+  };
+  LowIRRuntimeGen.buildRtMapFree = function(module) {
+    const builder = new LowIRBuilder(module);
+    builder.reset();
+    const pt = module.ptrType;
+    let params = [];
+    const descP = new LowIRParam();
+    descP.name = "desc";
+    descP.irType = pt;
+    params.push(descP);
+    builder.startBlock("entry");
+    const zero = builder.emitConst(pt, "0");
+    const isNull = builder.emitIcmp("eq", "%desc", zero);
+    const retLabel = builder.freshLabel("mapfree_ret");
+    const bodyLabel = builder.freshLabel("mapfree_body");
+    builder.terminateBrIf(isNull, retLabel, bodyLabel);
+    builder.startBlock(bodyLabel);
+    const keys = LowIRRuntimeGen.emitKeysPtr(builder, module, "%desc");
+    const vals = LowIRRuntimeGen.emitValsPtr(builder, module, "%desc");
+    LowIRRuntimeGen.emitFreePtr(builder, module, keys);
+    LowIRRuntimeGen.emitFreePtr(builder, module, vals);
+    LowIRRuntimeGen.emitFreePtr(builder, module, "%desc");
+    builder.terminateRet("void", "");
+    builder.startBlock(retLabel);
+    builder.terminateRet("void", "");
+    LowIRRuntimeGen.finishFn(builder, module, "RtMap_free", "void", params, false);
   };
   LowIRRuntimeGen.buildRtMapHashSlot = function(module) {
     const builder = new LowIRBuilder(module);
@@ -30556,12 +30710,18 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     valP.name = "val";
     valP.irType = "i32";
     params.push(valP);
+    const retLabel = builder.freshLabel("putat_ret");
+    const bodyLabel = builder.freshLabel("putat_body");
+    const updLabel = builder.freshLabel("putat_upd");
+    const checkEmpty = builder.freshLabel("putat_chk");
+    const emptyLabel = builder.freshLabel("putat_empty");
+    const recurseLabel = builder.freshLabel("putat_rec");
     builder.startBlock("entry");
     const cap = LowIRRuntimeGen.emitCap(builder, module, "%desc");
     const geCap = builder.emitIcmp("sge", "%slot", cap);
-    const retLabel = builder.freshLabel("putat_ret");
-    const bodyLabel = builder.freshLabel("putat_body");
     builder.terminateBrIf(geCap, retLabel, bodyLabel);
+    builder.startBlock(retLabel);
+    builder.terminateRet("void", "");
     builder.startBlock(bodyLabel);
     const keysPtr = LowIRRuntimeGen.emitKeysPtr(builder, module, "%desc");
     const valsPtr = LowIRRuntimeGen.emitValsPtr(builder, module, "%desc");
@@ -30570,11 +30730,10 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     const k = builder.emitPtrLoadTyped(kp, "i32");
     const negOne = builder.emitConst("i32", "-1");
     const eqKey = builder.emitIcmp("eq", k, "%key");
-    const updLabel = builder.freshLabel("putat_upd");
-    const emptyLabel = builder.freshLabel("putat_empty");
-    const recurseLabel = builder.freshLabel("putat_rec");
-    const checkEmpty = builder.freshLabel("putat_chk");
     builder.terminateBrIf(eqKey, updLabel, checkEmpty);
+    builder.startBlock(updLabel);
+    builder.emitPtrStoreTyped(vp, "%val", "i32");
+    builder.terminateRet("void", "");
     builder.startBlock(checkEmpty);
     const isEmpty = builder.emitIcmp("eq", k, negOne);
     builder.terminateBrIf(isEmpty, emptyLabel, recurseLabel);
@@ -30585,9 +30744,6 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     const one = builder.emitConst("i32", "1");
     const newSize = builder.emitBin("add", "i32", size, one);
     builder.emitStoreI32At("%desc", sizeOff, newSize);
-    builder.terminateRet("void", "");
-    builder.startBlock(updLabel);
-    builder.emitPtrStoreTyped(vp, "%val", "i32");
     builder.terminateRet("void", "");
     builder.startBlock(recurseLabel);
     const one2 = builder.emitConst("i32", "1");
@@ -30604,8 +30760,6 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     args.push("%val");
     argTypes.push("i32");
     builder.emitCall("RtMap_putAt", "void", args, argTypes);
-    builder.terminateRet("void", "");
-    builder.startBlock(retLabel);
     builder.terminateRet("void", "");
     LowIRRuntimeGen.finishFn(builder, module, "RtMap_putAt", "void", params, false);
   };
@@ -30627,6 +30781,32 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     valP.irType = "i32";
     params.push(valP);
     builder.startBlock("entry");
+    const guardKey = builder.emitConst("i32", "-1");
+    const isSentinel = builder.emitIcmp("eq", "%key", guardKey);
+    const sentinelRet = builder.freshLabel("put_sentinel_ret");
+    const putGo = builder.freshLabel("put_go");
+    builder.terminateBrIf(isSentinel, sentinelRet, putGo);
+    builder.startBlock(sentinelRet);
+    builder.terminateRet("void", "");
+    builder.startBlock(putGo);
+    if ( module.useFreeListHeap ) {
+      const size0 = LowIRRuntimeGen.emitSize(builder, module, "%desc");
+      const cap0 = LowIRRuntimeGen.emitCap(builder, module, "%desc");
+      const twoG = builder.emitConst("i32", "2");
+      const sz2 = builder.emitBin("mul", "i32", size0, twoG);
+      const full = builder.emitIcmp("sge", sz2, cap0);
+      const growLabel = builder.freshLabel("put_grow");
+      const contLabel = builder.freshLabel("put_cont");
+      builder.terminateBrIf(full, growLabel, contLabel);
+      builder.startBlock(growLabel);
+      let gargs = [];
+      let gtypes = [];
+      gargs.push("%desc");
+      gtypes.push(pt);
+      builder.emitCall("RtMap_grow", "void", gargs, gtypes);
+      builder.terminateBr(contLabel);
+      builder.startBlock(contLabel);
+    }
     let hashArgs = [];
     let hashTypes = [];
     hashArgs.push("%desc");
@@ -30665,32 +30845,37 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     keyP.name = "key";
     keyP.irType = "i32";
     params.push(keyP);
+    const negRet1 = builder.freshLabel("getat_neg1");
+    const bodyLabel = builder.freshLabel("getat_body");
+    const negRet2 = builder.freshLabel("getat_neg2");
+    const keyCheck = builder.freshLabel("getat_key");
+    const valRet = builder.freshLabel("getat_val");
+    const recurseRet = builder.freshLabel("getat_rec");
     builder.startBlock("entry");
     const cap = LowIRRuntimeGen.emitCap(builder, module, "%desc");
     const negOne = builder.emitConst("i32", "-1");
-    const negRet = builder.freshLabel("getat_neg");
-    const bodyLabel = builder.freshLabel("getat_body");
     const geCap = builder.emitIcmp("sge", "%slot", cap);
-    builder.terminateBrIf(geCap, negRet, bodyLabel);
+    builder.terminateBrIf(geCap, negRet1, bodyLabel);
+    builder.startBlock(negRet1);
+    const negOne1 = builder.emitConst("i32", "-1");
+    builder.terminateRet("i32", negOne1);
     builder.startBlock(bodyLabel);
     const keysPtr = LowIRRuntimeGen.emitKeysPtr(builder, module, "%desc");
     const kp = LowIRRuntimeGen.emitSlotAddr(builder, module, keysPtr, "%slot");
     const k = builder.emitPtrLoadTyped(kp, "i32");
     const isEmpty = builder.emitIcmp("eq", k, negOne);
-    const keyCheck = builder.freshLabel("getat_key");
-    builder.terminateBrIf(isEmpty, negRet, keyCheck);
+    builder.terminateBrIf(isEmpty, negRet2, keyCheck);
+    builder.startBlock(negRet2);
+    const negOne2 = builder.emitConst("i32", "-1");
+    builder.terminateRet("i32", negOne2);
     builder.startBlock(keyCheck);
     const eqKey = builder.emitIcmp("eq", k, "%key");
-    const valRet = builder.freshLabel("getat_val");
-    const recurseRet = builder.freshLabel("getat_rec");
     builder.terminateBrIf(eqKey, valRet, recurseRet);
     builder.startBlock(valRet);
     const valsPtr = LowIRRuntimeGen.emitValsPtr(builder, module, "%desc");
     const vp = LowIRRuntimeGen.emitSlotAddr(builder, module, valsPtr, "%slot");
     const v = builder.emitPtrLoadTyped(vp, "i32");
     builder.terminateRet("i32", v);
-    builder.startBlock(negRet);
-    builder.terminateRet("i32", negOne);
     builder.startBlock(recurseRet);
     const one = builder.emitConst("i32", "1");
     const nextSlot = builder.emitBin("add", "i32", "%slot", one);
@@ -32657,6 +32842,9 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     bindCollectionSlot (varName, kind, desc, lctx) {
       this.bindSlot(varName, lctx.ptrType, desc, lctx);
       lctx.collectionSlots[varName] = kind;
+      if ( this.wasmCollectionRcEnabled(lctx) ) {
+        lctx.ownedCollectionLocals.push(varName);
+      }
     };
     loadCollectionDesc (varName, lctx) {
       return this.loadSlot(varName, lctx.ptrType, lctx);
@@ -33981,7 +34169,11 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       let argTypes = [];
       args.push(desc);
       argTypes.push(lctx.ptrType);
-      lctx.builder.emitCall("ranger_ptrarray_release", "void", args, argTypes);
+      let relFn = "ranger_ptrarray_release";
+      if ( this.collectionKind(varName, lctx) == "map" ) {
+        relFn = "RtMap_free";
+      }
+      lctx.builder.emitCall(relFn, "void", args, argTypes);
     };
     emitOwnedStringInit (varName, valNode, strPtr, lctx) {
       if ( this.wasmStrEnabled(lctx) == false ) {
@@ -35240,6 +35432,16 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           const val_1 = this.lowerExpr((argsNode.children[1]), lctx);
           builder.emitPtrStore8(ptr_3, val_1);
           return handledVoid;
+        }
+        return notIntrinsic;
+      }
+      if ( fnName == "Mem_memSize" ) {
+        return builder.emitMemSize();
+      }
+      if ( fnName == "Mem_memGrow" ) {
+        if ( (argsNode.children.length) > 0 ) {
+          const pages = this.lowerExpr((argsNode.children[0]), lctx);
+          return builder.emitMemGrow(pages);
         }
         return notIntrinsic;
       }
@@ -36546,6 +36748,15 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           this.writeGet(ins.arg1, wr);
           this.writeGet(ins.arg2, wr);
           wr.out("      i32.store8", true);
+          break;
+        case "mem_size" : 
+          wr.out("      memory.size", true);
+          wr.out("      local.set " + this.wasmName(ins.dest), true);
+          break;
+        case "mem_grow" : 
+          this.writeGet(ins.arg1, wr);
+          wr.out("      memory.grow", true);
+          wr.out("      local.set " + this.wasmName(ins.dest), true);
           break;
         case "inttoptr_struct" : 
           this.writeGet(ins.arg1, wr);

--- a/compiler/ng_LowIR.rgr
+++ b/compiler/ng_LowIR.rgr
@@ -615,6 +615,20 @@ class LowIRBuilder {
     return dest
   }
 
+  ; Address of a class type descriptor in the static data segment (WASM). The
+  ; writer resolves the class name to the descriptor's data-segment address.
+  fn emitTypeDescPtr:string (className:string) {
+    def tag:string "td"
+    def dest (this.freshTemp(tag))
+    def ins@(lives):LowIRInstr (new LowIRInstr())
+    ins.op = "typedesc_ptr"
+    ins.dest = dest
+    ins.irType = "i32"
+    ins.arg1 = className
+    this.emit(ins)
+    return dest
+  }
+
   fn terminateRet:void (retType:string value:string) {
     def cur (unwrap this.currentBlock)
     cur.termKind = "ret"

--- a/compiler/ng_LowIR.rgr
+++ b/compiler/ng_LowIR.rgr
@@ -189,6 +189,11 @@ class LowIRModule {
   def triple:string "unknown-unknown-unknown"
   def ptrType:string "i32"
   def useLibcHeap:boolean false
+  ; freestanding WASM under -wasmrc: route heap_alloc through the free-list Heap
+  ; (Heap_alloc/Heap_free) so collections share the one coherent heap that
+  ; objects and strings use — not the leak-forever bump pointer, which would also
+  ; collide with the free-list control words at Mem[0]/Mem[4].
+  def useFreeListHeap:boolean false
   def structs:[LowIRStruct]
   def typeDescs:[LowIRTypeDesc]
   def functions:[LowIRFunction]
@@ -447,6 +452,16 @@ class LowIRBuilder {
       push args sizeArg
       push argTypes ptrType
       return (this.emitCall("calloc" ptrType args argTypes))
+    }
+    ; freestanding WASM under -wasmrc: allocate from the free-list Heap so the
+    ; block can later be freed (Heap.alloc zeroes nothing, but collection/new
+    ; code initialises what it needs). One coherent heap for all allocation.
+    if this.irModule.useFreeListHeap {
+      def hargs:[string]
+      def hargTypes:[string]
+      push hargs sizeArg
+      push hargTypes "i32"
+      return (this.emitCall("Heap_calloc" ptrType hargs hargTypes))
     }
     def tag:string "h"
     def dest (this.freshTemp(tag))

--- a/compiler/ng_LowIR.rgr
+++ b/compiler/ng_LowIR.rgr
@@ -597,6 +597,30 @@ class LowIRBuilder {
     this.emit(ins)
   }
 
+  ; current linear-memory size in 64 KiB pages (wasm memory.size)
+  fn emitMemSize:string () {
+    def dest (this.freshTemp("m"))
+    def ins@(lives):LowIRInstr (new LowIRInstr())
+    ins.op = "mem_size"
+    ins.dest = dest
+    ins.irType = "i32"
+    this.emit(ins)
+    return dest
+  }
+
+  ; grow linear memory by `pages` 64 KiB pages; result = previous page count, or
+  ; -1 on failure (wasm memory.grow)
+  fn emitMemGrow:string (pages:string) {
+    def dest (this.freshTemp("m"))
+    def ins@(lives):LowIRInstr (new LowIRInstr())
+    ins.op = "mem_grow"
+    ins.dest = dest
+    ins.irType = "i32"
+    ins.arg1 = pages
+    this.emit(ins)
+    return dest
+  }
+
   fn emitI32At:string (base:string byteOff:int) {
     def pt (this.irModule.ptrType)
     def off (this.emitConst(pt ("" + byteOff)))

--- a/compiler/ng_LowIR.rgr
+++ b/compiler/ng_LowIR.rgr
@@ -560,6 +560,28 @@ class LowIRBuilder {
     this.emit(ins)
   }
 
+  fn emitPtrLoad8:string (ptr:string) {
+    def dest (this.freshTemp("m"))
+    def ins@(lives):LowIRInstr (new LowIRInstr())
+    ins.op = "ptr_load8"
+    ins.dest = dest
+    ins.irType = "i32"
+    ins.arg1 = ptr
+    this.emit(ins)
+    return dest
+  }
+
+  fn emitPtrStore8:void (ptr:string value:string) {
+    def n (this.tempCounter)
+    this.tempCounter = n + 1
+    def ins@(lives):LowIRInstr (new LowIRInstr())
+    ins.op = "ptr_store8"
+    ins.dest = ("ps" + ("" + n))
+    ins.arg1 = ptr
+    ins.arg2 = value
+    this.emit(ins)
+  }
+
   fn emitI32At:string (base:string byteOff:int) {
     def pt (this.irModule.ptrType)
     def off (this.emitConst(pt ("" + byteOff)))

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -3270,6 +3270,17 @@ class LowIRBuilderPass {
     }
     if (has lctx.slots varName) {
       def slot (unwrap (get lctx.slots varName))
+      ; release-before-reassign: `x = (new T)` on an owned object local must free
+      ; the previous object first (the new one is already allocated in `tmp`).
+      ; releaseOwnedLocal self-gates on objRcEnabled + escaped, and loads the
+      ; slot's current (old) value.
+      if (rhs.hasNewOper) {
+        if (has lctx.objectSlots varName) {
+          if (this.isOwnedObjectLocal(varName lctx)) {
+            this.releaseOwnedLocal(varName lctx)
+          }
+        }
+      }
       def storeType (irType)
       if (has lctx.slotTypes varName) {
         storeType = (unwrap (get lctx.slotTypes varName))

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -2302,18 +2302,23 @@ class LowIRBuilderPass {
   }
 
   fn emitReleaseFieldValue:void (className:string fieldName:string rawVal:string lctx:LowIRLowerContext) {
-    if (this.memEnabled(lctx) == false) {
-      return
-    }
     def builder (lctx.builder)
     def voidType:string "void"
     def args:[string]
     def argTypes:[string]
+    ; string fields carry a dup'd private copy on both the libc (memEnabled) and
+    ; freestanding-WASM (wasmStrEnabled) paths, so both release it on overwrite.
     if (this.fieldIsStringSlot(className fieldName)) {
-      def i8p (builder.emitIntToI8Ptr(rawVal lctx.ptrType))
-      push args i8p
-      push argTypes "i8*"
-      builder.emitCall("ranger_str_release" voidType args argTypes)
+      if ((this.memEnabled(lctx)) || (this.wasmStrEnabled(lctx))) {
+        def i8p (builder.emitIntToI8Ptr(rawVal lctx.ptrType))
+        push args i8p
+        push argTypes "i8*"
+        builder.emitCall("ranger_str_release" voidType args argTypes)
+      }
+      return
+    }
+    ; remaining field kinds (buffer) are libc-only
+    if (this.memEnabled(lctx) == false) {
       return
     }
     if (this.fieldIsBufferSlot(className fieldName)) {
@@ -2336,6 +2341,17 @@ class LowIRBuilderPass {
     if (this.memEnabled(lctx)) {
       def oldRaw (builder.emitLoad(ftype fieldPtr))
       this.emitReleaseFieldValue(className fieldName oldRaw lctx)
+    } {
+      ; freestanding WASM string RC: free the old string this field held before
+      ; overwriting it (the field owns a dup'd copy). Object/buffer fields stay
+      ; libc-only. Field is zero-initialised by obj_new, so the first store sees
+      ; 0 and str_release is a no-op.
+      if (this.wasmStrEnabled(lctx)) {
+        if (this.fieldIsStringSlot(className fieldName)) {
+          def oldRawW (builder.emitLoad(ftype fieldPtr))
+          this.emitReleaseFieldValue(className fieldName oldRawW lctx)
+        }
+      }
     }
     def storeVal:string value
     if (this.fieldIsStringSlot(className fieldName)) {
@@ -2647,6 +2663,22 @@ class LowIRBuilderPass {
     return 0
   }
 
+  ; True when the class has at least one owned field (a string field today;
+  ; object/ptr-array fields are borrow until borrow analysis promotes them), so
+  ; its objects need a type descriptor for recursive destruction on WASM.
+  fn classHasOwnedFields:boolean (className:string) {
+    for this.irModule.typeDescs td:LowIRTypeDesc i {
+      if (td.className == className) {
+        for td.fields fd:LowIRTypeFieldDesc j {
+          if (fd.owned == 1) {
+            return true
+          }
+        }
+      }
+    }
+    return false
+  }
+
   fn lowerNewObject:string (className:string argsNode:CodeNode lctx:LowIRLowerContext) {
     def builder (lctx.builder)
     def byteCnt (this.structByteSize(className this.irModule))
@@ -2675,15 +2707,22 @@ class LowIRBuilderPass {
       heapAddr = (builder.emitCallWithSig("ranger_obj_new" lctx.ptrType newSig newArgs newArgTypes))
     } {
       if (this.objRcEnabled(lctx)) {
-        ; WASM free-list RC: ranger_obj_new(size, typeDesc). typeDesc = 0 in v1
-        ; (no owned-field recursion yet); the runtime prepends the rc/size/type
+        ; WASM free-list RC: ranger_obj_new(size, typeDesc). typeDesc points at
+        ; the class descriptor in the static data segment when the class has
+        ; owned (string) fields, so obj_release -> destroyFields frees them; 0
+        ; otherwise (nothing to recurse). The runtime prepends the rc/size/type
         ; header and returns the body pointer.
-        def zeroTd (builder.emitConst("i32" "0"))
+        def tdArg:string ""
+        if (this.classHasOwnedFields(className)) {
+          tdArg = (builder.emitTypeDescPtr(className))
+        } {
+          tdArg = (builder.emitConst("i32" "0"))
+        }
         def wArgs:[string]
         def wArgTypes:[string]
         push wArgs bytes
         push wArgTypes "i32"
-        push wArgs zeroTd
+        push wArgs tdArg
         push wArgTypes "i32"
         heapAddr = (builder.emitCall("ranger_obj_new" lctx.ptrType wArgs wArgTypes))
       } {
@@ -3511,16 +3550,10 @@ class LowIRBuilderPass {
               }
             }
           }
-          ; Storing an owned string local into a string field: the field now
-          ; references its buffer, so it must not be freed at scope end. Mark it
-          ; escaped (conservatively leaks; field-owned string RC is future work).
-          if (this.fieldIsStringSlot(cls fld)) {
-            if (rhs.value_type == RangerNodeType.VRef) {
-              if (this.isOwnedStringLocal(rhs.vref lctx)) {
-                set lctx.escapedLocals rhs.vref "1"
-              }
-            }
-          }
+          ; A string field takes a dup'd private copy (emitFieldStoreOn), so an
+          ; owned string local stored into it is NOT consumed — it keeps its own
+          ; buffer and is still released normally at scope end. The field's copy
+          ; is freed on overwrite and by the object destructor (typedesc kind 0).
           this.emitFieldStoreOn(cls sptr fld tmp lctx)
           return
         }

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -16,6 +16,7 @@ class LowIRLowerContext {
   def ownedObjectLocals:[string]
   def ownedCollectionLocals:[string]
   def ownedStringLocals:[string]
+  def pendingStringTemps:[string]
   def escapedLocals:[string:string]
   def currentRetType:string "i32"
   def llvmRetType:string "i32"
@@ -638,29 +639,19 @@ class LowIRBuilderPass {
       push cargs sb
       push cargTypes "i8*"
       def cres (builder.emitCall("ranger_str_concat" "i8*" cargs cargTypes))
-      ; free the intermediate string temporaries: int->string conversions we just
-      ; allocated (aStr/bStr == false), and fresh nested operands (a concat/
-      ; to_string result). Borrowed operands (literal/VRef/field) are left alone —
-      ; str_release is a no-op for static-literal pointers, and freeing a VRef
-      ; would double-free the local that owns it. concat already copied the bytes.
-      def freeA (aStr == false)
-      if aStr {
-        if (this.exprIsFreshString(aNode lctx)) {
-          freeA = true
-        }
+      ; register the intermediates + result with the statement arena. The
+      ; int->string conversions we just allocated (aStr/bStr == false) are fresh;
+      ; a fresh nested operand (concat/to_string result) is already pending from
+      ; its own producer, so it is not re-registered. Borrowed operands
+      ; (literal/VRef/field) are never registered. Everything unclaimed is freed
+      ; at statement end (concat already copied the bytes into `cres`).
+      if (aStr == false) {
+        this.registerFreshStringTemp(sa lctx)
       }
-      if freeA {
-        this.emitStrReleasePtr(sa lctx)
+      if (bStr == false) {
+        this.registerFreshStringTemp(sb lctx)
       }
-      def freeB (bStr == false)
-      if bStr {
-        if (this.exprIsFreshString(bNode lctx)) {
-          freeB = true
-        }
-      }
-      if freeB {
-        this.emitStrReleasePtr(sb lctx)
-      }
+      this.registerFreshStringTemp(cres lctx)
       return cres
     }
     def sz (builder.emitConst("i32" "4096"))
@@ -1497,7 +1488,9 @@ class LowIRBuilderPass {
       def sargTypes:[string]
       push sargs iv
       push sargTypes "i32"
-      return (builder.emitCall("ranger_str_from_int" "i8*" sargs sargTypes))
+      def sres (builder.emitCall("ranger_str_from_int" "i8*" sargs sargTypes))
+      this.registerFreshStringTemp(sres lctx)
+      return sres
     }
     def sz (builder.emitConst("i32" "64"))
     def raw (builder.emitHeapAlloc(sz))
@@ -2790,6 +2783,8 @@ class LowIRBuilderPass {
     lctx.ownedCollectionLocals = emptyColl
     def emptyStr:[string]
     lctx.ownedStringLocals = emptyStr
+    def emptyPending:[string]
+    lctx.pendingStringTemps = emptyPending
     def emptyEscaped:[string:string]
     lctx.escapedLocals = emptyEscaped
     if isInstance {
@@ -2956,6 +2951,60 @@ class LowIRBuilderPass {
     return false
   }
 
+  ; --- fresh-string temp arena (statement-scoped) -------------------------
+  ; A fresh heap string produced mid-expression (concat/to_string/string-call)
+  ; that is not (yet) owned by a local. Registered here, then either CLAIMED by
+  ; an owner (assigned to a local, or returned/escaped) or FLUSHED at statement
+  ; end. This frees inline throwaways like `host.drawText("S " + n)` — the concat
+  ; result and its int->string temporaries — every statement, so a frame loop
+  ; stays heap-flat without the value ever being bound to a named local.
+  fn registerFreshStringTemp:void (tmp:string lctx:LowIRLowerContext) {
+    if (this.wasmStrEnabled(lctx) == false) {
+      return
+    }
+    push lctx.pendingStringTemps tmp
+  }
+
+  ; the temp became owned (moved to a local) or escaped (returned) -> drop it
+  ; from the pending set so it is not double-freed at statement end.
+  fn claimStringTemp:void (tmp:string lctx:LowIRLowerContext) {
+    if (this.wasmStrEnabled(lctx) == false) {
+      return
+    }
+    def kept:[string]
+    for lctx.pendingStringTemps t:string i {
+      if (t != tmp) {
+        push kept t
+      }
+    }
+    lctx.pendingStringTemps = kept
+  }
+
+  ; release + drop every pending temp registered since `mark`. Emits into the
+  ; current block, so callers must flush while the temps still dominate (i.e. at
+  ; the end of the linear statement / condition that produced them).
+  fn flushStringTempsFrom:void (mark:int lctx:LowIRLowerContext) {
+    if (this.wasmStrEnabled(lctx) == false) {
+      return
+    }
+    def n (array_length lctx.pendingStringTemps)
+    if (n <= mark) {
+      return
+    }
+    def k mark
+    while (< k n) {
+      this.emitStrReleasePtr((itemAt lctx.pendingStringTemps k) lctx)
+      k = (+ k 1)
+    }
+    def kept:[string]
+    def j 0
+    while (< j mark) {
+      push kept (itemAt lctx.pendingStringTemps j)
+      j = (+ j 1)
+    }
+    lctx.pendingStringTemps = kept
+  }
+
   ; free a bare string pointer (an intermediate temporary) via ranger_str_release
   fn emitStrReleasePtr:void (ptr:string lctx:LowIRLowerContext) {
     def args:[string]
@@ -2996,6 +3045,10 @@ class LowIRBuilderPass {
     def owned strPtr
     if ((this.exprIsFreshString(valNode lctx)) == false) {
       owned = (this.emitStrdupExpr(strPtr lctx))
+    } {
+      ; owning a fresh temp directly: move it out of the statement arena so it is
+      ; not double-freed (the local's scope-end release now owns its lifetime).
+      this.claimStringTemp(strPtr lctx)
     }
     if (this.isOwnedStringLocal(varName lctx) == false) {
       push lctx.ownedStringLocals varName
@@ -3017,6 +3070,8 @@ class LowIRBuilderPass {
     def owned strPtr
     if ((this.exprIsFreshString(valNode lctx)) == false) {
       owned = (this.emitStrdupExpr(strPtr lctx))
+    } {
+      this.claimStringTemp(strPtr lctx)
     }
     if (this.isOwnedStringLocal(varName lctx) == false) {
       push lctx.ownedStringLocals varName
@@ -3137,7 +3192,32 @@ class LowIRBuilderPass {
     return (fc.vref == "=")
   }
 
+  ; Statement wrapper: after a leaf statement lowers, release the fresh-string
+  ; temporaries it produced but nobody claimed (inline throwaways such as
+  ; `host.drawText("S " + n)`), so a frame loop stays heap-flat. Statements that
+  ; terminate the block (return) or open nested regions (if/while/for) manage
+  ; their own temps and their condition flush; here the current block is either
+  ; terminated (skip — cannot emit past a terminator) or the range is already
+  ; empty, so this flush is a safe leaf-only cleanup.
   fn lowerStmt:void (node:CodeNode lctx:LowIRLowerContext) {
+    if node.disabled_node {
+      return
+    }
+    if (this.wasmStrEnabled(lctx) == false) {
+      this.lowerStmtDispatch(node lctx)
+      return
+    }
+    def strMark (array_length lctx.pendingStringTemps)
+    this.lowerStmtDispatch(node lctx)
+    if (!null? lctx.builder.currentBlock) {
+      def curBlock (unwrap lctx.builder.currentBlock)
+      if (curBlock.termKind == "") {
+        this.flushStringTempsFrom(strMark lctx)
+      }
+    }
+  }
+
+  fn lowerStmtDispatch:void (node:CodeNode lctx:LowIRLowerContext) {
     if node.disabled_node {
       return
     }
@@ -3500,6 +3580,11 @@ class LowIRBuilderPass {
       } {
         tmp = (this.lowerExpr(valNode lctx))
       }
+      ; the returned value escapes to the caller: claim it out of the statement
+      ; arena so it is not freed, then release the remaining intermediates (e.g.
+      ; the int->string temps of `return ("a" + n)`) before the terminator.
+      this.claimStringTemp(tmp lctx)
+      this.flushStringTempsFrom(0 lctx)
       this.emitReleaseOwnedLocals(lctx)
       builder.terminateRet(retType tmp)
     } {
@@ -3666,7 +3751,12 @@ class LowIRBuilderPass {
     def builder (lctx.builder)
     def condNode (node.getSecond())
     def thenNode (node.getThird())
+    def condMark (array_length lctx.pendingStringTemps)
     def cond (this.lowerCond(condNode lctx))
+    ; a fresh string temp built in the condition (e.g. (("a"+x) == y)) is dead
+    ; once the i1 is computed; free it here, in the pre-branch block where it is
+    ; still valid, rather than leaking to the merge block.
+    this.flushStringTempsFrom(condMark lctx)
     def thenTag:string "then"
     def elseTag:string "else"
     def mergeTag:string "merge"
@@ -3723,7 +3813,11 @@ class LowIRBuilderPass {
 
     builder.terminateBr(condLabel)
     builder.startBlock(condLabel)
+    def condMark (array_length lctx.pendingStringTemps)
     def cond (this.lowerCond(condNode lctx))
+    ; free per-iteration condition string temps in the condition block (runs each
+    ; iteration), so a loop whose test builds a string doesn't leak every turn.
+    this.flushStringTempsFrom(condMark lctx)
     builder.terminateBrIf(cond bodyLabel exitLabel)
 
     ; snapshot owned-object and owned-string locals so any declared INSIDE the
@@ -4070,12 +4164,11 @@ class LowIRBuilderPass {
         }
       }
     }
-    ; a string-returning call: the returned buffer is the caller's to own
-    if (exprNode.has_call || exprNode.is_direct_method_call || exprNode.hasFnCall) {
-      if (this.exprIsStringish(exprNode lctx)) {
-        return true
-      }
-    }
+    ; A string-returning call is deliberately NOT treated as fresh. The return
+    ; path does not dup, so a getter (`return this.name`) hands back a borrowed
+    ; field pointer; owning+freeing it would dangle the field. Duping the result
+    ; (the not-fresh path) is always safe — at worst it leaks a genuinely fresh
+    ; callee result, which is recoverable, whereas a wrong free corrupts memory.
     return false
   }
 

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -15,6 +15,7 @@ class LowIRLowerContext {
   def ptrArrayElemTypes:[string:string]
   def ownedObjectLocals:[string]
   def ownedCollectionLocals:[string]
+  def ownedStringLocals:[string]
   def escapedLocals:[string:string]
   def currentRetType:string "i32"
   def llvmRetType:string "i32"
@@ -636,7 +637,31 @@ class LowIRBuilderPass {
       push cargTypes "i8*"
       push cargs sb
       push cargTypes "i8*"
-      return (builder.emitCall("ranger_str_concat" "i8*" cargs cargTypes))
+      def cres (builder.emitCall("ranger_str_concat" "i8*" cargs cargTypes))
+      ; free the intermediate string temporaries: int->string conversions we just
+      ; allocated (aStr/bStr == false), and fresh nested operands (a concat/
+      ; to_string result). Borrowed operands (literal/VRef/field) are left alone —
+      ; str_release is a no-op for static-literal pointers, and freeing a VRef
+      ; would double-free the local that owns it. concat already copied the bytes.
+      def freeA (aStr == false)
+      if aStr {
+        if (this.exprIsFreshString(aNode lctx)) {
+          freeA = true
+        }
+      }
+      if freeA {
+        this.emitStrReleasePtr(sa lctx)
+      }
+      def freeB (bStr == false)
+      if bStr {
+        if (this.exprIsFreshString(bNode lctx)) {
+          freeB = true
+        }
+      }
+      if freeB {
+        this.emitStrReleasePtr(sb lctx)
+      }
+      return cres
     }
     def sz (builder.emitConst("i32" "4096"))
     def raw (builder.emitHeapAlloc(sz))
@@ -2763,6 +2788,8 @@ class LowIRBuilderPass {
     lctx.ownedObjectLocals = emptyOwned
     def emptyColl:[string]
     lctx.ownedCollectionLocals = emptyColl
+    def emptyStr:[string]
+    lctx.ownedStringLocals = emptyStr
     def emptyEscaped:[string:string]
     lctx.escapedLocals = emptyEscaped
     if isInstance {
@@ -2916,6 +2943,87 @@ class LowIRBuilderPass {
     builder.emitCall("ranger_obj_release" voidType args argTypes)
   }
 
+  ; --- string RC (freestanding WASM, -wasmrc) ------------------------------
+  ; Games churn temporary strings ("SCORE " + n) every frame; without release
+  ; the heap grows unbounded. Owned string locals are released at scope end via
+  ; ranger_str_release (a no-op for static literal pointers below the heap base).
+  fn isOwnedStringLocal:boolean (varName:string lctx:LowIRLowerContext) {
+    for lctx.ownedStringLocals n:string i {
+      if (n == varName) {
+        return true
+      }
+    }
+    return false
+  }
+
+  ; free a bare string pointer (an intermediate temporary) via ranger_str_release
+  fn emitStrReleasePtr:void (ptr:string lctx:LowIRLowerContext) {
+    def args:[string]
+    def argTypes:[string]
+    push args ptr
+    push argTypes "i8*"
+    lctx.builder.emitCall("ranger_str_release" "void" args argTypes)
+  }
+
+  fn releaseOwnedString:void (varName:string lctx:LowIRLowerContext) {
+    if (this.wasmStrEnabled(lctx) == false) {
+      return
+    }
+    if (has lctx.escapedLocals varName) {
+      return
+    }
+    if (false == (has lctx.slots varName)) {
+      return
+    }
+    def builder (lctx.builder)
+    def voidType:string "void"
+    def val (this.loadSlot(varName "i8*" lctx))
+    def args:[string]
+    def argTypes:[string]
+    push args val
+    push argTypes "i8*"
+    builder.emitCall("ranger_str_release" voidType args argTypes)
+  }
+
+  ; Prepare a string value for a freshly-defined owned local and register it for
+  ; scope-end release. Fresh strings (concat/to_string/string-call) are owned
+  ; directly; borrowed ones (literal/VRef/field) are dup'd so the local owns a
+  ; private copy. Non-wasm targets keep the legacy always-dup behaviour.
+  fn emitOwnedStringInit:string (varName:string valNode:CodeNode strPtr:string lctx:LowIRLowerContext) {
+    if (this.wasmStrEnabled(lctx) == false) {
+      return (this.emitStrdupExpr(strPtr lctx))
+    }
+    def owned strPtr
+    if ((this.exprIsFreshString(valNode lctx)) == false) {
+      owned = (this.emitStrdupExpr(strPtr lctx))
+    }
+    if (this.isOwnedStringLocal(varName lctx) == false) {
+      push lctx.ownedStringLocals varName
+    }
+    return owned
+  }
+
+  ; Reassignment of an owned string local: free the previous buffer first, then
+  ; own the new value (fresh directly, borrowed dup'd). `strPtr` already holds the
+  ; new value, computed independently of the old slot, so freeing old is safe
+  ; even for `s = (s + "x")` (concat copied the old bytes into a fresh buffer).
+  fn emitOwnedStringReassign:string (varName:string valNode:CodeNode strPtr:string lctx:LowIRLowerContext) {
+    if (this.wasmStrEnabled(lctx) == false) {
+      return (this.emitStrdupExpr(strPtr lctx))
+    }
+    if (this.isOwnedStringLocal(varName lctx)) {
+      this.releaseOwnedString(varName lctx)
+    }
+    def owned strPtr
+    if ((this.exprIsFreshString(valNode lctx)) == false) {
+      owned = (this.emitStrdupExpr(strPtr lctx))
+    }
+    if (this.isOwnedStringLocal(varName lctx) == false) {
+      push lctx.ownedStringLocals varName
+    }
+    return owned
+  }
+
   fn strictOwnershipEnabled:boolean (lctx:LowIRLowerContext) {
     def ctx (unwrap lctx.ctx)
     return (ctx.hasCompilerFlag("strict-ownership"))
@@ -2958,6 +3066,11 @@ class LowIRBuilderPass {
     }
     for lctx.ownedObjectLocals name:string i {
       this.releaseOwnedLocal(name lctx)
+    }
+    ; owned string locals (freestanding WASM): free per-scope temporaries so a
+    ; frame's throwaway strings don't accumulate on the heap.
+    for lctx.ownedStringLocals sname:string si {
+      this.releaseOwnedString(sname lctx)
     }
     ; owned collections need the ptr-array runtime, which is libc-only for now
     ; (WASM string/array RC is PLAN_WASM_MEMORY v2).
@@ -3243,7 +3356,7 @@ class LowIRBuilderPass {
       set lctx.objectSlots varName typeName
     }
     if (irType == "i8*") {
-      tmp = (this.emitStrdupExpr(tmp lctx))
+      tmp = (this.emitOwnedStringInit(varName val tmp lctx))
     }
     ; A double-typed local initialized from an integer-valued expression: widen
     ; the i32 result to double so the slot store types match.
@@ -3314,6 +3427,16 @@ class LowIRBuilderPass {
               }
             }
           }
+          ; Storing an owned string local into a string field: the field now
+          ; references its buffer, so it must not be freed at scope end. Mark it
+          ; escaped (conservatively leaks; field-owned string RC is future work).
+          if (this.fieldIsStringSlot(cls fld)) {
+            if (rhs.value_type == RangerNodeType.VRef) {
+              if (this.isOwnedStringLocal(rhs.vref lctx)) {
+                set lctx.escapedLocals rhs.vref "1"
+              }
+            }
+          }
           this.emitFieldStoreOn(cls sptr fld tmp lctx)
           return
         }
@@ -3352,7 +3475,7 @@ class LowIRBuilderPass {
         }
       }
       if (storeType == "i8*") {
-        tmp = (this.emitStrdupExpr(tmp lctx))
+        tmp = (this.emitOwnedStringReassign(varName rhs tmp lctx))
       }
       builder.emitStore(storeType tmp slot)
       return
@@ -3603,15 +3726,17 @@ class LowIRBuilderPass {
     def cond (this.lowerCond(condNode lctx))
     builder.terminateBrIf(cond bodyLabel exitLabel)
 
-    ; snapshot owned-object locals so any declared INSIDE the loop body can be
-    ; released once per iteration (block scope), not leaked until function end.
+    ; snapshot owned-object and owned-string locals so any declared INSIDE the
+    ; loop body are released once per iteration (block scope), not leaked until
+    ; function end — critical for per-frame throwaway strings.
     def ownedBefore (array_length lctx.ownedObjectLocals)
+    def ownedStrBefore (array_length lctx.ownedStringLocals)
 
     builder.startBlock(bodyLabel)
     this.lowerBlock(bodyNode lctx)
     def bodyBlock (unwrap builder.currentBlock)
     if (bodyBlock.termKind == "") {
-      this.releaseLoopBodyOwned(ownedBefore lctx)
+      this.releaseLoopBodyOwned(ownedBefore ownedStrBefore lctx)
       builder.terminateBr(condLabel)
     }
 
@@ -3622,27 +3747,42 @@ class LowIRBuilderPass {
   ; >= ownedBefore), then drop them from the function-level list so the scope-end
   ; cleanup does not double-release. Escaped locals are skipped by releaseOwned
   ; Local. Gated on -wasmrc so the native path's existing behaviour is unchanged.
-  fn releaseLoopBodyOwned:void (ownedBefore:int lctx:LowIRLowerContext) {
+  fn releaseLoopBodyOwned:void (ownedBefore:int ownedStrBefore:int lctx:LowIRLowerContext) {
     def ctx (unwrap lctx.ctx)
     if ((ctx.hasCompilerFlag("wasmrc")) == false) {
       return
     }
     def n (array_length lctx.ownedObjectLocals)
-    if (n <= ownedBefore) {
-      return
+    if (n > ownedBefore) {
+      def k ownedBefore
+      while (< k n) {
+        this.releaseOwnedLocal((itemAt lctx.ownedObjectLocals k) lctx)
+        k = (+ k 1)
+      }
+      def kept:[string]
+      def j 0
+      while (< j ownedBefore) {
+        push kept (itemAt lctx.ownedObjectLocals j)
+        j = (+ j 1)
+      }
+      lctx.ownedObjectLocals = kept
     }
-    def k ownedBefore
-    while (< k n) {
-      this.releaseOwnedLocal((itemAt lctx.ownedObjectLocals k) lctx)
-      k = (+ k 1)
+    ; same per-iteration release for owned string locals introduced in the body
+    def sn (array_length lctx.ownedStringLocals)
+    if (sn > ownedStrBefore) {
+      def sk ownedStrBefore
+      while (< sk sn) {
+        this.releaseOwnedString((itemAt lctx.ownedStringLocals sk) lctx)
+        sk = (+ sk 1)
+      }
+      def keptS:[string]
+      def sj 0
+      while (< sj ownedStrBefore) {
+        push keptS (itemAt lctx.ownedStringLocals sj)
+        sj = (+ sj 1)
+      }
+      lctx.ownedStringLocals = keptS
     }
-    def kept:[string]
-    def j 0
-    while (< j ownedBefore) {
-      push kept (itemAt lctx.ownedObjectLocals j)
-      j = (+ j 1)
-    }
-    lctx.ownedObjectLocals = kept
   }
 
   fn lowerExpr:string (node:CodeNode lctx:LowIRLowerContext) {
@@ -3900,6 +4040,41 @@ class LowIRBuilderPass {
     }
     if (op == "substring") {
       return true
+    }
+    return false
+  }
+
+  ; A string expression that yields a FRESHLY heap-allocated buffer uniquely
+  ; owned by this expression: a concat, a string-producing operator
+  ; (to_string/substring/strfromcode/...), or a string-returning call whose
+  ; result the caller owns (return convention marks it escaped, not freed, in
+  ; the callee). Such a value is owned directly (no dup) and released at scope
+  ; end. Literals and VRefs are NOT fresh (borrowed) -> the caller dups to own a
+  ; private copy. Conservative: unknown shapes return false; the dup path is
+  ; always safe (owns a private heap copy), it just costs one extra alloc/free.
+  fn exprIsFreshString:boolean (node:CodeNode lctx:LowIRLowerContext) {
+    if (this.wasmStrEnabled(lctx) == false) {
+      return false
+    }
+    def exprNode (this.unwrapCondExpr(node))
+    if exprNode.has_operator {
+      def op (exprNode.getOperator())
+      if (this.operatorReturnsString(op)) {
+        return true
+      }
+      if (op == "+") {
+        def aNode (exprNode.getSecond())
+        def bNode (exprNode.getThird())
+        if ((this.exprMightBeString(aNode lctx)) || (this.exprMightBeString(bNode lctx))) {
+          return true
+        }
+      }
+    }
+    ; a string-returning call: the returned buffer is the caller's to own
+    if (exprNode.has_call || exprNode.is_direct_method_call || exprNode.hasFnCall) {
+      if (this.exprIsStringish(exprNode lctx)) {
+        return true
+      }
     }
     return false
   }

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -1374,6 +1374,23 @@ class LowIRBuilderPass {
         itemAddr = (lctx.builder.emitCast("zext" "i64" "i32" itemAddr))
       }
     }
+    ; Freestanding WASM [string] array: the array owns a dup'd private copy of
+    ; each element (like a string field), freed via str_release on array release.
+    ; The source value keeps its own lifetime (arena temp / owned local).
+    if (this.wasmStrEnabled(lctx)) {
+      if (LowIRUtil.isStringType((this.arrayElemTypeName(arrNode lctx)))) {
+        def dupStr (this.emitStrdupExpr(itemAddr lctx))
+        def sArgs:[string]
+        def sArgTypes:[string]
+        push sArgs desc
+        push sArgTypes lctx.ptrType
+        push sArgs dupStr
+        push sArgTypes lctx.ptrType
+        this.usedPtrArrayRuntime = true
+        lctx.builder.emitCall("RtPtrArray_push" "void" sArgs sArgTypes)
+        return
+      }
+    }
     def args:[string]
     def argTypes:[string]
     push args desc
@@ -1394,8 +1411,20 @@ class LowIRBuilderPass {
             isMove = true
           }
         }
-        if isMove {
-          set lctx.escapedLocals itemNode.vref "1"
+        ; A freshly-constructed `new T()` pushed directly has rc=1 and no other
+        ; owner, so it is moved (the array owns that single reference and frees it
+        ; on release) rather than retained — retaining would leave rc=1 after the
+        ; array releases, leaking it. WASM only, to keep the libc path unchanged.
+        def freshNew:boolean false
+        if itemNode.hasNewOper {
+          if (this.wasmCollectionRcEnabled(lctx)) {
+            freshNew = true
+          }
+        }
+        if (isMove || freshNew) {
+          if (itemNode.value_type == RangerNodeType.VRef) {
+            set lctx.escapedLocals itemNode.vref "1"
+          }
           this.usedPtrArrayRuntime = true
           lctx.builder.emitCall("RtPtrArray_push" voidType args argTypes)
           return
@@ -1597,7 +1626,19 @@ class LowIRBuilderPass {
     return false
   }
 
-  fn emitPtrArrayNewEmpty:string (lctx:LowIRLowerContext owned:boolean) {
+  fn isStringArrayTypeNode:boolean (node:CodeNode) {
+    if (node.value_type == RangerNodeType.Array) {
+      return (LowIRUtil.isStringType(node.array_type))
+    }
+    return false
+  }
+
+  ; elemKind: 0 = plain values (int, no element release), 1 = owned objects
+  ; (obj_release each on free), 2 = owned strings (str_release each on free).
+  ; The value is written to the descriptor's flag word; the release runtime
+  ; dispatches on it. libc reads it as a truthy "owned" flag (kind 1 = its
+  ; existing object-array behaviour).
+  fn emitPtrArrayNewEmpty:string (lctx:LowIRLowerContext elemKind:int) {
     this.usedPtrArrayRuntime = true
     def builder (lctx.builder)
     def cap (builder.emitConst("i32" "256"))
@@ -1606,9 +1647,9 @@ class LowIRBuilderPass {
     push args cap
     push argTypes "i32"
     def desc (builder.emitCall("RtPtrArray_new" lctx.ptrType args argTypes))
-    if owned {
-      def one (builder.emitConst("i32" "1"))
-      builder.emitStoreI32At(desc (this.ptrArrayOwnedOff(lctx)) one)
+    if (elemKind > 0) {
+      def kindC (builder.emitConst("i32" ("" + elemKind)))
+      builder.emitStoreI32At(desc (this.ptrArrayOwnedOff(lctx)) kindC)
     }
     return desc
   }
@@ -3433,13 +3474,21 @@ class LowIRBuilderPass {
     }
     if (null? valNode) {
       if (this.isIntArrayTypeNode(nameNode)) {
-        def emptyArr (this.emitPtrArrayNewEmpty(lctx false))
+        def emptyArr (this.emitPtrArrayNewEmpty(lctx 0))
         this.bindPtrArraySlot(varName emptyArr lctx false)
         set lctx.ptrArrayElemTypes varName "int"
         return
       }
+      ; a [string] array owns str-releasable elements (kind 2); check before the
+      ; general object-array case, which also matches non-int element types.
+      if (this.isStringArrayTypeNode(nameNode)) {
+        def emptyStrArr (this.emitPtrArrayNewEmpty(lctx 2))
+        this.bindPtrArraySlot(varName emptyStrArr lctx true)
+        set lctx.ptrArrayElemTypes varName "string"
+        return
+      }
       if (this.isObjectPtrArrayTypeNode(nameNode)) {
-        def emptyPtrArr (this.emitPtrArrayNewEmpty(lctx true))
+        def emptyPtrArr (this.emitPtrArrayNewEmpty(lctx 1))
         this.bindPtrArraySlot(varName emptyPtrArr lctx true)
         return
       }

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -142,6 +142,11 @@ class LowIRBuilderPass {
     this.irModule.useLibcHeap = target.usesLibc
     if target.usesLibc {
       this.ensureLibcExtern(target)
+    } {
+      ; freestanding WASM with -wasmrc: unify all allocation on the free-list heap
+      if (appCtx.hasCompilerFlag("wasmrc")) {
+        this.irModule.useFreeListHeap = true
+      }
     }
 
     for appCtx.definedClassList cName:string i {
@@ -1377,9 +1382,12 @@ class LowIRBuilderPass {
     push argTypes lctx.ptrType
     def voidType:string "void"
     if (this.exprIsObjectPtr(itemNode lctx)) {
-      if (this.memEnabled(lctx)) {
-        ; Move ownership of an owned local into the array (no retain).
-        ; The array owns the element and releases it once on free.
+      if ((this.memEnabled(lctx)) || (this.wasmCollectionRcEnabled(lctx))) {
+        ; Move ownership of an owned local into the array (no retain): the array
+        ; owns the element and releases it once on free. Marking it escaped stops
+        ; the scope-end release, so the object is freed exactly once (by the
+        ; array). A non-owned element (fresh `new` result, borrowed ref) is
+        ; retained by push_owned so the array's release is balanced.
         def isMove:boolean false
         if (itemNode.value_type == RangerNodeType.VRef) {
           if (this.isOwnedObjectLocal(itemNode.vref lctx)) {
@@ -1392,8 +1400,10 @@ class LowIRBuilderPass {
           lctx.builder.emitCall("RtPtrArray_push" voidType args argTypes)
           return
         }
-        this.usedMemRuntime = true
-        this.ensureMemExtern((LowIRTarget.resolve((unwrap lctx.ctx))))
+        if (this.memEnabled(lctx)) {
+          this.usedMemRuntime = true
+          this.ensureMemExtern((LowIRTarget.resolve((unwrap lctx.ctx))))
+        }
         lctx.builder.emitCall("ranger_ptrarray_push_owned" voidType args argTypes)
         return
       }
@@ -1608,7 +1618,28 @@ class LowIRBuilderPass {
     set lctx.collectionSlots varName "ptr_array"
     if owned {
       push lctx.ownedCollectionLocals varName
+    } {
+      ; On freestanding WASM every locally-created array (including [int], which
+      ; is owned=0 at the element level) must still be freed at scope end — its
+      ; backing store and descriptor live on the free-list heap. ranger_ptrarray_
+      ; release reads the descriptor's owned flag, so it frees int arrays without
+      ; touching elements. The libc path keeps its existing behaviour.
+      if (this.wasmCollectionRcEnabled(lctx)) {
+        push lctx.ownedCollectionLocals varName
+      }
     }
+  }
+
+  ; Collections are freed on scope exit on the freestanding-WASM path too (not
+  ; only libc): -wasmrc routes their allocation to the free-list heap, so they
+  ; can — and must — be released.
+  fn wasmCollectionRcEnabled:boolean (lctx:LowIRLowerContext) {
+    def memTarget (LowIRTarget.resolve((unwrap lctx.ctx)))
+    if (memTarget.usesLibc) {
+      return false
+    }
+    def ctx (unwrap lctx.ctx)
+    return (ctx.hasCompilerFlag("wasmrc"))
   }
 
   fn collectionKind:string (varName:string lctx:LowIRLowerContext) {
@@ -3077,6 +3108,24 @@ class LowIRBuilderPass {
     builder.emitCall("ranger_str_release" voidType args argTypes)
   }
 
+  ; Release one owned collection local (free backing store + descriptor, and, for
+  ; element-owned object arrays, each element). Escaped collections (returned or
+  ; stored into a field) are skipped. Used at scope end and per loop iteration.
+  fn releaseOwnedCollectionLocal:void (varName:string lctx:LowIRLowerContext) {
+    if (has lctx.escapedLocals varName) {
+      return
+    }
+    if (false == (has lctx.slots varName)) {
+      return
+    }
+    def desc (this.loadSlot(varName lctx.ptrType lctx))
+    def args:[string]
+    def argTypes:[string]
+    push args desc
+    push argTypes lctx.ptrType
+    lctx.builder.emitCall("ranger_ptrarray_release" "void" args argTypes)
+  }
+
   ; Prepare a string value for a freshly-defined owned local and register it for
   ; scope-end release. Fresh strings (concat/to_string/string-call) are owned
   ; directly; borrowed ones (literal/VRef/field) are dup'd so the local owns a
@@ -3170,26 +3219,17 @@ class LowIRBuilderPass {
     for lctx.ownedStringLocals sname:string si {
       this.releaseOwnedString(sname lctx)
     }
-    ; owned collections need the ptr-array runtime, which is libc-only for now
-    ; (WASM string/array RC is PLAN_WASM_MEMORY v2).
+    ; owned collections: freed on the libc path and on freestanding WASM (-wasmrc,
+    ; where their storage is on the free-list heap). ranger_ptrarray_release frees
+    ; the backing store + descriptor and, when the descriptor is element-owned
+    ; (object arrays), releases each element.
     if (memTarget.usesLibc == false) {
-      return
+      if ((this.wasmCollectionRcEnabled(lctx)) == false) {
+        return
+      }
     }
-    def builder (lctx.builder)
-    def voidType:string "void"
     for lctx.ownedCollectionLocals name:string i {
-      if (has lctx.escapedLocals name) {
-        continue
-      }
-      if (false == (has lctx.slots name)) {
-        continue
-      }
-      def desc (this.loadSlot(name lctx.ptrType lctx))
-      def args:[string]
-      def argTypes:[string]
-      push args desc
-      push argTypes lctx.ptrType
-      builder.emitCall("ranger_ptrarray_release" voidType args argTypes)
+      this.releaseOwnedCollectionLocal(name lctx)
     }
   }
 
@@ -3862,12 +3902,13 @@ class LowIRBuilderPass {
     ; function end — critical for per-frame throwaway strings.
     def ownedBefore (array_length lctx.ownedObjectLocals)
     def ownedStrBefore (array_length lctx.ownedStringLocals)
+    def ownedCollBefore (array_length lctx.ownedCollectionLocals)
 
     builder.startBlock(bodyLabel)
     this.lowerBlock(bodyNode lctx)
     def bodyBlock (unwrap builder.currentBlock)
     if (bodyBlock.termKind == "") {
-      this.releaseLoopBodyOwned(ownedBefore ownedStrBefore lctx)
+      this.releaseLoopBodyOwned(ownedBefore ownedStrBefore ownedCollBefore lctx)
       builder.terminateBr(condLabel)
     }
 
@@ -3878,7 +3919,7 @@ class LowIRBuilderPass {
   ; >= ownedBefore), then drop them from the function-level list so the scope-end
   ; cleanup does not double-release. Escaped locals are skipped by releaseOwned
   ; Local. Gated on -wasmrc so the native path's existing behaviour is unchanged.
-  fn releaseLoopBodyOwned:void (ownedBefore:int ownedStrBefore:int lctx:LowIRLowerContext) {
+  fn releaseLoopBodyOwned:void (ownedBefore:int ownedStrBefore:int ownedCollBefore:int lctx:LowIRLowerContext) {
     def ctx (unwrap lctx.ctx)
     if ((ctx.hasCompilerFlag("wasmrc")) == false) {
       return
@@ -3913,6 +3954,22 @@ class LowIRBuilderPass {
         sj = (+ sj 1)
       }
       lctx.ownedStringLocals = keptS
+    }
+    ; same per-iteration release for owned collection locals introduced in the body
+    def cn (array_length lctx.ownedCollectionLocals)
+    if (cn > ownedCollBefore) {
+      def ck ownedCollBefore
+      while (< ck cn) {
+        this.releaseOwnedCollectionLocal((itemAt lctx.ownedCollectionLocals ck) lctx)
+        ck = (+ ck 1)
+      }
+      def keptC:[string]
+      def cj 0
+      while (< cj ownedCollBefore) {
+        push keptC (itemAt lctx.ownedCollectionLocals cj)
+        cj = (+ cj 1)
+      }
+      lctx.ownedCollectionLocals = keptC
     }
   }
 

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -409,6 +409,18 @@ class LowIRBuilderPass {
     return (ctx.hasCompilerFlag("wasmrc"))
   }
 
+  ; The freestanding-WASM string runtime (ranger_str_*) is in play: non-libc
+  ; target under -wasmrc. When true, string ops route to the WASM-native runtime
+  ; (ranger_str_len/concat/from_int/dup/cmp) instead of libc (strlen/sprintf/...).
+  fn wasmStrEnabled:boolean (lctx:LowIRLowerContext) {
+    def memTarget (LowIRTarget.resolve((unwrap lctx.ctx)))
+    if (memTarget.usesLibc) {
+      return false
+    }
+    def ctx (unwrap lctx.ctx)
+    return (ctx.hasCompilerFlag("wasmrc"))
+  }
+
   fn isLowerableParamType:boolean (typeName:string) {
     if (LowIRUtil.isSupportedParam(typeName)) {
       return true
@@ -581,7 +593,11 @@ class LowIRBuilderPass {
     def dupArgTypes:[string]
     push dupArgs strPtr
     push dupArgTypes "i8*"
-    return (lctx.builder.emitCall("ranger_strdup" "i8*" dupArgs dupArgTypes))
+    def dupFn:string "ranger_strdup"
+    if (this.wasmStrEnabled(lctx)) {
+      dupFn = "ranger_str_dup"
+    }
+    return (lctx.builder.emitCall(dupFn "i8*" dupArgs dupArgTypes))
   }
 
   fn lowerStringConcat:string (aNode:CodeNode bNode:CodeNode lctx:LowIRLowerContext) {
@@ -593,6 +609,34 @@ class LowIRBuilderPass {
     }
     if (this.exprIsString(bNode)) {
       bStr = true
+    }
+    ; freestanding WASM: convert int operands to strings, then ranger_str_concat.
+    if (this.wasmStrEnabled(lctx)) {
+      def aV (this.lowerConcatOperand(aNode aStr lctx))
+      def sa aV
+      if (aStr == false) {
+        def a1:[string]
+        def a1t:[string]
+        push a1 aV
+        push a1t "i32"
+        sa = (builder.emitCall("ranger_str_from_int" "i8*" a1 a1t))
+      }
+      def bV (this.lowerConcatOperand(bNode bStr lctx))
+      def sb bV
+      if (bStr == false) {
+        def b1:[string]
+        def b1t:[string]
+        push b1 bV
+        push b1t "i32"
+        sb = (builder.emitCall("ranger_str_from_int" "i8*" b1 b1t))
+      }
+      def cargs:[string]
+      def cargTypes:[string]
+      push cargs sa
+      push cargTypes "i8*"
+      push cargs sb
+      push cargTypes "i8*"
+      return (builder.emitCall("ranger_str_concat" "i8*" cargs cargTypes))
     }
     def sz (builder.emitConst("i32" "4096"))
     def raw (builder.emitHeapAlloc(sz))
@@ -1418,6 +1462,18 @@ class LowIRBuilderPass {
     def valNode (node.getSecond())
     def isF64 (this.exprIsF64(valNode))
     def val (this.lowerExpr(valNode lctx))
+    ; freestanding WASM: ranger_str_from_int (f64 truncated to i32 for now).
+    if (this.wasmStrEnabled(lctx)) {
+      def iv val
+      if isF64 {
+        iv = (builder.emitCast("fptosi" "i32" "f64" val))
+      }
+      def sargs:[string]
+      def sargTypes:[string]
+      push sargs iv
+      push sargTypes "i32"
+      return (builder.emitCall("ranger_str_from_int" "i8*" sargs sargTypes))
+    }
     def sz (builder.emitConst("i32" "64"))
     def raw (builder.emitHeapAlloc(sz))
     def buf (builder.emitIntToI8Ptr(raw lctx.ptrType))
@@ -1475,7 +1531,11 @@ class LowIRBuilderPass {
     def argTypes:[string]
     push args strPtr
     push argTypes "i8*"
-    return (builder.emitCall("strlen" "i32" args argTypes))
+    def lenFn:string "strlen"
+    if (this.wasmStrEnabled(lctx)) {
+      lenFn = "ranger_str_len"
+    }
+    return (builder.emitCall(lenFn "i32" args argTypes))
   }
 
   fn isIntArrayTypeNode:boolean (node:CodeNode) {
@@ -4094,6 +4154,22 @@ class LowIRBuilderPass {
         def ptr (this.lowerExpr((itemAt argsNode.children 0) lctx))
         def val (this.lowerExpr((itemAt argsNode.children 1) lctx))
         builder.emitPtrStore(ptr val)
+        return handledVoid
+      }
+      return notIntrinsic
+    }
+    if (fnName == "Mem_loadU8") {
+      if ((array_length argsNode.children) > 0) {
+        def ptr (this.lowerExpr((itemAt argsNode.children 0) lctx))
+        return (builder.emitPtrLoad8(ptr))
+      }
+      return notIntrinsic
+    }
+    if (fnName == "Mem_storeU8") {
+      if ((array_length argsNode.children) > 1) {
+        def ptr (this.lowerExpr((itemAt argsNode.children 0) lctx))
+        def val (this.lowerExpr((itemAt argsNode.children 1) lctx))
+        builder.emitPtrStore8(ptr val)
         return handledVoid
       }
       return notIntrinsic

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -396,6 +396,19 @@ class LowIRBuilderPass {
     return this.usedMemRuntime
   }
 
+  ; Object reference-counting enabled: the libc path (full RC), OR the WASM
+  ; free-list path under -wasmrc. This gates ONLY the object new/release path;
+  ; string/array RC stays behind memEnabled/usesLibc because their WASM runtime
+  ; (ranger_ptrarray_*, ranger_str_*) is not emitted yet (PLAN_WASM_MEMORY v2).
+  fn objRcEnabled:boolean (lctx:LowIRLowerContext) {
+    def memTarget (LowIRTarget.resolve((unwrap lctx.ctx)))
+    if (memTarget.usesLibc) {
+      return true
+    }
+    def ctx (unwrap lctx.ctx)
+    return (ctx.hasCompilerFlag("wasmrc"))
+  }
+
   fn isLowerableParamType:boolean (typeName:string) {
     if (LowIRUtil.isSupportedParam(typeName)) {
       return true
@@ -2579,7 +2592,21 @@ class LowIRBuilderPass {
       def newSig:string ("i32, ptr")
       heapAddr = (builder.emitCallWithSig("ranger_obj_new" lctx.ptrType newSig newArgs newArgTypes))
     } {
-      heapAddr = (builder.emitHeapAlloc(bytes))
+      if (this.objRcEnabled(lctx)) {
+        ; WASM free-list RC: ranger_obj_new(size, typeDesc). typeDesc = 0 in v1
+        ; (no owned-field recursion yet); the runtime prepends the rc/size/type
+        ; header and returns the body pointer.
+        def zeroTd (builder.emitConst("i32" "0"))
+        def wArgs:[string]
+        def wArgTypes:[string]
+        push wArgs bytes
+        push wArgTypes "i32"
+        push wArgs zeroTd
+        push wArgTypes "i32"
+        heapAddr = (builder.emitCall("ranger_obj_new" lctx.ptrType wArgs wArgTypes))
+      } {
+        heapAddr = (builder.emitHeapAlloc(bytes))
+      }
     }
     def objSlot (builder.emitIntToStructPtr(className heapAddr))
     this.initFieldDefaultsInObject(className objSlot lctx)
@@ -2810,8 +2837,7 @@ class LowIRBuilderPass {
   }
 
   fn releaseOwnedLocal:void (varName:string lctx:LowIRLowerContext) {
-    def memTarget (LowIRTarget.resolve((unwrap lctx.ctx)))
-    if (memTarget.usesLibc == false) {
+    if (this.objRcEnabled(lctx) == false) {
       return
     }
     if (has lctx.escapedLocals varName) {
@@ -2864,7 +2890,7 @@ class LowIRBuilderPass {
 
   fn emitReleaseOwnedLocals:void (lctx:LowIRLowerContext) {
     def memTarget (LowIRTarget.resolve((unwrap lctx.ctx)))
-    if (memTarget.isManualMemory() == false) {
+    if (this.objRcEnabled(lctx) == false) {
       return
     }
     if (this.strictOwnershipEnabled(lctx)) {
@@ -2872,6 +2898,11 @@ class LowIRBuilderPass {
     }
     for lctx.ownedObjectLocals name:string i {
       this.releaseOwnedLocal(name lctx)
+    }
+    ; owned collections need the ptr-array runtime, which is libc-only for now
+    ; (WASM string/array RC is PLAN_WASM_MEMORY v2).
+    if (memTarget.usesLibc == false) {
+      return
     }
     def builder (lctx.builder)
     def voidType:string "void"
@@ -3501,14 +3532,46 @@ class LowIRBuilderPass {
     def cond (this.lowerCond(condNode lctx))
     builder.terminateBrIf(cond bodyLabel exitLabel)
 
+    ; snapshot owned-object locals so any declared INSIDE the loop body can be
+    ; released once per iteration (block scope), not leaked until function end.
+    def ownedBefore (array_length lctx.ownedObjectLocals)
+
     builder.startBlock(bodyLabel)
     this.lowerBlock(bodyNode lctx)
     def bodyBlock (unwrap builder.currentBlock)
     if (bodyBlock.termKind == "") {
+      this.releaseLoopBodyOwned(ownedBefore lctx)
       builder.terminateBr(condLabel)
     }
 
     builder.startBlock(exitLabel)
+  }
+
+  ; Release owned-object locals that were introduced within a loop body (indices
+  ; >= ownedBefore), then drop them from the function-level list so the scope-end
+  ; cleanup does not double-release. Escaped locals are skipped by releaseOwned
+  ; Local. Gated on -wasmrc so the native path's existing behaviour is unchanged.
+  fn releaseLoopBodyOwned:void (ownedBefore:int lctx:LowIRLowerContext) {
+    def ctx (unwrap lctx.ctx)
+    if ((ctx.hasCompilerFlag("wasmrc")) == false) {
+      return
+    }
+    def n (array_length lctx.ownedObjectLocals)
+    if (n <= ownedBefore) {
+      return
+    }
+    def k ownedBefore
+    while (< k n) {
+      this.releaseOwnedLocal((itemAt lctx.ownedObjectLocals k) lctx)
+      k = (+ k 1)
+    }
+    def kept:[string]
+    def j 0
+    while (< j ownedBefore) {
+      push kept (itemAt lctx.ownedObjectLocals j)
+      j = (+ j 1)
+    }
+    lctx.ownedObjectLocals = kept
   }
 
   fn lowerExpr:string (node:CodeNode lctx:LowIRLowerContext) {

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -1237,7 +1237,9 @@ class LowIRBuilderPass {
     push argTypes "i32"
     push args end
     push argTypes "i32"
-    return (lctx.builder.emitCall("ranger_substring" "i8*" args argTypes))
+    def subRes (lctx.builder.emitCall("ranger_substring" "i8*" args argTypes))
+    this.registerFreshStringTemp(subRes lctx)
+    return subRes
   }
 
   fn lowerAtArgs:string (textNode:CodeNode posNode:CodeNode lctx:LowIRLowerContext) {
@@ -1532,7 +1534,9 @@ class LowIRBuilderPass {
     def argTypes:[string]
     push args code
     push argTypes "i32"
-    return (builder.emitCall(fnName "i8*" args argTypes))
+    def codeRes (builder.emitCall(fnName "i8*" args argTypes))
+    this.registerFreshStringTemp(codeRes lctx)
+    return codeRes
   }
 
   fn lowerStrlen:string (node:CodeNode lctx:LowIRLowerContext) {
@@ -4244,7 +4248,11 @@ class LowIRBuilderPass {
     push argTypes "i8*"
     push args rhs
     push argTypes "i8*"
-    def sc (builder.emitCall("strcmp" "i32" args argTypes))
+    def cmpFn:string "strcmp"
+    if (this.wasmStrEnabled(lctx)) {
+      cmpFn = "ranger_str_cmp"
+    }
+    def sc (builder.emitCall(cmpFn "i32" args argTypes))
     def zero (builder.emitConst("i32" "0"))
     return (builder.emitIcmp(pred sc zero))
   }

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -1678,6 +1678,11 @@ class LowIRBuilderPass {
   fn bindCollectionSlot:void (varName:string kind:string desc:string lctx:LowIRLowerContext) {
     this.bindSlot(varName lctx.ptrType desc lctx)
     set lctx.collectionSlots varName kind
+    ; On freestanding WASM a locally-created map is freed at scope end too. The
+    ; release loop dispatches by collectionKind (map -> RtMap_free).
+    if (this.wasmCollectionRcEnabled(lctx)) {
+      push lctx.ownedCollectionLocals varName
+    }
   }
 
   fn loadCollectionDesc:string (varName:string lctx:LowIRLowerContext) {
@@ -3123,7 +3128,14 @@ class LowIRBuilderPass {
     def argTypes:[string]
     push args desc
     push argTypes lctx.ptrType
-    lctx.builder.emitCall("ranger_ptrarray_release" "void" args argTypes)
+    ; dispatch by collection kind: maps free desc+keys+vals via RtMap_free;
+    ; ptr-arrays (int and object) free backing+desc (+ element RC) via
+    ; ranger_ptrarray_release.
+    def relFn:string "ranger_ptrarray_release"
+    if ((this.collectionKind(varName lctx)) == "map") {
+      relFn = "RtMap_free"
+    }
+    lctx.builder.emitCall(relFn "void" args argTypes)
   }
 
   ; Prepare a string value for a freshly-defined owned local and register it for
@@ -4537,6 +4549,16 @@ class LowIRBuilderPass {
         def val (this.lowerExpr((itemAt argsNode.children 1) lctx))
         builder.emitPtrStore8(ptr val)
         return handledVoid
+      }
+      return notIntrinsic
+    }
+    if (fnName == "Mem_memSize") {
+      return (builder.emitMemSize())
+    }
+    if (fnName == "Mem_memGrow") {
+      if ((array_length argsNode.children) > 0) {
+        def pages (this.lowerExpr((itemAt argsNode.children 0) lctx))
+        return (builder.emitMemGrow(pages))
       }
       return notIntrinsic
     }

--- a/compiler/ng_LowIRRuntime.rgr
+++ b/compiler/ng_LowIRRuntime.rgr
@@ -663,7 +663,11 @@ class LowIRRuntimeGen {
     push rat pt
     push ra newBytes
     push rat pt
-    def newData (builder.emitCall("realloc" pt ra rat))
+    def reallocFn:string "realloc"
+    if module.useFreeListHeap {
+      reallocFn = "Heap_realloc"
+    }
+    def newData (builder.emitCall(reallocFn pt ra rat))
     builder.emitPtrStore("%desc" newData)
     builder.emitStoreI32At("%desc" capOff newCap)
     builder.terminateBr(cont)

--- a/compiler/ng_LowIRRuntime.rgr
+++ b/compiler/ng_LowIRRuntime.rgr
@@ -26,6 +26,10 @@ class LowIRRuntimeGen {
       return
     }
     LowIRRuntimeGen.buildRtMapNew(module)
+    if module.useFreeListHeap {
+      LowIRRuntimeGen.buildRtMapGrow(module)
+      LowIRRuntimeGen.buildRtMapFree(module)
+    }
     LowIRRuntimeGen.buildRtMapHashSlot(module)
     LowIRRuntimeGen.buildRtMapPutAt(module)
     LowIRRuntimeGen.buildRtMapPut(module)
@@ -144,6 +148,24 @@ class LowIRRuntimeGen {
     return (builder.emitBin("add" pt base off))
   }
 
+  ; Emit a free of `ptr` on whichever heap the module uses: libc free, or the
+  ; freestanding-WASM free-list Heap_free. The bump allocator cannot free, so
+  ; nothing is emitted there (the historic leak-forever behaviour).
+  static fn emitFreePtr:void (builder:LowIRBuilder module:LowIRModule ptr:string) {
+    def pt (module.ptrType)
+    def args:[string]
+    def argTypes:[string]
+    push args ptr
+    push argTypes pt
+    if module.useLibcHeap {
+      builder.emitCall("free" "void" args argTypes)
+      return
+    }
+    if module.useFreeListHeap {
+      builder.emitCall("Heap_free" "void" args argTypes)
+    }
+  }
+
   static fn buildRtMapNew:void (module:LowIRModule) {
     def builder@(lives):LowIRBuilder (new LowIRBuilder(module))
     builder.reset()
@@ -200,6 +222,143 @@ class LowIRRuntimeGen {
     LowIRRuntimeGen.finishFn(builder module "RtMap_new" pt params false)
   }
 
+  ; Double the bucket capacity and rehash, so open-addressing insertion always
+  ; finds an empty slot (a full map otherwise probes forever — the historic
+  ; infinite-recursion bug). Old key/value arrays are freed. Only emitted on the
+  ; free-list-heap path; other targets keep their fixed-capacity behaviour.
+  static fn buildRtMapGrow:void (module:LowIRModule) {
+    def builder@(lives):LowIRBuilder (new LowIRBuilder(module))
+    builder.reset()
+    def pt (module.ptrType)
+    def valsOff (LowIRRuntimeGen.mapValsOff(module))
+    def capOff (LowIRRuntimeGen.mapCapOff(module))
+    def sizeOff (LowIRRuntimeGen.mapSizeOff(module))
+    def params:[LowIRParam]
+    def descP@(lives):LowIRParam (new LowIRParam())
+    descP.name = "desc"
+    descP.irType = pt
+    push params descP
+    builder.startBlock("entry")
+
+    def oldCap (LowIRRuntimeGen.emitCap(builder module "%desc"))
+    def oldKeys (LowIRRuntimeGen.emitKeysPtr(builder module "%desc"))
+    def oldVals (LowIRRuntimeGen.emitValsPtr(builder module "%desc"))
+    def two (builder.emitConst("i32" "2"))
+    def newCap (builder.emitBin("mul" "i32" oldCap two))
+    def four (builder.emitConst("i32" "4"))
+    def nbytes (builder.emitBin("mul" "i32" newCap four))
+    def newKeys (builder.emitHeapAlloc(nbytes))
+    def newVals (builder.emitHeapAlloc(nbytes))
+    def zero (builder.emitConst("i32" "0"))
+    def negOne (builder.emitConst("i32" "-1"))
+
+    ; init newKeys[i] = -1 (empty marker; key 0 is valid so 0 can't mean empty)
+    def iSlot (builder.freshTemp("i"))
+    builder.emitAlloca("i32" iSlot)
+    builder.emitStore("i32" zero iSlot)
+    def ic (builder.freshLabel("grow_init_cond"))
+    def ib (builder.freshLabel("grow_init_body"))
+    def idn (builder.freshLabel("grow_init_done"))
+    builder.terminateBr(ic)
+    builder.startBlock(ic)
+    def iV (builder.emitLoad("i32" iSlot))
+    def iLt (builder.emitIcmp("slt" iV newCap))
+    builder.terminateBrIf(iLt ib idn)
+    builder.startBlock(ib)
+    def nkp (LowIRRuntimeGen.emitSlotAddr(builder module newKeys iV))
+    builder.emitPtrStoreTyped(nkp negOne "i32")
+    def one (builder.emitConst("i32" "1"))
+    def iN (builder.emitBin("add" "i32" iV one))
+    builder.emitStore("i32" iN iSlot)
+    builder.terminateBr(ic)
+    builder.startBlock(idn)
+
+    ; install the new arrays and reset size before rehashing
+    builder.emitPtrStore("%desc" newKeys)
+    def valsFld (builder.emitConst(pt ("" + valsOff)))
+    def valsAddr (builder.emitBin("add" pt "%desc" valsFld))
+    builder.emitPtrStore(valsAddr newVals)
+    builder.emitStoreI32At("%desc" capOff newCap)
+    builder.emitStoreI32At("%desc" sizeOff zero)
+
+    ; rehash every occupied old slot back in (size stays under the grow
+    ; threshold of the doubled table, so this cannot recursively re-grow)
+    def jSlot (builder.freshTemp("j"))
+    builder.emitAlloca("i32" jSlot)
+    builder.emitStore("i32" zero jSlot)
+    def rc (builder.freshLabel("grow_rehash_cond"))
+    def rb (builder.freshLabel("grow_rehash_body"))
+    def rd (builder.freshLabel("grow_rehash_done"))
+    def rput (builder.freshLabel("grow_rehash_put"))
+    def rinc (builder.freshLabel("grow_rehash_inc"))
+    builder.terminateBr(rc)
+    builder.startBlock(rc)
+    def jV (builder.emitLoad("i32" jSlot))
+    def jLt (builder.emitIcmp("slt" jV oldCap))
+    builder.terminateBrIf(jLt rb rd)
+    builder.startBlock(rb)
+    def okp (LowIRRuntimeGen.emitSlotAddr(builder module oldKeys jV))
+    def k (builder.emitPtrLoadTyped(okp "i32"))
+    ; branch to the put block (which precedes the increment block) on the TRUE
+    ; edge, so the structured reconstruction sees then-target before merge.
+    def notEmpty (builder.emitIcmp("ne" k negOne))
+    builder.terminateBrIf(notEmpty rput rinc)
+    builder.startBlock(rput)
+    def ovp (LowIRRuntimeGen.emitSlotAddr(builder module oldVals jV))
+    def v (builder.emitPtrLoadTyped(ovp "i32"))
+    def pargs:[string]
+    def ptypes:[string]
+    push pargs "%desc"
+    push ptypes pt
+    push pargs k
+    push ptypes "i32"
+    push pargs v
+    push ptypes "i32"
+    builder.emitCall("RtMap_put" "void" pargs ptypes)
+    builder.terminateBr(rinc)
+    builder.startBlock(rinc)
+    def jOne (builder.emitConst("i32" "1"))
+    def jN (builder.emitBin("add" "i32" jV jOne))
+    builder.emitStore("i32" jN jSlot)
+    builder.terminateBr(rc)
+    builder.startBlock(rd)
+
+    LowIRRuntimeGen.emitFreePtr(builder module oldKeys)
+    LowIRRuntimeGen.emitFreePtr(builder module oldVals)
+    builder.terminateRet("void" "")
+    LowIRRuntimeGen.finishFn(builder module "RtMap_grow" "void" params false)
+  }
+
+  ; Free a map's key array, value array, and descriptor. Keys/values are plain
+  ; ints, so there is no element RC (parity with the ptr-array release for int
+  ; arrays). Only emitted on the free-list-heap path.
+  static fn buildRtMapFree:void (module:LowIRModule) {
+    def builder@(lives):LowIRBuilder (new LowIRBuilder(module))
+    builder.reset()
+    def pt (module.ptrType)
+    def params:[LowIRParam]
+    def descP@(lives):LowIRParam (new LowIRParam())
+    descP.name = "desc"
+    descP.irType = pt
+    push params descP
+    builder.startBlock("entry")
+    def zero (builder.emitConst(pt "0"))
+    def isNull (builder.emitIcmp("eq" "%desc" zero))
+    def retLabel (builder.freshLabel("mapfree_ret"))
+    def bodyLabel (builder.freshLabel("mapfree_body"))
+    builder.terminateBrIf(isNull retLabel bodyLabel)
+    builder.startBlock(bodyLabel)
+    def keys (LowIRRuntimeGen.emitKeysPtr(builder module "%desc"))
+    def vals (LowIRRuntimeGen.emitValsPtr(builder module "%desc"))
+    LowIRRuntimeGen.emitFreePtr(builder module keys)
+    LowIRRuntimeGen.emitFreePtr(builder module vals)
+    LowIRRuntimeGen.emitFreePtr(builder module "%desc")
+    builder.terminateRet("void" "")
+    builder.startBlock(retLabel)
+    builder.terminateRet("void" "")
+    LowIRRuntimeGen.finishFn(builder module "RtMap_free" "void" params false)
+  }
+
   static fn buildRtMapHashSlot:void (module:LowIRModule) {
     def builder@(lives):LowIRBuilder (new LowIRBuilder(module))
     builder.reset()
@@ -254,13 +413,27 @@ class LowIRRuntimeGen {
     valP.name = "val"
     valP.irType = "i32"
     push params valP
-    builder.startBlock("entry")
-
-    def cap (LowIRRuntimeGen.emitCap(builder module "%desc"))
-    def geCap (builder.emitIcmp("sge" "%slot" cap))
+    ; Blocks are emitted so each early-return target immediately follows its
+    ; guard header (retLabel after entry, updLabel after bodyLabel, emptyLabel
+    ; after checkEmpty). The WAT structured reconstruction assumes a br_if's
+    ; true-target precedes its false-target; emitting the return blocks last
+    ; (their natural authoring order) made those then-regions empty, silently
+    ; dropping the bounds check and the key-update path. Order is irrelevant to
+    ; the LLVM/native backend.
     def retLabel (builder.freshLabel("putat_ret"))
     def bodyLabel (builder.freshLabel("putat_body"))
+    def updLabel (builder.freshLabel("putat_upd"))
+    def checkEmpty (builder.freshLabel("putat_chk"))
+    def emptyLabel (builder.freshLabel("putat_empty"))
+    def recurseLabel (builder.freshLabel("putat_rec"))
+
+    builder.startBlock("entry")
+    def cap (LowIRRuntimeGen.emitCap(builder module "%desc"))
+    def geCap (builder.emitIcmp("sge" "%slot" cap))
     builder.terminateBrIf(geCap retLabel bodyLabel)
+
+    builder.startBlock(retLabel)
+    builder.terminateRet("void" "")
 
     builder.startBlock(bodyLabel)
     def keysPtr (LowIRRuntimeGen.emitKeysPtr(builder module "%desc"))
@@ -270,11 +443,11 @@ class LowIRRuntimeGen {
     def k (builder.emitPtrLoadTyped(kp "i32"))
     def negOne (builder.emitConst("i32" "-1"))
     def eqKey (builder.emitIcmp("eq" k "%key"))
-    def updLabel (builder.freshLabel("putat_upd"))
-    def emptyLabel (builder.freshLabel("putat_empty"))
-    def recurseLabel (builder.freshLabel("putat_rec"))
-    def checkEmpty (builder.freshLabel("putat_chk"))
     builder.terminateBrIf(eqKey updLabel checkEmpty)
+
+    builder.startBlock(updLabel)
+    builder.emitPtrStoreTyped(vp "%val" "i32")
+    builder.terminateRet("void" "")
 
     builder.startBlock(checkEmpty)
     def isEmpty (builder.emitIcmp("eq" k negOne))
@@ -287,10 +460,6 @@ class LowIRRuntimeGen {
     def one (builder.emitConst("i32" "1"))
     def newSize (builder.emitBin("add" "i32" size one))
     builder.emitStoreI32At("%desc" sizeOff newSize)
-    builder.terminateRet("void" "")
-
-    builder.startBlock(updLabel)
-    builder.emitPtrStoreTyped(vp "%val" "i32")
     builder.terminateRet("void" "")
 
     builder.startBlock(recurseLabel)
@@ -308,9 +477,6 @@ class LowIRRuntimeGen {
     push args "%val"
     push argTypes "i32"
     builder.emitCall("RtMap_putAt" "void" args argTypes)
-    builder.terminateRet("void" "")
-
-    builder.startBlock(retLabel)
     builder.terminateRet("void" "")
     LowIRRuntimeGen.finishFn(builder module "RtMap_putAt" "void" params false)
   }
@@ -333,6 +499,41 @@ class LowIRRuntimeGen {
     valP.irType = "i32"
     push params valP
     builder.startBlock("entry")
+
+    ; -1 is the reserved empty-slot sentinel, so it can never be a stored key.
+    ; Guarding here makes the rehash loop robust (an empty source slot maps to a
+    ; harmless no-op) and keeps a stray -1 key out of the table. Both arms
+    ; terminate, so the structured WAT reconstruction stays unambiguous.
+    def guardKey (builder.emitConst("i32" "-1"))
+    def isSentinel (builder.emitIcmp("eq" "%key" guardKey))
+    def sentinelRet (builder.freshLabel("put_sentinel_ret"))
+    def putGo (builder.freshLabel("put_go"))
+    builder.terminateBrIf(isSentinel sentinelRet putGo)
+    builder.startBlock(sentinelRet)
+    builder.terminateRet("void" "")
+    builder.startBlock(putGo)
+
+    ; free-list path: keep the load factor under 50% by doubling+rehashing when
+    ; needed, so open-addressing insertion always terminates (a full fixed table
+    ; would probe forever). Done before hashSlot, which depends on cap.
+    if module.useFreeListHeap {
+      def size0 (LowIRRuntimeGen.emitSize(builder module "%desc"))
+      def cap0 (LowIRRuntimeGen.emitCap(builder module "%desc"))
+      def twoG (builder.emitConst("i32" "2"))
+      def sz2 (builder.emitBin("mul" "i32" size0 twoG))
+      def full (builder.emitIcmp("sge" sz2 cap0))
+      def growLabel (builder.freshLabel("put_grow"))
+      def contLabel (builder.freshLabel("put_cont"))
+      builder.terminateBrIf(full growLabel contLabel)
+      builder.startBlock(growLabel)
+      def gargs:[string]
+      def gtypes:[string]
+      push gargs "%desc"
+      push gtypes pt
+      builder.emitCall("RtMap_grow" "void" gargs gtypes)
+      builder.terminateBr(contLabel)
+      builder.startBlock(contLabel)
+    }
 
     def hashArgs:[string]
     def hashTypes:[string]
@@ -374,27 +575,41 @@ class LowIRRuntimeGen {
     keyP.name = "key"
     keyP.irType = "i32"
     push params keyP
-    builder.startBlock("entry")
+    ; Reconstruction-friendly block order (see buildRtMapPutAt): each early
+    ; return sits immediately after its guard. The missing-key return (-1) is the
+    ; target of two guards (out-of-range slot, and an empty slot), so it is
+    ; duplicated rather than shared — a shared forward target cannot follow both
+    ; guards and would be dropped by the structured WAT reconstruction.
+    def negRet1 (builder.freshLabel("getat_neg1"))
+    def bodyLabel (builder.freshLabel("getat_body"))
+    def negRet2 (builder.freshLabel("getat_neg2"))
+    def keyCheck (builder.freshLabel("getat_key"))
+    def valRet (builder.freshLabel("getat_val"))
+    def recurseRet (builder.freshLabel("getat_rec"))
 
+    builder.startBlock("entry")
     def cap (LowIRRuntimeGen.emitCap(builder module "%desc"))
     def negOne (builder.emitConst("i32" "-1"))
-    def negRet (builder.freshLabel("getat_neg"))
-    def bodyLabel (builder.freshLabel("getat_body"))
     def geCap (builder.emitIcmp("sge" "%slot" cap))
-    builder.terminateBrIf(geCap negRet bodyLabel)
+    builder.terminateBrIf(geCap negRet1 bodyLabel)
+
+    builder.startBlock(negRet1)
+    def negOne1 (builder.emitConst("i32" "-1"))
+    builder.terminateRet("i32" negOne1)
 
     builder.startBlock(bodyLabel)
     def keysPtr (LowIRRuntimeGen.emitKeysPtr(builder module "%desc"))
     def kp (LowIRRuntimeGen.emitSlotAddr(builder module keysPtr "%slot"))
     def k (builder.emitPtrLoadTyped(kp "i32"))
     def isEmpty (builder.emitIcmp("eq" k negOne))
-    def keyCheck (builder.freshLabel("getat_key"))
-    builder.terminateBrIf(isEmpty negRet keyCheck)
+    builder.terminateBrIf(isEmpty negRet2 keyCheck)
+
+    builder.startBlock(negRet2)
+    def negOne2 (builder.emitConst("i32" "-1"))
+    builder.terminateRet("i32" negOne2)
 
     builder.startBlock(keyCheck)
     def eqKey (builder.emitIcmp("eq" k "%key"))
-    def valRet (builder.freshLabel("getat_val"))
-    def recurseRet (builder.freshLabel("getat_rec"))
     builder.terminateBrIf(eqKey valRet recurseRet)
 
     builder.startBlock(valRet)
@@ -402,9 +617,6 @@ class LowIRRuntimeGen {
     def vp (LowIRRuntimeGen.emitSlotAddr(builder module valsPtr "%slot"))
     def v (builder.emitPtrLoadTyped(vp "i32"))
     builder.terminateRet("i32" v)
-
-    builder.startBlock(negRet)
-    builder.terminateRet("i32" negOne)
 
     builder.startBlock(recurseRet)
     def one (builder.emitConst("i32" "1"))

--- a/compiler/ng_WATWriter.rgr
+++ b/compiler/ng_WATWriter.rgr
@@ -600,6 +600,15 @@ class WATWriter {
         this.writeGet(ins.arg2 wr)
         wr.out("      i32.store8" true)
       }
+      case "mem_size" {
+        wr.out("      memory.size" true)
+        wr.out(("      local.set " + (this.wasmName(ins.dest))) true)
+      }
+      case "mem_grow" {
+        this.writeGet(ins.arg1 wr)
+        wr.out("      memory.grow" true)
+        wr.out(("      local.set " + (this.wasmName(ins.dest))) true)
+      }
       case "inttoptr_struct" {
         this.writeGet(ins.arg1 wr)
         wr.out(("      local.set " + (this.wasmName(ins.dest))) true)

--- a/compiler/ng_WATWriter.rgr
+++ b/compiler/ng_WATWriter.rgr
@@ -532,6 +532,16 @@ class WATWriter {
         this.writeGet(ins.arg2 wr)
         wr.out("      i32.store" true)
       }
+      case "ptr_load8" {
+        this.writeGet(ins.arg1 wr)
+        wr.out("      i32.load8_u" true)
+        wr.out(("      local.set " + (this.wasmName(ins.dest))) true)
+      }
+      case "ptr_store8" {
+        this.writeGet(ins.arg1 wr)
+        this.writeGet(ins.arg2 wr)
+        wr.out("      i32.store8" true)
+      }
       case "inttoptr_struct" {
         this.writeGet(ins.arg1 wr)
         wr.out(("      local.set " + (this.wasmName(ins.dest))) true)

--- a/compiler/ng_WATWriter.rgr
+++ b/compiler/ng_WATWriter.rgr
@@ -6,6 +6,80 @@ Import "ng_LowIR.rgr"
 
 class WATWriter {
 
+  ; string-literal global name -> its static byte address in linear memory
+  def strAddrs:[string:int]
+
+  ; --- string literal data segments --------------------------------------
+  ; Layout: [0,16) control, [16, heapEnd) literals, heapEnd.. heap. The heap
+  ; base (heapEnd) is written to Mem[4]; ranger_heap.base() reads it. Literals
+  ; are null-terminated UTF-8 char* buffers, matching the char* string model.
+  fn utf8Encode:[int] (text:string) {
+    def bytes:[int]
+    def i 0
+    def n (strlen text)
+    while (< i n) {
+      def c (charAt text i)
+      if (< c 128) {
+        push bytes c
+      } {
+        if (< c 2048) {
+          push bytes (bit_or 192 (bit_shr c 6))
+          push bytes (bit_or 128 (bit_and c 63))
+        } {
+          push bytes (bit_or 224 (bit_shr c 12))
+          push bytes (bit_or 128 (bit_and (bit_shr c 6) 63))
+          push bytes (bit_or 128 (bit_and c 63))
+        }
+      }
+      i = (+ i 1)
+    }
+    return bytes
+  }
+
+  fn hexDigit:string (d:int) {
+    if (< d 10) {
+      return ("" + d)
+    }
+    return (strfromcode (+ 97 (- d 10)))
+  }
+
+  fn hexByte:string (b:int) {
+    return ("\\" + ((this.hexDigit((bit_and (bit_shr b 4) 15))) + (this.hexDigit((bit_and b 15)))))
+  }
+
+  fn dataEscape:string (bytes:[int]) {
+    def s ""
+    for bytes b:int i {
+      s = (s + (this.hexByte(b)))
+    }
+    return s
+  }
+
+  fn leWord:string (v:int) {
+    def s ""
+    s = (s + (this.hexByte((bit_and v 255))))
+    s = (s + (this.hexByte((bit_and (bit_shr v 8) 255))))
+    s = (s + (this.hexByte((bit_and (bit_shr v 16) 255))))
+    s = (s + (this.hexByte((bit_and (bit_shr v 24) 255))))
+    return s
+  }
+
+  fn emitStringData:void (module:LowIRModule wr:CodeWriter) {
+    def addr 16
+    for module.stringGlobals g:LowIRStringGlobal i {
+      def bytes (this.utf8Encode(g.text))
+      if g.withNewline {
+        push bytes 10
+      }
+      set this.strAddrs g.name addr
+      wr.out(("  (data (i32.const " + (("" + addr) + (") \"" + ((this.dataEscape(bytes)) + "\\00\")")))) true)
+      addr = (+ addr (+ (array_length bytes) 1))
+    }
+    ; heap base = end of literals, rounded up to 16; stored at Mem[4]
+    def base (bit_and (+ addr 15) (bit_xor -1 15))
+    wr.out(("  (data (i32.const 4) \"" + ((this.leWord(base)) + "\")")) true)
+  }
+
   fn wasmName:string (llvmName:string) {
     if ((strlen llvmName) == 0) {
       return ""
@@ -75,9 +149,13 @@ class WATWriter {
 
   fn writeModule:void (module:LowIRModule wr:CodeWriter) {
     wr.out("(module" true)
-    if (this.moduleUsesHeap(module)) {
+    def hasLiterals ((array_length module.stringGlobals) > 0)
+    if ((this.moduleUsesHeap(module)) || hasLiterals) {
       wr.out("  (memory (export \"memory\") 1)" true)
       wr.out("  (global $heap_ptr (mut i32) (i32.const 0))" true)
+    }
+    if hasLiterals {
+      this.emitStringData(module wr)
     }
     for module.functions fn:LowIRFunction i {
       this.writeFunction(fn wr fn.exportFn)
@@ -471,7 +549,11 @@ class WATWriter {
         wr.out(("      local.set " + (this.wasmName(ins.dest))) true)
       }
       case "str_ptr" {
-        wr.out(("      i32.const 0") true)
+        def addr 0
+        if (has this.strAddrs ins.arg1) {
+          addr = (unwrap (get this.strAddrs ins.arg1))
+        }
+        wr.out(("      i32.const " + ("" + addr)) true)
         wr.out(("      local.set " + (this.wasmName(ins.dest))) true)
       }
       case "icmp" {

--- a/compiler/ng_WATWriter.rgr
+++ b/compiler/ng_WATWriter.rgr
@@ -9,6 +9,9 @@ class WATWriter {
   ; string-literal global name -> its static byte address in linear memory
   def strAddrs:[string:int]
 
+  ; class name -> its type-descriptor header address in the static data segment
+  def typeDescAddrs:[string:int]
+
   ; --- string literal data segments --------------------------------------
   ; Layout: [0,16) control, [16, heapEnd) literals, heapEnd.. heap. The heap
   ; base (heapEnd) is written to Mem[4]; ranger_heap.base() reads it. Literals
@@ -64,7 +67,37 @@ class WATWriter {
     return s
   }
 
-  fn emitStringData:void (module:LowIRModule wr:CodeWriter) {
+  fn align4:int (a:int) {
+    return (bit_and (+ a 3) (bit_xor -1 3))
+  }
+
+  ; A type descriptor is worth emitting only if it has at least one owned field
+  ; (the destructor walk does nothing otherwise). String fields are owned;
+  ; object/ptr-array fields are borrow (owned=0) until borrow analysis promotes.
+  fn descHasOwned:boolean (td:LowIRTypeDesc) {
+    for td.fields fd:LowIRTypeFieldDesc i {
+      if (fd.owned == 1) {
+        return true
+      }
+    }
+    return false
+  }
+
+  fn moduleHasOwnedTypeDescs:boolean (module:LowIRModule) {
+    for module.typeDescs td:LowIRTypeDesc i {
+      if (this.descHasOwned(td)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  ; Emit the static data segment: string literals from 16, then type descriptors
+  ; (field arrays + 12-byte headers) that recursive object destruction reads.
+  ; The heap base (end of all static data, rounded to 16) is written to Mem[4].
+  ; Runtime layout — TypeDesc: [ size | fieldCount | fieldsPtr ];
+  ; Field(12): [ offset | kind | owned ]   (kind 0=string 1=object 2=ptrarray).
+  fn emitStaticData:void (module:LowIRModule wr:CodeWriter) {
     def addr 16
     for module.stringGlobals g:LowIRStringGlobal i {
       def bytes (this.utf8Encode(g.text))
@@ -75,7 +108,30 @@ class WATWriter {
       wr.out(("  (data (i32.const " + (("" + addr) + (") \"" + ((this.dataEscape(bytes)) + "\\00\")")))) true)
       addr = (+ addr (+ (array_length bytes) 1))
     }
-    ; heap base = end of literals, rounded up to 16; stored at Mem[4]
+    ; type descriptors (4-aligned so the runtime's i32 loads stay aligned)
+    for module.typeDescs td:LowIRTypeDesc i {
+      if (this.descHasOwned(td)) {
+        addr = (this.align4(addr))
+        def fieldsPtr addr
+        for td.fields fd:LowIRTypeFieldDesc j {
+          def fw ""
+          fw = (fw + (this.leWord(fd.offset)))
+          fw = (fw + (this.leWord(fd.kind)))
+          fw = (fw + (this.leWord(fd.owned)))
+          wr.out(("  (data (i32.const " + (("" + addr) + (") \"" + (fw + "\")")))) true)
+          addr = (+ addr 12)
+        }
+        def hdrPtr addr
+        def hw ""
+        hw = (hw + (this.leWord(td.size)))
+        hw = (hw + (this.leWord((array_length td.fields))))
+        hw = (hw + (this.leWord(fieldsPtr)))
+        wr.out(("  (data (i32.const " + (("" + addr) + (") \"" + (hw + "\")")))) true)
+        set this.typeDescAddrs td.className hdrPtr
+        addr = (+ addr 12)
+      }
+    }
+    ; heap base = end of static data, rounded up to 16; stored at Mem[4]
     def base (bit_and (+ addr 15) (bit_xor -1 15))
     wr.out(("  (data (i32.const 4) \"" + ((this.leWord(base)) + "\")")) true)
   }
@@ -150,12 +206,14 @@ class WATWriter {
   fn writeModule:void (module:LowIRModule wr:CodeWriter) {
     wr.out("(module" true)
     def hasLiterals ((array_length module.stringGlobals) > 0)
-    if ((this.moduleUsesHeap(module)) || hasLiterals) {
+    def hasTypeDescs (this.moduleHasOwnedTypeDescs(module))
+    def hasStatic (hasLiterals || hasTypeDescs)
+    if ((this.moduleUsesHeap(module)) || hasStatic) {
       wr.out("  (memory (export \"memory\") 1)" true)
       wr.out("  (global $heap_ptr (mut i32) (i32.const 0))" true)
     }
-    if hasLiterals {
-      this.emitStringData(module wr)
+    if hasStatic {
+      this.emitStaticData(module wr)
     }
     for module.functions fn:LowIRFunction i {
       this.writeFunction(fn wr fn.exportFn)
@@ -550,6 +608,10 @@ class WATWriter {
         this.writeGet(ins.arg1 wr)
         wr.out(("      local.set " + (this.wasmName(ins.dest))) true)
       }
+      case "ptr_to_int" {
+        this.writeGet(ins.arg1 wr)
+        wr.out(("      local.set " + (this.wasmName(ins.dest))) true)
+      }
       case "zext" {
         this.writeGet(ins.arg1 wr)
         wr.out(("      local.set " + (this.wasmName(ins.dest))) true)
@@ -564,6 +626,14 @@ class WATWriter {
           addr = (unwrap (get this.strAddrs ins.arg1))
         }
         wr.out(("      i32.const " + ("" + addr)) true)
+        wr.out(("      local.set " + (this.wasmName(ins.dest))) true)
+      }
+      case "typedesc_ptr" {
+        def tdAddr 0
+        if (has this.typeDescAddrs ins.arg1) {
+          tdAddr = (unwrap (get this.typeDescAddrs ins.arg1))
+        }
+        wr.out(("      i32.const " + ("" + tdAddr)) true)
         wr.out(("      local.set " + (this.wasmName(ins.dest))) true)
       }
       case "icmp" {

--- a/runtime/wasm/coll_rc_demo.rgr
+++ b/runtime/wasm/coll_rc_demo.rgr
@@ -70,6 +70,27 @@ class SG {
         return (Heap.frontier())
     }
 
+    ; push a freshly-constructed object directly (not via a local): it is moved
+    ; into the array (rc stays 1), so array release frees it — no leak.
+    sfn sumEntsNew:int (n:int) {
+        def es:[Ent]
+        def i 0
+        while (< i n) {
+            push es (new Ent())
+            i = (+ i 1)
+        }
+        return (array_length es)
+    }
+
+    sfn churnEntsNew:int (reps:int size:int) {
+        def r 0
+        while (< r reps) {
+            def _ (SG.sumEntsNew(size))
+            r = (+ r 1)
+        }
+        return (Heap.frontier())
+    }
+
     ; array created INSIDE the loop body must be freed each iteration
     ; (releaseLoopBodyOwned), not accumulate until function end
     sfn churnBodyList:int (reps:int size:int) {

--- a/runtime/wasm/coll_rc_demo.rgr
+++ b/runtime/wasm/coll_rc_demo.rgr
@@ -1,0 +1,96 @@
+; ============================================================================
+; coll_rc_demo.rgr — built-in collections on the free-list heap with RC
+; (PLAN_WASM_MEMORY Phase 4b). [int] and [Ent] arrays allocate their descriptor
+; and backing store from the free-list Heap (via Heap_calloc / Heap_realloc) and
+; are freed at scope end; an object array releases each owned element too. A
+; create/use/drop loop must stay heap-flat.
+; ============================================================================
+
+Import "./ranger_obj.rgr"
+
+class Ent {
+    def hp:int 0
+}
+
+class SG {
+    ; int array: build, sum, drop. Backing grows across 256 -> 512 -> ...
+    sfn sumList:int (n:int) {
+        def xs:[int]
+        def i 0
+        while (< i n) {
+            push xs i
+            i = (+ i 1)
+        }
+        def s 0
+        def j 0
+        while (< j (array_length xs)) {
+            s = (+ s (itemAt xs j))
+            j = (+ j 1)
+        }
+        return s
+    }
+
+    ; object array: push owned Ent locals (move), sum a field, drop. On release
+    ; the array frees each Ent and its own storage.
+    sfn sumEnts:int (n:int) {
+        def es:[Ent]
+        def i 0
+        while (< i n) {
+            def e (new Ent())
+            e.hp = i
+            push es e
+            i = (+ i 1)
+        }
+        def s 0
+        def j 0
+        while (< j (array_length es)) {
+            def e2 (itemAt es j)
+            s = (+ s e2.hp)
+            j = (+ j 1)
+        }
+        return s
+    }
+
+    ; leak check: build+drop an int list `reps` times; heap flat => leak-free
+    sfn churnList:int (reps:int size:int) {
+        def r 0
+        while (< r reps) {
+            def _ (SG.sumList(size))
+            r = (+ r 1)
+        }
+        return (Heap.frontier())
+    }
+
+    sfn churnEnts:int (reps:int size:int) {
+        def r 0
+        while (< r reps) {
+            def _ (SG.sumEnts(size))
+            r = (+ r 1)
+        }
+        return (Heap.frontier())
+    }
+
+    ; array created INSIDE the loop body must be freed each iteration
+    ; (releaseLoopBodyOwned), not accumulate until function end
+    sfn churnBodyList:int (reps:int size:int) {
+        def r 0
+        while (< r reps) {
+            def xs:[int]
+            def i 0
+            while (< i size) {
+                push xs i
+                i = (+ i 1)
+            }
+            r = (+ r 1)
+        }
+        return (Heap.frontier())
+    }
+
+    sfn liveBlocks:int () {
+        return (ranger.obj_live())
+    }
+
+    sfn frontier:int () {
+        return (Heap.frontier())
+    }
+}

--- a/runtime/wasm/coll_rc_test.mjs
+++ b/runtime/wasm/coll_rc_test.mjs
@@ -36,6 +36,16 @@ x.Heap_init();
 x.SG_churnEnts(500, 150);
 ok("no live blocks after churnEnts", x.SG_liveBlocks(), 0);
 
+// push a fresh `new Ent()` directly (move, not retain): no leak
+x.Heap_init();
+ok("sumEntsNew(10)", x.SG_sumEntsNew(10), 10);
+const en1  = x.SG_churnEntsNew(1, 200);
+const en1k = x.SG_churnEntsNew(1000, 200);
+ok("churnEntsNew flat", en1k, en1);
+x.Heap_init();
+x.SG_churnEntsNew(500, 150);
+ok("no live blocks after churnEntsNew", x.SG_liveBlocks(), 0);
+
 // array created inside a loop body: freed per iteration, not accumulated
 x.Heap_init();
 const b1  = x.SG_churnBodyList(1, 300);

--- a/runtime/wasm/coll_rc_test.mjs
+++ b/runtime/wasm/coll_rc_test.mjs
@@ -1,0 +1,49 @@
+// Collection RC test (PLAN_WASM_MEMORY Phase 4b).
+// Build:
+//   node bin/output.js -l=llvm -wat -freestanding -wasmrc \
+//     runtime/wasm/coll_rc_demo.rgr -nodecli -d=tmp/collrc -o=g.wat
+//   cp tmp/collrc/g.wat.ll tmp/collrc/g.wat && wat2wasm tmp/collrc/g.wat -o tmp/collrc/g.wasm
+import fs from "fs";
+const x = new WebAssembly.Instance(new WebAssembly.Module(
+  fs.readFileSync(new URL("../../tmp/collrc/g.wasm", import.meta.url)))).exports;
+let pass = 0, fail = 0;
+const ok = (n, g, e) => { if (g === e) pass++; else { fail++; console.log("FAIL", n, JSON.stringify(g), "exp", JSON.stringify(e)); } };
+
+x.Heap_init();
+// correctness (values), including multiple grows of the backing store
+ok("sumList(5)", x.SG_sumList(5), 10);
+ok("sumList(100)", x.SG_sumList(100), 4950);
+ok("sumList(1000)", x.SG_sumList(1000), 499500);
+ok("sumEnts(5)", x.SG_sumEnts(5), 10);
+ok("sumEnts(300)", x.SG_sumEnts(300), 44850);
+
+// leak-freedom: build+drop N times, heap frontier must be identical
+x.Heap_init();
+const l1  = x.SG_churnList(1, 500);
+const l1k = x.SG_churnList(1000, 500);
+ok("churnList flat", l1k, l1);
+
+x.Heap_init();
+const e1  = x.SG_churnEnts(1, 200);
+const e1k = x.SG_churnEnts(1000, 200);
+ok("churnEnts flat", e1k, e1);
+
+// zero live blocks after churn — arrays, backing stores, and elements all freed
+x.Heap_init();
+x.SG_churnList(500, 400);
+ok("no live blocks after churnList", x.SG_liveBlocks(), 0);
+x.Heap_init();
+x.SG_churnEnts(500, 150);
+ok("no live blocks after churnEnts", x.SG_liveBlocks(), 0);
+
+// array created inside a loop body: freed per iteration, not accumulated
+x.Heap_init();
+const b1  = x.SG_churnBodyList(1, 300);
+const b1k = x.SG_churnBodyList(2000, 300);
+ok("churnBodyList flat", b1k, b1);
+x.Heap_init();
+x.SG_churnBodyList(1000, 200);
+ok("no live blocks after churnBodyList", x.SG_liveBlocks(), 0);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/runtime/wasm/field_rc_demo.rgr
+++ b/runtime/wasm/field_rc_demo.rgr
@@ -1,0 +1,61 @@
+; ============================================================================
+; field_rc_demo.rgr — owned string-FIELD release on object destruction
+; (PLAN_WASM_MEMORY Phase 4a). An Entity owns a string field `name`; when the
+; Entity is released, obj_release -> obj_destroyFields walks the type descriptor
+; and frees the string field. A create/destroy loop must stay heap-flat.
+; ============================================================================
+
+Import "./ranger_obj.rgr"
+
+class Entity {
+    def name:string ""
+    def hp:int 0
+}
+
+class SG {
+    ; content check: the field holds a correct dup'd copy while the Entity lives
+    sfn nameLen:int (i:int) {
+        def e (new Entity())
+        e.name = ("player" + i)
+        return (strlen e.name)
+    }
+
+    sfn nameFirst:int (i:int) {
+        def e (new Entity())
+        e.name = ("player" + i)
+        return (charAt e.name 0)
+    }
+
+    ; create + set a string field + destroy, N times. Each Entity and its name
+    ; buffer (plus the concat/int temporaries) must be freed each iteration.
+    sfn churnEntity:int (n:int) {
+        def i 0
+        while (< i n) {
+            def e (new Entity())
+            e.name = ("player" + i)
+            i = (+ i 1)
+        }
+        return (Heap.frontier())
+    }
+
+    ; reassign a field in a loop on a single long-lived Entity: the previous
+    ; buffer must be freed before each overwrite (release-before-overwrite), so
+    ; the field does not leak per iteration; the Entity frees the last one.
+    sfn reassignField:int (n:int) {
+        def e (new Entity())
+        def i 0
+        while (< i n) {
+            e.name = ("v" + i)
+            i = (+ i 1)
+        }
+        return 0
+    }
+
+    sfn liveBlocks:int () {
+        return (ranger.obj_live())
+    }
+
+    sfn frontier:int () {
+        return (Heap.frontier())
+    }
+}

--- a/runtime/wasm/field_rc_test.mjs
+++ b/runtime/wasm/field_rc_test.mjs
@@ -1,0 +1,44 @@
+// Owned string-FIELD release test (PLAN_WASM_MEMORY Phase 4a).
+// Build:
+//   node bin/output.js -l=llvm -wat -freestanding -wasmrc \
+//     runtime/wasm/field_rc_demo.rgr -nodecli -d=tmp/fieldrc -o=g.wat
+//   cp tmp/fieldrc/g.wat.ll tmp/fieldrc/g.wat && wat2wasm tmp/fieldrc/g.wat -o tmp/fieldrc/g.wasm
+import fs from "fs";
+const x = new WebAssembly.Instance(new WebAssembly.Module(
+  fs.readFileSync(new URL("../../tmp/fieldrc/g.wasm", import.meta.url)))).exports;
+let pass = 0, fail = 0;
+const ok = (n, g, e) => { if (g === e) pass++; else { fail++; console.log("FAIL", n, JSON.stringify(g), "exp", JSON.stringify(e)); } };
+
+x.Heap_init();
+// content: the field holds a correct private copy while the Entity is alive
+ok("nameLen(7) = 'player7'", x.SG_nameLen(7), 7);
+ok("nameLen(42) = 'player42'", x.SG_nameLen(42), 8);
+ok("nameFirst(3) = 'p'", x.SG_nameFirst(3), 112);
+
+// create + set string field + destroy loop stays heap-flat (Entity, its name
+// buffer, and the concat/int temporaries all freed each iteration)
+x.Heap_init();
+const e1   = x.SG_churnEntity(1);
+const e1k  = x.SG_churnEntity(1000);
+const e50k = x.SG_churnEntity(50000);
+ok("churnEntity flat 1 vs 1000", e1k, e1);
+ok("churnEntity flat 1 vs 50000", e50k, e1);
+
+// zero live objects after the churn — Entity + its string field both freed
+x.Heap_init();
+x.SG_churnEntity(3000);
+ok("no live blocks after churnEntity", x.SG_liveBlocks(), 0);
+
+// field reassignment: old buffer freed before each overwrite, Entity frees last
+x.Heap_init();
+const base = x.SG_frontier();
+x.SG_reassignField(1);
+const rf1 = x.SG_frontier();
+x.SG_reassignField(10000);
+const rf10k = x.SG_frontier();
+ok("reassignField back to base (1)", rf1, base);
+ok("reassignField back to base (10000)", rf10k, base);
+ok("no live blocks after reassignField", x.SG_liveBlocks(), 0);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/runtime/wasm/heap_test.mjs
+++ b/runtime/wasm/heap_test.mjs
@@ -49,11 +49,15 @@ const big = x.Heap_alloc(40);
 ok("coalesced hole serves a bigger request", big === p1);
 x.Heap_free(p3); x.Heap_free(big);
 
-// exhaustion returns 0
+// growth: the heap grows linear memory past the initial 64 KiB page instead of
+// exhausting there (memory.grow). Allocate well beyond one page and confirm
+// every allocation succeeds and the memory actually grew.
 x.Heap_init();
-let oom = false;
-for (let i = 0; i < 100000; i++) { if (x.Heap_alloc(64) === 0) { oom = true; break; } }
-ok("exhaustion returns 0 (no trap)", oom);
+const pagesBefore = x.memory.buffer.byteLength / 65536;
+let allSucceeded = true;
+for (let i = 0; i < 4000; i++) { if (x.Heap_alloc(64) === 0) { allSucceeded = false; break; } }
+ok("allocations past one page succeed (heap grows)", allSucceeded);
+ok("linear memory actually grew", x.memory.buffer.byteLength / 65536 > pagesBefore);
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/runtime/wasm/heap_test.mjs
+++ b/runtime/wasm/heap_test.mjs
@@ -1,0 +1,59 @@
+import fs from "fs";
+const x = new WebAssembly.Instance(new WebAssembly.Module(fs.readFileSync(new URL("../../tmp/heap.wasm", import.meta.url)))).exports;
+let pass = 0, fail = 0;
+const ok = (n, c) => { if (c) { pass++; } else { fail++; console.log("FAIL:", n); } };
+
+x.Heap_init();
+ok("empty heap: 0 blocks", x.Heap_usedBlocks() === 0);
+const base = 16;
+
+// distinct, aligned pointers
+const a = x.Heap_alloc(12), b = x.Heap_alloc(20), c = x.Heap_alloc(8);
+ok("a aligned", a % 8 === 0 && a === base + 8);
+ok("distinct ptrs", a !== b && b !== c);
+ok("3 blocks", x.Heap_usedBlocks() === 3);
+ok("usedBytes = 16+24+8", x.Heap_usedBytes() === 16 + 24 + 8); // 12->16, 20->24, 8->8
+
+// reuse: free middle, re-alloc same size -> reuses the hole, frontier unchanged
+const fr = x.Heap_frontier();
+x.Heap_free(b);
+ok("free drops a block", x.Heap_usedBlocks() === 2);
+const b2 = x.Heap_alloc(20);
+ok("reused the hole (same addr)", b2 === b);
+ok("frontier did not grow on reuse", x.Heap_frontier() === fr);
+
+// split: free b2 (24), alloc small (8) -> splits, leaves a free remainder
+x.Heap_free(b2);
+const s = x.Heap_alloc(8);
+ok("split reused start of hole", s === b2);
+const s2 = x.Heap_alloc(8);
+ok("split remainder is usable", s2 !== 0 && s2 !== s);
+
+// tail reclaim + coalesce: free everything -> frontier back to base
+x.Heap_free(a); x.Heap_free(c); x.Heap_free(s); x.Heap_free(s2);
+ok("all freed -> 0 blocks", x.Heap_usedBlocks() === 0);
+ok("tail reclaim -> frontier back to base", x.Heap_frontier() === base);
+
+// stress: many alloc/free cycles must not grow the frontier unboundedly
+x.Heap_init();
+let maxFront = 0;
+for (let i = 0; i < 5000; i++) { const p = x.Heap_alloc(16 + (i % 5) * 8); maxFront = Math.max(maxFront, x.Heap_frontier()); x.Heap_free(p); }
+ok("alloc/free loop does not leak (frontier bounded, back to base)", x.Heap_frontier() === base);
+ok("5000-cycle frontier stayed tiny", maxFront < 200);
+
+// coalescing: free two adjacent, ensure a big alloc fits in the merged hole
+x.Heap_init();
+const p1 = x.Heap_alloc(16), p2 = x.Heap_alloc(16), p3 = x.Heap_alloc(16);
+x.Heap_free(p1); x.Heap_free(p2); // adjacent -> coalesce to 40 (16+8+16)
+const big = x.Heap_alloc(40);
+ok("coalesced hole serves a bigger request", big === p1);
+x.Heap_free(p3); x.Heap_free(big);
+
+// exhaustion returns 0
+x.Heap_init();
+let oom = false;
+for (let i = 0; i < 100000; i++) { if (x.Heap_alloc(64) === 0) { oom = true; break; } }
+ok("exhaustion returns 0 (no trap)", oom);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/runtime/wasm/map_rc_demo.rgr
+++ b/runtime/wasm/map_rc_demo.rgr
@@ -1,0 +1,62 @@
+; ============================================================================
+; map_rc_demo.rgr — [int:int] maps on the free-list heap with growth + release
+; (PLAN_WASM_MEMORY Phase 4b). The map's descriptor/keys/vals live on the
+; free-list heap; the table doubles + rehashes when the load factor passes 50%
+; (so a full table never probes forever), linear memory grows past 64 KiB on
+; demand, and the map is freed at scope end.
+; ============================================================================
+
+Import "./ranger_obj.rgr"
+
+class SG {
+    ; put 0..n-1 -> *10, then sum by lookup. Exercises many grows for large n.
+    sfn mapSum:int (n:int) {
+        def m:[int:int]
+        def i 0
+        while (< i n) {
+            set m i (* i 10)
+            i = (+ i 1)
+        }
+        def s 0
+        def j 0
+        while (< j n) {
+            s = (+ s (get m j))
+            j = (+ j 1)
+        }
+        return s
+    }
+
+    ; overwrite the same keys repeatedly — size must not grow, values update
+    sfn mapOverwrite:int (n:int reps:int) {
+        def m:[int:int]
+        def r 0
+        while (< r reps) {
+            def i 0
+            while (< i n) {
+                set m i (+ r i)
+                i = (+ i 1)
+            }
+            r = (+ r 1)
+        }
+        def last (+ 0 (get m (- n 1)))
+        return last
+    }
+
+    ; build+drop a map `reps` times; heap flat => descriptor/keys/vals all freed
+    sfn churnMap:int (reps:int size:int) {
+        def r 0
+        while (< r reps) {
+            def _ (SG.mapSum(size))
+            r = (+ r 1)
+        }
+        return (Heap.frontier())
+    }
+
+    sfn liveBlocks:int () {
+        return (ranger.obj_live())
+    }
+
+    sfn frontier:int () {
+        return (Heap.frontier())
+    }
+}

--- a/runtime/wasm/map_rc_test.mjs
+++ b/runtime/wasm/map_rc_test.mjs
@@ -1,0 +1,37 @@
+// Map RC / growth test (PLAN_WASM_MEMORY Phase 4b).
+// Build:
+//   node bin/output.js -l=llvm -wat -freestanding -wasmrc \
+//     runtime/wasm/map_rc_demo.rgr -nodecli -d=tmp/maprc -o=g.wat
+//   cp tmp/maprc/g.wat.ll tmp/maprc/g.wat && wat2wasm tmp/maprc/g.wat -o tmp/maprc/g.wasm
+import fs from "fs";
+const x = new WebAssembly.Instance(new WebAssembly.Module(
+  fs.readFileSync(new URL("../../tmp/maprc/g.wasm", import.meta.url)))).exports;
+let pass = 0, fail = 0;
+const ok = (n, g, e) => { if (g === e) pass++; else { fail++; console.log("FAIL", n, JSON.stringify(g), "exp", JSON.stringify(e)); } };
+const sum10 = (n) => 10 * (n * (n - 1) / 2);
+
+// correctness across many table doublings + rehashes (no infinite probe)
+x.Heap_init();
+ok("mapSum(5)", x.SG_mapSum(5), sum10(5));
+ok("mapSum(50)", x.SG_mapSum(50), sum10(50));
+ok("mapSum(500)", x.SG_mapSum(500), sum10(500));
+// large map forces linear memory to grow past the initial 64 KiB page
+x.Heap_init();
+ok("mapSum(5000) (memory grows)", x.SG_mapSum(5000), sum10(5000));
+ok("mapSum(20000) (memory grows)", x.SG_mapSum(20000), sum10(20000));
+
+// overwrite: repeated puts of the same keys update in place, size bounded
+x.Heap_init();
+ok("mapOverwrite(30,10)", x.SG_mapOverwrite(30, 10), 9 + 29); // r=9, i=29
+
+// leak-freedom: build+drop a map many times, heap frontier identical
+x.Heap_init();
+const m1  = x.SG_churnMap(1, 200);
+const m1k = x.SG_churnMap(1000, 200);
+ok("churnMap flat", m1k, m1);
+x.Heap_init();
+x.SG_churnMap(500, 300);
+ok("no live blocks after churnMap", x.SG_liveBlocks(), 0);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/runtime/wasm/obj_test.mjs
+++ b/runtime/wasm/obj_test.mjs
@@ -1,0 +1,45 @@
+import fs from "fs";
+const x = new WebAssembly.Instance(new WebAssembly.Module(fs.readFileSync(new URL("../../tmp/objmem/obj.wasm", import.meta.url)))).exports;
+const mem = new DataView(x.memory.buffer);
+const R = (o) => mem.getInt32(o, true), W = (o, v) => mem.setInt32(o, v, true);
+let pass = 0, fail = 0;
+const ok = (n, c) => { if (c) pass++; else { fail++; console.log("FAIL:", n); } };
+
+x.Heap_init();
+// Build a permanent typedesc for a node { value@0, next@4 } — next is an owned object field.
+const fields = x.Heap_alloc(12); W(fields, 4); W(fields + 4, 1); W(fields + 8, 1);   // offset=4 kind=object owned=1
+const td = x.Heap_alloc(12); W(td, 8); W(td + 4, 1); W(td + 8, fields);               // structSize=8 fieldCount=1 fieldsPtr
+const baseline = x.RangerObj_liveBlocks(); // 2 permanent typedesc blocks
+ok("baseline = 2 typedesc blocks", baseline === 2);
+
+// --- recursive teardown: a chain of 5 nodes, release the head ---
+let head = x.RangerObj_new(8, td), prev = head;
+for (let i = 1; i < 5; i++) { const n = x.RangerObj_new(8, td); W(prev + 4, n); prev = n; }
+ok("5 nodes allocated", x.RangerObj_liveBlocks() === baseline + 5);
+x.RangerObj_release(head);
+ok("releasing head recursively frees the whole chain", x.RangerObj_liveBlocks() === baseline);
+
+// --- refcount: retain keeps it alive until the matching release ---
+const a = x.RangerObj_new(8, td);
+x.RangerObj_retain(a);
+ok("rc after new+retain = 2", x.RangerObj_refCount(a) === 2);
+x.RangerObj_release(a);
+ok("one release -> still live (rc 1)", x.RangerObj_liveBlocks() === baseline + 1 && x.RangerObj_refCount(a) === 1);
+x.RangerObj_release(a);
+ok("second release -> freed", x.RangerObj_liveBlocks() === baseline);
+
+// --- shared ownership: two parents own one child (retained) ---
+const pA = x.RangerObj_new(8, td), pB = x.RangerObj_new(8, td), child = x.RangerObj_new(8, td);
+W(pA + 4, child); W(pB + 4, child); x.RangerObj_retain(child); // child now owned by both, rc=2
+ok("3 objects live", x.RangerObj_liveBlocks() === baseline + 3);
+x.RangerObj_release(pA);
+ok("release pA -> pA gone, child survives (rc 1)", x.RangerObj_liveBlocks() === baseline + 2 && x.RangerObj_refCount(child) === 1);
+x.RangerObj_release(pB);
+ok("release pB -> pB and child both gone", x.RangerObj_liveBlocks() === baseline);
+
+// --- no-leak: 2000 build-and-release cycles keep the heap flat ---
+for (let i = 0; i < 2000; i++) { let h = x.RangerObj_new(8, td), p = h; for (let k = 0; k < 4; k++){ const n = x.RangerObj_new(8, td); W(p+4,n); p=n; } x.RangerObj_release(h); }
+ok("2000 chain build/release cycles -> no leak", x.RangerObj_liveBlocks() === baseline);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/runtime/wasm/obj_test.mjs
+++ b/runtime/wasm/obj_test.mjs
@@ -9,37 +9,37 @@ x.Heap_init();
 // Build a permanent typedesc for a node { value@0, next@4 } — next is an owned object field.
 const fields = x.Heap_alloc(12); W(fields, 4); W(fields + 4, 1); W(fields + 8, 1);   // offset=4 kind=object owned=1
 const td = x.Heap_alloc(12); W(td, 8); W(td + 4, 1); W(td + 8, fields);               // structSize=8 fieldCount=1 fieldsPtr
-const baseline = x.RangerObj_liveBlocks(); // 2 permanent typedesc blocks
+const baseline = x.ranger_obj_live(); // 2 permanent typedesc blocks
 ok("baseline = 2 typedesc blocks", baseline === 2);
 
 // --- recursive teardown: a chain of 5 nodes, release the head ---
-let head = x.RangerObj_new(8, td), prev = head;
-for (let i = 1; i < 5; i++) { const n = x.RangerObj_new(8, td); W(prev + 4, n); prev = n; }
-ok("5 nodes allocated", x.RangerObj_liveBlocks() === baseline + 5);
-x.RangerObj_release(head);
-ok("releasing head recursively frees the whole chain", x.RangerObj_liveBlocks() === baseline);
+let head = x.ranger_obj_new(8, td), prev = head;
+for (let i = 1; i < 5; i++) { const n = x.ranger_obj_new(8, td); W(prev + 4, n); prev = n; }
+ok("5 nodes allocated", x.ranger_obj_live() === baseline + 5);
+x.ranger_obj_release(head);
+ok("releasing head recursively frees the whole chain", x.ranger_obj_live() === baseline);
 
 // --- refcount: retain keeps it alive until the matching release ---
-const a = x.RangerObj_new(8, td);
-x.RangerObj_retain(a);
-ok("rc after new+retain = 2", x.RangerObj_refCount(a) === 2);
-x.RangerObj_release(a);
-ok("one release -> still live (rc 1)", x.RangerObj_liveBlocks() === baseline + 1 && x.RangerObj_refCount(a) === 1);
-x.RangerObj_release(a);
-ok("second release -> freed", x.RangerObj_liveBlocks() === baseline);
+const a = x.ranger_obj_new(8, td);
+x.ranger_obj_retain(a);
+ok("rc after new+retain = 2", x.ranger_obj_refcount(a) === 2);
+x.ranger_obj_release(a);
+ok("one release -> still live (rc 1)", x.ranger_obj_live() === baseline + 1 && x.ranger_obj_refcount(a) === 1);
+x.ranger_obj_release(a);
+ok("second release -> freed", x.ranger_obj_live() === baseline);
 
 // --- shared ownership: two parents own one child (retained) ---
-const pA = x.RangerObj_new(8, td), pB = x.RangerObj_new(8, td), child = x.RangerObj_new(8, td);
-W(pA + 4, child); W(pB + 4, child); x.RangerObj_retain(child); // child now owned by both, rc=2
-ok("3 objects live", x.RangerObj_liveBlocks() === baseline + 3);
-x.RangerObj_release(pA);
-ok("release pA -> pA gone, child survives (rc 1)", x.RangerObj_liveBlocks() === baseline + 2 && x.RangerObj_refCount(child) === 1);
-x.RangerObj_release(pB);
-ok("release pB -> pB and child both gone", x.RangerObj_liveBlocks() === baseline);
+const pA = x.ranger_obj_new(8, td), pB = x.ranger_obj_new(8, td), child = x.ranger_obj_new(8, td);
+W(pA + 4, child); W(pB + 4, child); x.ranger_obj_retain(child); // child now owned by both, rc=2
+ok("3 objects live", x.ranger_obj_live() === baseline + 3);
+x.ranger_obj_release(pA);
+ok("release pA -> pA gone, child survives (rc 1)", x.ranger_obj_live() === baseline + 2 && x.ranger_obj_refcount(child) === 1);
+x.ranger_obj_release(pB);
+ok("release pB -> pB and child both gone", x.ranger_obj_live() === baseline);
 
 // --- no-leak: 2000 build-and-release cycles keep the heap flat ---
-for (let i = 0; i < 2000; i++) { let h = x.RangerObj_new(8, td), p = h; for (let k = 0; k < 4; k++){ const n = x.RangerObj_new(8, td); W(p+4,n); p=n; } x.RangerObj_release(h); }
-ok("2000 chain build/release cycles -> no leak", x.RangerObj_liveBlocks() === baseline);
+for (let i = 0; i < 2000; i++) { let h = x.ranger_obj_new(8, td), p = h; for (let k = 0; k < 4; k++){ const n = x.ranger_obj_new(8, td); W(p+4,n); p=n; } x.ranger_obj_release(h); }
+ok("2000 chain build/release cycles -> no leak", x.ranger_obj_live() === baseline);
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/runtime/wasm/ranger_heap.rgr
+++ b/runtime/wasm/ranger_heap.rgr
@@ -1,0 +1,200 @@
+; ============================================================================
+; ranger_heap.rgr — a free-list allocator in Ranger linear memory (WASM Phase 0).
+;
+; PLAN_WASM_MEMORY.md Phase 0. This is the deallocating heap that replaces the
+; WAT backend's leak-forever bump allocator. It is written in Ranger and
+; compiled to WASM so the algorithm can be validated end-to-end (heap_test.mjs)
+; before it is emitted by the compiler as a runtime prelude (Phase 2).
+;
+; Block layout (8-byte header + payload, all contiguous from HEAP_BASE):
+;   [ size (payload bytes) ][ free flag (0=used,1=free) ][ payload... ]
+;   total block bytes = size + 8 ; the pointer handed out is (block + 8).
+;
+; Policy: first-fit search with block splitting on alloc; forward coalescing on
+; free; the tail block, once free, is returned to the bump frontier so a fully
+; freed heap costs nothing. Backward coalescing (footers) is a Phase-0.1 follow
+; up. One 64 KiB page for now; memory.grow is a later step.
+;
+; Control words live below HEAP_BASE:  [0] = top (bump frontier).
+; ============================================================================
+
+class Mem {
+    sfn alloc:int (nBytes:int) {
+        return 0
+    }
+
+    sfn loadI32:int (ptr:int) {
+        return 0
+    }
+
+    sfn storeI32:void (ptr:int val:int) {
+    }
+}
+
+class Heap {
+    ; --- fixed geometry -----------------------------------------------------
+    sfn base:int () {
+        return 16
+    }
+
+    sfn limit:int () {
+        return 65536
+    }
+
+    sfn top:int () {
+        return (Mem.loadI32(0))
+    }
+
+    sfn setTop:void (v:int) {
+        Mem.storeI32(0 v)
+    }
+
+    sfn init:void () {
+        Mem.storeI32(0 (Heap.base()))
+    }
+
+    ; round a request up to the 8-byte block granularity (min one word pair)
+    sfn roundUp:int (n:int) {
+        def r (bit_and (+ n 7) (bit_xor -1 7))
+        if (< r 8) {
+            return 8
+        }
+        return r
+    }
+
+    ; --- block header accessors --------------------------------------------
+    sfn blockSize:int (b:int) {
+        return (Mem.loadI32(b))
+    }
+
+    sfn blockFree:int (b:int) {
+        return (Mem.loadI32((+ b 4)))
+    }
+
+    sfn setBlock:void (b:int size:int free:int) {
+        Mem.storeI32(b size)
+        Mem.storeI32((+ b 4) free)
+    }
+
+    ; total bytes occupied by a block (header + payload)
+    sfn blockTotal:int (b:int) {
+        return (+ (Heap.blockSize(b)) 8)
+    }
+
+    ; --- allocation ---------------------------------------------------------
+    sfn alloc:int (n:int) {
+        def need (Heap.roundUp(n))
+
+        ; first-fit over existing blocks
+        def b (Heap.base())
+        def top (Heap.top())
+        while (< b top) {
+            if (== (Heap.blockFree(b)) 1) {
+                if (>= (Heap.blockSize(b)) need) {
+                    Heap.splitIfWorth(b need)
+                    Heap.setBlock(b (Heap.blockSize(b)) 0)
+                    return (+ b 8)
+                }
+            }
+            b = (+ b (Heap.blockTotal(b)))
+        }
+
+        ; no reusable block: carve a fresh one at the bump frontier
+        def block top
+        if (> (+ (+ block need) 8) (Heap.limit())) {
+            return 0
+        }
+        Heap.setBlock(block need 0)
+        Heap.setTop((+ (+ block need) 8))
+        return (+ block 8)
+    }
+
+    ; if a chosen free block is large enough to hold `need` plus a whole second
+    ; block (header + one word pair), split off the remainder as a free block.
+    sfn splitIfWorth:void (b:int need:int) {
+        def sz (Heap.blockSize(b))
+        if (>= sz (+ need 16)) {
+            def rest (- (- sz need) 8)
+            def nb (+ (+ b 8) need)
+            Heap.setBlock(nb rest 1)
+            Mem.storeI32(b need)
+        }
+    }
+
+    ; --- free -> mark, then a full coalesce pass ---------------------------
+    ; A whole-heap coalesce keeps the free list fully merged regardless of the
+    ; order blocks are freed in (forward-only merge cannot join a block to an
+    ; already-free predecessor without footers). O(n) per free in Phase 0; the
+    ; compiler-emitted runtime can switch to an explicit free list later.
+    sfn free:void (ptr:int) {
+        Mem.storeI32((+ (- ptr 8) 4) 1)
+        Heap.coalesceAll()
+    }
+
+    sfn coalesceAll:void () {
+        ; forward-merge every run of adjacent free blocks
+        def b (Heap.base())
+        while (< b (Heap.top())) {
+            if (== (Heap.blockFree(b)) 1) {
+                def done 0
+                while (== done 0) {
+                    def nextp (+ b (Heap.blockTotal(b)))
+                    if (>= nextp (Heap.top())) {
+                        done = 1
+                    } {
+                        if (== (Heap.blockFree(nextp)) 1) {
+                            Mem.storeI32(b (+ (+ (Heap.blockSize(b)) 8) (Heap.blockSize(nextp))))
+                        } {
+                            done = 1
+                        }
+                    }
+                }
+            }
+            b = (+ b (Heap.blockTotal(b)))
+        }
+
+        ; tail reclaim: a trailing free block goes back to the bump frontier
+        def last (Heap.base())
+        def scan (Heap.base())
+        while (< scan (Heap.top())) {
+            last = scan
+            scan = (+ scan (Heap.blockTotal(scan)))
+        }
+        if (< last (Heap.top())) {
+            if (== (Heap.blockFree(last)) 1) {
+                Heap.setTop(last)
+            }
+        }
+    }
+
+    ; --- stats (for tests) --------------------------------------------------
+    sfn usedBytes:int () {
+        def b (Heap.base())
+        def top (Heap.top())
+        def sum 0
+        while (< b top) {
+            if (== (Heap.blockFree(b)) 0) {
+                sum = (+ sum (Heap.blockSize(b)))
+            }
+            b = (+ b (Heap.blockTotal(b)))
+        }
+        return sum
+    }
+
+    sfn usedBlocks:int () {
+        def b (Heap.base())
+        def top (Heap.top())
+        def cnt 0
+        while (< b top) {
+            if (== (Heap.blockFree(b)) 0) {
+                cnt = (+ cnt 1)
+            }
+            b = (+ b (Heap.blockTotal(b)))
+        }
+        return cnt
+    }
+
+    sfn frontier:int () {
+        return (Heap.top())
+    }
+}

--- a/runtime/wasm/ranger_heap.rgr
+++ b/runtime/wasm/ranger_heap.rgr
@@ -125,6 +125,50 @@ class Heap {
         return (+ block 8)
     }
 
+    ; calloc-equivalent: allocate and zero the payload. Freed blocks are reused
+    ; with stale bytes, so callers that rely on zero-initialised memory (the
+    ; collection descriptors' metadata, non-owned flags) must go through here —
+    ; this is what the compiler routes emitHeapAlloc to under -wasmrc, matching
+    ; libc calloc. (Object/string runtimes use bare alloc and init themselves.)
+    sfn calloc:int (n:int) {
+        def p (Heap.alloc(n))
+        if (== p 0) {
+            return 0
+        }
+        def sz (Heap.blockSize((- p 8)))
+        def i 0
+        while (< i sz) {
+            Mem.storeU8((+ p i) 0)
+            i = (+ i 1)
+        }
+        return p
+    }
+
+    ; realloc-equivalent: grow/shrink a block, copying the smaller of old/new
+    ; payload bytes into a fresh block and freeing the old one. Used by the
+    ; collection push-grow path in place of libc realloc on freestanding WASM.
+    sfn realloc:int (ptr:int newBytes:int) {
+        if (== ptr 0) {
+            return (Heap.alloc(newBytes))
+        }
+        def np (Heap.alloc(newBytes))
+        if (== np 0) {
+            return 0
+        }
+        def old (Heap.blockSize((- ptr 8)))
+        def copy old
+        if (< newBytes copy) {
+            copy = newBytes
+        }
+        def i 0
+        while (< i copy) {
+            Mem.storeU8((+ np i) (Mem.loadU8((+ ptr i))))
+            i = (+ i 1)
+        }
+        Heap.free(ptr)
+        return np
+    }
+
     ; if a chosen free block is large enough to hold `need` plus a whole second
     ; block (header + one word pair), split off the remainder as a free block.
     sfn splitIfWorth:void (b:int need:int) {

--- a/runtime/wasm/ranger_heap.rgr
+++ b/runtime/wasm/ranger_heap.rgr
@@ -83,6 +83,9 @@ class Heap {
 
     ; --- allocation ---------------------------------------------------------
     sfn alloc:int (n:int) {
+        if (== (Heap.top()) 0) {
+            Heap.init()
+        }
         def need (Heap.roundUp(n))
 
         ; first-fit over existing blocks

--- a/runtime/wasm/ranger_heap.rgr
+++ b/runtime/wasm/ranger_heap.rgr
@@ -36,6 +36,16 @@ class Mem {
 
     sfn storeU8:void (ptr:int val:int) {
     }
+
+    ; wasm memory.size / memory.grow (intrinsics; bodies are placeholders the
+    ; compiler replaces). Sizes are in 64 KiB pages.
+    sfn memSize:int () {
+        return 0
+    }
+
+    sfn memGrow:int (pages:int) {
+        return 0
+    }
 }
 
 class Heap {
@@ -50,8 +60,10 @@ class Heap {
         return b
     }
 
+    ; the heap may use all of linear memory; its ceiling is the current memory
+    ; size (grown on demand by alloc via memory.grow), not a fixed one page.
     sfn limit:int () {
-        return 65536
+        return (* (Mem.memSize()) 65536)
     }
 
     sfn top:int () {
@@ -115,10 +127,18 @@ class Heap {
             b = (+ b (Heap.blockTotal(b)))
         }
 
-        ; no reusable block: carve a fresh one at the bump frontier
+        ; no reusable block: carve a fresh one at the bump frontier, growing
+        ; linear memory by whole pages when the carve would overrun the current
+        ; ceiling. memory.grow returning -1 (host cap reached) is a real OOM -> 0.
         def block top
-        if (> (+ (+ block need) 8) (Heap.limit())) {
-            return 0
+        def endNeed (+ (+ block need) 8)
+        if (> endNeed (Heap.limit())) {
+            def deficit (- endNeed (Heap.limit()))
+            def pages (idiv (+ deficit 65535) 65536)
+            def r (Mem.memGrow(pages))
+            if (< r 0) {
+                return 0
+            }
         }
         Heap.setBlock(block need 0)
         Heap.setTop((+ (+ block need) 8))

--- a/runtime/wasm/ranger_heap.rgr
+++ b/runtime/wasm/ranger_heap.rgr
@@ -29,12 +29,25 @@ class Mem {
 
     sfn storeI32:void (ptr:int val:int) {
     }
+
+    sfn loadU8:int (ptr:int) {
+        return 0
+    }
+
+    sfn storeU8:void (ptr:int val:int) {
+    }
 }
 
 class Heap {
     ; --- fixed geometry -----------------------------------------------------
+    ; The heap base is the end of the string-literal region, which the compiler
+    ; writes to Mem[4] (0 when there are no literals -> default 16).
     sfn base:int () {
-        return 16
+        def b (Mem.loadI32(4))
+        if (== b 0) {
+            return 16
+        }
+        return b
     }
 
     sfn limit:int () {

--- a/runtime/wasm/ranger_obj.rgr
+++ b/runtime/wasm/ranger_obj.rgr
@@ -1,26 +1,28 @@
 ; ============================================================================
 ; ranger_obj.rgr — reference-counted objects on the WASM free-list heap
-; (PLAN_WASM_MEMORY.md Phase 1). The Ranger/WASM equivalent of the native
-; runtime/ranger_mem.c: an object header in front of the body plus
-; ranger_obj_new / retain / release, where release walks a type descriptor to
-; free owned fields recursively.
+; (PLAN_WASM_MEMORY.md Phase 1/2). The Ranger/WASM equivalent of the native
+; runtime/ranger_mem.c.
+;
+; The class is named `ranger` with methods `obj_new` / `obj_retain` /
+; `obj_release` so the WAT backend's mangled names are exactly `ranger_obj_new`
+; / `ranger_obj_retain` / `ranger_obj_release` — the very symbols the compiler's
+; RC insertion already emits (ng_LowIRBuilder.rgr lowerNewObject / releaseOwned
+; Local). So a program that imports this module gets drop-in memory management
+; under -wasmrc, no codegen name changes required.
 ;
 ; Object memory:  [ rc | size | typeDesc | pad ][ body... ]   (16-byte header)
 ;   the pointer handed to Ranger code is `body` = block + 16.
 ;
-; Type descriptor (in linear memory, produced by the compiler in the real
-; system; built by the test here):
+; Type descriptor (typeDesc == 0 means "no owned fields", used by Phase-2 v1):
 ;   TypeDesc : [ structSize | fieldCount | fieldsPtr ]
-;   Field(12): [ offset | kind | owned ]      kind 0=string 1=object 2=ptrarray
-; release recurses into owned OBJECT fields; string / ptr-array field kinds are
-; stubbed here (they arrive with the string + array runtime in a later step).
+;   Field(12): [ offset | kind | owned ]    kind 0=string 1=object 2=ptrarray
 ; ============================================================================
 
 Import "./ranger_heap.rgr"
 
-class RangerObj {
+class ranger {
     ; --- allocate a zeroed, rc=1 object -------------------------------------
-    sfn new:int (size:int typeDesc:int) {
+    sfn obj_new:int (size:int typeDesc:int) {
         def block (Heap.alloc((+ 16 size)))
         if (== block 0) {
             return 0
@@ -38,11 +40,11 @@ class RangerObj {
         return body
     }
 
-    sfn refCount:int (body:int) {
+    sfn obj_refcount:int (body:int) {
         return (Mem.loadI32((- body 16)))
     }
 
-    sfn retain:void (body:int) {
+    sfn obj_retain:void (body:int) {
         if (!= body 0) {
             def block (- body 16)
             Mem.storeI32(block (+ (Mem.loadI32(block)) 1))
@@ -50,7 +52,7 @@ class RangerObj {
     }
 
     ; --- release: decrement, and on reaching zero destroy fields + free -----
-    sfn release:void (body:int) {
+    sfn obj_release:void (body:int) {
         if (== body 0) {
             return
         }
@@ -60,12 +62,12 @@ class RangerObj {
         if (> rc 0) {
             return
         }
-        RangerObj.destroyFields(body (Mem.loadI32((+ block 8))))
+        ranger.obj_destroyFields(body (Mem.loadI32((+ block 8))))
         Heap.free(block)
     }
 
-    ; walk the type descriptor and release each owned field
-    sfn destroyFields:void (body:int td:int) {
+    ; walk the type descriptor and release each owned object field
+    sfn obj_destroyFields:void (body:int td:int) {
         if (== td 0) {
             return
         }
@@ -80,7 +82,7 @@ class RangerObj {
                 def val (Mem.loadI32((+ body (Mem.loadI32(f)))))
                 if (!= val 0) {
                     if (== kind 1) {
-                        RangerObj.release(val)
+                        ranger.obj_release(val)
                     }
                 }
             }
@@ -88,9 +90,8 @@ class RangerObj {
         }
     }
 
-    ; live object count (heap blocks minus the caller's permanent typedescs is
-    ; computed test-side); exposed for the harness.
-    sfn liveBlocks:int () {
+    ; live heap-block count (for tests / liveObjects checks)
+    sfn obj_live:int () {
         return (Heap.usedBlocks())
     }
 }

--- a/runtime/wasm/ranger_obj.rgr
+++ b/runtime/wasm/ranger_obj.rgr
@@ -302,8 +302,8 @@ class ranger {
         if (== desc 0) {
             return
         }
-        def owned (Mem.loadI32((+ desc 12)))
-        if (!= owned 0) {
+        def kind (Mem.loadI32((+ desc 12)))
+        if (== kind 1) {
             if (!= val 0) {
                 ranger.obj_retain(val)
             }
@@ -326,24 +326,29 @@ class ranger {
         Mem.storeI32((+ desc 4) (+ len2 1))
     }
 
+    ; kind (flag word at desc+12): 0 = plain values (no element release),
+    ; 1 = owned objects (obj_release), 2 = owned strings (str_release).
     sfn ptrarray_release:void (desc:int) {
         if (== desc 0) {
             return
         }
-        def owned (Mem.loadI32((+ desc 12)))
+        def kind (Mem.loadI32((+ desc 12)))
         def data (Mem.loadI32(desc))
-        if (!= owned 0) {
-            if (!= data 0) {
+        if (!= data 0) {
+            if (!= kind 0) {
                 def len (Mem.loadI32((+ desc 4)))
                 def i 0
                 while (< i len) {
                     def el (Mem.loadI32((+ data (* i 4))))
-                    ranger.obj_release(el)
+                    if (== kind 1) {
+                        ranger.obj_release(el)
+                    }
+                    if (== kind 2) {
+                        ranger.str_release(el)
+                    }
                     i = (+ i 1)
                 }
             }
-        }
-        if (!= data 0) {
             Heap.free(data)
         }
         Heap.free(desc)

--- a/runtime/wasm/ranger_obj.rgr
+++ b/runtime/wasm/ranger_obj.rgr
@@ -84,6 +84,9 @@ class ranger {
                     if (== kind 1) {
                         ranger.obj_release(val)
                     }
+                    if (== kind 0) {
+                        ranger.str_release(val)
+                    }
                 }
             }
             i = (+ i 1)

--- a/runtime/wasm/ranger_obj.rgr
+++ b/runtime/wasm/ranger_obj.rgr
@@ -1,0 +1,96 @@
+; ============================================================================
+; ranger_obj.rgr — reference-counted objects on the WASM free-list heap
+; (PLAN_WASM_MEMORY.md Phase 1). The Ranger/WASM equivalent of the native
+; runtime/ranger_mem.c: an object header in front of the body plus
+; ranger_obj_new / retain / release, where release walks a type descriptor to
+; free owned fields recursively.
+;
+; Object memory:  [ rc | size | typeDesc | pad ][ body... ]   (16-byte header)
+;   the pointer handed to Ranger code is `body` = block + 16.
+;
+; Type descriptor (in linear memory, produced by the compiler in the real
+; system; built by the test here):
+;   TypeDesc : [ structSize | fieldCount | fieldsPtr ]
+;   Field(12): [ offset | kind | owned ]      kind 0=string 1=object 2=ptrarray
+; release recurses into owned OBJECT fields; string / ptr-array field kinds are
+; stubbed here (they arrive with the string + array runtime in a later step).
+; ============================================================================
+
+Import "./ranger_heap.rgr"
+
+class RangerObj {
+    ; --- allocate a zeroed, rc=1 object -------------------------------------
+    sfn new:int (size:int typeDesc:int) {
+        def block (Heap.alloc((+ 16 size)))
+        if (== block 0) {
+            return 0
+        }
+        Mem.storeI32(block 1)               ; rc = 1
+        Mem.storeI32((+ block 4) size)
+        Mem.storeI32((+ block 8) typeDesc)
+        Mem.storeI32((+ block 12) 0)        ; pad
+        def body (+ block 16)
+        def i 0
+        while (< i size) {                  ; zero the body -> null fields
+            Mem.storeI32((+ body i) 0)
+            i = (+ i 4)
+        }
+        return body
+    }
+
+    sfn refCount:int (body:int) {
+        return (Mem.loadI32((- body 16)))
+    }
+
+    sfn retain:void (body:int) {
+        if (!= body 0) {
+            def block (- body 16)
+            Mem.storeI32(block (+ (Mem.loadI32(block)) 1))
+        }
+    }
+
+    ; --- release: decrement, and on reaching zero destroy fields + free -----
+    sfn release:void (body:int) {
+        if (== body 0) {
+            return
+        }
+        def block (- body 16)
+        def rc (- (Mem.loadI32(block)) 1)
+        Mem.storeI32(block rc)
+        if (> rc 0) {
+            return
+        }
+        RangerObj.destroyFields(body (Mem.loadI32((+ block 8))))
+        Heap.free(block)
+    }
+
+    ; walk the type descriptor and release each owned field
+    sfn destroyFields:void (body:int td:int) {
+        if (== td 0) {
+            return
+        }
+        def fieldCount (Mem.loadI32((+ td 4)))
+        def fieldsPtr (Mem.loadI32((+ td 8)))
+        def i 0
+        while (< i fieldCount) {
+            def f (+ fieldsPtr (* i 12))
+            def owned (Mem.loadI32((+ f 8)))
+            if (!= owned 0) {
+                def kind (Mem.loadI32((+ f 4)))
+                def val (Mem.loadI32((+ body (Mem.loadI32(f)))))
+                if (!= val 0) {
+                    if (== kind 1) {
+                        RangerObj.release(val)
+                    }
+                }
+            }
+            i = (+ i 1)
+        }
+    }
+
+    ; live object count (heap blocks minus the caller's permanent typedescs is
+    ; computed test-side); exposed for the harness.
+    sfn liveBlocks:int () {
+        return (Heap.usedBlocks())
+    }
+}

--- a/runtime/wasm/ranger_obj.rgr
+++ b/runtime/wasm/ranger_obj.rgr
@@ -207,4 +207,83 @@ class ranger {
             Heap.free(s)
         }
     }
+
+    ; ======================================================================
+    ; Character access. The compiler emits calls to these exact mangled names
+    ; (ranger_char_at / ranger_substring / ranger_str_fromcode /
+    ; ranger_str_frombyte) for charAt / substring / strfromcode / rawbytechar.
+    ; ======================================================================
+
+    ; byte at index (games use ASCII; a UTF-8 lead byte is returned as-is)
+    sfn char_at:int (s:int pos:int) {
+        if (== s 0) {
+            return 0
+        }
+        return (Mem.loadU8((+ s pos)))
+    }
+
+    ; fresh heap copy of the byte range [start, end), clamped to [0, len]
+    sfn substring:int (s:int start:int end:int) {
+        def n (ranger.str_len(s))
+        def st start
+        if (< st 0) {
+            st = 0
+        }
+        def en end
+        if (> en n) {
+            en = n
+        }
+        if (< en st) {
+            en = st
+        }
+        def len (- en st)
+        def buf (Heap.alloc((+ len 1)))
+        def i 0
+        while (< i len) {
+            Mem.storeU8((+ buf i) (Mem.loadU8((+ (+ s st) i))))
+            i = (+ i 1)
+        }
+        Mem.storeU8((+ buf len) 0)
+        return buf
+    }
+
+    ; UTF-8 encode one code point into a fresh heap string
+    sfn str_fromcode:int (code:int) {
+        if (< code 128) {
+            def b (Heap.alloc(2))
+            Mem.storeU8(b code)
+            Mem.storeU8((+ b 1) 0)
+            return b
+        }
+        if (< code 2048) {
+            def b (Heap.alloc(3))
+            Mem.storeU8(b (bit_or 192 (bit_shr code 6)))
+            Mem.storeU8((+ b 1) (bit_or 128 (bit_and code 63)))
+            Mem.storeU8((+ b 2) 0)
+            return b
+        }
+        if (< code 65536) {
+            def b (Heap.alloc(4))
+            Mem.storeU8(b (bit_or 224 (bit_shr code 12)))
+            Mem.storeU8((+ b 1) (bit_or 128 (bit_and (bit_shr code 6) 63)))
+            Mem.storeU8((+ b 2) (bit_or 128 (bit_and code 63)))
+            Mem.storeU8((+ b 3) 0)
+            return b
+        }
+        def b (Heap.alloc(5))
+        Mem.storeU8(b (bit_or 240 (bit_shr code 18)))
+        Mem.storeU8((+ b 1) (bit_or 128 (bit_and (bit_shr code 12) 63)))
+        Mem.storeU8((+ b 2) (bit_or 128 (bit_and (bit_shr code 6) 63)))
+        Mem.storeU8((+ b 3) (bit_or 128 (bit_and code 63)))
+        Mem.storeU8((+ b 4) 0)
+        return b
+    }
+
+    ; single raw byte -> fresh 1-char heap string
+    sfn str_frombyte:int (byte:int) {
+        def buf (Heap.alloc(2))
+        Mem.storeU8(buf (bit_and byte 255))
+        Mem.storeU8((+ buf 1) 0)
+        return buf
+    }
 }

--- a/runtime/wasm/ranger_obj.rgr
+++ b/runtime/wasm/ranger_obj.rgr
@@ -289,4 +289,63 @@ class ranger {
         Mem.storeU8((+ buf 1) 0)
         return buf
     }
+
+    ; ======================================================================
+    ; Pointer-array (list) runtime. Descriptor layout (wasm, i32 slots):
+    ;   [ data@0 | len@4 | cap@8 | owned@12 ]   (16 bytes)
+    ; `owned` == 1 means the array owns its elements (objects) and releases each
+    ; via obj_release on free. Int arrays are owned==0 (elements are values). The
+    ; compiler emits calls to these exact mangled names; the backing store and
+    ; descriptor live on the free-list heap (Heap_calloc via emitHeapAlloc).
+    ; ======================================================================
+    sfn ptrarray_push_owned:void (desc:int val:int) {
+        if (== desc 0) {
+            return
+        }
+        def owned (Mem.loadI32((+ desc 12)))
+        if (!= owned 0) {
+            if (!= val 0) {
+                ranger.obj_retain(val)
+            }
+        }
+        def len (Mem.loadI32((+ desc 4)))
+        def cap (Mem.loadI32((+ desc 8)))
+        if (>= len cap) {
+            def newCap (* cap 2)
+            if (== newCap 0) {
+                newCap = 4
+            }
+            def data0 (Mem.loadI32(desc))
+            def nd (Heap.realloc(data0 (* newCap 4)))
+            Mem.storeI32(desc nd)
+            Mem.storeI32((+ desc 8) newCap)
+        }
+        def data (Mem.loadI32(desc))
+        def len2 (Mem.loadI32((+ desc 4)))
+        Mem.storeI32((+ data (* len2 4)) val)
+        Mem.storeI32((+ desc 4) (+ len2 1))
+    }
+
+    sfn ptrarray_release:void (desc:int) {
+        if (== desc 0) {
+            return
+        }
+        def owned (Mem.loadI32((+ desc 12)))
+        def data (Mem.loadI32(desc))
+        if (!= owned 0) {
+            if (!= data 0) {
+                def len (Mem.loadI32((+ desc 4)))
+                def i 0
+                while (< i len) {
+                    def el (Mem.loadI32((+ data (* i 4))))
+                    ranger.obj_release(el)
+                    i = (+ i 1)
+                }
+            }
+        }
+        if (!= data 0) {
+            Heap.free(data)
+        }
+        Heap.free(desc)
+    }
 }

--- a/runtime/wasm/ranger_obj.rgr
+++ b/runtime/wasm/ranger_obj.rgr
@@ -94,4 +94,117 @@ class ranger {
     sfn obj_live:int () {
         return (Heap.usedBlocks())
     }
+
+    ; ======================================================================
+    ; String runtime — null-terminated UTF-8 char* strings. Literals live in
+    ; the static region [16, heapBase); concat/from_int results are heap blocks.
+    ; ======================================================================
+    sfn str_len:int (s:int) {
+        if (== s 0) {
+            return 0
+        }
+        def n 0
+        while (!= (Mem.loadU8((+ s n))) 0) {
+            n = (+ n 1)
+        }
+        return n
+    }
+
+    sfn str_concat:int (a:int b:int) {
+        def la (ranger.str_len(a))
+        def lb (ranger.str_len(b))
+        def buf (Heap.alloc((+ (+ la lb) 1)))
+        def i 0
+        while (< i la) {
+            Mem.storeU8((+ buf i) (Mem.loadU8((+ a i))))
+            i = (+ i 1)
+        }
+        def j 0
+        while (< j lb) {
+            Mem.storeU8((+ (+ buf la) j) (Mem.loadU8((+ b j))))
+            j = (+ j 1)
+        }
+        Mem.storeU8((+ buf (+ la lb)) 0)
+        return buf
+    }
+
+    sfn str_dup:int (s:int) {
+        if (== s 0) {
+            return 0
+        }
+        def n (ranger.str_len(s))
+        def buf (Heap.alloc((+ n 1)))
+        def i 0
+        while (< i n) {
+            Mem.storeU8((+ buf i) (Mem.loadU8((+ s i))))
+            i = (+ i 1)
+        }
+        Mem.storeU8((+ buf n) 0)
+        return buf
+    }
+
+    ; int -> decimal string (heap-allocated)
+    sfn str_from_int:int (n:int) {
+        if (== n 0) {
+            def z (Heap.alloc(2))
+            Mem.storeU8(z 48)
+            Mem.storeU8((+ z 1) 0)
+            return z
+        }
+        def neg 0
+        def v n
+        if (< v 0) {
+            neg = 1
+            v = (- 0 v)
+        }
+        def digits 0
+        def t v
+        while (> t 0) {
+            digits = (+ digits 1)
+            t = (idiv t 10)
+        }
+        def len (+ digits neg)
+        def buf (Heap.alloc((+ len 1)))
+        Mem.storeU8((+ buf len) 0)
+        def pos (- len 1)
+        def vv v
+        while (> vv 0) {
+            Mem.storeU8((+ buf pos) (+ 48 (% vv 10)))
+            vv = (idiv vv 10)
+            pos = (- pos 1)
+        }
+        if (> neg 0) {
+            Mem.storeU8(buf 45)
+        }
+        return buf
+    }
+
+    ; strcmp-style: 0 when equal, non-zero otherwise
+    sfn str_cmp:int (a:int b:int) {
+        def i 0
+        def r -999
+        while (== r -999) {
+            def ca (Mem.loadU8((+ a i)))
+            def cb (Mem.loadU8((+ b i)))
+            if (!= ca cb) {
+                r = (- ca cb)
+            } {
+                if (== ca 0) {
+                    r = 0
+                }
+            }
+            i = (+ i 1)
+        }
+        return r
+    }
+
+    ; free a heap string; a literal (ptr below the heap base) is left alone
+    sfn str_release:void (s:int) {
+        if (== s 0) {
+            return
+        }
+        if (>= s (Heap.base())) {
+            Heap.free(s)
+        }
+    }
 }

--- a/runtime/wasm/rc_demo.rgr
+++ b/runtime/wasm/rc_demo.rgr
@@ -1,0 +1,66 @@
+; ============================================================================
+; rc_demo.rgr — end-to-end demo of automatic memory management under -wasmrc
+; (PLAN_WASM_MEMORY.md Phase 2). Compile with:
+;   node bin/output.js -l=llvm -wat -freestanding -wasmrc runtime/wasm/rc_demo.rgr
+; `new` allocates via the free-list heap (ranger_obj_new); owned locals are
+; released automatically at scope end and — the point of Phase 2 — at the end
+; of each loop iteration, so an allocating loop does not leak.
+;
+; Works today: single-scope `new`, and `def x (new T)` declared inside a loop
+; body (the idiomatic pattern). Known v1 limitation: `x = (new T)` reassignment
+; of a function-scoped variable does not yet release the old value (the assign
+; path lacks release-before-reassign) — use `def` inside the loop instead.
+; ============================================================================
+
+Import "./ranger_obj.rgr"
+
+class Thing {
+    def x:int 0
+    def y:int 0
+}
+
+class Demo {
+    ; single scope: t released at function end
+    sfn oneAlloc:int () {
+        def t (new Thing)
+        t.x = 42
+        return (t.x)
+    }
+
+    ; idiomatic: a fresh object per iteration, released before the back-edge
+    sfn loopAlloc:int (iters:int) {
+        def sum 0
+        def i 0
+        while (< i iters) {
+            def t (new Thing)
+            t.x = i
+            t.y = (* i 2)
+            sum = (+ sum (+ t.x t.y))
+            i = (+ i 1)
+        }
+        return sum
+    }
+
+    ; nested loops: inner objects freed each inner iteration, outer each outer
+    sfn nestedAlloc:int (a:int b:int) {
+        def total 0
+        def i 0
+        while (< i a) {
+            def outer (new Thing)
+            outer.x = i
+            def j 0
+            while (< j b) {
+                def inner (new Thing)
+                inner.x = j
+                total = (+ total 1)
+                j = (+ j 1)
+            }
+            i = (+ i 1)
+        }
+        return total
+    }
+
+    sfn liveNow:int () {
+        return (ranger.obj_live())
+    }
+}

--- a/runtime/wasm/rc_demo_test.mjs
+++ b/runtime/wasm/rc_demo_test.mjs
@@ -1,0 +1,19 @@
+import fs from "fs";
+const x = new WebAssembly.Instance(new WebAssembly.Module(fs.readFileSync(new URL("../../tmp/rcdemo/rc.wasm", import.meta.url)))).exports;
+let pass = 0, fail = 0;
+const ok = (n, c) => { if (c) pass++; else { fail++; console.log("FAIL:", n); } };
+const reset = () => x.Heap_init(); // fresh heap per case (linear memory persists across calls)
+
+reset(); ok("single-scope new: correct value", x.Demo_oneAlloc() === 42);
+ok("single-scope new: object auto-freed at return", x.Demo_liveNow() === 0);
+
+reset(); ok("loop 1000 def-in-body: correct sum", x.Demo_loopAlloc(1000) === (() => { let s = 0; for (let i = 0; i < 1000; i++) s += i + i * 2; return s; })());
+ok("loop 1000: no leak (heap empty)", x.Demo_liveNow() === 0);
+
+reset(); x.Demo_loopAlloc(50000); ok("loop 50000: no leak, no OOM (free-list reuse)", x.Demo_liveNow() === 0);
+
+reset(); ok("nested loops 100x100: count", x.Demo_nestedAlloc(100, 100) === 10000);
+ok("nested loops: no leak (inner+outer freed per iteration)", x.Demo_liveNow() === 0);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/runtime/wasm/str_demo.rgr
+++ b/runtime/wasm/str_demo.rgr
@@ -1,0 +1,17 @@
+Import "./ranger_obj.rgr"
+class G {
+    sfn hud:string (hits:int) {
+        def s ("HITS " + hits)
+        return s
+    }
+    sfn combine:string (a:int b:int) {
+        return (("(" + a) + ("," + b))
+    }
+    sfn lenHud:int (hits:int) {
+        return (strlen ("SCORE " + hits))
+    }
+    sfn greetLen:int () {
+        def g "hello world"
+        return (strlen g)
+    }
+}

--- a/runtime/wasm/str_rc_demo.rgr
+++ b/runtime/wasm/str_rc_demo.rgr
@@ -1,0 +1,66 @@
+; ============================================================================
+; str_rc_demo.rgr — string reference-counting / leak-freedom demo (Phase 3.4).
+;
+; Games churn throwaway HUD strings every frame ("SCORE " + n). Without release
+; the WASM heap grows without bound. These functions exercise the compiler's
+; owned-string tracking: fresh concat results are owned by the local and freed
+; at scope end (or per loop iteration), and the int->string temporaries the
+; concat allocates internally are freed too. A leak-free build keeps the heap
+; frontier flat across any iteration count.
+; ============================================================================
+
+Import "./ranger_obj.rgr"
+
+class SG {
+    ; Build and discard N HUD strings. Each iteration: `"HITS " + i` allocates an
+    ; int->string temp AND a concat result; both must be freed per iteration.
+    ; Returns the heap frontier after the loop — flat => leak-free.
+    sfn churnHud:int (n:int) {
+        def i 0
+        while (< i n) {
+            def s ("HITS " + i)
+            def L (strlen s)
+            i = (+ i 1)
+        }
+        return (Heap.frontier())
+    }
+
+    ; Nested concat in a loop: (("(" + i) + ("," + i)) — two inner fresh results
+    ; feed an outer concat; all intermediates must be freed each iteration.
+    sfn churnNested:int (n:int) {
+        def i 0
+        while (< i n) {
+            def s (("(" + i) + ("," + i))
+            def L (strlen s)
+            i = (+ i 1)
+        }
+        return (Heap.frontier())
+    }
+
+    ; Reassignment in a loop: the old buffer must be freed before the new one is
+    ; stored (release-before-reassign), so a single slot doesn't leak per frame.
+    sfn churnReassign:int (n:int) {
+        def s "start"
+        def i 0
+        while (< i n) {
+            s = ("v" + i)
+            i = (+ i 1)
+        }
+        def L (strlen s)
+        return (Heap.frontier())
+    }
+
+    sfn liveBlocks:int () {
+        return (ranger.obj_live())
+    }
+
+    sfn frontier:int () {
+        return (Heap.frontier())
+    }
+
+    ; sanity: the HUD string is still correct while being freed each call
+    sfn hud:string (hits:int) {
+        def s ("HITS " + hits)
+        return s
+    }
+}

--- a/runtime/wasm/str_rc_demo.rgr
+++ b/runtime/wasm/str_rc_demo.rgr
@@ -87,4 +87,72 @@ class SG {
         def s ("HITS " + hits)
         return s
     }
+
+    ; --- string comparison (==/!=) via ranger_str_cmp ---------------------
+    ; 1 when the built HUD equals the literal. Exercises == on a fresh concat
+    ; local vs a static literal.
+    sfn eqHits:int (n:int) {
+        def s ("HITS " + n)
+        if (s == "HITS 5") {
+            return 1
+        }
+        return 0
+    }
+
+    sfn neHits:int (n:int) {
+        def s ("HITS " + n)
+        if (s != "HITS 5") {
+            return 1
+        }
+        return 0
+    }
+
+    ; comparison in a loop must not leak the per-iteration concat operand
+    sfn churnCompare:int (n:int) {
+        def hits 0
+        def i 0
+        while (< i n) {
+            if (("K" + i) == "K7") {
+                hits = (+ hits 1)
+            }
+            i = (+ i 1)
+        }
+        return (Heap.frontier())
+    }
+
+    ; --- char access ------------------------------------------------------
+    sfn charOf:int (pos:int) {
+        def s "HELLO"
+        return (charAt s pos)
+    }
+
+    sfn subLen:int (start:int end:int) {
+        def s "HELLO"
+        def sub (substring s start end)
+        return (strlen sub)
+    }
+
+    ; return the first byte of substring(s,start,end) (for content check)
+    sfn subFirst:int (start:int end:int) {
+        def s "HELLO"
+        def sub (substring s start end)
+        return (charAt sub 0)
+    }
+
+    sfn codeChar:int (code:int) {
+        def s (strfromcode code)
+        return (charAt s 0)
+    }
+
+    ; substring churn must stay heap-flat (fresh result freed each iteration)
+    sfn churnSubstring:int (n:int) {
+        def s "HELLOWORLD"
+        def i 0
+        while (< i n) {
+            def sub (substring s 0 5)
+            def L (strlen sub)
+            i = (+ i 1)
+        }
+        return (Heap.frontier())
+    }
 }

--- a/runtime/wasm/str_rc_demo.rgr
+++ b/runtime/wasm/str_rc_demo.rgr
@@ -50,6 +50,30 @@ class SG {
         return (Heap.frontier())
     }
 
+    ; Inline throwaway: the concat is never bound to a local — it is built
+    ; directly as an argument (here to strlen, standing in for host.drawText).
+    ; The statement arena must free the concat result AND its int->string temp at
+    ; statement end, or every frame leaks two buffers.
+    sfn churnInline:int (n:int) {
+        def i 0
+        def acc 0
+        while (< i n) {
+            acc = (+ acc (strlen ("HITS " + i)))
+            i = (+ i 1)
+        }
+        return (Heap.frontier())
+    }
+
+    ; Inline nested throwaway discarded as a bare expression statement.
+    sfn churnInlineNested:int (n:int) {
+        def i 0
+        while (< i n) {
+            def _ (strlen (("[" + i) + "]"))
+            i = (+ i 1)
+        }
+        return (Heap.frontier())
+    }
+
     sfn liveBlocks:int () {
         return (ranger.obj_live())
     }

--- a/runtime/wasm/str_rc_test.mjs
+++ b/runtime/wasm/str_rc_test.mjs
@@ -64,5 +64,35 @@ x.Heap_init();
 x.SG_churnInline(5000);
 ok("no live blocks after churnInline", x.SG_liveBlocks(), 0);
 
+// --- string comparison (==/!=) ---
+x.Heap_init();
+ok("eqHits(5) == 'HITS 5'", x.SG_eqHits(5), 1);
+ok("eqHits(3) != 'HITS 5'", x.SG_eqHits(3), 0);
+ok("neHits(3)", x.SG_neHits(3), 1);
+ok("neHits(5)", x.SG_neHits(5), 0);
+x.Heap_init();
+const cbase = x.SG_frontier();
+x.SG_churnCompare(1);
+const cc1 = x.SG_frontier();
+x.SG_churnCompare(10000);
+const cc10k = x.SG_frontier();
+ok("churnCompare flat", cc10k, cc1);
+ok("churnCompare back to base", cc1, cbase);
+
+// --- char access ---
+x.Heap_init();
+ok("charOf(0)='H'", x.SG_charOf(0), 72);
+ok("charOf(4)='O'", x.SG_charOf(4), 79);
+ok("subLen(1,3)=2", x.SG_subLen(1, 3), 2);
+ok("subFirst(1,3)='E'", x.SG_subFirst(1, 3), 69);
+ok("codeChar(65)='A'", x.SG_codeChar(65), 65);
+x.Heap_init();
+const sb1  = x.SG_churnSubstring(1);
+const sb10k= x.SG_churnSubstring(10000);
+ok("churnSubstring flat", sb10k, sb1);
+x.Heap_init();
+x.SG_churnSubstring(3000);
+ok("no live blocks after churnSubstring", x.SG_liveBlocks(), 0);
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/runtime/wasm/str_rc_test.mjs
+++ b/runtime/wasm/str_rc_test.mjs
@@ -1,0 +1,53 @@
+// String RC / leak-freedom test (PLAN_WASM_MEMORY Phase 3.4).
+// Build:
+//   node bin/output.js -l=llvm -wat -freestanding -wasmrc \
+//     runtime/wasm/str_rc_demo.rgr -nodecli -d=tmp/strrc -o=g.wat
+//   cp tmp/strrc/g.wat.ll tmp/strrc/g.wat && wat2wasm tmp/strrc/g.wat -o tmp/strrc/g.wasm
+import fs from "fs";
+const x = new WebAssembly.Instance(new WebAssembly.Module(
+  fs.readFileSync(new URL("../../tmp/strrc/g.wasm", import.meta.url)))).exports;
+const mem = new Uint8Array(x.memory.buffer);
+const rd = (p) => { let e = p; while (mem[e]) e++; return Buffer.from(mem.slice(p, e)).toString("utf8"); };
+let pass = 0, fail = 0;
+const ok = (n, g, e) => { if (g === e) pass++; else { fail++; console.log("FAIL", n, JSON.stringify(g), "exp", JSON.stringify(e)); } };
+
+x.Heap_init();
+
+// correctness: the HUD string is right even though it's freed every call
+ok("hud(42)", rd(x.SG_hud(42)), "HITS 42");
+ok("hud(7)", rd(x.SG_hud(7)), "HITS 7");
+
+// leak-freedom: the heap frontier must be identical no matter how many
+// throwaway strings we build. If any per-iteration temp leaked, the frontier
+// would climb with the iteration count.
+x.Heap_init();
+const f1   = x.SG_churnHud(1);
+const f1k  = x.SG_churnHud(1000);
+const f100k= x.SG_churnHud(100000);
+ok("churnHud flat 1 vs 1000", f1k, f1);
+ok("churnHud flat 1 vs 100000", f100k, f1);
+
+x.Heap_init();
+const n1  = x.SG_churnNested(1);
+const n10k= x.SG_churnNested(10000);
+ok("churnNested flat", n10k, n1);
+
+// churnReassign keeps `s` live until function scope-end, so measure AFTER the
+// call returns (the scope-end release frees s; a leak-free heap is then empty).
+x.Heap_init();
+const base = x.SG_frontier();
+x.SG_churnReassign(1);
+const rf1 = x.SG_frontier();
+x.SG_churnReassign(10000);
+const rf10k = x.SG_frontier();
+ok("churnReassign frontier back to base (1)", rf1, base);
+ok("churnReassign frontier back to base (10000)", rf10k, base);
+ok("churnReassign no live blocks", x.SG_liveBlocks(), 0);
+
+// after all that churn, zero live heap blocks remain (everything freed)
+x.Heap_init();
+x.SG_churnHud(5000);
+ok("no live blocks after churn", x.SG_liveBlocks(), 0);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/runtime/wasm/str_rc_test.mjs
+++ b/runtime/wasm/str_rc_test.mjs
@@ -44,10 +44,25 @@ ok("churnReassign frontier back to base (1)", rf1, base);
 ok("churnReassign frontier back to base (10000)", rf10k, base);
 ok("churnReassign no live blocks", x.SG_liveBlocks(), 0);
 
+// inline throwaway temps (statement arena): concat built directly as a call
+// argument, never bound to a local. Heap must stay flat across iterations.
+x.Heap_init();
+const in1  = x.SG_churnInline(1);
+const in10k= x.SG_churnInline(10000);
+ok("churnInline flat", in10k, in1);
+
+x.Heap_init();
+const ins1  = x.SG_churnInlineNested(1);
+const ins10k= x.SG_churnInlineNested(10000);
+ok("churnInlineNested flat", ins10k, ins1);
+
 // after all that churn, zero live heap blocks remain (everything freed)
 x.Heap_init();
 x.SG_churnHud(5000);
-ok("no live blocks after churn", x.SG_liveBlocks(), 0);
+ok("no live blocks after churnHud", x.SG_liveBlocks(), 0);
+x.Heap_init();
+x.SG_churnInline(5000);
+ok("no live blocks after churnInline", x.SG_liveBlocks(), 0);
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/runtime/wasm/str_test.mjs
+++ b/runtime/wasm/str_test.mjs
@@ -1,0 +1,16 @@
+// Build first:  node bin/output.js -l=llvm -wat -freestanding -wasmrc \
+//   runtime/wasm/str_demo.rgr -nodecli -d=tmp/strfull -o=g.wat  &&  wat2wasm ...
+import fs from "fs";
+const x = new WebAssembly.Instance(new WebAssembly.Module(fs.readFileSync(new URL("../../tmp/strfull/g.wasm", import.meta.url)))).exports;
+const mem = new Uint8Array(x.memory.buffer);
+const rd = (p) => { let e = p; while (mem[e]) e++; return Buffer.from(mem.slice(p, e)).toString("utf8"); };
+let pass = 0, fail = 0;
+const ok = (n, g, e) => { if (g === e) pass++; else { fail++; console.log("FAIL", n, JSON.stringify(g), "exp", JSON.stringify(e)); } };
+x.Heap_init();
+ok("hud(42)", rd(x.G_hud(42)), "HITS 42");             // literal + int concat
+ok("hud(0)", rd(x.G_hud(0)), "HITS 0");
+ok("combine(3,7)", rd(x.G_combine(3,7)), "(3,7");       // nested concat
+ok("lenHud(1234)", x.G_lenHud(1234), 10);               // strlen of concat
+ok("greetLen()", x.G_greetLen(), 11);                   // strlen of stored literal
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/runtime/wasm/strarr_rc_demo.rgr
+++ b/runtime/wasm/strarr_rc_demo.rgr
@@ -1,0 +1,57 @@
+; ============================================================================
+; strarr_rc_demo.rgr — [string] arrays with per-element RC (PLAN_WASM_MEMORY
+; Phase 4b tail). A string array owns a dup'd copy of each element; on release
+; each is str_release'd (kind 2 in the descriptor), then backing + descriptor
+; are freed. A build/use/drop loop must stay heap-flat.
+; ============================================================================
+
+Import "./ranger_obj.rgr"
+
+class SG {
+    ; build a [string] of "item<i>", sum their lengths, drop. Elements are
+    ; dup'd into the array; the concat temporaries are freed by the arena.
+    sfn lenSum:int (n:int) {
+        def names:[string]
+        def i 0
+        while (< i n) {
+            push names ("item" + i)
+            i = (+ i 1)
+        }
+        def s 0
+        def j 0
+        while (< j (array_length names)) {
+            s = (+ s (strlen (itemAt names j)))
+            j = (+ j 1)
+        }
+        return s
+    }
+
+    ; first byte of a stored element, to confirm content survives the dup
+    sfn firstByte:int (n:int idx:int) {
+        def names:[string]
+        def i 0
+        while (< i n) {
+            push names ("K" + i)
+            i = (+ i 1)
+        }
+        return (charAt (itemAt names idx) 0)
+    }
+
+    ; build+drop `reps` times; heap flat => every element + array freed
+    sfn churn:int (reps:int size:int) {
+        def r 0
+        while (< r reps) {
+            def _ (SG.lenSum(size))
+            r = (+ r 1)
+        }
+        return (Heap.frontier())
+    }
+
+    sfn liveBlocks:int () {
+        return (ranger.obj_live())
+    }
+
+    sfn frontier:int () {
+        return (Heap.frontier())
+    }
+}

--- a/runtime/wasm/strarr_rc_test.mjs
+++ b/runtime/wasm/strarr_rc_test.mjs
@@ -1,0 +1,32 @@
+// [string] array element RC test (PLAN_WASM_MEMORY Phase 4b tail).
+// Build:
+//   node bin/output.js -l=llvm -wat -freestanding -wasmrc \
+//     runtime/wasm/strarr_rc_demo.rgr -nodecli -d=tmp/strarr -o=g.wat
+//   cp tmp/strarr/g.wat.ll tmp/strarr/g.wat && wat2wasm tmp/strarr/g.wat -o tmp/strarr/g.wasm
+import fs from "fs";
+const x = new WebAssembly.Instance(new WebAssembly.Module(
+  fs.readFileSync(new URL("../../tmp/strarr/g.wasm", import.meta.url)))).exports;
+let pass = 0, fail = 0;
+const ok = (n, g, e) => { if (g === e) pass++; else { fail++; console.log("FAIL", n, JSON.stringify(g), "exp", JSON.stringify(e)); } };
+
+x.Heap_init();
+// content correctness: "item0".."item4" -> lengths 5..5 (all "itemN", N single digit)
+ok("lenSum(5)", x.SG_lenSum(5), 5 * 5);          // "item0".."item4" = 5 chars each = 25
+ok("lenSum(10)", x.SG_lenSum(10), 10 * 5);       // "item0".."item9" all single-digit = 50
+ok("lenSum(12)", x.SG_lenSum(12), 10 * 5 + 2 * 6); // + "item10","item11" (6 chars) = 62
+ok("firstByte(3,0)='K'", x.SG_firstByte(3, 0), 75);
+ok("firstByte(3,2)='K'", x.SG_firstByte(3, 2), 75);
+
+// leak-freedom: build+drop many times, heap frontier identical
+x.Heap_init();
+const c1  = x.SG_churn(1, 100);
+const c1k = x.SG_churn(1000, 100);
+ok("churn flat", c1k, c1);
+
+// zero live blocks after churn: every dup'd element + backing + descriptor freed
+x.Heap_init();
+x.SG_churn(500, 80);
+ok("no live blocks after churn", x.SG_liveBlocks(), 0);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Evaluates how Ranger classes + `new` should be handled in WASM. Finds that the
project already chose light RC + static scope-cleanup (RAII-style, no GC) for
manual/libc targets, with the ownership analysis and retain/release insertion
living target-agnostically in ng_LowIRBuilder.rgr — gated off for WASM only by
usesLibc=false. Recommends porting that model to WASM (self-contained free-list
allocator + ranger_obj_new/release/retain + typedescs in linear memory + a
manual-wasm memory-model flag) rather than building a tracing GC (rejected:
real-time pauses) or adopting wasm-gc (rejected: incompatible with the fixed-
offset linear-memory ABI and unsupported by the wasm3 host). Adds a per-frame
arena as the cheapest complementary win for game loops. Includes phasing,
risks, and an effort verdict (medium, mostly reuse).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PhKhA739wK4UTfc4WurqSS