### PR TITLE
web: add Breakout, Web Audio sound, gamepad input, cache-busting

### DIFF
--- a/gallery/game_engine/web/README.md
+++ b/gallery/game_engine/web/README.md
@@ -113,6 +113,17 @@ building this).
 |------|--------------|
 | **Pong** | Pure-Ranger game logic, text-only package |
 | **Ylos 2 (Pomppija)** | PNG sprite-sheet loading (binary VFS path), split-screen |
+| **Breakout** | Multi-file script, sound effects (brick/wall/win) |
+
+## Sound & input
+
+- **Sound** is the engine's own synth. `WebAudioSink` (in `web_game_host.rgr`)
+  captures the int16 PCM the engine hands its audio sink per `soundEvent`, and
+  `runner.js` plays each buffer through the Web Audio API. Created on the first
+  user gesture (autoplay policy); a Sound toggle mutes it.
+- **Gamepad/joystick** — yes, the browser supports it. `runner.js` polls
+  `navigator.getGamepads()` each frame (pad 0 → P1, pad 1 → P2; d-pad/left-stick
+  + face buttons) and ORs it with the keyboard.
 
 ## Roadmap
 

--- a/gallery/game_engine/web/build.mjs
+++ b/gallery/game_engine/web/build.mjs
@@ -18,6 +18,7 @@
 // ============================================================================
 
 import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -69,6 +70,21 @@ const GAMES = [
       "gallery/game_engine/games/ylos2/assets/enemy_walk.png",
     ],
     controls: "P1: WASD + Space · P2: ↑ ↓ ← → · split-screen platformer with PNG sprites.",
+  },
+  {
+    id: "breakout",
+    title: "Breakout",
+    kind: "ranger",
+    width: 480,
+    height: 270,
+    scriptDir: "gallery/game_engine/games/breakout",
+    script: "index.tsx",
+    package: [
+      "gallery/game_engine/games/breakout/index.tsx",
+      "gallery/game_engine/games/breakout/breakout_bricks.tsx",
+      "gallery/game_engine/lib/game_helpers.tsx",
+    ],
+    controls: "← → or A / D to move · Space to launch/restart · sound on brick/wall/win.",
   },
 ];
 
@@ -272,12 +288,39 @@ function copyRuntime() {
   fs.copyFileSync(path.join(HERE, "index.html"), path.join(OUT, "index.html"));
 }
 
+// Cache-bust local asset references in index.html so a redeploy never serves a
+// stale runner.js against a newer index.html (which was the "getSource is not a
+// function" symptom). The version is a short content hash of the runtime files,
+// so it only changes when they actually change.
+function cacheBust() {
+  const names = [
+    "vfs.js", "engine-host.js", "runner.js",
+    "engine.bundle.js", "games.json",
+    "editor.bundle.js", "editor.bundle.css",
+  ];
+  const h = crypto.createHash("sha1");
+  for (const n of names) {
+    const p = path.join(OUT, n);
+    if (fs.existsSync(p)) h.update(fs.readFileSync(p));
+  }
+  const ver = h.digest("hex").slice(0, 10);
+  const idx = path.join(OUT, "index.html");
+  let html = fs.readFileSync(idx, "utf8");
+  for (const n of names) {
+    // Match ./name in both <script src>/<link href> and fetch("./name") literals.
+    html = html.replaceAll("./" + n, "./" + n + "?v=" + ver);
+  }
+  fs.writeFileSync(idx, html);
+  log("cache-bust version", ver);
+}
+
 // ------------------------------------------------------------------- main
 fs.mkdirSync(OUT, { recursive: true });
 compileEngineBundle();
 packageGames();
 const editorOk = await buildEditor();
 copyRuntime();
