### PR TITLE
feat(tsx): support Math.random() in the ComponentEngine interpreter

### DIFF
--- a/compiler/Lang.rgr
+++ b/compiler/Lang.rgr
@@ -244,6 +244,19 @@ language {
             templates {
                 es6 ('Math.random()')
                 kotlin ('Math.random()' (imp "java.lang.Math"))
+                cpp ( "rg_random_double()" (imp "<random>")
+(create_polyfill "
+double rg_random_double() {
+    static thread_local std::mt19937 _rg{std::random_device{}()};
+    static thread_local std::uniform_real_distribution<double> _rd(0.0, 1.0);
+    return _rd(_rg);
+}
+")
+                )
+                go ( 'rand.Float64()' (imp "math/rand") )
+                ; std-only (rustc, no crates): each RandomState::new() draws a fresh
+                ; OS-seeded key, so hashing a constant yields a varying 53-bit value.
+                rust ( '{ use std::hash::{BuildHasher, Hasher}; let mut h = std::collections::hash_map::RandomState::new().build_hasher(); h.write_u64(0); ((h.finish() >> 11) as f64) / ((1u64 << 53) as f64) }' )
             }
         }
 

--- a/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
+++ b/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
@@ -5110,6 +5110,12 @@ class ComponentEngine {
                     }
                 }
                 if (mathObjName == "Math") {
+                    ; Math.random() — real, unseeded randomness (host RNG). Zero
+                    ; args, so handle it before the single-argument methods.
+                    if (methodName == "random") {
+                        def rv:double (random)
+                        return (EvalValue.number(rv))
+                    }
                     if ((array_length node.children) > 0) {
                         def argNode:TSNode (itemAt node.children 0)
                         def argVal:EvalValue (this.evaluateExpr(argNode))


### PR DESCRIPTION
Adds real, unseeded `Math.random()` to the TSX game interpreter.

### Problem
`Math.random()` wasn't implemented in `ComponentEngine`. Because it takes no arguments it fell through the `Math` dispatch to the "Unhandled method call" path and returned `null` → **0**, so any game using it silently got `0` every frame (a quiet bug, not an error).

### Change
- **`ComponentEngine.rgr`**: handle `Math.random()` in the `Math` dispatch (zero-arg, so before the single-argument methods) via the existing `random` operator.
- **`Lang.rgr`**: the `random _:double ()` operator only had `es6`/`kotlin` templates. Since `ComponentEngine` is compiled to more than one backend, I added templates for every backend it actually targets, so all builds still compile:
  - `cpp` — thread-local `std::mt19937` seeded from `std::random_device` (via `create_polyfill`)
  - `go` — `rand.Float64()`
  - `rust` — **std-only** (the tool's rust build uses `rustc` with no Cargo, so no `rand` crate): a fresh `RandomState` per call yields a varying 53-bit value scaled to `[0,1)`

### Verification
- `Math.random()` now **varies run-to-run** in the es6 interpreter (8 runs of `floor(50.7 + random()*1000)` → 198, 227, 833, 473, 163, 982, 980, 199); previously stuck at 50.
- Standalone `random` programs **compile and run** under cpp (g++), go, and rust (`rustc -O`).
- The real `ComponentEngine` consumer `evg_component_tool` still **transpiles to go**.
- The **pong gallery smoke** (ComponentEngine end-to-end) passes; `Math.floor` and the other Math methods are unchanged.

### Note on determinism
This is intentionally **non-deterministic**, as requested. Games that want reproducible runs (replay/netcode) should keep a seed in their own state — e.g. `games/mathquiz` uses an LCG (`nextSeed(s) = (s*75+74) % 65537`). This tradeoff is the same one discussed in #329.

### Pre-existing, out of scope
`evg_component_tool → rust` fails to transpile due to unrelated operators (`keys`, `=`) lacking rust templates — that predates this change (the errors don't mention `random`, which now resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2SqqCTtqwuuw9ZHhsPxyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2SqqCTtqwuuw9ZHhsPxyj)_