### PR TITLE
Ranger → WASM: game guest ABI, WAT backend fixes, and a full memory + OO runtime

### DIFF
--- a/bin/output.js
+++ b/bin/output.js
@@ -33537,10 +33537,21 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       }
     };
     emitFieldStoreOn (className, structPtr, fieldName, value, lctx) {
+      this.emitFieldStoreOnEx(className, structPtr, fieldName, value, false, lctx);
+    };
+    emitFieldStoreOnEx (className, structPtr, fieldName, value, srcIsFresh, lctx) {
       const builder = lctx.builder;
       const idx = this.findFieldIndex(className, fieldName, this.irModule);
       const fieldPtr = builder.emitGep(className, structPtr, idx);
       const ftype = this.fieldIrTypeFor(className, fieldName);
+      let isWasmObjField = false;
+      if ( this.objRcEnabled(lctx) ) {
+        if ( this.memEnabled(lctx) == false ) {
+          if ( this.fieldIsObjectSlot(className, fieldName) ) {
+            isWasmObjField = true;
+          }
+        }
+      }
       if ( this.memEnabled(lctx) ) {
         const oldRaw = builder.emitLoad(ftype, fieldPtr);
         this.emitReleaseFieldValue(className, fieldName, oldRaw, lctx);
@@ -33551,6 +33562,10 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             this.emitReleaseFieldValue(className, fieldName, oldRawW, lctx);
           }
         }
+        if ( isWasmObjField ) {
+          const oldObj = builder.emitLoad(ftype, fieldPtr);
+          this.emitObjReleasePtr(oldObj, lctx);
+        }
       }
       let storeVal = value;
       if ( this.fieldIsStringSlot(className, fieldName) ) {
@@ -33560,10 +33575,29 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         if ( this.fieldIsBoolSlot(className, fieldName) ) {
           storeVal = builder.emitZextI1ToI32(value);
         } else {
+          if ( isWasmObjField ) {
+            if ( srcIsFresh == false ) {
+              this.emitObjRetainPtr(value, lctx);
+            }
+          }
           storeVal = value;
         }
       }
       builder.emitStore(ftype, storeVal, fieldPtr);
+    };
+    emitObjRetainPtr (ptr, lctx) {
+      let args = [];
+      let argTypes = [];
+      args.push(ptr);
+      argTypes.push(lctx.ptrType);
+      lctx.builder.emitCall("ranger_obj_retain", "void", args, argTypes);
+    };
+    emitObjReleasePtr (ptr, lctx) {
+      let args = [];
+      let argTypes = [];
+      args.push(ptr);
+      argTypes.push(lctx.ptrType);
+      lctx.builder.emitCall("ranger_obj_release", "void", args, argTypes);
     };
     emitFieldLoad (fieldName, lctx) {
       return this.emitFieldLoadOn(lctx.className, lctx.selfPtr, fieldName, lctx);
@@ -33748,7 +33782,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         }
         if ( (clsName.length) > 0 ) {
           const newPtr = this.lowerNewObject(clsName, valNode.getThird(), lctx);
-          this.emitFieldStoreOn(className, objPtr, fieldName, newPtr, lctx);
+          this.emitFieldStoreOnEx(className, objPtr, fieldName, newPtr, true, lctx);
           return;
         }
       }
@@ -33842,6 +33876,11 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             var fd = td.fields[j];
             if ( fd.owned == 1 ) {
               return true;
+            }
+            if ( this.irModule.useFreeListHeap ) {
+              if ( fd.kind == 1 ) {
+                return true;
+              }
             }
           };
         }
@@ -34708,20 +34747,22 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           const cls = this.resolveObjectClassChain(recvPrefix, lctx);
           if ( (cls.length) > 0 ) {
             const sptr = this.resolveObjectPtrChain(recvPrefix, cls, lctx);
-            if ( this.fieldIsObjectSlot(cls, fld) ) {
-              if ( rhs.value_type == 11 ) {
-                if ( this.isOwnedObjectLocal(rhs.vref, lctx) ) {
-                  lctx.escapedLocals[rhs.vref] = "1";
+            if ( this.memEnabled(lctx) ) {
+              if ( this.fieldIsObjectSlot(cls, fld) ) {
+                if ( rhs.value_type == 11 ) {
+                  if ( this.isOwnedObjectLocal(rhs.vref, lctx) ) {
+                    lctx.escapedLocals[rhs.vref] = "1";
+                  }
                 }
               }
             }
-            this.emitFieldStoreOn(cls, sptr, fld, tmp, lctx);
+            this.emitFieldStoreOnEx(cls, sptr, fld, tmp, rhs.hasNewOper, lctx);
             return;
           }
         }
       }
       if ( this.isClassField(varName, lctx.className, this.irModule) ) {
-        this.emitFieldStore(varName, tmp, lctx);
+        this.emitFieldStoreOnEx(lctx.className, lctx.selfPtr, varName, tmp, rhs.hasNewOper, lctx);
         return;
       }
       if ( ( typeof(lctx.slots[varName] ) != "undefined" && lctx.slots.hasOwnProperty(varName) ) ) {
@@ -36402,10 +36443,16 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     align4 (a) {
       return ((a + 3) & ((-1 ^ 3)));
     };
+    fieldOwnedFlag (fd) {
+      if ( fd.kind == 1 ) {
+        return 1;
+      }
+      return fd.owned;
+    };
     descHasOwned (td) {
       for ( let i = 0; i < td.fields.length; i++) {
         var fd = td.fields[i];
-        if ( fd.owned == 1 ) {
+        if ( this.fieldOwnedFlag(fd) == 1 ) {
           return true;
         }
       };
@@ -36442,7 +36489,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             let fw = "";
             fw = fw + this.leWord(fd.offset);
             fw = fw + this.leWord(fd.kind);
-            fw = fw + this.leWord(fd.owned);
+            fw = fw + this.leWord(this.fieldOwnedFlag(fd));
             wr.out("  (data (i32.const " + (("" + addr) + (") \"" + (fw + "\")"))), true);
             addr = addr + 12;
           };

--- a/bin/output.js
+++ b/bin/output.js
@@ -29890,6 +29890,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       this.functions = [];
       this.stringGlobals = [];
       this.externDecls = [];
+      this.singletonClasses = [];
     }
   }
   class LowIRSession  {
@@ -30270,6 +30271,26 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       ins.arg1 = pages;
       this.emit(ins);
       return dest;
+    };
+    emitGlobalGet (name) {
+      const dest = this.freshTemp("g");
+      const ins = new LowIRInstr();
+      ins.op = "global_get";
+      ins.dest = dest;
+      ins.irType = "i32";
+      ins.arg1 = name;
+      this.emit(ins);
+      return dest;
+    };
+    emitGlobalSet (name, value) {
+      const n = this.tempCounter;
+      this.tempCounter = n + 1;
+      const ins = new LowIRInstr();
+      ins.op = "global_set";
+      ins.dest = "gs" + ("" + n);
+      ins.arg1 = name;
+      ins.arg2 = value;
+      this.emit(ins);
     };
     emitI32At (base, byteOff) {
       const pt = this.irModule.ptrType;
@@ -31477,6 +31498,11 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             this.lowerFunction(m_2, cl.name, appCtx, false, false, true);
           }
         };
