### PR TITLE
gfx_sdl: render untextured GLB meshes (bind a white fallback texture)

### DIFF
--- a/gallery/game_engine/gfx_sdl.rgr
+++ b/gallery/game_engine/gfx_sdl.rgr
@@ -2292,6 +2292,23 @@ static GLint g_scn_uAmbient=-1, g_scn_uNumDir=-1, g_scn_uDirDir=-1, g_scn_uDirCo
 static GLint g_scn_uNumPt=-1, g_scn_uPtPos=-1, g_scn_uPtCol=-1, g_scn_uPtRange=-1;
 static GLint g_scn_uBaseColor=-1, g_scn_uEmissive=-1;
 static GLint g_scn_uUvOffset=-1, g_scn_uUvScale=-1, g_scn_uUnlit=-1, g_scn_uAlphaCut=-1;
+// 1x1 opaque-white texture bound for meshes that have no texture, so the
+// shader's texture2D(uTex)*uBaseColor yields the material's base colour instead
+// of black (an unbound sampler reads as 0 -> the mesh renders invisible).
+static GLuint g_scn_white_tex = 0;
+static GLuint rgfx_scene_ensure_white() {
+    if (g_scn_white_tex == 0) {
+        const unsigned char px[4] = {255, 255, 255, 255};
+        glGenTextures(1, &g_scn_white_tex);
+        glBindTexture(GL_TEXTURE_2D, g_scn_white_tex);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, px);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    }
+    return g_scn_white_tex;
+}
 
 static int rgfx_scene_valid(int id) { return id > 0 && id <= (int) g_scene.size() && g_scene[(size_t)(id-1)].alive; }
 
@@ -2646,7 +2663,8 @@ extern \"C\" void rgfx_scene_render(int w, int h) {
         float mvp[16]; rgfx_m4_mul(vp, model, mvp);
         float nm[9]; nm[0]=r3[0];nm[1]=r3[1];nm[2]=r3[2];nm[3]=r3[3];nm[4]=r3[4];nm[5]=r3[5];nm[6]=r3[6];nm[7]=r3[7];nm[8]=r3[8];
         glUniformMatrix4fv(g_scn_uMVP,1,GL_FALSE,mvp); glUniformMatrix4fv(g_scn_uModel,1,GL_FALSE,model); glUniformMatrix3fv(g_scn_uNormalMat,1,GL_FALSE,nm);
-        if (e.texId>0 && e.texId<=(int)g_rgfx_gl_textures.size()) glBindTexture(GL_TEXTURE_2D, g_rgfx_gl_textures[(size_t)(e.texId-1)]);
+        if (e.texId>0 && e.texId<=(int)g_rgfx_gl_textures.size()) { glBindTexture(GL_TEXTURE_2D, g_rgfx_gl_textures[(size_t)(e.texId-1)]); }
+        else { glBindTexture(GL_TEXTURE_2D, rgfx_scene_ensure_white()); }
         glBindBuffer(GL_ARRAY_BUFFER,m.vbo); glBindBuffer(GL_ELEMENT_ARRAY_BUFFER,m.ebo);
         if(g_scn_aPos>=0){glEnableVertexAttribArray(g_scn_aPos); glVertexAttribPointer(g_scn_aPos,3,GL_FLOAT,GL_FALSE,32,(void*)0);}
         if(g_scn_aNormal>=0){glEnableVertexAttribArray(g_scn_aNormal); glVertexAttribPointer(g_scn_aNormal,3,GL_FLOAT,GL_FALSE,32,(void*)12);}


### PR DESCRIPTION
## Problem

In the host-managed 3D scene, GLB models **without a texture** rendered completely invisible, while textured ones (Duck, BoxTextured, Chair) rendered fine. In the model viewer this made `Box` (a red `baseColorFactor`) and `BoxVertexColors` blank.

## Cause

The scene fragment shader multiplies the sampled texture by the base colour:

```glsl
vec4 t = texture2D(uTex, uv) * uBaseColor;
```

But the mesh draw only bound a texture when `e.texId > 0`:

```cpp
if (e.texId > 0 && e.texId <= (int)g_rgfx_gl_textures.size())
    glBindTexture(GL_TEXTURE_2D, g_rgfx_gl_textures[e.texId - 1]);
```

For a mesh with no texture the sampler was left unbound, so `texture2D(uTex, …)` read as `(0,0,0,0)` → `t = 0 * uBaseColor = 0` → every fragment came out black/transparent and the mesh was invisible.

## Fix

Lazily create a 1×1 opaque-white texture and bind it whenever a mesh has no texture, so the shader yields `white * uBaseColor = uBaseColor` and the material's base colour shows. Untextured GLB materials now render.

```cpp
if (e.texId > 0 && e.texId <= (int)g_rgfx_gl_textures.size()) { glBindTexture(GL_TEXTURE_2D, g_rgfx_gl_textures[e.texId - 1]); }
else { glBindTexture(GL_TEXTURE_2D, rgfx_scene_ensure_white()); }
```

One file (`gallery/game_engine/gfx_sdl.rgr`), +19/−1. This is the last of the GLB render-path issues surfaced by real test models; the earlier ones (32-bit indices, high-precision positions, presentation `radius`) already landed on `master`.

## Verification

C++ inside `gfx_sdl.rgr`; the root cause was read directly from the shader + draw code, but confirming on screen needs the native SDL build. `wasm3d_runner` still compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Umert9tBqHgs1UJVVBG4R

---
_Generated by [Claude Code](https://claude.ai/code/session_012Umert9tBqHgs1UJVVBG4R)_