### PR TITLE
fix(pi): WASM-deploy flakiness + model_viewer bounce-to-menu

### DIFF
--- a/gallery/game_engine/games/model_viewer_wasm/README.md
+++ b/gallery/game_engine/games/model_viewer_wasm/README.md
@@ -33,8 +33,13 @@ Free Khronos [glTF-Sample-Assets](https://github.com/KhronosGroup/glTF-Sample-As
 | `BoxVertexColors` | per-vertex `COLOR_0` (RGB cube gradient) |
 | `Duck` | 4,212-triangle textured mesh with a node hierarchy |
 
-Re-download with `tools/fetch_models.sh`. To use different models, drop supported
-GLBs into `models/` and update the `NAMES` list in `src/src/lib.rs`.
+Plus a nature pack (`tree_*`, `bush_*`, …) in `models/`. Oversized assets (e.g.
+`Chair.glb`) live in `models/heavy/` and are **not** eagerly preloaded — the Pi
+host skips that subdirectory (and any GLB over ~2 MiB / 80k verts) so launch
+cannot OOM.
+
+Re-download the Khronos four with `tools/fetch_models.sh`. Drop other supported
+GLBs into `models/`; the guest discovers them via `rg_list_resources`.
 
 ## Build
 

--- a/gallery/game_engine/gfx_sdl.rgr
+++ b/gallery/game_engine/gfx_sdl.rgr
@@ -2364,7 +2364,20 @@ extern \"C\" int rgfx_scene_resource_names(const char* kind, char* out, int cap)
     return need;
 }
 