+        if ( appCtx.hasCompilerFlag("wat") ) {
+          if ( cl.isSingletonClass() ) {
+            this.lowerSingletonAccessor(cl, appCtx);
+          }
+        }
       };
       if ( this.usedArrayRuntime ) {
         LowIRRuntimeGen.ensureArrayRuntime(this.irModule);
@@ -34082,6 +34108,62 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       }
       builder.finishFunction(fnName, lctx.llvmRetType, params, exportFn, isMain);
     };
+    lowerSingletonAccessor (cl, appCtx) {
+      const builder = new LowIRBuilder(this.irModule);
+      builder.reset();
+      const lctx = new LowIRLowerContext();
+      lctx.ctx = appCtx;
+      lctx.builder = builder;
+      lctx.target = LowIRTarget.resolve(appCtx);
+      lctx.ptrType = lctx.target.ptrType;
+      let emptySlots = {};
+      lctx.slots = emptySlots;
+      let emptySlotTypes = {};
+      lctx.slotTypes = emptySlotTypes;
+      let emptyObjects = {};
+      lctx.objectSlots = emptyObjects;
+      let emptyCollections = {};
+      lctx.collectionSlots = emptyCollections;
+      let emptyElemTypes = {};
+      lctx.ptrArrayElemTypes = emptyElemTypes;
+      let emptyOwned = [];
+      lctx.ownedObjectLocals = emptyOwned;
+      let emptyColl = [];
+      lctx.ownedCollectionLocals = emptyColl;
+      let emptyStr = [];
+      lctx.ownedStringLocals = emptyStr;
+      let emptyPending = [];
+      lctx.pendingStringTemps = emptyPending;
+      let emptyEscaped = {};
+      lctx.escapedLocals = emptyEscaped;
+      lctx.currentRetType = cl.name;
+      lctx.llvmRetType = lctx.ptrType;
+      this.irModule.singletonClasses.push(cl.name);
+      const globalName = "singleton_" + cl.name;
+      let factory;
+      if ( (typeof(cl.classNode) !== "undefined" && cl.classNode != null )  ) {
+        factory = cl.classNode;
+      } else {
+        factory = cl.nameNode;
+      }
+      const argsNode = ((factory)).newVRefNode("");
+      const initLabel = builder.freshLabel("sgl_init");
+      const retLabel = builder.freshLabel("sgl_ret");
+      builder.startBlock("entry");
+      const cur = builder.emitGlobalGet(globalName);
+      const zero = builder.emitConst(lctx.ptrType, "0");
+      const isZero = builder.emitIcmp("eq", cur, zero);
+      builder.terminateBrIf(isZero, initLabel, retLabel);
+      builder.startBlock(initLabel);
+      const obj = this.lowerNewObject(cl.name, argsNode, lctx);
+      builder.emitGlobalSet(globalName, obj);
+      builder.terminateRet(lctx.ptrType, obj);
+      builder.startBlock(retLabel);
+      builder.terminateRet(lctx.ptrType, cur);
+      const fnName = LowIRUtil.mangleMethod(cl.name, "__singleton");
+      let params = [];
+      builder.finishFunction(fnName, lctx.ptrType, params, false, false);
+    };
     isOwnedObjectLocal (varName, lctx) {
       for ( let i = 0; i < lctx.ownedObjectLocals.length; i++) {
         var n = lctx.ownedObjectLocals[i];
@@ -36440,8 +36522,12 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       if ( hasStatic ) {
         this.emitStaticData(module, wr);
       }
-      for ( let i = 0; i < module.functions.length; i++) {
-        var fn = module.functions[i];
+      for ( let i = 0; i < module.singletonClasses.length; i++) {
+        var sc = module.singletonClasses[i];
+        wr.out("  (global $singleton_" + (sc + " (mut i32) (i32.const 0))"), true);
+      };
+      for ( let i_1 = 0; i_1 < module.functions.length; i_1++) {
+        var fn = module.functions[i_1];
         this.writeFunction(fn, wr, fn.exportFn);
       };
       wr.out(")", true);
@@ -36793,6 +36879,14 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           this.writeGet(ins.arg1, wr);
           wr.out("      memory.grow", true);
           wr.out("      local.set " + this.wasmName(ins.dest), true);
+          break;
+        case "global_get" : 
+          wr.out("      global.get $" + ins.arg1, true);
+          wr.out("      local.set " + this.wasmName(ins.dest), true);
+          break;
+        case "global_set" : 
+          this.writeGet(ins.arg2, wr);
+          wr.out("      global.set $" + ins.arg1, true);
           break;
         case "inttoptr_struct" : 
           this.writeGet(ins.arg1, wr);

--- a/bin/output.js
+++ b/bin/output.js
@@ -34620,11 +34620,12 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       if ( (varName.indexOf(".")) >= 0 ) {
         const parts = varName.split(".");
         if ( (parts.length) >= 2 ) {
-          const recv = parts[0];
-          const fld = parts[1];
-          const cls = this.resolveObjectClass(recv, lctx);
+          const n = parts.length;
+          const recvPrefix = this.joinDotPrefix(parts, (n - 1));
+          const fld = parts[(n - 1)];
+          const cls = this.resolveObjectClassChain(recvPrefix, lctx);
           if ( (cls.length) > 0 ) {
-            const sptr = this.resolveObjectPtr(recv, cls, lctx);
+            const sptr = this.resolveObjectPtrChain(recvPrefix, cls, lctx);
             if ( this.fieldIsObjectSlot(cls, fld) ) {
               if ( rhs.value_type == 11 ) {
                 if ( this.isOwnedObjectLocal(rhs.vref, lctx) ) {
@@ -35155,11 +35156,12 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         if ( (node.vref.indexOf(".")) >= 0 ) {
           const parts = node.vref.split(".");
           if ( (parts.length) >= 2 ) {
-            const recv = parts[0];
-            const fld = parts[1];
-            const cls = this.resolveObjectClass(recv, lctx);
+            const n = parts.length;
+            const recvPrefix = this.joinDotPrefix(parts, (n - 1));
+            const fld = parts[(n - 1)];
+            const cls = this.resolveObjectClassChain(recvPrefix, lctx);
             if ( (cls.length) > 0 ) {
-              const sptr = this.resolveObjectPtr(recv, cls, lctx);
+              const sptr = this.resolveObjectPtrChain(recvPrefix, cls, lctx);
               return this.emitFieldLoadOn(cls, sptr, fld, lctx);
             }
           }

--- a/compiler/ng_LowIR.rgr
+++ b/compiler/ng_LowIR.rgr
@@ -199,6 +199,9 @@ class LowIRModule {
   def functions:[LowIRFunction]
   def stringGlobals:[LowIRStringGlobal]
   def externDecls:[LowIRExternDecl]
+  ; class names that need a mutable wasm global holding their lazy singleton
+  ; instance (the WAT writer emits `(global $singleton_<name> (mut i32) 0)`).
+  def singletonClasses:[string]
 }
 
 ; Compile-session singleton ? holds the module being built for one translation unit.
@@ -619,6 +622,30 @@ class LowIRBuilder {
     ins.arg1 = pages
     this.emit(ins)
     return dest
+  }
+
+  ; read a named mutable wasm global (wasm global.get)
+  fn emitGlobalGet:string (name:string) {
+    def dest (this.freshTemp("g"))
+    def ins@(lives):LowIRInstr (new LowIRInstr())
+    ins.op = "global_get"
+    ins.dest = dest
+    ins.irType = "i32"
+    ins.arg1 = name
+    this.emit(ins)
+    return dest
+  }
+
+  ; write a named mutable wasm global (wasm global.set)
+  fn emitGlobalSet:void (name:string value:string) {
+    def n (this.tempCounter)
+    this.tempCounter = n + 1
+    def ins@(lives):LowIRInstr (new LowIRInstr())
+    ins.op = "global_set"
+    ins.dest = ("gs" + ("" + n))
+    ins.arg1 = name
+    ins.arg2 = value
+    this.emit(ins)
   }
 
   fn emitI32At:string (base:string byteOff:int) {

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -3635,11 +3635,16 @@ class LowIRBuilderPass {
     if ((indexOf varName ".") >= 0) {
       def parts:[string] (strsplit varName ".")
       if ((array_length parts) >= 2) {
-        def recv (itemAt parts 0)
-        def fld (itemAt parts 1)
-        def cls (this.resolveObjectClass(recv lctx))
+        ; The target field is the LAST segment; everything before it is the
+        ; receiver chain. For `h.pos.x` the receiver is `h.pos` (resolved by
+        ; loading each intermediate object field) and the field is `x`. Using
+        ; only the first two segments stored into `h.pos` itself, dropping `.x`.
+        def n:int (array_length parts)
+        def recvPrefix:string (this.joinDotPrefix(parts (n - 1)))
+        def fld (itemAt parts (n - 1))
+        def cls (this.resolveObjectClassChain(recvPrefix lctx))
         if ((strlen cls) > 0) {
-          def sptr (this.resolveObjectPtr(recv cls lctx))
+          def sptr (this.resolveObjectPtrChain(recvPrefix cls lctx))
           ; Storing an owned local into a (borrow) object field: the field now
           ; holds the reference, so the local must not be released at scope end
           ; (would dangle the field). Mark it escaped. Object fields don't own,
@@ -4238,11 +4243,15 @@ class LowIRBuilderPass {
       if ((indexOf node.vref ".") >= 0) {
         def parts:[string] (strsplit node.vref ".")
         if ((array_length parts) >= 2) {
-          def recv (itemAt parts 0)
-          def fld (itemAt parts 1)
-          def cls (this.resolveObjectClass(recv lctx))
+          ; last segment is the field; everything before it is the receiver chain
+          ; (`h.pos.x` -> receiver `h.pos`, field `x`), resolved by loading each
+          ; intermediate object field.
+          def n:int (array_length parts)
+          def recvPrefix:string (this.joinDotPrefix(parts (n - 1)))
+          def fld (itemAt parts (n - 1))
+          def cls (this.resolveObjectClassChain(recvPrefix lctx))
           if ((strlen cls) > 0) {
-            def sptr (this.resolveObjectPtr(recv cls lctx))
+            def sptr (this.resolveObjectPtrChain(recvPrefix cls lctx))
             return (this.emitFieldLoadOn(cls sptr fld lctx))
           }
         }

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -2419,23 +2419,43 @@ class LowIRBuilderPass {
   }
 
   fn emitFieldStoreOn:void (className:string structPtr:string fieldName:string value:string lctx:LowIRLowerContext) {
+    this.emitFieldStoreOnEx(className structPtr fieldName value false lctx)
+  }
+
+  ; srcIsFresh: the value is a freshly-constructed object (rc=1, sole owner) that
+  ; the field takes over by MOVE (no retain). A borrowed value (local/param/field)
+  ; is RETAINED so the field holds a counted reference — RC then frees it exactly
+  ; once regardless of how many fields alias it (cycles still leak, never crash).
+  fn emitFieldStoreOnEx:void (className:string structPtr:string fieldName:string value:string srcIsFresh:boolean lctx:LowIRLowerContext) {
     def builder (lctx.builder)
     def idx (this.findFieldIndex(className fieldName this.irModule))
     def fieldPtr (builder.emitGep(className structPtr idx))
     def ftype (this.fieldIrTypeFor(className fieldName))
+    def isWasmObjField:boolean false
+    if (this.objRcEnabled(lctx)) {
+      if (this.memEnabled(lctx) == false) {
+        if (this.fieldIsObjectSlot(className fieldName)) {
+          isWasmObjField = true
+        }
+      }
+    }
     if (this.memEnabled(lctx)) {
       def oldRaw (builder.emitLoad(ftype fieldPtr))
       this.emitReleaseFieldValue(className fieldName oldRaw lctx)
     } {
-      ; freestanding WASM string RC: free the old string this field held before
-      ; overwriting it (the field owns a dup'd copy). Object/buffer fields stay
-      ; libc-only. Field is zero-initialised by obj_new, so the first store sees
-      ; 0 and str_release is a no-op.
+      ; freestanding WASM RC: release the old value this field held before
+      ; overwriting it (string field: str_release its dup'd copy; object field:
+      ; obj_release its retained/owned reference). Field is zero-initialised by
+      ; obj_new, so the first store sees 0 and the release is a no-op.
       if (this.wasmStrEnabled(lctx)) {
         if (this.fieldIsStringSlot(className fieldName)) {
           def oldRawW (builder.emitLoad(ftype fieldPtr))
           this.emitReleaseFieldValue(className fieldName oldRawW lctx)
         }
+      }
+      if isWasmObjField {
+        def oldObj (builder.emitLoad(ftype fieldPtr))
+        this.emitObjReleasePtr(oldObj lctx)
       }
     }
     def storeVal:string value
@@ -2446,11 +2466,33 @@ class LowIRBuilderPass {
       if (this.fieldIsBoolSlot(className fieldName)) {
         storeVal = (builder.emitZextI1ToI32(value))
       } {
-        ; Object fields are borrows: store the pointer without retaining.
+        ; Object field on WASM: retain a borrowed reference (a fresh `new` is
+        ; moved in as-is). libc keeps borrow semantics (no retain).
+        if isWasmObjField {
+          if (srcIsFresh == false) {
+            this.emitObjRetainPtr(value lctx)
+          }
+        }
         storeVal = value
       }
     }
     builder.emitStore(ftype storeVal fieldPtr)
+  }
+
+  fn emitObjRetainPtr:void (ptr:string lctx:LowIRLowerContext) {
+    def args:[string]
+    def argTypes:[string]
+    push args ptr
+    push argTypes lctx.ptrType
+    lctx.builder.emitCall("ranger_obj_retain" "void" args argTypes)
+  }
+
+  fn emitObjReleasePtr:void (ptr:string lctx:LowIRLowerContext) {
+    def args:[string]
+    def argTypes:[string]
+    push args ptr
+    push argTypes lctx.ptrType
+    lctx.builder.emitCall("ranger_obj_release" "void" args argTypes)
   }
 
   fn emitFieldLoad:string (fieldName:string lctx:LowIRLowerContext) {
@@ -2661,7 +2703,8 @@ class LowIRBuilderPass {
       }
       if ((strlen clsName) > 0) {
         def newPtr (this.lowerNewObject(clsName (valNode.getThird()) lctx))
-        this.emitFieldStoreOn(className objPtr fieldName newPtr lctx)
+        ; the default `(new T)` is a fresh sole-owner object -> move into the field
+        this.emitFieldStoreOnEx(className objPtr fieldName newPtr true lctx)
         return
       }
     }
@@ -2757,6 +2800,13 @@ class LowIRBuilderPass {
         for td.fields fd:LowIRTypeFieldDesc j {
           if (fd.owned == 1) {
             return true
+          }
+          ; WASM retains object fields (kind 1), so they are freed on destruction
+          ; too — the class needs a descriptor even if only object fields are owned.
+          if this.irModule.useFreeListHeap {
+            if (fd.kind == 1) {
+              return true
+            }
           }
         }
       }
@@ -3723,22 +3773,24 @@ class LowIRBuilderPass {
         def cls (this.resolveObjectClassChain(recvPrefix lctx))
         if ((strlen cls) > 0) {
           def sptr (this.resolveObjectPtrChain(recvPrefix cls lctx))
-          ; Storing an owned local into a (borrow) object field: the field now
-          ; holds the reference, so the local must not be released at scope end
-          ; (would dangle the field). Mark it escaped. Object fields don't own,
-          ; so the object leaks until borrow analysis can assign an owner.
-          if (this.fieldIsObjectSlot(cls fld)) {
-            if (rhs.value_type == RangerNodeType.VRef) {
-              if (this.isOwnedObjectLocal(rhs.vref lctx)) {
-                set lctx.escapedLocals rhs.vref "1"
+          ; libc (borrow/move model): storing an owned local into an object field
+          ; moves it in, so the local must not be released at scope end (would
+          ; dangle the field) — mark it escaped. On WASM the field RETAINS the
+          ; value instead (emitFieldStoreOnEx), so the local keeps its own
+          ; reference and is freed normally; no escape.
+          if (this.memEnabled(lctx)) {
+            if (this.fieldIsObjectSlot(cls fld)) {
+              if (rhs.value_type == RangerNodeType.VRef) {
+                if (this.isOwnedObjectLocal(rhs.vref lctx)) {
+                  set lctx.escapedLocals rhs.vref "1"
+                }
               }
             }
           }
           ; A string field takes a dup'd private copy (emitFieldStoreOn), so an
-          ; owned string local stored into it is NOT consumed — it keeps its own
-          ; buffer and is still released normally at scope end. The field's copy
-          ; is freed on overwrite and by the object destructor (typedesc kind 0).
-          this.emitFieldStoreOn(cls sptr fld tmp lctx)
+          ; owned string local stored into it is NOT consumed. An object field on
+          ; WASM retains a borrowed value / moves a fresh `new` (rhs.hasNewOper).
+          this.emitFieldStoreOnEx(cls sptr fld tmp rhs.hasNewOper lctx)
           return
         }
       }
@@ -3749,7 +3801,7 @@ class LowIRBuilderPass {
       ; for boolean fields. Pre-zexting produced an invalid double
       ; "zext i1 <i32> to i32" (the receiver "recv.fld" path above never did
       ; this, which is why only bare field assignments miscompiled).
-      this.emitFieldStore(varName tmp lctx)
+      this.emitFieldStoreOnEx(lctx.className lctx.selfPtr varName tmp rhs.hasNewOper lctx)
       return
     }
     if (has lctx.slots varName) {

--- a/compiler/ng_LowIRBuilder.rgr
+++ b/compiler/ng_LowIRBuilder.rgr
@@ -194,6 +194,14 @@ class LowIRBuilderPass {
           this.lowerFunction(m cl.name appCtx false false true)
         }
       }
+      ; WASM/WAT: emit the `__singleton()` accessor (lazy-init into a wasm global).
+      ; The freestanding backend has no global data, so this is the singleton
+      ; storage mechanism. Gated on -wat (global.get/set are wasm-only ops).
+      if (appCtx.hasCompilerFlag("wat")) {
+        if (cl.isSingletonClass()) {
+          this.lowerSingletonAccessor(cl appCtx)
+        }
+      }
     }
     if this.usedArrayRuntime {
       LowIRRuntimeGen.ensureArrayRuntime(this.irModule)
@@ -3027,6 +3035,76 @@ class LowIRBuilderPass {
     }
 
     builder.finishFunction(fnName lctx.llvmRetType params exportFn isMain)
+  }
+
+  ; Generate `ClassName___singleton()` for a @singleton(true) class on the WAT
+  ; backend: lazily construct the instance into a mutable wasm global and return
+  ; it. Body:  cur = global; if (cur == 0) { obj = new Class(); global = obj;
+  ; return obj }  return cur.  Supports no-argument construction (field defaults
+  ; + a no-arg Constructor). Blocks are ordered init-before-return so the
+  ; structured WAT reconstruction keeps both arms.
+  fn lowerSingletonAccessor:void (cl:RangerAppClassDesc appCtx:RangerAppWriterContext) {
+    def builder@(lives):LowIRBuilder (new LowIRBuilder(this.irModule))
+    builder.reset()
+    def lctx@(lives):LowIRLowerContext (new LowIRLowerContext())
+    lctx.ctx = appCtx
+    lctx.builder = builder
+    lctx.target = (LowIRTarget.resolve(appCtx))
+    lctx.ptrType = lctx.target.ptrType
+    def emptySlots:[string:string]
+    lctx.slots = emptySlots
+    def emptySlotTypes:[string:string]
+    lctx.slotTypes = emptySlotTypes
+    def emptyObjects:[string:string]
+    lctx.objectSlots = emptyObjects
+    def emptyCollections:[string:string]
+    lctx.collectionSlots = emptyCollections
+    def emptyElemTypes:[string:string]
+    lctx.ptrArrayElemTypes = emptyElemTypes
+    def emptyOwned:[string]
+    lctx.ownedObjectLocals = emptyOwned
+    def emptyColl:[string]
+    lctx.ownedCollectionLocals = emptyColl
+    def emptyStr:[string]
+    lctx.ownedStringLocals = emptyStr
+    def emptyPending:[string]
+    lctx.pendingStringTemps = emptyPending
+    def emptyEscaped:[string:string]
+    lctx.escapedLocals = emptyEscaped
+    lctx.currentRetType = cl.name
+    lctx.llvmRetType = lctx.ptrType
+
+    push this.irModule.singletonClasses cl.name
+    def globalName:string ("singleton_" + cl.name)
+
+    ; empty args node (no-arg constructor) built from the class's own AST node
+    def factory@(weak optional):CodeNode
+    if (!null? cl.classNode) {
+      factory = cl.classNode
+    } {
+      factory = cl.nameNode
+    }
+    def argsNode:CodeNode ((unwrap factory).newVRefNode(""))
+
+    def initLabel (builder.freshLabel("sgl_init"))
+    def retLabel (builder.freshLabel("sgl_ret"))
+    builder.startBlock("entry")
+    def cur (builder.emitGlobalGet(globalName))
+    def zero (builder.emitConst(lctx.ptrType "0"))
+    def isZero (builder.emitIcmp("eq" cur zero))
+    builder.terminateBrIf(isZero initLabel retLabel)
+
+    builder.startBlock(initLabel)
+    def obj (this.lowerNewObject(cl.name argsNode lctx))
+    builder.emitGlobalSet(globalName obj)
+    builder.terminateRet(lctx.ptrType obj)
+
+    builder.startBlock(retLabel)
+    builder.terminateRet(lctx.ptrType cur)
+
+    def fnName (LowIRUtil.mangleMethod(cl.name "__singleton"))
+    def params:[LowIRParam]
+    builder.finishFunction(fnName lctx.ptrType params false false)
   }
 
   fn isOwnedObjectLocal:boolean (varName:string lctx:LowIRLowerContext) {

--- a/compiler/ng_WATWriter.rgr
+++ b/compiler/ng_WATWriter.rgr
@@ -215,6 +215,10 @@ class WATWriter {
     if hasStatic {
       this.emitStaticData(module wr)
     }
+    ; one mutable global per singleton class, holding its lazy instance pointer
+    for module.singletonClasses sc:string i {
+      wr.out(("  (global $singleton_" + (sc + " (mut i32) (i32.const 0))")) true)
+    }
     for module.functions fn:LowIRFunction i {
       this.writeFunction(fn wr fn.exportFn)
     }
@@ -608,6 +612,14 @@ class WATWriter {
         this.writeGet(ins.arg1 wr)
         wr.out("      memory.grow" true)
         wr.out(("      local.set " + (this.wasmName(ins.dest))) true)
+      }
+      case "global_get" {
+        wr.out(("      global.get $" + ins.arg1) true)
+        wr.out(("      local.set " + (this.wasmName(ins.dest))) true)
+      }
+      case "global_set" {
+        this.writeGet(ins.arg2 wr)
+        wr.out(("      global.set $" + ins.arg1) true)
       }
       case "inttoptr_struct" {
         this.writeGet(ins.arg1 wr)

--- a/compiler/ng_WATWriter.rgr
+++ b/compiler/ng_WATWriter.rgr
@@ -71,12 +71,23 @@ class WATWriter {
     return (bit_and (+ a 3) (bit_xor -1 3))
   }
 
+  ; The owned flag the WAT backend emits for a field. String fields carry their
+  ; declared owned flag; OBJECT fields (kind 1) are always owned on WASM — stores
+  ; retain a borrowed value / move a fresh one, so the destructor releases each
+  ; exactly once (RC handles aliasing; cycles leak but never double-free).
+  ; ptr-array fields (kind 2) stay borrow.
+  fn fieldOwnedFlag:int (fd:LowIRTypeFieldDesc) {
+    if (fd.kind == 1) {
+      return 1
+    }
+    return fd.owned
+  }
+
   ; A type descriptor is worth emitting only if it has at least one owned field
-  ; (the destructor walk does nothing otherwise). String fields are owned;
-  ; object/ptr-array fields are borrow (owned=0) until borrow analysis promotes.
+  ; (the destructor walk does nothing otherwise).
   fn descHasOwned:boolean (td:LowIRTypeDesc) {
     for td.fields fd:LowIRTypeFieldDesc i {
-      if (fd.owned == 1) {
+      if ((this.fieldOwnedFlag(fd)) == 1) {
         return true
       }
     }
@@ -117,7 +128,7 @@ class WATWriter {
           def fw ""
           fw = (fw + (this.leWord(fd.offset)))
           fw = (fw + (this.leWord(fd.kind)))
-          fw = (fw + (this.leWord(fd.owned)))
+          fw = (fw + (this.leWord((this.fieldOwnedFlag(fd)))))
           wr.out(("  (data (i32.const " + (("" + addr) + (") \"" + (fw + "\")")))) true)
           addr = (+ addr 12)
         }

--- a/gallery/game_engine/README.md
+++ b/gallery/game_engine/README.md
@@ -492,7 +492,7 @@ Kaikki alla oleva on **testattu** WASM-käännöksellä (`runtime/wasm/*_test.mj
 | **Hash-taulut** `[int:int]` — `set`/`get`, kasvavat | ✅ | `def m:[int:int]` |
 | Suora `Mem`-slotti-tila (staattiset metodit, ei varausta) | ✅ | ranger_autopeli |
 | **Sisäkkäiset oliot**: kentän-kentän luku/kirjoitus `a.b.c` (mielivaltainen syvyys) | ✅ | `o.mid.inner.v = 99` |
-| Olio-kenttä (`def v:Vec (new Vec)`) rekursiivinen vapautus | ⚠️ vuotaa | borrow-oletus |
+| **Olio-kenttä** (`def v:Vec (new Vec)`) rekursiivinen vapautus + jako | ✅ | RC: retain/move + release |
 | **Singletonit** (`@singleton(true)`) — jaettu tila framejen yli | ✅ | `World.__singleton()` |
 | **Lambdat / sulkeumat** (`(fn:… (){})`, `{ … }`) | ❌ | funktio-osoittimia ei emitoida |
 

--- a/gallery/game_engine/README.md
+++ b/gallery/game_engine/README.md
@@ -491,7 +491,7 @@ Kaikki alla oleva on **testattu** WASM-käännöksellä (`runtime/wasm/*_test.mj
 | Listat `[int]`, `[T]`, `[string]` — push/itemAt/array_length/for | ✅ | |
 | **Hash-taulut** `[int:int]` — `set`/`get`, kasvavat | ✅ | `def m:[int:int]` |
 | Suora `Mem`-slotti-tila (staattiset metodit, ei varausta) | ✅ | ranger_autopeli |
-| **Sisäkkäisen** olion kentän mutatointi ketjulla `a.b.c = …` | ⚠️ bugi | ks. alla |
+| **Sisäkkäiset oliot**: kentän-kentän luku/kirjoitus `a.b.c` (mielivaltainen syvyys) | ✅ | `o.mid.inner.v = 99` |
 | Olio-kenttä (`def v:Vec (new Vec)`) rekursiivinen vapautus | ⚠️ vuotaa | borrow-oletus |
 | **Singletonit** (`@singleton(true)`) | ❌ | ei tueta (ks. alla) |
 | **Lambdat / sulkeumat** (`(fn:… (){})`, `{ … }`) | ❌ | funktio-osoittimia ei emitoida |

--- a/gallery/game_engine/README.md
+++ b/gallery/game_engine/README.md
@@ -493,15 +493,35 @@ Kaikki alla oleva on **testattu** WASM-käännöksellä (`runtime/wasm/*_test.mj
 | Suora `Mem`-slotti-tila (staattiset metodit, ei varausta) | ✅ | ranger_autopeli |
 | **Sisäkkäiset oliot**: kentän-kentän luku/kirjoitus `a.b.c` (mielivaltainen syvyys) | ✅ | `o.mid.inner.v = 99` |
 | Olio-kenttä (`def v:Vec (new Vec)`) rekursiivinen vapautus | ⚠️ vuotaa | borrow-oletus |
-| **Singletonit** (`@singleton(true)`) | ❌ | ei tueta (ks. alla) |
+| **Singletonit** (`@singleton(true)`) — jaettu tila framejen yli | ✅ | `World.__singleton()` |
 | **Lambdat / sulkeumat** (`(fn:… (){})`, `{ … }`) | ❌ | funktio-osoittimia ei emitoida |
 
-**Singletonit ja globaali tila.** `@singleton(true)`:n `__singleton()`-aksessoria
-ei (vielä) emitoida WAT-backendissä — WASM-globaaleja ei varata. Peleissä globaali
-tila kannattaa pitää joko (a) **staattisilla metodeilla + kiinteissä linear-
-memory-slotissa** (`Mem.storeI32`/`loadI32`) — juuri niin ranger_autopeli tekee —
-tai (b) luoda oliot ja langoittaa ne kutsuketjun läpi. Ei erillistä globaalia
-säiliötä yhdelle jaetulle instanssille ilman singleton- tai globaalitukea.
+**Singletonit ja globaali tila.** `@singleton(true)` toimii: `__singleton()`
+rakentaa instanssin laiskasti mutable-wasm-globaaliin ja palauttaa saman olion
+jatkossa, joten tila säilyy `update()`-kutsujen (framejen) välillä — luonteva
+tapa pitää pelin globaali tila OO-tyylissä. Kutsu paikallisen kautta:
+
+```ranger
+class World @singleton(true) {
+    def frame:int 0
+    def enemies:[int]
+    fn tick:void () {
+        frame = (+ frame 1)
+        push enemies frame
+    }
+}
+class G {
+    sfn update:void () {
+        def w (World.__singleton())   ; sama instanssi joka framessa
+        w.tick()
+    }
+}
+```
+
+Vaihtoehtoina toki myös (a) staattiset metodit + kiinteät linear-memory-slotit
+(`Mem.storeI32`/`loadI32`, kuten ranger_autopeli) tai (b) oliot langoitettuna
+kutsuketjun läpi. (Huom: kutsu `(World.__singleton()).metodi()` suoraan ketjuna
+sekoittaa tyypintarkistuksen — talleta ensin `def w (World.__singleton())`.)
 
 **Sisäkkäiset oliot.** Litteä olio toimii (`v.x = 10  v.y = 32`), mutta
 kentän-kentän ketjumutatointi (`p.pos.x = …` kun `pos` on olio-kenttä) osoittaa

--- a/gallery/game_engine/README.md
+++ b/gallery/game_engine/README.md
@@ -523,12 +523,18 @@ Vaihtoehtoina toki myös (a) staattiset metodit + kiinteät linear-memory-slotit
 kutsuketjun läpi. (Huom: kutsu `(World.__singleton()).metodi()` suoraan ketjuna
 sekoittaa tyypintarkistuksen — talleta ensin `def w (World.__singleton())`.)
 
-**Sisäkkäiset oliot.** Litteä olio toimii (`v.x = 10  v.y = 32`), mutta
-kentän-kentän ketjumutatointi (`p.pos.x = …` kun `pos` on olio-kenttä) osoittaa
-tällä hetkellä väärään slottiin, ja olio-kentät ovat **borrow**-oletuksena
-(owned=0) joten niitä ei vapauteta automaattisesti (vuoto, kunnes borrow-analyysi
-tulee). Pidä pelilogiikan tila litteänä (primitiivit + kokoelmat + merkkijonot),
-tai käytä `Mem`-slotteja, kunnes nämä on korjattu.
+**Sisäkkäiset oliot.** Olio-kentät toimivat: kentän-kentän luku ja kirjoitus
+mielivaltaisella syvyydellä (`o.mid.inner.v = 99`) osuu oikeaan slottiin, ja
+olio-kentät ovat **viittauslaskettuja** — tuore `new` siirretään (move),
+lainattu jaettu viittaus retainataan, ja vanha vapautetaan ylikirjoituksessa.
+Näin jaettu lapsi (sama olio kahdessa kentässä) vapautuu **täsmälleen kerran**.
+Ainoa raja: **syklit** (`a.next = b; b.next = a`) vuotavat — RC:n luontainen
+rajoitus — mutta eivät kaadu eivätkä korruptoi muistia. Vältä sykliset
+olio-graafit, tai katkaise ne (aseta kenttä nulliksi) ennen kuin päästät irti.
+
+**Ei (vielä) tuettu.** Lambdat / sulkeumat (`(fn:… (){})`, `{ … }`): WAT-backend
+ei emitoi funktio-osoittimia eikä `call_indirect`ia, joten callbackit ja
+funktioarvot eivät käänny. Käytä metodeja + `for`/`while`-silmukoita.
 
 ### Sudenkuopat
 

--- a/runtime/wasm/objfield_rc_demo.rgr
+++ b/runtime/wasm/objfield_rc_demo.rgr
@@ -1,0 +1,77 @@
+; ============================================================================
+; objfield_rc_demo.rgr — owned OBJECT-field recursive free on WASM. An object
+; field holds a reference-counted child: a fresh `new` is moved in (rc stays 1),
+; a borrowed reference is retained (rc++), the old value is released on overwrite,
+; and the destructor releases each field. RC frees a shared child exactly once;
+; cycles leak (never double-free). Exercises the double-free-critical paths.
+; ============================================================================
+
+Import "./ranger_obj.rgr"
+
+class Vec {
+    def x:int 0
+    def y:int 0
+}
+class Holder {
+    def pos:Vec (new Vec)
+}
+class Node {
+    def next:Node
+    def val:int 0
+}
+class SG {
+    ; fresh default field: Holder owns its Vec; both freed when Holder dies.
+    sfn churnDefault:int (n:int) {
+        def i 0
+        while (< i n) {
+            def h (new Holder)
+            h.pos.x = (+ i 1)
+            i = (+ i 1)
+        }
+        return (Heap.frontier())
+    }
+
+    ; sharing: one Vec referenced by two Holders' fields (retain), plus the local.
+    ; RC must free it exactly once after all three references go away.
+    sfn churnShared:int (n:int) {
+        def i 0
+        while (< i n) {
+            def shared (new Vec)
+            shared.x = i
+            def a (new Holder)
+            def b (new Holder)
+            a.pos = shared
+            b.pos = shared
+            i = (+ i 1)
+        }
+        return (Heap.frontier())
+    }
+
+    ; overwrite: reassign a field repeatedly; each old child released before the
+    ; new one, so no per-iteration leak.
+    sfn churnOverwrite:int (n:int) {
+        def h (new Holder)
+        def i 0
+        while (< i n) {
+            h.pos = (new Vec)
+            i = (+ i 1)
+        }
+        return 0
+    }
+
+    ; content sanity while shared
+    sfn sharedVal:int () {
+        def shared (new Vec)
+        shared.x = 77
+        def a (new Holder)
+        a.pos = shared
+        return (+ 0 a.pos.x)
+    }
+
+    sfn liveBlocks:int () {
+        return (ranger.obj_live())
+    }
+    sfn frontier:int () {
+        return (Heap.frontier())
+    }
+}

--- a/runtime/wasm/objfield_rc_test.mjs
+++ b/runtime/wasm/objfield_rc_test.mjs
@@ -1,0 +1,35 @@
+// Owned object-field RC test (WASM). Build:
+//   node bin/output.js -l=llvm -wat -freestanding -wasmrc \
+//     runtime/wasm/objfield_rc_demo.rgr -nodecli -d=tmp/objf -o=g.wat
+//   cp tmp/objf/g.wat.ll tmp/objf/g.wat && wat2wasm tmp/objf/g.wat -o tmp/objf/g.wasm
+import fs from "fs";
+const x = new WebAssembly.Instance(new WebAssembly.Module(
+  fs.readFileSync(new URL("../../tmp/objf/g.wasm", import.meta.url)))).exports;
+let pass = 0, fail = 0;
+const ok = (n, g, e) => { if (g === e) pass++; else { fail++; console.log("FAIL", n, JSON.stringify(g), "exp", JSON.stringify(e)); } };
+
+x.Heap_init();
+ok("shared field content", x.SG_sharedVal(), 77);
+
+// fresh default field (Holder owns its Vec): create/destroy loop stays flat
+x.Heap_init();
+ok("churnDefault flat", x.SG_churnDefault(1000), x.SG_churnDefault(1));
+// a Vec shared by two Holder fields + a local: RC frees it exactly once
+x.Heap_init();
+ok("churnShared flat", x.SG_churnShared(1000), x.SG_churnShared(1));
+// field overwrite releases the old child each iteration
+x.Heap_init();
+const base = x.SG_frontier();
+x.SG_churnOverwrite(1);
+const o1 = x.SG_frontier();
+x.SG_churnOverwrite(10000);
+ok("churnOverwrite flat", x.SG_frontier(), o1);
+
+// zero live blocks after churn: parents AND their object children all freed
+x.Heap_init(); x.SG_churnDefault(500);
+ok("no live blocks after churnDefault", x.SG_liveBlocks(), 0);
+x.Heap_init(); x.SG_churnShared(500);
+ok("no live blocks after churnShared (shared freed once)", x.SG_liveBlocks(), 0);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/runtime/wasm/singleton_demo.rgr
+++ b/runtime/wasm/singleton_demo.rgr
@@ -1,0 +1,57 @@
+; ============================================================================
+; singleton_demo.rgr — @singleton(true) on the WASM backend. The lazy instance
+; lives in a mutable wasm global ($singleton_World); World.__singleton() builds
+; it on first use and returns the same object thereafter, so state persists
+; across separate exported calls (frames) — the natural way to hold game state.
+; ============================================================================
+
+Import "./ranger_obj.rgr"
+
+class World @singleton(true) {
+    def frame:int 0
+    def score:int 0
+    def enemies:[int]
+
+    fn tick:void () {
+        frame = (+ frame 1)
+        score = (+ score (* frame 10))
+        push enemies frame
+    }
+    fn getFrame:int () {
+        return frame
+    }
+    fn getScore:int () {
+        return score
+    }
+    fn enemyCount:int () {
+        return (array_length enemies)
+    }
+}
+
+class G {
+    sfn update:void () {
+        def w (World.__singleton())
+        w.tick()
+    }
+    sfn frame:int () {
+        def w (World.__singleton())
+        return (w.getFrame())
+    }
+    sfn score:int () {
+        def w (World.__singleton())
+        return (w.getScore())
+    }
+    sfn enemies:int () {
+        def w (World.__singleton())
+        return (w.enemyCount())
+    }
+    ; the instance is created lazily and shared: two lookups return the same rc
+    sfn sameInstance:int () {
+        def a (World.__singleton())
+        def b (World.__singleton())
+        if (a == b) {
+            return 1
+        }
+        return 0
+    }
+}

--- a/runtime/wasm/singleton_test.mjs
+++ b/runtime/wasm/singleton_test.mjs
@@ -1,0 +1,25 @@
+// Singleton test (@singleton(true) on the WASM backend).
+// Build:
+//   node bin/output.js -l=llvm -wat -freestanding -wasmrc \
+//     runtime/wasm/singleton_demo.rgr -nodecli -d=tmp/sgl -o=g.wat
+//   cp tmp/sgl/g.wat.ll tmp/sgl/g.wat && wat2wasm tmp/sgl/g.wat -o tmp/sgl/g.wasm
+import fs from "fs";
+const x = new WebAssembly.Instance(new WebAssembly.Module(
+  fs.readFileSync(new URL("../../tmp/sgl/g.wasm", import.meta.url)))).exports;
+let pass = 0, fail = 0;
+const ok = (n, g, e) => { if (g === e) pass++; else { fail++; console.log("FAIL", n, JSON.stringify(g), "exp", JSON.stringify(e)); } };
+
+x.Heap_init();
+// state persists across separate exported calls (frames) via the wasm global
+ok("same instance on repeat lookup", x.G_sameInstance(), 1);
+ok("frame starts 0", x.G_frame(), 0);
+for (let i = 0; i < 5; i++) x.G_update();
+ok("frame after 5 updates", x.G_frame(), 5);
+ok("score 10+20+30+40+50", x.G_score(), 150);      // sum frame*10
+ok("enemies list grew to 5", x.G_enemies(), 5);
+x.G_update();
+ok("frame after 6th update", x.G_frame(), 6);
+ok("score after 6th", x.G_score(), 210);           // 150 + 60
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Overview

This branch makes it possible to author a game-engine WASM guest **in the Ranger language**, and to write real memory-managed, object-oriented Ranger code that compiles to WebAssembly. It spans three arcs: the game port + WAT backend fixes, a from-scratch WASM memory-management runtime with reference counting, and OO language features (nested objects, object-field RC, singletons).

Everything new is gated behind the freestanding-WASM path (`-wat` / `-wasmrc` / `useFreeListHeap`); **the libc/LLVM-native path is byte-unchanged** throughout (verified repeatedly). **115 runtime tests pass** and the ported `ranger_autopeli` game still runs headless (PASS).

## 1. Ranger game guest + WAT backend

- Ported the "autopeli" car game to Ranger (`gallery/game_engine/games/ranger_autopeli/`), compiled to `logic.wasm` and driven by the engine's RGW1 linear ABI + RGU1 HUD — feature parity with the Rust guest, no host HUD fallback.
- WAT backend fixes uncovered along the way: instance-field load/store (GEP off-by-one), two-branch `if/else` emission, and a recursive control-flow reconstruction for nested `if`/`while`.
- Added **f64** support to the WAT backend (fadd/fsub/fmul/fdiv, comparisons, sitofp/fptosi).

## 2. WASM memory management (see `PLAN_WASM_MEMORY.md`)

A complete reference-counting runtime for freestanding WASM under `-wasmrc`, replacing the leak-forever bump allocator:

- **Free-list heap** (`runtime/wasm/ranger_heap.rgr`): alloc/free/calloc/realloc + coalescing, and **`memory.grow`** so the heap scales past the initial 64 KiB page (new `Mem.memSize`/`Mem.memGrow` → `memory.size`/`memory.grow`).
- **Objects** (`ranger_obj.rgr`): rc header + typedesc-driven recursive destruction; `new` is reference counted, leak-free in loops.
- **Strings**: freestanding runtime (len/concat/dup/from_int/cmp/release, literals in a data segment), owned-local RC, a statement-scoped arena that frees inline throwaways (`host.drawText("SCORE " + n)`), `==`/`!=` via `ranger_str_cmp`, and `charAt`/`substring`/`strfromcode`.
- **Collections**: `[int]`, `[T]`, `[string]` and `[K:V]` maps all allocate on the free-list heap, grow, and free with element RC where owned. Maps double + rehash (fixing an infinite-probe hang) and free their storage. Unified the allocator so collections no longer collide with the heap control words.
- **Owned string fields** freed on object destruction (typedesc emission into the data segment).

## 3. OO language features on WASM

- **Chained field access** `a.b.c` (any depth) — fixed an all-targets bug where the receiver chain used only the first two segments, silently overwriting the intermediate pointer.
- **Reference-counted object fields**: a fresh `new` is moved into a field, a borrowed reference is retained, the old value released on overwrite — so a shared child is freed exactly once (cycles leak but never corrupt).
- **Singletons** (`@singleton(true)`): a mutable wasm global + generated lazy `__singleton()` accessor, so game state persists across `update()` calls in OO style.

## Documentation

- `gallery/game_engine/README.md` gains a **"WASM-guest Rangerilla"** guide: the compile pipeline, `-wasmrc`, a tested "which programming patterns work" table (classes, object fields, collections, hash maps, singletons — and the current limits), and the gotchas.
- `PLAN_WASM_MEMORY.md` documents the whole memory model.

## Known limitation

**Lambdas / closures** are not supported on the WAT backend (no function pointers / `call_indirect` / closure environments emitted) — a dedicated follow-up. Everything else in the pattern table is tested and working.

## Testing

`runtime/wasm/*_test.mjs` (115 assertions): heap 17, obj 10, rc 7, str 5, str_rc 25, field_rc 9, coll_rc 14, map_rc 8, strarr 7, singleton 7, objfield 6. Plus the LLVM/WAT fixtures and the headless `ranger_autopeli` host (PASS). libc golden path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhKhA739wK4UTfc4WurqSS)_