### PR TITLE
web: 3D glTF model viewer demo (host-side model3d, compiled to JS)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -61,6 +61,10 @@ jobs:
       - name: Build games site
         run: node gallery/game_engine/web/build.mjs --out "$GITHUB_WORKSPACE/_site/games"
 
+      # ---- 3D model viewer demo (glTF -> SoftRenderer3D, host-side) -------
+      - name: Build 3D model demo
+        run: node gallery/game_engine/web/build-model3d.mjs --out "$GITHUB_WORKSPACE/_site/games/model3d"
+
       # ---- Playground at the site root -----------------------------------
       - name: Install playground dependencies
         working-directory: playground

--- a/gallery/game_engine/model3d/demo/SoftRenderer3D.rgr
+++ b/gallery/game_engine/model3d/demo/SoftRenderer3D.rgr
@@ -29,6 +29,9 @@ class SoftRenderer3D {
     def bgR:int 24
     def bgG:int 26
     def bgB:int 34
+    ; optional camera orbit around the world-up (Y) axis, radians. 0 keeps the
+    ; original fixed 3/4 view; a driver can advance it per frame to spin the model.
+    def orbitYRad:double 0.0
 
     fn init:void (width:int height:int) {
         w = width
@@ -198,6 +201,13 @@ class SoftRenderer3D {
         def vx:double 0.55
         def vy:double 0.42
         def vz:double 1.0
+        ; orbit the horizontal (x,z) part of the view direction around Y
+        def ca:double (cos orbitYRad)
+        def sa:double (sin orbitYRad)
+        def rvx:double ((vx * ca) + (vz * sa))
+        def rvz:double ((vz * ca) - (vx * sa))
+        vx = rvx
+        vz = rvz
         def vl:double (sqrt (((vx * vx) + (vy * vy)) + (vz * vz)))
         def eye:Vec3 (Vec3.of((cx + ((vx / vl) * dist)) (cy + ((vy / vl) * dist)) (cz + ((vz / vl) * dist))))
         def target:Vec3 (Vec3.of(cx cy cz))

--- a/gallery/game_engine/web/README.md
+++ b/gallery/game_engine/web/README.md
@@ -125,13 +125,37 @@ building this).
   `navigator.getGamepads()` each frame (pad 0 → P1, pad 1 → P2; d-pad/left-stick
   + face buttons) and ORs it with the keyboard.
 
+## 3D model viewer (`/games/model3d`)
+
+A second page renders real `.glb` (glTF) models in the browser via Ranger's
+host-side `model3d` pipeline — no WASM, no WebGL:
+
+```
+GLB → ModelLoader (container + accessors + embedded PNG/JPEG)
+    → instantiate (entity scene + world transforms)
+    → SoftRenderer3D (textured, directionally-lit, z-buffered rasteriser)
+    → RGB buffer → canvas
+```
+
+- **`web_model_viewer.rgr`** — `WebModelViewer`: `load(dir,file)` / `render(w,h)` /
+  `raw()` (RGB) / `setOrbit(rad)`. Compiled to `viewer.bundle.js`.
+- **`src/model-viewer.js`** — rAF loop: orbit the camera, blit RGB→RGBA; drag to
+  rotate, auto-spin when idle.
+- **`build-model3d.mjs`** — compiles the viewer and packages a few committed GLBs
+  (Duck, textured box, trees) into a stored zip mounted at their repo paths.
+
+The GLB read goes through the same VFS-backed `require('fs')`, so the model is
+just a file in the zip. Same renderer as the native build — `SoftRenderer3D`
+gained only an optional `orbitYRad` field (default 0 = unchanged behaviour).
+
 ## Roadmap
 
 - **WASM game logic** — the car game (`autopeli_wasm`). The engine's `wasm_*`
   operators are stubbed in the es6 backend (`wasm_runtime.rgr`); wiring them to
   the browser `WebAssembly` API (the `games/*/tools/render.cjs` hosts are the
   reference) unlocks WASM guests in-browser.
-- **GPU / 3D demo** — `cube3d_wasm` style host-side rasterisation, then WebGL.
+- **3D** — ✅ host-side glTF viewer shipped (see above). Next: WebGL path for
+  larger scenes; a glTF model as an entity inside a scripted game.
 - **Monaco IDE** — ✅ done (editor + live reload; see above). Next: multi-file
   editing (the VFS already holds every game file), persisting edits to IndexedDB,
   and a share-a-URL button.

--- a/gallery/game_engine/web/build-model3d.mjs
+++ b/gallery/game_engine/web/build-model3d.mjs
@@ -1,0 +1,94 @@
+// ============================================================================
+// build-model3d.mjs — assemble the browser 3D-model viewer demo.
+// ============================================================================
+//
+//   node gallery/game_engine/web/build-model3d.mjs [--out <dir>]
+//
+// Compiles web_model_viewer.rgr (ModelLoader + SoftRenderer3D, host-side, no
+// WASM / no GPU) to a JS factory bundle, packages a few committed GLB models
+// into a stored zip at their repo-relative paths, and copies the runtime + page.
+// The result renders real glTF models to a canvas entirely in the browser.
+// ============================================================================
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+
+const HERE = path.dirname(url.fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, "..", "..", "..");
+const SRC = path.join(HERE, "src");
+const argv = process.argv.slice(2);
+const outArg = argv.indexOf("--out");
+const OUT = path.resolve(outArg >= 0 ? argv[outArg + 1] : path.join(HERE, "dist", "model3d"));
+
+const VIEWER_RGR = "gallery/game_engine/web/web_model_viewer.rgr";
+const MODEL_DIR = "gallery/game_engine/games/model_viewer_wasm/models";
+
+// The picker's models (all already committed in the repo). `size` seeds the
+// canvas; the camera auto-frames so any GLB works.
+const MODELS = [
+  { id: "duck", title: "Duck (Khronos sample)", file: "Duck.glb" },
+  { id: "box", title: "Textured Box", file: "BoxTextured.glb" },
+  { id: "tree", title: "Tree", file: "tree_1.glb" },
+  { id: "pine", title: "Pine", file: "tree_pine_1.glb" },
+];
+
+const log = (...a) => console.log("[model3d-build]", ...a);
+const sh = (cmd, args, opts) => execFileSync(cmd, args, { stdio: "inherit", cwd: ROOT, ...opts });
+
+// --- stored zip (matches vfs.mountZip) --------------------------------------
+const CRC = (() => { const t = new Uint32Array(256); for (let n = 0; n < 256; n++) { let c = n; for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1; t[n] = c >>> 0; } return t; })();
+const crc32 = (b) => { let c = 0xffffffff; for (let i = 0; i < b.length; i++) c = CRC[(c ^ b[i]) & 0xff] ^ (c >>> 8); return (c ^ 0xffffffff) >>> 0; };
+function makeStoredZip(entries) {
+  const chunks = [], central = []; let offset = 0; const enc = new TextEncoder();
+  for (const { name, bytes } of entries) {
+    const nb = enc.encode(name), crc = crc32(bytes);
+    const l = Buffer.alloc(30);
+    l.writeUInt32LE(0x04034b50, 0); l.writeUInt16LE(20, 4); l.writeUInt16LE(0, 8);
+    l.writeUInt32LE(crc, 14); l.writeUInt32LE(bytes.length, 18); l.writeUInt32LE(bytes.length, 22);
+    l.writeUInt16LE(nb.length, 26);
+    chunks.push(l, Buffer.from(nb), Buffer.from(bytes));
+    const cd = Buffer.alloc(46);
+    cd.writeUInt32LE(0x02014b50, 0); cd.writeUInt16LE(20, 4); cd.writeUInt16LE(20, 6);
+    cd.writeUInt32LE(crc, 16); cd.writeUInt32LE(bytes.length, 20); cd.writeUInt32LE(bytes.length, 24);
+    cd.writeUInt16LE(nb.length, 28); cd.writeUInt32LE(offset, 42);
+    central.push(cd, Buffer.from(nb));
+    offset += l.length + nb.length + bytes.length;
+  }
+  const cdStart = offset; let cdSize = 0; for (const c of central) cdSize += c.length;
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0); end.writeUInt16LE(entries.length, 8); end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(cdSize, 12); end.writeUInt32LE(cdStart, 16);
+  return Buffer.concat([...chunks, ...central, end]);
+}
+
+// --- build ------------------------------------------------------------------
+fs.mkdirSync(OUT, { recursive: true });
+
+const rawDir = path.join(OUT, "_raw");
+fs.mkdirSync(rawDir, { recursive: true });
+log("compiling viewer:", VIEWER_RGR);
+sh("node", ["bin/output.js", "-es6", VIEWER_RGR, "-d=" + path.relative(ROOT, rawDir), "-o=viewer.raw.js", "-nodecli"], {
+  env: { ...process.env, RANGER_LIB: "./compiler/Lang.rgr:./lib/stdops.rgr" },
+});
+let src = fs.readFileSync(path.join(rawDir, "viewer.raw.js"), "utf8").replace(/^#![^\n]*\n/, "");
+src = src.replace(/\n__js_main\(\);\s*$/, "\n").replace(/\n[A-Za-z_$][\w$]*\(\);\s*$/, "\n");
+src += "\n;return { WebModelViewer };\n";
+fs.writeFileSync(path.join(OUT, "viewer.bundle.js"), src);
+fs.rmSync(rawDir, { recursive: true, force: true });
+log("wrote viewer.bundle.js (" + (src.length / 1024).toFixed(0) + " KB)");
+
+// Package the models at their repo-relative VFS paths.
+const entries = MODELS.map((m) => ({ name: MODEL_DIR + "/" + m.file, bytes: fs.readFileSync(path.join(ROOT, MODEL_DIR, m.file)) }));
+fs.writeFileSync(path.join(OUT, "models.zip"), makeStoredZip(entries));
+fs.writeFileSync(path.join(OUT, "models.json"), JSON.stringify(
+  MODELS.map((m) => ({ id: m.id, title: m.title, dir: MODEL_DIR, file: m.file })), null, 2));
+log("packaged " + MODELS.length + " models");
+
+// Runtime + page.
+for (const f of ["vfs.js", "engine-host.js", "model-viewer.js"]) {
+  fs.copyFileSync(path.join(SRC, f), path.join(OUT, f));
+}
+fs.copyFileSync(path.join(HERE, "model3d.html"), path.join(OUT, "index.html"));
+log("done ->", OUT);

--- a/gallery/game_engine/web/model3d.html
+++ b/gallery/game_engine/web/model3d.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ranger 3D — glTF models in the browser</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='14' font-size='14'>🦆</text></svg>"
+    />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0c1020; --panel: #151a2e; --ink: #e6e9f3; --muted: #97a0bd; --accent: #6ea8ff;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0; min-height: 100vh; color: var(--ink);
+        font: 15px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+        background: radial-gradient(1200px 600px at 50% -10%, #1b2140, var(--bg));
+        display: flex; flex-direction: column; align-items: center; padding: 32px 16px 64px;
+      }
+      h1 { margin: 0 0 4px; font-size: 24px; letter-spacing: -0.02em; }
+      .sub { color: var(--muted); margin: 0 0 22px; text-align: center; max-width: 640px; }
+      .sub code { color: var(--accent); }
+      .stage { background: var(--panel); border: 1px solid #262d47; border-radius: 14px; padding: 18px; box-shadow: 0 20px 60px -20px #000a; }
+      canvas { display: block; width: 480px; max-width: 86vw; height: auto; aspect-ratio: 1 / 1; border-radius: 8px; background: #181a22; touch-action: none; }
+      .bar { display: flex; gap: 12px; align-items: center; justify-content: space-between; margin-top: 14px; flex-wrap: wrap; }
+      select, button { font: inherit; color: var(--ink); background: #1e2540; border: 1px solid #313a5c; border-radius: 8px; padding: 8px 12px; cursor: pointer; }
+      button:hover, select:hover { border-color: var(--accent); }
+      .status { color: var(--muted); font-size: 13px; min-height: 1.2em; margin-top: 10px; }
+      footer { margin-top: 26px; color: var(--muted); font-size: 12.5px; text-align: center; max-width: 640px; }
+      footer code { color: var(--accent); }
+    </style>
+  </head>
+  <body>
+    <h1>Ranger 3D — glTF in the browser</h1>
+    <p class="sub">
+      Real <code>.glb</code> models loaded and software-rendered by Ranger's
+      <code>model3d</code> pipeline (glTF parser + textured, z-buffered rasteriser),
+      <code>compiled to JavaScript</code>. No WebGL, no WASM — the same host-side
+      renderer as the native build, via the <code>virtual filesystem</code>.
+    </p>
+
+    <div class="stage">
+      <canvas id="screen" width="384" height="384"></canvas>
+      <div class="bar">
+        <label>Model <select id="model"></select></label>
+        <label style="color:var(--muted)"><input type="checkbox" id="spin" checked /> Auto-spin</label>
+        <span class="status" id="status">loading…</span>
+      </div>
+    </div>
+
+    <footer>
+      Drag the model to rotate. <code>ModelLoader</code> → <code>SoftRenderer3D</code>,
+      the whole pipeline running client-side.
+    </footer>
+
+    <script src="./vfs.js"></script>
+    <script src="./engine-host.js"></script>
+    <script src="./model-viewer.js"></script>
+    <script>
+      const statusEl = document.getElementById("status");
+      const modelEl = document.getElementById("model");
+      const spinEl = document.getElementById("spin");
+      const canvas = document.getElementById("screen");
+      let bundleSource = null, zipBuffer = null, registry = [], session = null;
+
+      const setStatus = (m) => (statusEl.textContent = m);
+      async function fetchText(u) { const r = await fetch(u); if (!r.ok) throw new Error(u + " " + r.status); return r.text(); }
+      async function fetchBuffer(u) { const r = await fetch(u); if (!r.ok) throw new Error(u + " " + r.status); return r.arrayBuffer(); }
+
+      async function show(entry) {
+        if (session) session.stop();
+        setStatus("loading " + entry.title + "…");
+        try {
+          session = await window.RangerModelViewer.launch({
+            bundleSource, zipBuffer, canvas, size: 384, dir: entry.dir, file: entry.file,
+          });
+          session.autospin = spinEl.checked;
+          setStatus(entry.title + " — drag to rotate");
+        } catch (e) {
+          setStatus("error: " + e.message);
+          console.error(e);
+        }
+      }
+
+      async function boot() {
+        try {
+          bundleSource = await fetchText("./viewer.bundle.js");
+          zipBuffer = await fetchBuffer("./models.zip");
+          registry = JSON.parse(await fetchText("./models.json"));
+          modelEl.innerHTML = registry.map((m, i) => '<option value="' + i + '">' + m.title + "</option>").join("");
+          modelEl.onchange = () => show(registry[+modelEl.value]);
+          spinEl.onchange = () => { if (session) session.autospin = spinEl.checked; };
+          await show(registry[0]);
+        } catch (e) {
+          setStatus("error: " + e.message);
+          console.error(e);
+        }
+      }
+      boot();
+    </script>
+  </body>
+</html>

--- a/gallery/game_engine/web/src/engine-host.js
+++ b/gallery/game_engine/web/src/engine-host.js
@@ -51,8 +51,11 @@
       bundleSource,
     );
     const mod = { exports: {} };
+    // The bundle epilogue `return { ... }` yields the exported classes (e.g.
+    // WebGameHost, WebModelViewer). Fall back to module.exports if a bundle used
+    // CommonJS instead.
     const api = factory(req, proc, Buf, mod, mod.exports);
-    return api && api.WebGameHost ? api : mod.exports;
+    return api && Object.keys(api).length ? api : mod.exports;
   }
 
   root.RangerEngineHost = { createEngine };

--- a/gallery/game_engine/web/src/model-viewer.js
+++ b/gallery/game_engine/web/src/model-viewer.js
@@ -1,0 +1,100 @@
+// ============================================================================
+// model-viewer.js — drive a Ranger WebModelViewer onto a canvas (browser only).
+// ============================================================================
+//
+// Mounts a GLB package into a VFS, instantiates the compiled 3D viewer, and runs
+// a requestAnimationFrame loop that orbits the camera and blits the renderer's
+// RGB buffer to the canvas. Drag to rotate; it auto-spins when idle.
+// ============================================================================
+
+(function (root) {
+  "use strict";
+
+  class ModelSession {
+    constructor(config) {
+      this.canvas = config.canvas;
+      this.ctx = this.canvas.getContext("2d");
+      this.viewer = config.viewer; // engine WebModelViewer instance
+      this.size = config.size || 384;
+      this.canvas.width = this.size;
+      this.canvas.height = this.size;
+      this._image = this.ctx.createImageData(this.size, this.size);
+      this.orbit = 0.6;
+      this.autospin = true;
+      this._raf = 0;
+      this._dragging = false;
+      this._lastX = 0;
+      this._tick = this._tick.bind(this);
+      this._bindDrag();
+    }
+
+    _bindDrag() {
+      const c = this.canvas;
+      c.style.cursor = "grab";
+      c.addEventListener("pointerdown", (e) => {
+        this._dragging = true;
+        this.autospin = false;
+        this._lastX = e.clientX;
+        c.setPointerCapture(e.pointerId);
+        c.style.cursor = "grabbing";
+      });
+      c.addEventListener("pointermove", (e) => {
+        if (!this._dragging) return;
+        this.orbit += (e.clientX - this._lastX) * 0.01;
+        this._lastX = e.clientX;
+      });
+      const end = () => { this._dragging = false; c.style.cursor = "grab"; };
+      c.addEventListener("pointerup", end);
+      c.addEventListener("pointercancel", end);
+    }
+
+    load(dir, file) {
+      const ok = this.viewer.load(dir, file);
+      if (!ok) throw new Error("model load failed: " + this.viewer.error());
+      this.renderOnce();
+      return ok;
+    }
+
+    renderOnce() {
+      this.viewer.setOrbit(this.orbit);
+      this.viewer.render(this.size, this.size);
+      const rgb = new Uint8Array(this.viewer.raw()); // w*h*3
+      const out = this._image.data; // w*h*4
+      for (let i = 0, j = 0; j < rgb.length; i += 4, j += 3) {
+        out[i] = rgb[j];
+        out[i + 1] = rgb[j + 1];
+        out[i + 2] = rgb[j + 2];
+        out[i + 3] = 255;
+      }
+      this.ctx.putImageData(this._image, 0, 0);
+    }
+
+    start() {
+      if (!this._raf) this._raf = requestAnimationFrame(this._tick);
+      return this;
+    }
+    stop() {
+      if (this._raf) cancelAnimationFrame(this._raf);
+      this._raf = 0;
+    }
+
+    _tick() {
+      if (this.autospin) this.orbit += 0.02;
+      this.renderOnce();
+      this._raf = requestAnimationFrame(this._tick);
+    }
+  }
+
+  async function launch(config) {
+    const vfs = new root.RangerVFS();
+    if (config.zipBuffer) vfs.mountZip(config.zipBuffer);
+    const engine = root.RangerEngineHost.createEngine(config.bundleSource, vfs, {});
+    const viewer = new engine.WebModelViewer();
+    const session = new ModelSession({ canvas: config.canvas, viewer, size: config.size });
+    session.load(config.dir, config.file);
+    if (config.autostart !== false) session.start();
+    return session;
+  }
+
+  root.RangerModelViewer = { ModelSession, launch };
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/gallery/game_engine/web/web_model_viewer.rgr
+++ b/gallery/game_engine/web/web_model_viewer.rgr
@@ -1,0 +1,82 @@
+; ==============================================================================
+; web_model_viewer — browser-facing wrapper for the model3d 3D asset pipeline.
+; ==============================================================================
+;
+; Same host-side (no-WASM, no-GPU) path the model3d/demo uses, exposed as a flat
+; API the JS/canvas harness drives:
+;
+;   ModelLoader   parses a GLB (glTF container + accessors + embedded PNG/JPEG)
+;   instantiate   builds the entity scene with world transforms
+;   SoftRenderer3D z-buffered, textured, directionally-lit software rasteriser
+;
+; File reads (the .glb) go through the same require('fs') the VFS shims, so the
+; model is just mounted into the VFS at its repo-relative path. render() fills an
+; RGB buffer (renderer.color) that the JS side turns into ImageData.
+; ==============================================================================
+
+Import "../model3d/ModelLoader.rgr"
+Import "../model3d/demo/SoftRenderer3D.rgr"
+
+class WebModelViewer {
+    def loader:ModelLoader (new ModelLoader)
+    def renderer:SoftRenderer3D (new SoftRenderer3D)
+    def modelId:int 0
+    def loaded:boolean false
+
+    ; Load + instantiate a GLB from the VFS. Returns false on parse failure
+    ; (see error()).
+    fn load:boolean (dir:string file:string) {
+        loaded = false
+        modelId = (loader.loadFromFile(dir file))
+        if (loader.ok == false) {
+            return false
+        }
+        loader.instantiate(modelId)
+        loaded = true
+        return true
+    }
+
+    ; Orbit the camera around the world-up axis (radians). Advance it per frame
+    ; for a spinning model.
+    fn setOrbit:void (rad:double) {
+        renderer.orbitYRad = rad
+    }
+
+    ; Software-render the loaded model into an w*h RGB frame. Camera auto-frames
+    ; the model's world bounding box.
+    fn render:void (w:int h:int) {
+        renderer.init(w h)
+        if (loaded == false) {
+            return
+        }
+        def model:ModelAsset (loader.getModel(modelId))
+        renderer.renderModel(model loader.entities)
+    }
+
+    ; The rendered frame as tightly packed RGB (w*h*3 bytes).
+    fn raw:buffer () {
+        return (renderer.color)
+    }
+
+    fn width:int () {
+        return (renderer.w)
+    }
+
+    fn height:int () {
+        return (renderer.h)
+    }
+
+    fn triangleCount:int () {
+        if (loaded == false) {
+            return 0
+        }
+        def model:ModelAsset (loader.getModel(modelId))
+        def mesh:MeshAsset (model.getMesh(0))
+        def prim:MeshPrimitiveAsset (itemAt mesh.primitives 0)
+        return (idiv (prim.indexCount()) 3)
+    }
+
+    fn error:string () {
+        return (loader.lastError)
+    }
+}


### PR DESCRIPTION
A browser page that loads real **`.glb`** (glTF) models and software-renders them client-side — **no WASM, no WebGL** — using Ranger's `model3d` pipeline compiled to JavaScript.

```
GLB → ModelLoader (glTF container + accessors + embedded PNG/JPEG texture)
    → instantiate (entity scene + world transforms)
    → SoftRenderer3D (textured, directionally-lit, z-buffered rasteriser)
    → RGB buffer → canvas
```

The GLB read goes through the same VFS-backed `require('fs')` the games site uses, so a model is just a file mounted into the VFS. This is the **same renderer as the native build** — it gained only one optional field.

### Changes
- **`web_model_viewer.rgr`** — `WebModelViewer`: `load(dir,file)` / `render(w,h)` / `raw()` (RGB) / `setOrbit(rad)`. Compiled to `viewer.bundle.js`.
- **`src/model-viewer.js`** — rAF loop: orbit the camera, blit RGB→RGBA; **drag to rotate**, auto-spin when idle.
- **`model3d.html`** — model picker (Duck, textured box, trees — all already committed in `games/model_viewer_wasm/models/`) + auto-spin toggle.
- **`build-model3d.mjs`** — compiles the viewer and packages the GLBs into a stored zip.
- **`SoftRenderer3D.rgr`** — added an optional `orbitYRad` field (default `0` = unchanged); the existing `render_glb_demo` behaves identically.
- **`engine-host.js`** — return whatever the bundle exports (was hardcoded to `WebGameHost`) so it also serves `WebModelViewer`.
- **`deploy-pages.yml`** — build the demo into `_site/games/model3d`.

### Verification
Chromium (Playwright): the Khronos **Duck** loads, renders textured + lit + z-buffered, and **spins** (canvas pixels change frame-to-frame); switching to the textured box works. Headless render of Duck = 4212 triangles.

### Notes
- No new binary assets — reuses GLBs already committed in the repo (incl. Khronos `Duck.glb`/`BoxTextured.glb`).
- Builds on the merged browser-engine + VFS foundation (#327). Independent of the open web PRs #328/#329/#332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2SqqCTtqwuuw9ZHhsPxyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2SqqCTtqwuuw9ZHhsPxyj)_