-extern \"C\" int rgfx_scene_reset() { g_scene.clear(); g_scene_active_cam = 0; return 0; }
+extern \"C\" int rgfx_scene_reset() {
+    g_scene.clear();
+    g_scene_active_cam = 0;
+    // Drop name registries so a subsequent preloadModels/sprites cannot grow
+    // forever across game launches (Pi OOM after a few 3D game starts). Mesh /
+    // texture GL objects are still retained in their pools for the process —
+    // registry clear at least stops the guest from resolving stale names and
+    // stops map growth on every launch.
+    g_scene_model_mesh.clear();
+    g_scene_mesh_deftex.clear();
+    g_scene_mesh_mat.clear();
+    g_scene_sprite_tex.clear();
+    return 0;
+}
 
 static int rgfx_scene_alloc(int type) {
     RgfxSceneEntity e; memset(&e, 0, sizeof(e));

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -454,15 +454,22 @@ class GameSdlRunner {
     ; the menu rather than entering a game with no module (which would render a
     ; broken default court / blank scene). The console already carries the
     ; specific reason ("[wasm] load failed" / "REJECTED …" / missing import).
+    ; Do NOT call loadMenuGame() here: launchSelected() is already nested inside
+    ; the active menu loop (TSX / EVG / classic). Reloading the classic menu from
+    ; a failed 3D/WASM launch used to clobber that loop and look like an instant
+    ; bounce back to the front page with a half-reset runner state.
     fn abortWasmLoad:void (wasmPath:string) {
         print ("[game-engine] wasm load FAILED, returning to menu: " + wasmPath)
         useWasmRunner = false
         useWasmPhysics = false
         useSpriteRunner = false
         useStreamRunner = false
+        useWasm3d = false
         splitScreenActive = false
         wasmSplitActive = false
-        this.loadMenuGame()
+        wasm3dRunner.closeModule()
+        inGame = false
+        inMenu = true
     }
 
     ; Load a render=3d wasm guest into the GPU 3D runner (Wasm3dRunner). The guest
@@ -679,6 +686,13 @@ class GameSdlRunner {
     fn loadMenuGame:void () {
         gfx_audio_clear
         useWasm3d = false
+        useWasmRunner = false
+        useWasmPhysics = false
+        useSpriteRunner = false
+        useStreamRunner = false
+        ; Free the wasm3 slot so repeated game launches cannot hit RG_WASM_MAX
+        ; ("[wasm] no free slot") and bounce straight back to the menu.
+        wasm3dRunner.closeModule()
         catalog.setGamesDir(gamesDir)
         catalog.scan()
         this.clearNavStack()
@@ -1854,9 +1868,11 @@ class GameSdlRunner {
                     this.clearNavStack()
                     nativeBridge.clearPendingNav()
                     inGame = false
+                    useWasm3d = false
                     splitScreenActive = false
                     wasmSplitActive = false
                     dualPlayerMode = false
+                    wasm3dRunner.closeModule()
                     gfx_clear_should_close
                     return
                 }

--- a/gallery/game_engine/scripting/wasm3d_runner.rgr
+++ b/gallery/game_engine/scripting/wasm3d_runner.rgr
@@ -148,11 +148,20 @@ class Wasm3dRunner {
         return (substring path 0 cut)
     }
 
-    fn loadModule:void (path:string) {
+    fn closeModule:void () {
         if (handle != 0) {
             wasm_close handle
             handle = 0
         }
+        modulePath = ""
+        sceneMode = false
+        hasUi = false
+        hudReady = false
+        uiRev = (0 - 1)
+    }
+
+    fn loadModule:void (path:string) {
+        this.closeModule()
         handle = (wasm_load path)
         modulePath = path
         gameDir = (this.dirOf(path))
@@ -316,6 +325,9 @@ class Wasm3dRunner {
     ; Preload every <gameDir>/models/*.glb into the scene's mesh/texture pools
     ; and register each under its basename, so a host-managed guest can call
     ; rg_load_model("name") during init() (IDEAL_3D §12.4 render bridge).
+    ; Subdirectories (e.g. models/heavy/) are ignored — put Pi-hostile assets
+    ; there so eager preload cannot OOM the launcher. Files larger than
+    ; maxGlbBytes, or meshes above maxVerts, are skipped with a log line.
     fn preloadModels:void () {
         if ((file_exists gameDir "models") == false) {
             return
@@ -324,44 +336,62 @@ class Wasm3dRunner {
         def names:[string] (list_dir_files dir)
         def loader:ModelLoader (new ModelLoader)
         def bridge:MeshBridge (new MeshBridge)
+        ; ~2 MiB GLB / 80k verts — keeps Pi RAM headroom while still admitting
+        ; Duck + the nature pack; Chair (~33 MiB / 228k verts) lives in heavy/.
+        def maxGlbBytes:int 2097152
+        def maxVerts:int 80000
         def i:int 0
         while (i < (array_length names)) {
             def fname:string (itemAt names i)
             if (this.endsWithGlb(fname)) {
-                def id:int (loader.loadFromFile(dir fname))
-                if (id >= 0) {
-                    def model:ModelAsset (loader.getModel(id))
-                    def em:EngineMeshData (bridge.fromModel(model))
-                    if em.ok {
-                        def meshId:int (gfx_3d_mesh_upload_hp em.vertsHp em.vertexCount em.indices em.indexCount)
-                        def texId:int 0
-                        if em.hasTexture {
-                            texId = (gfx_3d_upload_texture em.texRgba em.texWidth em.texHeight)
-                        }
-                        def base:string (this.stripGlb(fname))
-                        def cr:int (this.chan255(em.baseColorR))
-                        def cg:int (this.chan255(em.baseColorG))
-                        def cb:int (this.chan255(em.baseColorB))
-                        def ca:int (this.chan255(em.baseColorA))
-                        def colorRgba:int (((cr * 16777216) + (cg * 65536)) + ((cb * 256) + ca))
-                        def er:int (this.chan255(em.emissiveR))
-                        def eg:int (this.chan255(em.emissiveG))
-                        def eb:int (this.chan255(em.emissiveB))
-                        def emissiveRgb:int (((er * 16777216) + (eg * 65536)) + (eb * 256))
-                        def blendI:int 0
-                        if em.blend {
-                            blendI = 1
-                        }
-                        gfx_scene_register_model base meshId texId colorRgba emissiveRgb blendI
-                        def szx:double (em.maxX - em.minX)
-                        def szy:double (em.maxY - em.minY)
-                        def szz:double (em.maxZ - em.minZ)
-                        print ("[wasm3d] model '" + base + "' -> mesh=" + (to_string meshId) + " tex=" + (to_string texId) + " verts=" + (to_string em.vertexCount) + " size=" + (to_string szx) + "x" + (to_string szy) + "x" + (to_string szz) + " blend=" + (to_string blendI))
-                    } {
-                        print ("[wasm3d] model unusable: " + fname + " (" + em.error + ")")
-                    }
+                def bytes:buffer (buffer_read_file dir fname)
+                def nbytes:int (buffer_length bytes)
+                if (nbytes <= 0) {
+                    print ("[wasm3d] model empty/unreadable: " + fname)
                 } {
-                    print ("[wasm3d] model load failed: " + fname + " (" + loader.lastError + ")")
+                    if (nbytes > maxGlbBytes) {
+                        print ("[wasm3d] model skip (too large for eager preload): " + fname + " (" + (to_string nbytes) + " bytes; move to models/heavy/)")
+                    } {
+                        def id:int (loader.loadFromBuffer(bytes))
+                        if (id >= 0) {
+                            def model:ModelAsset (loader.getModel(id))
+                            def em:EngineMeshData (bridge.fromModel(model))
+                            if em.ok {
+                                if (em.vertexCount > maxVerts) {
+                                    print ("[wasm3d] model skip (too many verts for eager preload): " + fname + " verts=" + (to_string em.vertexCount))
+                                } {
+                                    def meshId:int (gfx_3d_mesh_upload_hp em.vertsHp em.vertexCount em.indices em.indexCount)
+                                    def texId:int 0
+                                    if em.hasTexture {
+                                        texId = (gfx_3d_upload_texture em.texRgba em.texWidth em.texHeight)
+                                    }
+                                    def base:string (this.stripGlb(fname))
+                                    def cr:int (this.chan255(em.baseColorR))
+                                    def cg:int (this.chan255(em.baseColorG))
+                                    def cb:int (this.chan255(em.baseColorB))
+                                    def ca:int (this.chan255(em.baseColorA))
+                                    def colorRgba:int (((cr * 16777216) + (cg * 65536)) + ((cb * 256) + ca))
+                                    def er:int (this.chan255(em.emissiveR))
+                                    def eg:int (this.chan255(em.emissiveG))
+                                    def eb:int (this.chan255(em.emissiveB))
+                                    def emissiveRgb:int (((er * 16777216) + (eg * 65536)) + (eb * 256))
+                                    def blendI:int 0
+                                    if em.blend {
+                                        blendI = 1
+                                    }
+                                    gfx_scene_register_model base meshId texId colorRgba emissiveRgb blendI
+                                    def szx:double (em.maxX - em.minX)
+                                    def szy:double (em.maxY - em.minY)
+                                    def szz:double (em.maxZ - em.minZ)
+                                    print ("[wasm3d] model '" + base + "' -> mesh=" + (to_string meshId) + " tex=" + (to_string texId) + " verts=" + (to_string em.vertexCount) + " size=" + (to_string szx) + "x" + (to_string szy) + "x" + (to_string szz) + " blend=" + (to_string blendI))
+                                }
+                            } {
+                                print ("[wasm3d] model unusable: " + fname + " (" + em.error + ")")
+                            }
+                        } {
+                            print ("[wasm3d] model load failed: " + fname + " (" + loader.lastError + ")")
+                        }
+                    }
                 }
             }
             i = (i + 1)

--- a/gallery/game_engine/scripts/deploy-pi.sh
+++ b/gallery/game_engine/scripts/deploy-pi.sh
@@ -77,21 +77,63 @@ build_wasm_modules() {
   (cd "$ROOT" && npm run engine:wasm:build:rust-pong)
 }
 
+# Every games/<id>/game.info that declares engine=wasm|ui|streaming must ship
+# its module file (usually logic.wasm). Previously only autopeli + rust_pong
+# were checked, so a missing model_viewer_wasm/logic.wasm still "deployed" and
+# the launcher bounced straight back to the menu on launch.
+collect_wasm_modules() {
+  local info mod engine
+  while IFS= read -r -d '' info; do
+    # grep exits 1 when a key is absent — must not trip `set -e`.
+    engine="$(grep -E '^engine=' "$info" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '\r' || true)"
+    case "$engine" in
+      wasm|ui|streaming) ;;
+      *) continue ;;
+    esac
+    mod="$(grep -E '^module=' "$info" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '\r' || true)"
+    mod="${mod:-logic.wasm}"
+    printf '%s\n' "$(dirname "$info")/$mod"
+  done < <(find "$GE_GAMES" -mindepth 2 -maxdepth 2 -name game.info -print0 | sort -z)
+}
+
 verify_wasm_artifacts() {
-  local missing=0
-  for wasm in \
-    "$GE_GAMES/autopeli_wasm/logic.wasm" \
-    "$GE_GAMES/rust_pong/logic.wasm"; do
+  local missing=0 wasm count=0
+  while IFS= read -r wasm; do
+    [[ -n "$wasm" ]] || continue
+    count=$((count + 1))
     if [[ ! -f "$wasm" ]]; then
       echo "error: missing WASM artifact: $wasm" >&2
-      echo "  Install Rust + wasm32 target, or run:" >&2
-      echo "  npm run engine:wasm:build:rust-autopeli" >&2
+      echo "  Build that game's src/build.sh (needs Rust wasm32 or asc), then re-deploy." >&2
       missing=1
+    else
+      echo "    ok  ${wasm#"$GE_GAMES/"} ($(wc -c < "$wasm" | tr -d ' ') bytes)"
     fi
-  done
+  done < <(collect_wasm_modules)
+  if [[ "$count" -eq 0 ]]; then
+    echo "error: no engine=wasm|ui|streaming games found under $GE_GAMES" >&2
+    exit 1
+  fi
+  echo "    checked $count WASM module(s)"
   if [[ "$missing" != "0" ]]; then
     exit 1
   fi
+}
+
+# After rsync, confirm the Pi actually has every module (catches partial sync /
+# disk-full truncations that local verify cannot see).
+verify_remote_wasm_artifacts() {
+  local list rel
+  list="$(collect_wasm_modules | while IFS= read -r wasm; do
+    rel="${wasm#"$ROOT/"}"
+    printf '%s\n' "$rel"
+  done)"
+  ssh "$TARGET" "cd ~/$REMOTE_DIR && missing=0; while IFS= read -r rel; do
+    [[ -n \"\$rel\" ]] || continue
+    if [[ ! -f \"\$rel\" ]]; then
+      echo \"error: missing on Pi: \$rel\" >&2
+      missing=1
+    fi
+  done; exit \$missing" <<< "$list"
 }
 
 # Verify a REAL camera on the Pi (over SSH). A Pi 5 exposes many /dev/video*
@@ -180,6 +222,14 @@ rsync -az --delete \
   --exclude 'gallery/game_engine/games/*/src/build' \
   --exclude 'gallery/game_engine/wasm/*/target' \
   "$ROOT/" "$TARGET:~/$REMOTE_DIR/"
+
+echo "==> Verify WASM modules on Pi after rsync"
+if ! verify_remote_wasm_artifacts; then
+  echo "error: rsync finished but one or more WASM modules are missing on $TARGET" >&2
+  echo "  Check disk space (df -h) and re-run deploy." >&2
+  exit 1
+fi
+echo "    remote WASM modules OK"
 
 echo "==> 5/$TOTAL_STEPS Build game launcher on Pi (CXX_OPT=$CXX_OPT, wasm3 embedded)"
 ssh "$TARGET" "cd ~/$REMOTE_DIR && npm install && npm run compile && CXX_OPT=$CXX_OPT npm run engine:game-sdl"
@@ -331,9 +381,11 @@ echo "Done. On the Pi:"
 echo "  ~/start.sh       — launch game launcher (TSX + WASM)"
 echo "  ~/initservice.sh — (re)configure boot autostart"
 echo ""
-echo "WASM games in launcher menu (e.g. Rust Autopeli):"
-echo "  ~/ranger/gallery/game_engine/games/autopeli_wasm/logic.wasm"
+echo "WASM games in launcher menu (committed logic.wasm, verified above):"
+echo "  e.g. ~/ranger/gallery/game_engine/games/autopeli_wasm/logic.wasm"
+echo "       ~/ranger/gallery/game_engine/games/model_viewer_wasm/logic.wasm"
 echo "  host binary: ~/ranger/tmp/game-sdl/game_sdl (wasm3 interpreter embedded)"
+echo "  Note: model_viewer_wasm/models/heavy/ is not eagerly preloaded (Pi RAM)."
 echo ""
 if [[ "$RANGER_PI_AUTOSTART" == "1" ]]; then
   echo "Autostart configured. Log: tail -f ~/ranger-game.log"

--- a/gallery/game_engine/scripts/sync-pi-games.sh
+++ b/gallery/game_engine/scripts/sync-pi-games.sh
@@ -50,6 +50,25 @@ fi
 echo "==> Test SSH: $TARGET"
 ssh -o ConnectTimeout=10 -o BatchMode=yes "$TARGET" 'echo ok'
 
+# Fail fast if a WASM game folder is missing its module — same class of bug as
+# deploy-pi.sh used to have (catalog shows the game, launch bounces to menu).
+missing=0
+while IFS= read -r -d '' info; do
+  # grep exits 1 when a key is absent — must not trip `set -e`.
+  engine="$(grep -E '^engine=' "$info" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '\r' || true)"
+  case "$engine" in wasm|ui|streaming) ;; *) continue ;; esac
+  mod="$(grep -E '^module=' "$info" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '\r' || true)"
+  mod="${mod:-logic.wasm}"
+  wasm="$(dirname "$info")/$mod"
+  if [[ ! -f "$wasm" ]]; then
+    echo "error: missing WASM artifact: $wasm" >&2
+    missing=1
+  fi
+done < <(find "$GE/games" -mindepth 2 -maxdepth 2 -name game.info -print0 | sort -z)
+if [[ "$missing" != "0" ]]; then
+  exit 1
+fi
+
 echo "==> Sync games -> $TARGET:$REMOTE_BASE/games/"
 ssh "$TARGET" "mkdir -p $REMOTE_BASE/games $REMOTE_BASE/lib"
 # games/<game>/src/ holds that game's WASM build sources (Rust crate / AS


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`deploy-pi.sh` sometimes left WASM games in a state where launching them (e.g. `model_viewer_wasm`) immediately returned to the main menu. Two separate problems stacked:

1. **Incomplete WASM verify** — deploy only checked `autopeli_wasm` + `rust_pong`. A missing/partial `logic.wasm` for other games still “deployed successfully”, and the launcher’s `abortWasmLoad` path bounced back to the menu.
2. **Pi-hostile eager preload** — `model_viewer_wasm` preloaded every `models/*.glb`, including `Chair.glb` (~33 MiB / 228k verts). That can OOM or hang the Pi during `setupScene`.

## Changes

- Verify **all** `engine=wasm|ui|streaming` modules locally, and again on the Pi after rsync (`deploy-pi.sh` + `sync-pi-games.sh`).
- Move `Chair.glb` → `models/heavy/` (not preloaded); skip GLBs over ~2 MiB / 80k verts on eager preload.
- Clear 3D name registries on `gfx_scene_reset`; close the wasm3 slot when returning to the menu (avoids `RG_WASM_MAX` / “no free slot”).
- `abortWasmLoad` no longer calls `loadMenuGame()` (was clobbering the active TSX/EVG menu loop).

## Test plan

- [ ] `bash gallery/game_engine/scripts/deploy-pi.sh pelit` — local + remote WASM verify both print all modules OK
- [ ] Launch **3D Model Viewer** from Tests — stays in-game (nature pack + Khronos boxes/Duck), does not bounce to menu
- [ ] Exit to menu and relaunch a few WASM games — no `[wasm] no free slot`
- [ ] `node gallery/game_engine/games/model_viewer_wasm/tools/headless_check.cjs` still passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11b48f0a-46a7-47bd-8e46-88dd94c8c07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11b48f0a-46a7-47bd-8e46-88dd94c8c07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

