### PR TITLE
gfx_sdl: 32-bit mesh indices (fix scrambled large GLB models, e.g. Ch…

### DIFF
--- a/gallery/game_engine/IDEAL_3D.md
+++ b/gallery/game_engine/IDEAL_3D.md
@@ -292,6 +292,22 @@ parse these — it only requests a load and receives a handle.
 | Ranger `.anim` | Animation clip | Skeleton keyframes |
 | Ranger `.skel` | Skeleton | Bone hierarchy + bind poses |
 
+### 5.1 GLB — implemented support level
+
+The native GLB path (`model3d/`, see its
+[`README.md`](./model3d/README.md#first-support-level)) currently loads: GLB 2.0
+(one JSON + one BIN chunk), scenes/nodes with `matrix` or TRS, multiple
+meshes/primitives, `TRIANGLES`, `POSITION` / `NORMAL` / `TEXCOORD_0` /
+**`COLOR_0`** (vertex colours), **non-indexed** primitives (indices synthesised),
+**missing `NORMAL`** (smooth normals generated), `u8` / `u16` / `u32` indices,
+interleaved `byteStride`, `baseColorFactor` + `baseColorTexture`,
+`emissiveFactor` (+ `KHR_materials_emissive_strength`), `alphaMode`,
+`KHR_materials_unlit`, multiple materials, and embedded PNG / JPEG textures.
+
+Rejected with a clear error (never a silently-wrong model): skins, animations,
+morph targets, sparse accessors, Draco / Meshopt / KTX2 (any
+`extensionsRequired`), and non-`TRIANGLES` modes.
+
 Future (not required for initial transition):
 
 - Terrain heightmaps
@@ -533,6 +549,11 @@ wrapper):
   registries are currently append-only);
 - command validation / stale-handle rejection — §7 command processor;
 - `rg_create_material` desc layout and the standalone `rg_load_texture` path;
+- **`COLOR_0` on the GPU path**: the loader reads per-vertex colours into
+  `MeshPrimitiveAsset.colors` and the software renderer (`SoftRenderer3D`) shows
+  them, but `MeshBridge`'s fixed-point vertex keeps the colour word (word 6) at 0
+  because the GLES2 shader in `gfx_sdl.rgr` does not yet read a vertex-colour
+  attribute — wiring that is a small C++ shader step;
 - optionally, the §7 Option B command buffer for batching.
 
 ### 12.6 Minimal end-to-end flow

--- a/gallery/game_engine/IDEAL_TODO.md
+++ b/gallery/game_engine/IDEAL_TODO.md
@@ -581,6 +581,21 @@ each stage runs before the next):
   — after H.4/H.5 those guests import `env.rg_create_box` etc. that the Node host does
   not yet provide, so headless render fails until this lands. The in-engine SDL host is
   unaffected.)_
