### PR TITLE
model3d: GPU render fixes (32-bit indices, COLOR_0 + importer gaps, precision, presentation radius)

### DIFF
--- a/gallery/game_engine/games/model_viewer_wasm/game.info
+++ b/gallery/game_engine/games/model_viewer_wasm/game.info
@@ -4,3 +4,8 @@ render=3d
 module=logic.wasm
 
 category=Tests
+
+# Present every model at the same size regardless of how it was authored:
+# scale so the farthest vertex from the origin is 1.0 unit. Lets the fixed
+# viewer camera frame a 0.5-unit chair and a 165-unit duck identically.
+model_radius=1.0

--- a/gallery/game_engine/model3d/AssetModel.rgr
+++ b/gallery/game_engine/model3d/AssetModel.rgr
@@ -149,6 +149,65 @@ class ModelAsset {
     fn getTexture:TextureAsset (index:int) {
         return (itemAt textures index)
     }
+
+    ; largest distance of any vertex from the origin, across all primitives
+    fn boundingRadius:double () {
+        def maxd:double 0.0
+        def mi:int 0
+        while (mi < (array_length meshes)) {
+            def mesh:MeshAsset (itemAt meshes mi)
+            def pi:int 0
+            while (pi < (array_length mesh.primitives)) {
+                def prim:MeshPrimitiveAsset (itemAt mesh.primitives pi)
+                def vc:int (array_length prim.positions)
+                def vi:int 0
+                while (vi < vc) {
+                    def p:Vec3 (itemAt prim.positions vi)
+                    def d:double (sqrt (((p.x * p.x) + (p.y * p.y)) + (p.z * p.z)))
+                    if (d > maxd) {
+                        maxd = d
+                    }
+                    vi = (vi + 1)
+                }
+                pi = (pi + 1)
+            }
+            mi = (mi + 1)
+        }
+        return maxd
+    }
+
+    ; uniformly scale all geometry so the farthest vertex from the origin sits
+    ; at distance `radius` (radius <= 0 leaves the model untouched). Presentation
+    ; size only — the model stays centred on wherever it was authored.
+    fn scaleToRadius:void (radius:double) {
+        if (radius <= 0.0) {
+            return
+        }
+        def maxd:double (this.boundingRadius())
+        if (maxd <= 0.0) {
+            return
+        }
+        def s:double (radius / maxd)
+        def mi:int 0
+        while (mi < (array_length meshes)) {
+            def mesh:MeshAsset (itemAt meshes mi)
+            def pi:int 0
+            while (pi < (array_length mesh.primitives)) {
+                def prim:MeshPrimitiveAsset (itemAt mesh.primitives pi)
+                def vc:int (array_length prim.positions)
+                def vi:int 0
+                while (vi < vc) {
+                    def p:Vec3 (itemAt prim.positions vi)
+                    p.x = (p.x * s)
+                    p.y = (p.y * s)
+                    p.z = (p.z * s)
+                    vi = (vi + 1)
+                }
+                pi = (pi + 1)
+            }
+            mi = (mi + 1)
+        }
+    }
 }
 
 ; Owns loaded models; the model id is its index in the registry.

--- a/gallery/game_engine/model3d/ModelLoader.rgr
+++ b/gallery/game_engine/model3d/ModelLoader.rgr
@@ -51,6 +51,24 @@ class ModelLoader {
         return (this.loadFromBuffer(bytes))
     }
 
+    ; load + scale so the model's farthest vertex from the origin sits at
+    ; `radius` units (radius <= 0 = no scaling). Presentation size, e.g. a viewer
+    ; can show any model — a 0.5-unit chair or a 165-unit duck — at a set size.
+    fn loadFromBufferRadius:int (bytes:buffer radius:double) {
+        def id:int (this.loadFromBuffer(bytes))
+        if (id >= 0) {
+            if (radius > 0.0) {
+                def model:ModelAsset (registry.getModel(id))
+                model.scaleToRadius(radius)
+            }
+        }
+        return id
+    }
+    fn loadFromFileRadius:int (dir:string file:string radius:double) {
+        def bytes:buffer (buffer_read_file dir file)
+        return (this.loadFromBufferRadius(bytes radius))
+    }
+
     fn getModel:ModelAsset (modelId:int) {
         return (registry.getModel(modelId))
     }

--- a/gallery/game_engine/model3d/README.md
+++ b/gallery/game_engine/model3d/README.md
@@ -40,6 +40,17 @@ def hand:int (loader.findChild(robot "RightHand"))          ; -> EntityId
 
 On failure `loader.ok` is `false` and `loader.lastError` explains why.
 
