### PR TITLE
gfx/model3d: high-precision mesh upload (fix Chair black-speckle holes)

### DIFF
--- a/gallery/game_engine/gfx_sdl.rgr
+++ b/gallery/game_engine/gfx_sdl.rgr
@@ -2139,6 +2139,40 @@ static int rgfx_mesh_upload(const int64_t* vw, int vcount, const int64_t* iv, in
     SDL_Log(\"[wasm3d] mesh upload vbo=%u ebo=%u v=%d i=%d glErr=%d\", m.vbo, m.ebo, vcount, icount, (int) glGetError());
     return (int) g_rgfx_meshes.size();
 }
+// High-precision variant: positions are Q16.16 (x65536) instead of the guest
+// ABI's x256, so detailed GLB models authored at unit scale (e.g. 200k+ verts
+// packed into a ~1-unit box) don't collapse nearby vertices into degenerate
+// (zero-area) triangles. Used by the model3d loader path; the guest RGMB path
+// keeps the x256 rgfx_mesh_upload above.
+static int rgfx_mesh_upload_hp(const int64_t* vw, int vcount, const int64_t* iv, int icount) {
+    if (!g_rgfx_gpu_mode || vw == nullptr || iv == nullptr || vcount <= 0 || icount <= 0) { return 0; }
+    rgfx_gl_ensure_current();
+    std::vector<float> verts;
+    verts.reserve((size_t) vcount * 8);
+    for (int i = 0; i < vcount; ++i) {
+        const int64_t* p = vw + (size_t) i * 8;
+        int32_t xi = (int32_t) p[0], yi = (int32_t) p[1], zi = (int32_t) p[2];
+        int32_t nxi = (int32_t) p[3], nyi = (int32_t) p[4], nzi = (int32_t) p[5];
+        uint32_t uvw = (uint32_t) p[7];
+        verts.push_back((float) xi / 65536.f); verts.push_back((float) yi / 65536.f); verts.push_back((float) zi / 65536.f);
+        verts.push_back((float) nxi / 65536.f); verts.push_back((float) nyi / 65536.f); verts.push_back((float) nzi / 65536.f);
+        verts.push_back((float) (uvw & 0xffffu) / 4096.f);
+        verts.push_back((float) ((uvw >> 16) & 0xffffu) / 4096.f);
+    }
+    std::vector<uint32_t> idx;
+    idx.reserve((size_t) icount);
+    for (int i = 0; i < icount; ++i) { idx.push_back((uint32_t) iv[i]); }
+    RgfxMesh3D m; m.vbo = 0; m.ebo = 0; m.icount = icount;
+    glGenBuffers(1, &m.vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, m.vbo);
+    glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) (verts.size() * 4), verts.data(), GL_STATIC_DRAW);
+    glGenBuffers(1, &m.ebo);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m.ebo);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr) (idx.size() * 4), idx.data(), GL_STATIC_DRAW);
+    g_rgfx_meshes.push_back(m);
+    SDL_Log(\"[wasm3d] mesh upload(hp) vbo=%u ebo=%u v=%d i=%d glErr=%d\", m.vbo, m.ebo, vcount, icount, (int) glGetError());
+    return (int) g_rgfx_meshes.size();
+}
 static void rgfx_3d_begin(int w, int h) {
     if (!g_rgfx_gpu_mode) { SDL_Log(\"[wasm3d] begin: NOT gpu_mode\"); return; }
     rgfx_gpu_start_frame(w, h);
@@ -2935,6 +2969,14 @@ extern \"C\" void rgfx_scene_render(int w, int h) {
     gfx_3d_mesh_upload _:int (verts:int_buffer vcount:int idx:int_buffer icount:int) {
         templates {
             cpp ( "rgfx_mesh_upload(" (e 1) ".data(), " (e 2) ", " (e 3) ".data(), " (e 4) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+    ; High-precision upload: positions are Q16.16 (x65536) not x256, so dense GLB
+    ; meshes don't quantise nearby vertices into degenerate triangles.
+    gfx_3d_mesh_upload_hp _:int (verts:int_buffer vcount:int idx:int_buffer icount:int) {
+        templates {
+            cpp ( "rgfx_mesh_upload_hp(" (e 1) ".data(), " (e 2) ", " (e 3) ".data(), " (e 4) ")" (imp "<SDL2/SDL.h>") )
             es6 ( "0" )
         }
     }

--- a/gallery/game_engine/model3d/MeshBridge.rgr
+++ b/gallery/game_engine/model3d/MeshBridge.rgr
@@ -23,6 +23,8 @@ Import "AssetModel.rgr"
 ; indices ready for `gfx_3d_mesh_upload`, plus the resolved base-colour texture.
 class EngineMeshData {
     def verts:int_buffer (int_buffer_alloc 0)
+    ; high-precision vertices: positions Q16.16 (x65536) for gfx_3d_mesh_upload_hp
+    def vertsHp:int_buffer (int_buffer_alloc 0)
     def indices:int_buffer (int_buffer_alloc 0)
     def vertexCount:int 0
     def indexCount:int 0
@@ -40,6 +42,15 @@ class EngineMeshData {
     def emissiveG:double 0.0
     def emissiveB:double 0.0
     def blend:boolean false
+    ; mesh-space bounding box of the converted primitive (before any node
+    ; transform) — lets the host see how big a model is (a fixed-camera viewer
+    ; can't frame a 100+ unit model placed at the origin).
+    def minX:double 0.0
+    def minY:double 0.0
+    def minZ:double 0.0
+    def maxX:double 0.0
+    def maxY:double 0.0
+    def maxZ:double 0.0
     def ok:boolean false
     def error:string ""
 }
@@ -119,6 +130,71 @@ class MeshBridge {
         return buf
     }
 
+    ; same interleaved layout as primitiveVerts, but positions are Q16.16
+    ; (x65536) so dense unit-scale meshes keep sub-1/256 precision.
+    fn primitiveVertsHp:int_buffer (prim:MeshPrimitiveAsset) {
+        def vc:int (prim.vertexCount())
+        def buf:int_buffer (int_buffer_alloc (vc * 8))
+        def hasN:boolean (prim.hasNormals())
+        def hasUv:boolean (prim.hasUvs())
+        def i:int 0
+        while (i < vc) {
+            def o:int (i * 8)
+            def p:Vec3 (itemAt prim.positions i)
+            int_buffer_set buf o (this.q16(p.x))
+            int_buffer_set buf (o + 1) (this.q16(p.y))
+            int_buffer_set buf (o + 2) (this.q16(p.z))
+            def nx:double 0.0
+            def ny:double 1.0
+            def nz:double 0.0
+            if hasN {
+                def n:Vec3 (itemAt prim.normals i)
+                nx = n.x
+                ny = n.y
+                nz = n.z
+            }
+            int_buffer_set buf (o + 3) (this.q16(nx))
+            int_buffer_set buf (o + 4) (this.q16(ny))
+            int_buffer_set buf (o + 5) (this.q16(nz))
+            int_buffer_set buf (o + 6) 0
+            def uu:double 0.0
+            def vv:double 0.0
+            if hasUv {
+                def uv:Vec2 (itemAt prim.uvs i)
+                uu = uv.x
+                vv = uv.y
+            }
+            int_buffer_set buf (o + 7) (this.packUv(uu vv))
+            i = (i + 1)
+        }
+        return buf
+    }
+
+    fn computeBounds:void (prim:MeshPrimitiveAsset out:EngineMeshData) {
+        def vc:int (prim.vertexCount())
+        if (vc <= 0) {
+            return
+        }
+        def p0:Vec3 (itemAt prim.positions 0)
+        out.minX = p0.x
+        out.maxX = p0.x
+        out.minY = p0.y
+        out.maxY = p0.y
+        out.minZ = p0.z
+        out.maxZ = p0.z
+        def i:int 1
+        while (i < vc) {
+            def p:Vec3 (itemAt prim.positions i)
+            if (p.x < out.minX) { out.minX = p.x }
+            if (p.x > out.maxX) { out.maxX = p.x }
+            if (p.y < out.minY) { out.minY = p.y }
+            if (p.y > out.maxY) { out.maxY = p.y }
+            if (p.z < out.minZ) { out.minZ = p.z }
+            if (p.z > out.maxZ) { out.maxZ = p.z }
+            i = (i + 1)
+        }
+    }
+
     fn primitiveIndices:int_buffer (prim:MeshPrimitiveAsset) {
         def ic:int (prim.indexCount())
         def buf:int_buffer (int_buffer_alloc ic)
@@ -149,9 +225,11 @@ class MeshBridge {
             return out
         }
         out.verts = (this.primitiveVerts(prim))
+        out.vertsHp = (this.primitiveVertsHp(prim))
         out.indices = (this.primitiveIndices(prim))
         out.vertexCount = (prim.vertexCount())
         out.indexCount = (prim.indexCount())
+        this.computeBounds(prim out)
         def matIdx:int (prim.material)
         if (matIdx >= 0) {
             def mat:MaterialAsset (model.getMaterial(matIdx))

--- a/gallery/game_engine/model3d/tests/MeshBridgeTest.rgr
+++ b/gallery/game_engine/model3d/tests/MeshBridgeTest.rgr
@@ -63,6 +63,12 @@ class MeshBridgeTest {
         ck.eqInt("v2.px" (int_buffer_get em.verts 16) 0)
         ck.eqInt("v2.py" (int_buffer_get em.verts 17) 256)
         ck.eqInt("v2.uv" (int_buffer_get em.verts 23) 268435456)
+        ; high-precision verts: positions are Q16.16 (x65536), rest unchanged
+        ck.eqInt("hp v0.px" (int_buffer_get em.vertsHp 0) 0)
+        ck.eqInt("hp v1.px" (int_buffer_get em.vertsHp 8) 65536)
+        ck.eqInt("hp v1.nz" (int_buffer_get em.vertsHp 13) 65536)
+        ck.eqInt("hp v2.py" (int_buffer_get em.vertsHp 17) 65536)
+        ck.eqInt("hp v1.uv" (int_buffer_get em.vertsHp 15) 4096)
         ; indices 0,1,2
         ck.eqInt("idx0" (int_buffer_get em.indices 0) 0)
         ck.eqInt("idx1" (int_buffer_get em.indices 1) 1)

--- a/gallery/game_engine/scripting/wasm3d_runner.rgr
+++ b/gallery/game_engine/scripting/wasm3d_runner.rgr
@@ -333,7 +333,7 @@ class Wasm3dRunner {
                     def model:ModelAsset (loader.getModel(id))
                     def em:EngineMeshData (bridge.fromModel(model))
                     if em.ok {
-                        def meshId:int (gfx_3d_mesh_upload em.verts em.vertexCount em.indices em.indexCount)
+                        def meshId:int (gfx_3d_mesh_upload_hp em.vertsHp em.vertexCount em.indices em.indexCount)
                         def texId:int 0
                         if em.hasTexture {
                             texId = (gfx_3d_upload_texture em.texRgba em.texWidth em.texHeight)
@@ -353,7 +353,10 @@ class Wasm3dRunner {
                             blendI = 1
                         }
                         gfx_scene_register_model base meshId texId colorRgba emissiveRgb blendI
-                        print ("[wasm3d] model '" + base + "' -> mesh=" + (to_string meshId) + " tex=" + (to_string texId) + " blend=" + (to_string blendI))
+                        def szx:double (em.maxX - em.minX)
+                        def szy:double (em.maxY - em.minY)
+                        def szz:double (em.maxZ - em.minZ)
+                        print ("[wasm3d] model '" + base + "' -> mesh=" + (to_string meshId) + " tex=" + (to_string texId) + " verts=" + (to_string em.vertexCount) + " size=" + (to_string szx) + "x" + (to_string szy) + "x" + (to_string szz) + " blend=" + (to_string blendI))
                     } {
                         print ("[wasm3d] model unusable: " + fname + " (" + em.error + ")")
                     }


### PR DESCRIPTION
The GLB render path packed vertex positions at x256 (the guest RGMB ABI's FP_SCALE) before GPU upload. For a dense model authored at unit scale — the Chair, 228k vertices in a ~1-unit box — the 1/256 quantisation collapsed many nearby vertices onto the same grid point, making ~22% of triangles degenerate (zero-area) so they dropped out: the scattered black holes across the surface. Measured on Chair: x256 -> 21.9% degenerate, x65536 -> 0.01% (source only).

Fix: a high-precision upload path for model3d meshes that packs positions as Q16.16 (x65536) instead of x256, leaving the guest RGMB path (which must stay x256 for the ABI) untouched:
- gfx_sdl.rgr: rgfx_mesh_upload_hp / gfx_3d_mesh_upload_hp (position /65536.f).
- MeshBridge: primitiveVertsHp + EngineMeshData.vertsHp; preloadModels uploads via the hp path.

Also: MeshBridge computes each model's mesh-space bounds and preloadModels logs verts + size. This surfaces why some models are blank in the viewer — e.g. the Duck GLB is ~165 units across (no scale-down node), so at the origin the fixed viewer camera sits inside it. A fit-to-view / model-normalisation step in the viewer is the follow-up for that.

Ranger side verified: Model3dTest 85, TextureDecode 20, MeshBridge 32 (hp assertions added); wasm3d_runner compiles. The C++ upload path needs the native SDL build to verify on screen.


Claude-Session: https://claude.ai/code/session_012Umert9tBqHgs1UJVVBG4R