+- [x] **H.7 GLB model loading (`model3d` → render bridge).** `Wasm3dRunner.preloadModels()`
+  loads every `<gameDir>/models/*.glb` through the native `model3d` loader
+  (`GlbImporter` → `ModelAsset` → `MeshBridge` → `gfx_3d_mesh_upload` /
+  `gfx_3d_upload_texture`) and registers each under its basename, so a host-managed
+  guest resolves it with `rg_load_model("name")` → `rg_create_mesh_entity` (§12.4).
+  Importer support level (see `model3d/README.md`): scenes/nodes (matrix or TRS),
+  `TRIANGLES`, `POSITION`/`NORMAL`/`TEXCOORD_0`/**`COLOR_0`**, **non-indexed** primitives
+  (synthesised indices), **missing `NORMAL`** (generated), `u8`/`u16`/`u32` indices,
+  interleaved `byteStride`, `baseColorFactor`/`baseColorTexture`, `emissiveFactor`
+  (+`KHR_materials_emissive_strength`), `alphaMode`, `KHR_materials_unlit`, embedded
+  PNG/JPEG; skins/animations/morph/sparse/Draco/Meshopt/KTX2 rejected with a clear
+  error. Games: `pyramid_wasm` (diamond gem) and `model_viewer_wasm` (Tests — browse
+  GLBs with the arrows). _(Deferred: `COLOR_0` on the GPU path — the loader reads
+  per-vertex colours and the software renderer shows them, but the GLES2 vertex shader
+  does not yet consume the colour word; see IDEAL_3D §12.5.)_
 
 ---
 

--- a/gallery/game_engine/games/model_viewer_wasm/README.md
+++ b/gallery/game_engine/games/model_viewer_wasm/README.md
@@ -30,7 +30,7 @@ Free Khronos [glTF-Sample-Assets](https://github.com/KhronosGroup/glTF-Sample-As
 | --- | --- |
 | `Box` | untextured, flat base colour |
 | `BoxTextured` | embedded PNG texture (decoded to RGBA) |
-| `BoxVertexColors` | loads fine; `COLORS_0` vertex colours are not read yet, so it renders in its base colour |
+| `BoxVertexColors` | per-vertex `COLOR_0` (RGB cube gradient) |
 | `Duck` | 4,212-triangle textured mesh with a node hierarchy |
 
 Re-download with `tools/fetch_models.sh`. To use different models, drop supported

--- a/gallery/game_engine/gfx_sdl.rgr
+++ b/gallery/game_engine/gfx_sdl.rgr
@@ -2123,16 +2123,18 @@ static int rgfx_mesh_upload(const int64_t* vw, int vcount, const int64_t* iv, in
         verts.push_back((float) (uvw & 0xffffu) / 4096.f);
         verts.push_back((float) ((uvw >> 16) & 0xffffu) / 4096.f);
     }
-    std::vector<uint16_t> idx;
+    // 32-bit indices: real GLB meshes routinely exceed 65535 vertices (a u16
+    // element buffer would wrap the indices and scramble the geometry).
+    std::vector<uint32_t> idx;
     idx.reserve((size_t) icount);
-    for (int i = 0; i < icount; ++i) { idx.push_back((uint16_t) iv[i]); }
+    for (int i = 0; i < icount; ++i) { idx.push_back((uint32_t) iv[i]); }
     RgfxMesh3D m; m.vbo = 0; m.ebo = 0; m.icount = icount;
     glGenBuffers(1, &m.vbo);
     glBindBuffer(GL_ARRAY_BUFFER, m.vbo);
     glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) (verts.size() * 4), verts.data(), GL_STATIC_DRAW);
     glGenBuffers(1, &m.ebo);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m.ebo);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr) (idx.size() * 2), idx.data(), GL_STATIC_DRAW);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr) (idx.size() * 4), idx.data(), GL_STATIC_DRAW);
     g_rgfx_meshes.push_back(m);
     SDL_Log(\"[wasm3d] mesh upload vbo=%u ebo=%u v=%d i=%d glErr=%d\", m.vbo, m.ebo, vcount, icount, (int) glGetError());
     return (int) g_rgfx_meshes.size();
@@ -2202,7 +2204,7 @@ static void rgfx_3d_draw(int meshId, int first, int count, int texId, float rx, 
     if (g_rgfx_3d_aPos >= 0) { glEnableVertexAttribArray(g_rgfx_3d_aPos); glVertexAttribPointer(g_rgfx_3d_aPos, 3, GL_FLOAT, GL_FALSE, 32, (void*) 0); }
     if (g_rgfx_3d_aNormal >= 0) { glEnableVertexAttribArray(g_rgfx_3d_aNormal); glVertexAttribPointer(g_rgfx_3d_aNormal, 3, GL_FLOAT, GL_FALSE, 32, (void*) 12); }
     if (g_rgfx_3d_aUv >= 0) { glEnableVertexAttribArray(g_rgfx_3d_aUv); glVertexAttribPointer(g_rgfx_3d_aUv, 2, GL_FLOAT, GL_FALSE, 32, (void*) 24); }
-    glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, (void*) (size_t) (first * 2));
+    glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, (void*) (size_t) (first * 4));
     static int draw_logged = 0;
     if (draw_logged < 2) {
         // project a real cube corner (1,1,1,1) to check the matrix spreads
@@ -2340,14 +2342,14 @@ static int rgfx_scene_alloc(int type) {
     return (int) g_scene.size();
 }
 // upload interleaved float verts (8 floats: pos3,normal3,uv2) + u16 indices -> meshId
-static int rgfx_mesh_make(const float* v8, int vcount, const uint16_t* idx, int icount) {
+static int rgfx_mesh_make(const float* v8, int vcount, const uint32_t* idx, int icount) {
     if (!g_rgfx_gpu_mode) { return 0; }
     rgfx_gl_ensure_current();
     RgfxMesh3D m; m.vbo = 0; m.ebo = 0; m.icount = icount;
     glGenBuffers(1, &m.vbo); glBindBuffer(GL_ARRAY_BUFFER, m.vbo);
     glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) ((size_t) vcount * 8 * 4), v8, GL_STATIC_DRAW);
     glGenBuffers(1, &m.ebo); glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m.ebo);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr) ((size_t) icount * 2), idx, GL_STATIC_DRAW);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr) ((size_t) icount * 4), idx, GL_STATIC_DRAW);
     g_rgfx_meshes.push_back(m);
     return (int) g_rgfx_meshes.size();
 }
@@ -2378,15 +2380,15 @@ extern \"C\" int rgfx_scene_create_box(float x0, float y0, float z0, float x1, f
         {{{x0,y0,z0},{x1,y0,z0},{x1,y0,z1},{x0,y0,z1}}, {0,-1,0}, dx, dz},  // -Y
     };
     float uvc[4][2] = {{0,0},{1,0},{1,1},{0,1}};
-    std::vector<float> vv; std::vector<uint16_t> ii;
+    std::vector<float> vv; std::vector<uint32_t> ii;
     for (int fi = 0; fi < 6; ++fi) {
-        uint16_t base = (uint16_t) (vv.size() / 8);
+        uint32_t base = (uint32_t) (vv.size() / 8);
         for (int k = 0; k < 4; ++k) {
             vv.push_back(faces[fi].c[k][0]); vv.push_back(faces[fi].c[k][1]); vv.push_back(faces[fi].c[k][2]);
             vv.push_back(faces[fi].n[0]); vv.push_back(faces[fi].n[1]); vv.push_back(faces[fi].n[2]);
             vv.push_back(uvc[k][0] * faces[fi].uw); vv.push_back(uvc[k][1] * faces[fi].uh);
         }
-        uint16_t tri[6] = {0,1,2,0,2,3};
+        uint32_t tri[6] = {0,1,2,0,2,3};
         for (int t = 0; t < 6; ++t) ii.push_back(base + tri[t]);
     }
     int meshId = rgfx_mesh_make(vv.data(), (int) (vv.size() / 8), ii.data(), (int) ii.size());
@@ -2417,7 +2419,7 @@ static int rgfx_scene_ensure_quad() {
          0.5f, 0.5f,0.f, 0.f,0.f,1.f, 1.f,0.f,
         -0.5f, 0.5f,0.f, 0.f,0.f,1.f, 0.f,0.f,
     };
-    uint16_t idx[6] = {0,1,2,0,2,3};
+    uint32_t idx[6] = {0,1,2,0,2,3};
     g_scene_quad = rgfx_mesh_make(v, 4, idx, 6);
     SDL_Log(\"[scene] billboard quad mesh=%d\", g_scene_quad);
     return g_scene_quad;
@@ -2591,7 +2593,7 @@ extern \"C\" void rgfx_scene_render(int w, int h) {
             if(g_scn_aPos>=0){glEnableVertexAttribArray(g_scn_aPos); glVertexAttribPointer(g_scn_aPos,3,GL_FLOAT,GL_FALSE,32,(void*)0);}
             if(g_scn_aNormal>=0){glEnableVertexAttribArray(g_scn_aNormal); glVertexAttribPointer(g_scn_aNormal,3,GL_FLOAT,GL_FALSE,32,(void*)12);}
             if(g_scn_aUv>=0){glEnableVertexAttribArray(g_scn_aUv); glVertexAttribPointer(g_scn_aUv,2,GL_FLOAT,GL_FALSE,32,(void*)24);}
-            glDrawElements(GL_TRIANGLES,m.icount,GL_UNSIGNED_SHORT,(void*)0);
+            glDrawElements(GL_TRIANGLES,m.icount,GL_UNSIGNED_INT,(void*)0);
             continue;
         }
         if (e.type!=RGE_MESH) continue;
@@ -2615,7 +2617,7 @@ extern \"C\" void rgfx_scene_render(int w, int h) {
         if(g_scn_aPos>=0){glEnableVertexAttribArray(g_scn_aPos); glVertexAttribPointer(g_scn_aPos,3,GL_FLOAT,GL_FALSE,32,(void*)0);}
         if(g_scn_aNormal>=0){glEnableVertexAttribArray(g_scn_aNormal); glVertexAttribPointer(g_scn_aNormal,3,GL_FLOAT,GL_FALSE,32,(void*)12);}
         if(g_scn_aUv>=0){glEnableVertexAttribArray(g_scn_aUv); glVertexAttribPointer(g_scn_aUv,2,GL_FLOAT,GL_FALSE,32,(void*)24);}
-        glDrawElements(GL_TRIANGLES,m.icount,GL_UNSIGNED_SHORT,(void*)0);
+        glDrawElements(GL_TRIANGLES,m.icount,GL_UNSIGNED_INT,(void*)0);
       }
     }
     glDepthMask(GL_TRUE); glDisable(GL_BLEND); glDisable(GL_DEPTH_TEST);

--- a/gallery/game_engine/model3d/AssetModel.rgr
+++ b/gallery/game_engine/model3d/AssetModel.rgr
@@ -55,6 +55,8 @@ class MeshPrimitiveAsset {
     def positions:[Vec3]
     def normals:[Vec3]
     def uvs:[Vec2]
+    ; per-vertex COLOR_0 (rgba, 0..1); empty when the primitive has none
+    def colors:[Vec4]
     def indices:[int]
     ; index into ModelAsset.materials, or -1 for none
     def material:int (0 - 1)
@@ -72,6 +74,9 @@ class MeshPrimitiveAsset {
     }
     fn hasUvs:boolean () {
         return ((array_length uvs) > 0)
+    }
+    fn hasColors:boolean () {
+        return ((array_length colors) > 0)
     }
 }
 

--- a/gallery/game_engine/model3d/GlbImporter.rgr
+++ b/gallery/game_engine/model3d/GlbImporter.rgr
@@ -187,6 +187,123 @@ class GlbImporter {
         return out
     }
 
+    ; per-vertex COLOR_0 (VEC3 -> alpha 1, VEC4); float or normalized u8/u16
+    fn readVec4:[Vec4] (accessorIndex:int) {
+        def out:[Vec4]
+        def a:GltfAccessor (itemAt doc.accessors accessorIndex)
+        def stride:int (this.accessorStride(a))
+        def base:int (this.accessorBase(a))
+        def comps:int (a.componentCount())
+        def i:int 0
+        while (i < a.count) {
+            def off:int (base + (i * stride))
+            def r:double 1.0
+            def g:double 1.0
+            def b:double 1.0
+            def al:double 1.0
+            if (a.componentType == 5126) {
+                r = (reader.f32at(off))
+                g = (reader.f32at(off + 4))
+                b = (reader.f32at(off + 8))
+                if (comps == 4) {
+                    al = (reader.f32at(off + 12))
+                }
+            } {
+                if (a.componentType == 5121) {
+                    r = ((to_double (reader.u8at(off))) / 255.0)
+                    g = ((to_double (reader.u8at(off + 1))) / 255.0)
+                    b = ((to_double (reader.u8at(off + 2))) / 255.0)
+                    if (comps == 4) {
+                        al = ((to_double (reader.u8at(off + 3))) / 255.0)
+                    }
+                } {
+                    if (a.componentType == 5123) {
+                        r = ((to_double (reader.u16at(off))) / 65535.0)
+                        g = ((to_double (reader.u16at(off + 2))) / 65535.0)
+                        b = ((to_double (reader.u16at(off + 4))) / 65535.0)
+                        if (comps == 4) {
+                            al = ((to_double (reader.u16at(off + 6))) / 65535.0)
+                        }
+                    }
+                }
+            }
+            def c:Vec4 (Vec4.of(r g b al))
+            push out c
+            i = (i + 1)
+        }
+        return out
+    }
+
+    ; sequential indices [0..count) for a non-indexed primitive
+    fn synthIndices:[int] (count:int) {
+        def out:[int]
+        def i:int 0
+        while (i < count) {
+            push out i
+            i = (i + 1)
+        }
+        return out
+    }
+
+    ; smooth normals from positions + triangle indices (area-weighted, then
+    ; normalized), used when a primitive ships no NORMAL attribute.
+    fn generateNormals:[Vec3] (positions:[Vec3] indices:[int]) {
+        def vc:int (array_length positions)
+        def ax:double_buffer (double_buffer_alloc vc)
+        def ay:double_buffer (double_buffer_alloc vc)
+        def az:double_buffer (double_buffer_alloc vc)
+        def z:int 0
+        while (z < vc) {
+            double_buffer_set ax z 0.0
+            double_buffer_set ay z 0.0
+            double_buffer_set az z 0.0
+            z = (z + 1)
+        }
+        def ic:int (array_length indices)
+        def t:int 0
+        while ((t + 2) < ic) {
+            def i0:int (itemAt indices t)
+            def i1:int (itemAt indices (t + 1))
+            def i2:int (itemAt indices (t + 2))
+            def p0:Vec3 (itemAt positions i0)
+            def p1:Vec3 (itemAt positions i1)
+            def p2:Vec3 (itemAt positions i2)
+            def e1x:double (p1.x - p0.x)
+            def e1y:double (p1.y - p0.y)
+            def e1z:double (p1.z - p0.z)
+            def e2x:double (p2.x - p0.x)
+            def e2y:double (p2.y - p0.y)
+            def e2z:double (p2.z - p0.z)
+            def nx:double ((e1y * e2z) - (e1z * e2y))
+            def ny:double ((e1z * e2x) - (e1x * e2z))
+            def nz:double ((e1x * e2y) - (e1y * e2x))
+            this.accum(ax ay az i0 nx ny nz)
+            this.accum(ax ay az i1 nx ny nz)
+            this.accum(ax ay az i2 nx ny nz)
+            t = (t + 3)
+        }
+        def out:[Vec3]
+        def v:int 0
+        while (v < vc) {
+            def nx:double (double_buffer_get ax v)
+            def ny:double (double_buffer_get ay v)
+            def nz:double (double_buffer_get az v)
+            def len:double (sqrt (((nx * nx) + (ny * ny)) + (nz * nz)))
+            def outv:Vec3 (Vec3.of(0.0 1.0 0.0))
+            if (len > 0.0) {
+                outv = (Vec3.of((nx / len) (ny / len) (nz / len)))
+            }
+            push out outv
+            v = (v + 1)
+        }
+        return out
+    }
+    fn accum:void (ax:double_buffer ay:double_buffer az:double_buffer idx:int nx:double ny:double nz:double) {
+        double_buffer_set ax idx ((double_buffer_get ax idx) + nx)
+        double_buffer_set ay idx ((double_buffer_get ay idx) + ny)
+        double_buffer_set az idx ((double_buffer_get az idx) + nz)
+    }
+
     ; ---- build the host ModelAsset -----------------------------------------
     fn buildTextures:void (model:ModelAsset) {
         def n:int (array_length doc.textures)
@@ -249,6 +366,7 @@ class GlbImporter {
             m.metallic = gm.metallic
             m.roughness = gm.roughness
             m.doubleSided = gm.doubleSided
+            m.unlit = gm.unlit
             m.emissiveR = (gm.emissiveR * gm.emissiveStrength)
             m.emissiveG = (gm.emissiveG * gm.emissiveStrength)
             m.emissiveB = (gm.emissiveB * gm.emissiveStrength)
@@ -274,14 +392,25 @@ class GlbImporter {
                 prim.mode = gp.mode
                 prim.material = gp.material
                 prim.positions = (this.readVec3(gp.posAccessor))
-                if (gp.normalAccessor >= 0) {
-                    prim.normals = (this.readVec3(gp.normalAccessor))
-                }
                 if (gp.uvAccessor >= 0) {
                     prim.uvs = (this.readVec2(gp.uvAccessor))
                 }
+                if (gp.colorAccessor >= 0) {
+                    prim.colors = (this.readVec4(gp.colorAccessor))
+                }
+                ; indices: use the accessor, or synthesise them for a
+                ; non-indexed primitive so downstream always has triangles
                 if (gp.indicesAccessor >= 0) {
                     prim.indices = (this.readIndices(gp.indicesAccessor))
+                } {
+                    def vcount:int (prim.vertexCount())
+                    prim.indices = (this.synthIndices(vcount))
+                }
+                ; normals: use NORMAL, else generate smooth normals
+                if (gp.normalAccessor >= 0) {
+                    prim.normals = (this.readVec3(gp.normalAccessor))
+                } {
+                    prim.normals = (this.generateNormals(prim.positions prim.indices))
                 }
                 push mesh.primitives prim
                 j = (j + 1)

--- a/gallery/game_engine/model3d/GltfDocument.rgr
+++ b/gallery/game_engine/model3d/GltfDocument.rgr
@@ -105,12 +105,15 @@ class GltfMaterial {
     def emissiveStrength:double 1.0
     ; 0 = OPAQUE, 1 = MASK, 2 = BLEND (glTF alphaMode)
     def alphaMode:int 0
+    ; KHR_materials_unlit: skip lighting, show base colour flat
+    def unlit:boolean false
 }
 
 class GltfPrimitive {
     def posAccessor:int (0 - 1)
     def normalAccessor:int (0 - 1)
     def uvAccessor:int (0 - 1)
+    def colorAccessor:int (0 - 1)
     def indicesAccessor:int (0 - 1)
     def material:int (0 - 1)
     def mode:int 4
@@ -366,6 +369,9 @@ class GltfDocument {
                         def es:JsonValue (ext.get("KHR_materials_emissive_strength"))
                         m.emissiveStrength = (es.doubleOr("emissiveStrength" 1.0))
                     }
+                    if (ext.has("KHR_materials_unlit")) {
+                        m.unlit = true
+                    }
                 }
                 push materials m
                 i = (i + 1)
@@ -403,6 +409,7 @@ class GltfDocument {
                     prim.posAccessor = (attrs.intOr("POSITION" (0 - 1)))
                     prim.normalAccessor = (attrs.intOr("NORMAL" (0 - 1)))
                     prim.uvAccessor = (attrs.intOr("TEXCOORD_0" (0 - 1)))
+                    prim.colorAccessor = (attrs.intOr("COLOR_0" (0 - 1)))
                     if (prim.posAccessor < 0) {
                         this.fail("primitive is missing POSITION attribute")
                         return

--- a/gallery/game_engine/model3d/README.md
+++ b/gallery/game_engine/model3d/README.md
@@ -61,10 +61,14 @@ Supported:
 - GLB 2.0, one JSON chunk + one BIN chunk
 - scenes and nodes; node `matrix` **or** TRS (translation/rotation/scale)
 - multiple meshes, multiple primitives per mesh
-- `TRIANGLES`; `POSITION`, `NORMAL`, `TEXCOORD_0`
+- `TRIANGLES`; `POSITION`, `NORMAL`, `TEXCOORD_0`, `COLOR_0` (vertex colours)
+- **non-indexed** primitives (indices are synthesised)
+- **missing `NORMAL`** → smooth normals are generated from the geometry
 - `u16` and `u32` (and `u8`) indices
 - interleaved `byteStride`
-- `baseColorFactor` + `baseColorTexture`, multiple materials
+- `baseColorFactor` + `baseColorTexture`, `emissiveFactor`
+  (+ `KHR_materials_emissive_strength`), `alphaMode`, `KHR_materials_unlit`,
+  multiple materials
 - embedded PNG / JPEG textures (decoded to RGBA)
 
 Explicitly rejected (with a clear error, never a silently-wrong model):

--- a/gallery/game_engine/model3d/demo/SoftRenderer3D.rgr
+++ b/gallery/game_engine/model3d/demo/SoftRenderer3D.rgr
@@ -248,18 +248,19 @@ class SoftRenderer3D {
         }
         def hasUv:boolean ((array_length prim.uvs) > 0)
         def hasNormals:boolean ((array_length prim.normals) > 0)
+        def hasColors:boolean ((array_length prim.colors) > 0)
         def idxN:int (array_length prim.indices)
         def t:int 0
         while ((t + 2) < idxN) {
             def i0:int (itemAt prim.indices t)
             def i1:int (itemAt prim.indices (t + 1))
             def i2:int (itemAt prim.indices (t + 2))
-            this.rasterTri(prim worldM vp i0 i1 i2 baseR baseG baseB tex hasTex hasUv hasNormals)
+            this.rasterTri(prim worldM vp i0 i1 i2 baseR baseG baseB tex hasTex hasUv hasNormals hasColors)
             t = (t + 3)
         }
     }
 
-    fn rasterTri:void (prim:MeshPrimitiveAsset worldM:Mat4 vp:Mat4 i0:int i1:int i2:int baseR:double baseG:double baseB:double tex:TextureAsset hasTex:boolean hasUv:boolean hasNormals:boolean) {
+    fn rasterTri:void (prim:MeshPrimitiveAsset worldM:Mat4 vp:Mat4 i0:int i1:int i2:int baseR:double baseG:double baseB:double tex:TextureAsset hasTex:boolean hasUv:boolean hasNormals:boolean hasColors:boolean) {
         def p0:Vec3 (itemAt prim.positions i0)
         def p1:Vec3 (itemAt prim.positions i1)
         def p2:Vec3 (itemAt prim.positions i2)
@@ -314,6 +315,30 @@ class SoftRenderer3D {
             u2 = t2.x
             v2 = t2.y
         }
+        ; per-vertex COLOR_0 (default white when the primitive has none)
+        def cr0:double 1.0
+        def cg0:double 1.0
+        def cb0:double 1.0
+        def cr1:double 1.0
+        def cg1:double 1.0
+        def cb1:double 1.0
+        def cr2:double 1.0
+        def cg2:double 1.0
+        def cb2:double 1.0
+        if hasColors {
+            def vc0:Vec4 (itemAt prim.colors i0)
+            def vc1:Vec4 (itemAt prim.colors i1)
+            def vc2:Vec4 (itemAt prim.colors i2)
+            cr0 = vc0.x
+            cg0 = vc0.y
+            cb0 = vc0.z
+            cr1 = vc1.x
+            cg1 = vc1.y
+            cb1 = vc1.z
+            cr2 = vc2.x
+            cg2 = vc2.y
+            cb2 = vc2.z
+        }
         ; bounding box
         def bxMin:int (this.clampI((floor (this.min3(sx0 sx1 sx2))) 0 (w - 1)))
         def bxMax:int (this.clampI((floor (this.max3(sx0 sx1 sx2))) 0 (w - 1)))
@@ -353,6 +378,14 @@ class SoftRenderer3D {
                             cr = (sc.x / 255.0)
                             cg = (sc.y / 255.0)
                             cb = (sc.z / 255.0)
+                        }
+                        if hasColors {
+                            def vcr:double ((((b0 * (cr0 * iw0)) + (b1 * (cr1 * iw1))) + (b2 * (cr2 * iw2))) / iw)
+                            def vcg:double ((((b0 * (cg0 * iw0)) + (b1 * (cg1 * iw1))) + (b2 * (cg2 * iw2))) / iw)
+                            def vcb:double ((((b0 * (cb0 * iw0)) + (b1 * (cb1 * iw1))) + (b2 * (cb2 * iw2))) / iw)
+                            cr = (cr * vcr)
+                            cg = (cg * vcg)
+                            cb = (cb * vcb)
                         }
                         def outR:int (this.toByte((cr * shade) * 255.0))
                         def outG:int (this.toByte((cg * shade) * 255.0))

--- a/gallery/game_engine/model3d/tests/GlbFixture.rgr
+++ b/gallery/game_engine/model3d/tests/GlbFixture.rgr
@@ -232,4 +232,86 @@ class GlbFixture {
         buffer_copy out (binChunkStart + 8) bin 0 blen
         return out
     }
+
+    ; assemble a GLB from a JSON string + a BIN buffer (shared by the fixtures)
+    sfn assemble:buffer (json:string bin:buffer) {
+        def jbuf:buffer (buffer_from_string json)
+        def jlen:int (buffer_length jbuf)
+        def jpad:int (GlbFixture.pad4(jlen))
+        def jtotal:int (jlen + jpad)
+        def blen:int (buffer_length bin)
+        def bpad:int (GlbFixture.pad4(blen))
+        def btotal:int (blen + bpad)
+        def total:int ((12 + (8 + jtotal)) + (8 + btotal))
+        def out:buffer (buffer_alloc total)
+        ByteReader.encodeU32(out 0 1179937895)
+        ByteReader.encodeU32(out 4 2)
+        ByteReader.encodeU32(out 8 total)
+        ByteReader.encodeU32(out 12 jtotal)
+        ByteReader.encodeU32(out 16 1313821514)
+        buffer_copy out 20 jbuf 0 jlen
+        def p:int 0
+        while (p < jpad) {
+            buffer_set out ((20 + jlen) + p) 32
+            p = (p + 1)
+        }
+        def binChunkStart:int (20 + jtotal)
+        ByteReader.encodeU32(out binChunkStart btotal)
+        ByteReader.encodeU32(out (binChunkStart + 4) 5130562)
+        buffer_copy out (binChunkStart + 8) bin 0 blen
+        return out
+    }
+
+    ; a non-indexed triangle with POSITION + COLOR_0 and NO NORMAL — exercises
+    ; vertex colours, synthesised indices, and generated normals.
+    sfn colorNoIndexBin:buffer () {
+        def b:buffer (buffer_alloc 84)
+        ; positions: (0,0,0) (1,0,0) (0,1,0)  [CCW in XY -> face normal +Z]
+        ByteReader.encodeF32(b 0 0.0)
+        ByteReader.encodeF32(b 4 0.0)
+        ByteReader.encodeF32(b 8 0.0)
+        ByteReader.encodeF32(b 12 1.0)
+        ByteReader.encodeF32(b 16 0.0)
+        ByteReader.encodeF32(b 20 0.0)
+        ByteReader.encodeF32(b 24 0.0)
+        ByteReader.encodeF32(b 28 1.0)
+        ByteReader.encodeF32(b 32 0.0)
+        ; colors at 36: red, green, blue (VEC4)
+        ByteReader.encodeF32(b 36 1.0)
+        ByteReader.encodeF32(b 40 0.0)
+        ByteReader.encodeF32(b 44 0.0)
+        ByteReader.encodeF32(b 48 1.0)
+        ByteReader.encodeF32(b 52 0.0)
+        ByteReader.encodeF32(b 56 1.0)
+        ByteReader.encodeF32(b 60 0.0)
+        ByteReader.encodeF32(b 64 1.0)
+        ByteReader.encodeF32(b 68 0.0)
+        ByteReader.encodeF32(b 72 0.0)
+        ByteReader.encodeF32(b 76 1.0)
+        ByteReader.encodeF32(b 80 1.0)
+        return b
+    }
+    sfn colorNoIndexJson:string () {
+        def s:string "{"
+        s = (s + "\"asset\":{\"version\":\"2.0\"},")
+        s = (s + "\"scene\":0,\"scenes\":[{\"nodes\":[0]}],")
+        s = (s + "\"nodes\":[{\"name\":\"CTri\",\"mesh\":0}],")
+        s = (s + "\"meshes\":[{\"name\":\"CTri\",\"primitives\":[{\"attributes\":{\"POSITION\":0,\"COLOR_0\":1},\"mode\":4}]}],")
+        s = (s + "\"accessors\":[")
+        s = (s + "{\"bufferView\":0,\"componentType\":5126,\"count\":3,\"type\":\"VEC3\"},")
+        s = (s + "{\"bufferView\":1,\"componentType\":5126,\"count\":3,\"type\":\"VEC4\"}")
+        s = (s + "],")
+        s = (s + "\"bufferViews\":[")
+        s = (s + "{\"buffer\":0,\"byteOffset\":0,\"byteLength\":36},")
+        s = (s + "{\"buffer\":0,\"byteOffset\":36,\"byteLength\":48}")
+        s = (s + "],")
+        s = (s + "\"buffers\":[{\"byteLength\":84}]")
+        s = (s + "}")
+        return s
+    }
+    sfn buildColorNoIndex:buffer () {
+        def json:string (GlbFixture.colorNoIndexJson())
+        def bin:buffer (GlbFixture.colorNoIndexBin())
+        return (GlbFixture.assemble(json bin))
+    }
 }

--- a/gallery/game_engine/model3d/tests/Model3dTest.rgr
+++ b/gallery/game_engine/model3d/tests/Model3dTest.rgr
@@ -161,6 +161,35 @@ class Model3dTest {
         Model3dTest.checkReject(ck "skins" "{\"asset\":{\"version\":\"2.0\"},\"skins\":[{\"joints\":[0]}]}" "unsupported feature: skins")
         Model3dTest.checkReject(ck "version" "{\"asset\":{\"version\":\"1.0\"}}" "unsupported glTF version '1.0' (need 2.x)")
 
+        print "== vertex colors + non-indexed + generated normals =="
+        def glb2:buffer (GlbFixture.buildColorNoIndex())
+        def imp2:GlbImporter (new GlbImporter)
+        def model2:ModelAsset (imp2.importModel(glb2))
+        ck.ok("cni import ok" imp2.ok)
+        def mesh2:MeshAsset (model2.getMesh(0))
+        def prim2:MeshPrimitiveAsset (itemAt mesh2.primitives 0)
+        ck.eqInt("cni vertex count" (prim2.vertexCount()) 3)
+        ck.ok("cni has colors" (prim2.hasColors()))
+        def col0:Vec4 (itemAt prim2.colors 0)
+        ck.eqD("color0 r" col0.x 1.0)
+        ck.eqD("color0 g" col0.y 0.0)
+        ck.eqD("color0 a" col0.w 1.0)
+        def col1:Vec4 (itemAt prim2.colors 1)
+        ck.eqD("color1 g" col1.y 1.0)
+        def col2:Vec4 (itemAt prim2.colors 2)
+        ck.eqD("color2 b" col2.z 1.0)
+        ; indices synthesised for the non-indexed primitive
+        ck.eqInt("cni index count" (prim2.indexCount()) 3)
+        ck.eqInt("cni index0" (itemAt prim2.indices 0) 0)
+        ck.eqInt("cni index1" (itemAt prim2.indices 1) 1)
+        ck.eqInt("cni index2" (itemAt prim2.indices 2) 2)
+        ; normals generated (CCW triangle in XY -> +Z)
+        ck.ok("cni has normals" (prim2.hasNormals()))
+        def nrm2:Vec3 (itemAt prim2.normals 0)
+        ck.eqD("gen normal x" nrm2.x 0.0)
+        ck.eqD("gen normal y" nrm2.y 0.0)
+        ck.eqD("gen normal z" nrm2.z 1.0)
+
         print "== summary =="
         print ("passed=" + (to_string ck.passed) + " failed=" + (to_string ck.failed))
         if (ck.failed == 0) {


### PR DESCRIPTION
…air)

The GLES2 3D mesh path truncated every index to uint16 and drew with GL_UNSIGNED_SHORT, so any model above 65535 vertices had its index buffer wrap — triangles connected far-apart vertices and the mesh rendered as spikes/garbage (the "Chair" test model, 228,359 vertices / 282,636 triangles, is exactly this).

The model data and the model3d loader were correct: rendering Chair.glb through the pure-Ranger SoftRenderer3D (full int indices) produces a clean chair, which isolates the bug to the C++ upload/draw path.

Fix: use 32-bit indices end to end in rgfx_mesh_upload / rgfx_mesh_make and the box/quad builders (uint32 element buffers), and draw with GL_UNSIGNED_INT. Positions were never the issue (Chair spans ±0.5, far under the fx256 i32 range).

Note: GL_UNSIGNED_INT indices are core in desktop GL 2.1 (the native SDL host); on strict GLES2 they need OES_element_index_uint (near-universal).


Claude-Session: https://claude.ai/code/session_012Umert9tBqHgs1UJVVBG4R