### PR TITLE
docs(game_engine): clarify which update() state keys the engine processes

### DIFF
--- a/gallery/game_engine/README.md
+++ b/gallery/game_engine/README.md
@@ -287,6 +287,35 @@ function update(props) {
 }
 ```
 
+#### Mitä engine lukee palautetusta tilasta — ja mitä ei
+
+`update()` palauttaa pelin **koko tilan**: se on reducerin akku, joka syötetään
+takaisin `props.state`-kenttänä seuraavalla framella. Engine ei omista tilan
+muotoa — se prosessoi siitä vain pienen joukon **sovittuja avaimia**:
+
+| Avain | Enginen käyttö |
+|-------|----------------|
+| `entities` | `{ id: { x, y } }` → siirtää `sprites()`-listan retained-objektit |
+| `cameraY` | vierittää `createStaticBg()`-taustaa |
+| `score1` / `score2` | HUD |
+| `events` | äänet, partikkelit, vokaaliefektit ym. (drainataan framen jälkeen) |
+| `collisionEvents`, `playerCount` / `playerSlots`, `screens` | törmäykset, pelaajamäärä, moniruutuisuus |
+| `physics` / `world` / `impulses` / `steer` | **vain** jos peli ottaa host-fysiikan käyttöön `config().physics`-kentällä |
+
+**Kaikki muut avaimet ovat pelin omaa työmuistia — engine ei lue eikä tulkitse
+niitä.** Esimerkiksi Ylos 2:n palauttamassa tilassa `diamonds`, `fruits`,
+`bullets`, `enemies`, `movingPlatforms`, `fireCd1` jne. ovat pelkkää pelilogiikkaa:
+engine tallettaa tilaobjektin sellaisenaan ja antaa sen muuttumattomana takaisin
+seuraavalle `update()`-kutsulle. Vain projektiokenttä `entities` — jonka peli
+tyypillisesti laskee domain-tilastaan joka framella (esim. ylos2:n
+`placeEntities(...)`) — sitoo pelin tilan enginen spriteihin.
+
+Miksi näin: peli omistaa tilansa muodon täysin ja engine pysyy geneerisenä
+(lukee `entities` + em. sovitut kentät, sivuuttaa loput). Tämä on myös se syy,
+miksi hot-reload säilyttää tilan — palautettu tila on pelkkää dataa, joka elää
+`update()`-rungon vaihdon yli, koska engine ei ole kytkeytynyt sen pelikohtaisiin
+kenttiin.
+
 Jaetut apurit: [`scripting/game_helpers.tsx`](./scripting/game_helpers.tsx) (`getScreen`, `soundEvent`, …). Jaetut moduulit: `import { foo } from "./utils"` (polku suhteessa pelikansioon).
 
 ### 3. Aja ja testaa

--- a/gallery/game_engine/games/ylos2/index.tsx
+++ b/gallery/game_engine/games/ylos2/index.tsx
@@ -1057,10 +1057,17 @@ function initState() {
     slots
   );
   return {
-    showNet: 0,
-    playerSlots: slots,
-    cameraY: cameraY,
-    entities: entities,
+    // ---- Platform keys: the Ranger engine reads these out of the returned
+    //      state. (Full list: gallery/game_engine/README.md.)
+    entities: entities,   // { id: { x, y } } -> positions the retained sprites()
+    cameraY: cameraY,     // scrolls the createStaticBg() background
+    score1: 0,            // HUD
+    score2: 0,            // HUD
+    playerSlots: slots,   // player count (dual / split-screen)
+    showNet: 0,           // center divider (0 = off)
+    // ---- Internal keys: this game's own working memory. The engine stores the
+    //      state object unchanged and hands it back to the next update(), but
+    //      never reads or interprets these — they exist only for our own logic.
     p1: p1,
     p2: p2,
     enemies: enemies,
@@ -1068,8 +1075,6 @@ function initState() {
     diamonds: diamonds,
     bullets: bullets,
     movingPlatforms: movingPlatforms,
-    score1: 0,
-    score2: 0,
     fireCd1: 0,
     fireCd2: 0,
     summitMusicStarted: 0


### PR DESCRIPTION
Documentation-only. Clarifies a point about the game-scripting contract that isn't obvious from reading a game like Ylos 2.

`update()` returns the game's **whole** state, but the engine only reads a small set of **conventional keys** from it:

| Key | Engine use |
|-----|-----------|
| `entities` | `{ id: { x, y } }` → positions the retained `sprites()` |
| `cameraY` | scrolls the `createStaticBg()` background |
| `score1` / `score2` | HUD |
| `events` | sounds, particles, etc. (drained after the frame) |
| `collisionEvents`, `playerCount`/`playerSlots`, `screens` | collisions, player count, multi-screen |
| `physics` / `world` / `impulses` / `steer` | **only** when a game opts into host physics via `config().physics` |

**Every other key is the game's own working memory** — e.g. Ylos 2's `diamonds`, `fruits`, `bullets`, `enemies`, `movingPlatforms`, `fireCd1`. The engine stores the returned state object as-is and hands it straight back to the next `update()` call, but never reads or interprets those fields. Only the derived `entities` projection (typically computed each frame, e.g. Ylos 2's `placeEntities(...)`) binds game state to engine sprites.

The note also explains *why* this matters: because the engine isn't coupled to the game's own keys, the returned state is plain data that survives a code swap — which is what makes hot reload preserve game state.

Added to the game-scripting section of `gallery/game_engine/README.md` (in Finnish, to match the surrounding doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2SqqCTtqwuuw9ZHhsPxyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2SqqCTtqwuuw9ZHhsPxyj)_