+cacheBust();
 // Expose editor availability to the page without probing globals.
 fs.writeFileSync(
   path.join(OUT, "build-info.json"),

--- a/gallery/game_engine/web/index.html
+++ b/gallery/game_engine/web/index.html
@@ -83,6 +83,7 @@
     <div class="toolbar">
       <label>Game <select id="game"></select></label>
       <label class="chk"><input type="checkbox" id="autoreload" checked /> Auto-reload on edit</label>
+      <label class="chk"><input type="checkbox" id="sound" checked /> Sound</label>
       <button id="reload">Reload now</button>
       <button id="restart">Restart</button>
       <button id="pause">Pause</button>
@@ -107,7 +108,8 @@
       Try editing a constant near the top of the script (a colour, a speed, a
       size) and watch the game update. Edits to <code>update</code>/<code>hud</code>
       keep the running state; edits to <code>initState</code>/<code>sprites</code>
-      rebuild the scene.
+      rebuild the scene. A connected <code>gamepad</code> works too (d-pad/stick +
+      A), and sound is the engine's own synth played through Web Audio.
     </p>
 
     <script src="./vfs.js"></script>
@@ -189,6 +191,7 @@
           canvas,
           scriptDir: entry.scriptDir,
           scriptFile: entry.script,
+          muted: !document.getElementById("sound").checked,
           onStats: (s) => {
             if (!document.hidden)
               setStatus(entry.title + " — score " + s.score1 + " : " + s.score2);
@@ -208,6 +211,9 @@
             .join("");
           selectEl.onchange = () => loadGame(registry[+selectEl.value]);
           document.getElementById("reload").onclick = applyEdit;
+          document.getElementById("sound").onchange = (e) => {
+            if (session) session.setMuted(!e.target.checked);
+          };
           document.getElementById("restart").onclick = () => loadGame(registry[+selectEl.value]);
           document.getElementById("pause").onclick = () => {
             if (!session) return;

--- a/gallery/game_engine/web/src/runner.js
+++ b/gallery/game_engine/web/src/runner.js
@@ -48,7 +48,12 @@
       this._image = this.ctx.createImageData(this.width, this.height);
       this._onKey = this._onKey.bind(this);
       this._tick = this._tick.bind(this);
+      this._resumeAudio = this._resumeAudio.bind(this);
       this.onStats = config.onStats || null;
+      // Audio: created lazily on the first user gesture (autoplay policy).
+      this.audioCtx = null;
+      this.muted = !!config.muted;
+      this.audioSupported = typeof this.host.audioPending === "function";
     }
 
     setup() {
@@ -63,6 +68,8 @@
     start() {
       window.addEventListener("keydown", this._onKey);
       window.addEventListener("keyup", this._onKey);
+      window.addEventListener("keydown", this._resumeAudio);
+      window.addEventListener("pointerdown", this._resumeAudio);
       this._last = performance.now();
       this._raf = requestAnimationFrame(this._tick);
       return this;
@@ -71,8 +78,25 @@
     stop() {
       window.removeEventListener("keydown", this._onKey);
       window.removeEventListener("keyup", this._onKey);
+      window.removeEventListener("keydown", this._resumeAudio);
+      window.removeEventListener("pointerdown", this._resumeAudio);
       if (this._raf) cancelAnimationFrame(this._raf);
       this._raf = 0;
+    }
+
+    setMuted(m) {
+      this.muted = !!m;
+    }
+
+    // Browsers block audio until a user gesture — create/resume on first input.
+    _resumeAudio() {
+      if (!this.audioSupported) return;
+      if (!this.audioCtx) {
+        const AC = window.AudioContext || window.webkitAudioContext;
+        if (AC) this.audioCtx = new AC();
+      } else if (this.audioCtx.state === "suspended") {
+        this.audioCtx.resume();
+      }
     }
 
     _onKey(e) {
@@ -80,6 +104,30 @@
       if (!slot) return;
       this.keys[slot] = e.type === "keydown";
       if (e.code.startsWith("Arrow") || e.code === "Space") e.preventDefault();
+    }
+
+    // Merge connected gamepads/joysticks (pad 0 -> P1, pad 1 -> P2). Standard
+    // mapping: d-pad buttons 12-15, left stick axes 0/1, face/start buttons.
+    _padInputs() {
+      const p1 = {}, p2 = {};
+      const nav = typeof navigator !== "undefined" ? navigator : null;
+      if (!nav || !nav.getGamepads) return { p1, p2 };
+      const pads = nav.getGamepads();
+      const read = (pad, r) => {
+        if (!pad) return r;
+        const a = pad.axes || [];
+        const b = pad.buttons || [];
+        const on = (i) => !!b[i] && (b[i].pressed || b[i].value > 0.5);
+        r.left = on(14) || a[0] < -0.4;
+        r.right = on(15) || a[0] > 0.4;
+        r.up = on(12) || a[1] < -0.4;
+        r.down = on(13) || a[1] > 0.4;
+        r.action = on(0) || on(1) || on(9); // A / B / Start
+        return r;
+      };
+      read(pads[0], p1);
+      read(pads[1], p2);
+      return { p1, p2 };
     }
 
     // Live reload: persist the edited source into the VFS (bumps its mtimeMs,
@@ -99,10 +147,11 @@
     step(dtMs) {
       const dt = Math.max(1, Math.min(50, dtMs | 0)) || 16;
       const k = this.keys;
+      const { p1, p2 } = this._padInputs(); // keyboard OR gamepad
       this.host.frame(
         dt,
-        k.up, k.down, k.left, k.right, k.action,
-        k.p2up, k.p2down, k.p2left, k.p2right, k.p2action,
+        k.up || p1.up, k.down || p1.down, k.left || p1.left, k.right || p1.right, k.action || p1.action,
+        k.p2up || p2.up, k.p2down || p2.down, k.p2left || p2.left, k.p2right || p2.right, k.p2action || p2.action,
         k.quit,
       );
       this.host.draw();
@@ -110,6 +159,35 @@
       const bytes = raw instanceof ArrayBuffer ? new Uint8Array(raw) : new Uint8Array(raw.buffer || raw);
       this._image.data.set(bytes.subarray(0, this._image.data.length));
       this.ctx.putImageData(this._image, 0, 0);
+      this._drainAudio();
+    }
+
+    // Play any sounds the engine synthesised this frame. GameAudio hands the
+    // WebAudioSink int16 mono PCM; we turn each into an AudioBuffer and play it.
+    _drainAudio() {
+      if (!this.audioSupported) return;
+      const n = this.host.audioPending();
+      if (!n) return;
+      if (this.audioCtx && !this.muted) {
+        for (let i = 0; i < n; i++) {
+          this._playPcm(this.host.audioPcm(i), this.host.audioRate(i));
+        }
+      }
+      this.host.audioClear(); // always drain, even when muted, to bound the queue
+    }
+
+    _playPcm(pcm, rate) {
+      const ab = pcm instanceof ArrayBuffer ? pcm : (pcm && pcm.buffer) || null;
+      if (!ab) return;
+      const i16 = new Int16Array(ab);
+      if (!i16.length) return;
+      const buf = this.audioCtx.createBuffer(1, i16.length, rate || 44100);
+      const ch = buf.getChannelData(0);
+      for (let j = 0; j < i16.length; j++) ch[j] = i16[j] / 32768;
+      const src = this.audioCtx.createBufferSource();
+      src.buffer = buf;
+      src.connect(this.audioCtx.destination);
+      src.start();
     }
 
     _tick(now) {
@@ -149,6 +227,7 @@
       scriptFile: config.scriptFile,
       keymap: config.keymap,
       onStats: config.onStats,
+      muted: config.muted,
     });
     session.setup();
     if (config.autostart !== false) session.start();

--- a/gallery/game_engine/web/web_game_host.rgr
+++ b/gallery/game_engine/web/web_game_host.rgr
@@ -17,11 +17,57 @@
 
 Import "../scripting/game_runtime.rgr"
 Import "../scripting/game_host_native.rgr"
+Import "../scripting/game_audio.rgr"
 Import "../scripting/game_input.rgr"
+
+; Audio sink that captures the engine's synthesised PCM instead of playing it
+; through SDL. GameAudio calls onSynthPlay(id, rate, frames, pcm) for every
+; sound (each note of a win/celebrate arpeggio is a separate call); we queue the
+; int16 mono PCM buffers for the JS harness to drain and play via Web Audio.
+class WebAudioSink extends GameAudioSink {
+    def qRate:[int]
+    def qCount:[int]
+    def qPcm:[buffer]
+
+    fn onSynthPlay:void (soundId:string sampleRate:int sampleCount:int pcm:buffer) {
+        push qRate sampleRate
+        push qCount sampleCount
+        push qPcm pcm
+    }
+
+    fn onClearQueue:void () {
+    }
+
+    fn pending:int () {
+        return (array_length qRate)
+    }
+
+    fn rateAt:int (i:int) {
+        return (itemAt qRate i)
+    }
+
+    fn countAt:int (i:int) {
+        return (itemAt qCount i)
+    }
+
+    fn pcmAt:buffer (i:int) {
+        return (itemAt qPcm i)
+    }
+
+    fn clear:void () {
+        def er:[int]
+        def ec:[int]
+        def ep:[buffer]
+        qRate = er
+        qCount = ec
+        qPcm = ep
+    }
+}
 
 class WebGameHost {
     def runner:GameRunner (new GameRunner)
     def bridge:GameHostNativeBridge (new GameHostNativeBridge)
+    def audioSink:WebAudioSink (new WebAudioSink)
 
     fn init:void (w:int h:int) {
         runner.init(w h)
@@ -35,6 +81,31 @@ class WebGameHost {
         runner.setScriptDir(scriptDir)
         runner.loadScript(src)
         runner.setupScene()
+        ; Route the engine's audio synth into our capture sink (after setupScene,
+        ; which wires the runner's GameAudio).
+        def audio:GameAudio (runner.audioRef())
+        audio.sink = audioSink
+    }
+
+    ; --- audio drain (called by the JS harness after each frame) ---
+    fn audioPending:int () {
+        return (audioSink.pending())
+    }
+
+    fn audioRate:int (i:int) {
+        return (audioSink.rateAt(i))
+    }
+
+    fn audioSamples:int (i:int) {
+        return (audioSink.countAt(i))
+    }
+
+    fn audioPcm:buffer (i:int) {
+        return (audioSink.pcmAt(i))
+    }
+
+    fn audioClear:void () {
+        audioSink.clear()
     }
 
     ; Two-player flat frame. Single-player games simply ignore the p2* slot.


### PR DESCRIPTION
- Breakout: register the game (index.tsx + breakout_bricks.tsx + the lib/ game_helpers.tsx it imports); text-only package.

- Sound: play the engine's own synth in the browser. WebAudioSink (a GameAudioSink subclass in web_game_host.rgr) captures the int16 mono PCM the engine synthesises for each soundEvent; WebGameHost exposes a per-frame drain API, and runner.js turns each buffer into a Web Audio AudioBuffer and plays it. AudioContext is created on the first user gesture (autoplay policy) and a Sound toggle mutes it; the queue is always drained so it stays bounded.

- Gamepad/joystick: runner.js polls navigator.getGamepads() each frame (pad 0 -> P1, pad 1 -> P2; d-pad buttons, left stick, A/B/Start) and ORs it with the keyboard.

- Cache-busting: build.mjs appends a short content-hash ?v= to the local asset references in index.html, so a redeploy never serves a stale runner.js against a newer index.html (the "session.getSource is not a function" symptom).

Verified in Chromium: Breakout renders and plays 8 synth sounds through Web Audio; an emulated gamepad holding "up" moves Pong's P1 paddle (centroid 134 -> 27).


Claude-Session: https://claude.ai/code/session_01E2SqqCTtqwuuw9ZHhsPxyj