+### Presentation size (optional `radius`)
+
+`loadFromFileRadius(dir, file, radius)` / `loadFromBufferRadius(bytes, radius)`
+load and then uniformly scale the geometry so the model's farthest vertex from
+the origin sits at `radius` units (`radius <= 0` = no scaling). This lets a
+fixed-camera viewer show any model at the same size — a 0.5-unit chair and a
+165-unit duck alike — via `ModelAsset.scaleToRadius(radius)` /
+`boundingRadius()`. In the host runner it is opt-in per game: add
+`model_radius=<n>` to the game's `game.info` (absent = models keep their
+authored size, so e.g. `pyramid_wasm`'s diamond is unaffected).
+
 ## Files
 
 | File | Role |

--- a/gallery/game_engine/model3d/tests/Model3dTest.rgr
+++ b/gallery/game_engine/model3d/tests/Model3dTest.rgr
@@ -190,6 +190,24 @@ class Model3dTest {
         ck.eqD("gen normal y" nrm2.y 0.0)
         ck.eqD("gen normal z" nrm2.z 1.0)
 
+        print "== scaleToRadius =="
+        def glb3:buffer (GlbFixture.build())
+        def imp3:GlbImporter (new GlbImporter)
+        def model3:ModelAsset (imp3.importModel(glb3))
+        ; fixture triangle (0,0,0)(1,0,0)(0,1,0): farthest vertex is 1.0 from origin
+        ck.eqD("bounding radius before" (model3.boundingRadius()) 1.0)
+        model3.scaleToRadius(4.0)
+        ck.eqD("bounding radius after scale" (model3.boundingRadius()) 4.0)
+        def mesh3:MeshAsset (model3.getMesh(0))
+        def prim3:MeshPrimitiveAsset (itemAt mesh3.primitives 0)
+        def sp1:Vec3 (itemAt prim3.positions 1)
+        ck.eqD("scaled pos1.x" sp1.x 4.0)
+        def sp2:Vec3 (itemAt prim3.positions 2)
+        ck.eqD("scaled pos2.y" sp2.y 4.0)
+        ; radius <= 0 is a no-op
+        model3.scaleToRadius(0.0)
+        ck.eqD("radius 0 is no-op" (model3.boundingRadius()) 4.0)
+
         print "== summary =="
         print ("passed=" + (to_string ck.passed) + " failed=" + (to_string ck.failed))
         if (ck.failed == 0) {

--- a/gallery/game_engine/scripting/wasm3d_runner.rgr
+++ b/gallery/game_engine/scripting/wasm3d_runner.rgr
@@ -313,6 +313,64 @@ class Wasm3dRunner {
         }
         return n
     }
+    fn findSub:int (hay:string needle:string) {
+        def hn:int (strlen hay)
+        def nn:int (strlen needle)
+        if (nn == 0) {
+            return 0
+        }
+        def i:int 0
+        while ((i + nn) <= hn) {
+            def sub:string (substring hay i (i + nn))
+            if (sub == needle) {
+                return i
+            }
+            i = (i + 1)
+        }
+        return (0 - 1)
+    }
+    ; Optional presentation size for a game's models: `model_radius=<n>` in the
+    ; game's game.info scales every preloaded model so its farthest vertex from
+    ; the origin sits at n units. Absent / <= 0 = no scaling (models keep their
+    ; authored size, e.g. pyramid's diamond).
+    fn readModelRadius:double () {
+        if ((file_exists gameDir "game.info") == false) {
+            return 0.0
+        }
+        def buf:buffer (buffer_read_file gameDir "game.info")
+        def txt:string (buffer_to_string buf)
+        def key:string "model_radius="
+        def ki:int (this.findSub(txt key))
+        if (ki < 0) {
+            return 0.0
+        }
+        def start:int (ki + (strlen key))
+        def n:int (strlen txt)
+        def endp:int start
+        def go:boolean true
+        while go {
+            if (endp >= n) {
+                go = false
+            } {
+                def c:int (charAt txt endp)
+                if (c == 10) {
+                    go = false
+                } {
+                    if (c == 13) {
+                        go = false
+                    } {
+                        endp = (endp + 1)
+                    }
+                }
+            }
+        }
+        def valStr:string (substring txt start endp)
+        def d@(optional):double (str2double valStr)
+        if d {
+            return (unwrap d)
+        }
+        return 0.0
+    }
     ; Preload every <gameDir>/models/*.glb into the scene's mesh/texture pools
     ; and register each under its basename, so a host-managed guest can call
     ; rg_load_model("name") during init() (IDEAL_3D §12.4 render bridge).
@@ -324,11 +382,17 @@ class Wasm3dRunner {
         def names:[string] (list_dir_files dir)
         def loader:ModelLoader (new ModelLoader)
         def bridge:MeshBridge (new MeshBridge)
+        def radius:double (this.readModelRadius())
         def i:int 0
         while (i < (array_length names)) {
             def fname:string (itemAt names i)
             if (this.endsWithGlb(fname)) {
-                def id:int (loader.loadFromFile(dir fname))
+                def id:int 0
+                if (radius > 0.0) {
+                    id = (loader.loadFromFileRadius(dir fname radius))
+                } {
+                    id = (loader.loadFromFile(dir fname))
+                }
                 if (id >= 0) {
                     def model:ModelAsset (loader.getModel(id))
                     def em:EngineMeshData (bridge.fromModel(model))


### PR DESCRIPTION
Fixes several issues that showed up once real GLB models (the `Chair`, `Duck`, Khronos boxes) were loaded through the host-managed 3D path, plus fills known gaps in the `model3d` importer. Four focused commits.

## 1. 32-bit mesh indices — fixes scrambled large models

The GLES2 mesh path truncated every index to `uint16` and drew with `GL_UNSIGNED_SHORT`, so any model above 65,535 vertices had its index buffer wrap — triangles connected far-apart vertices and the mesh rendered as spikes/garbage. The `Chair` (228,359 vertices / 282,636 triangles) hit this exactly.

The data and the loader were fine: rendering `Chair.glb` through the pure-Ranger `SoftRenderer3D` (full int indices) produces a clean chair, isolating the bug to the C++ upload/draw path. Fix: 32-bit indices end to end in `rgfx_mesh_upload` / `rgfx_mesh_make` and the box/quad builders (`uint32` element buffers), drawing with `GL_UNSIGNED_INT`.

## 2. `COLOR_0` + importer gaps

Broadens the importer's first support level (all pure Ranger, host-side):

- **`COLOR_0` vertex colours** — `GltfDocument` reads the attribute; `GlbImporter.readVec4` decodes `VEC3`(→a=1)/`VEC4`, float or normalized `u8`/`u16`, into `MeshPrimitiveAsset.colors`; `SoftRenderer3D` interpolates and modulates the fragment.
- **Non-indexed primitives** — synthesise sequential indices so downstream always has triangles.
- **Missing `NORMAL`** — generate area-weighted smooth normals from the geometry.
- **`KHR_materials_unlit`** flag (emissive + emissive_strength + alphaMode were already parsed).

## 3. High-precision mesh upload — fixes black-speckle holes

After #1 the `Chair` was coherent but peppered with black holes. Cause: positions were packed at `x256` (the guest RGMB ABI's `FP_SCALE`) before upload; for a dense model in a ~1-unit box, `1/256` quantisation collapsed nearby vertices onto the same grid point, making **~22% of triangles degenerate** (measured: x256 → 21.9% degenerate, x65536 → 0.01%). Fix: a separate high-precision upload (`rgfx_mesh_upload_hp` / `gfx_3d_mesh_upload_hp`, positions `Q16.16` = `x65536`) used by the model3d path; the guest RGMB path keeps `x256` for the ABI.

## 4. Optional load-time `radius` — present any model at a set size

The `Duck` GLB is ~165 units across (no scale-down node) while the `Chair` is ~1, so at the origin the fixed viewer camera sat inside the duck (blank). Adds a presentation-size option:

- `ModelAsset.boundingRadius()` / `scaleToRadius(radius)` — scale so the farthest vertex from the origin sits at `radius` units (`<= 0` = no-op).
- `ModelLoader.loadFromFileRadius` / `loadFromBufferRadius`.
- `wasm3d_runner.preloadModels` reads an opt-in `model_radius=<n>` line from the game's `game.info` (absent = authored size, so `pyramid_wasm`'s diamond is unchanged); `model_viewer_wasm` sets `model_radius=1.0`.

Also: `MeshBridge` now computes each model's mesh-space bounds and `preloadModels` logs `verts` + `size`, to surface why a model may be off-camera.

## Tests

All hermetic (in-memory GLB fixtures; run `bash gallery/game_engine/model3d/tests/run.sh`):

- `Model3dTest` — **90** checks (adds COLOR_0 / non-indexed / generated-normal / radius)
- `TextureDecodeTest` — **20**
- `MeshBridgeTest` — **32** (adds high-precision vertex assertions)

## Verification note

The pure-Ranger side is fully verified headless (tests above; `Chair.glb` renders correctly via `SoftRenderer3D`; the `game.info` radius parse returns 1.0 for the viewer and 0 when absent). The C++ changes in `gfx_sdl.rgr` (32-bit indices, high-precision upload) are near-exact edits to the existing paths but need the native SDL build to confirm on screen. The new `preloadModels` size logging is there to help pin down any remaining per-model framing issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Umert9tBqHgs1UJVVBG4R

---
_Generated by [Claude Code](https://claude.ai/code/session_012Umert9tBqHgs1UJVVBG4R)_