### PR TITLE
docs: note freestanding-WASM lambda/closure support in README + IDEAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ npm run demo:wasm            # smaller freestanding WASM demo (tests/fixtures/ll
 
 **Checked-in sample:** [`gallery/invaders/llvm/invaders.ll`](gallery/invaders/llvm/invaders.ll) is LLVM IR kept in the repo so you can inspect codegen without building. Regenerate with `cp tmp/invaders-native/invaders.ll gallery/invaders/llvm/invaders.ll` after `game:build:llvm` (see [`gallery/invaders/llvm/README.md`](gallery/invaders/llvm/README.md)).
 
-Status: experimental — libc-linked native builds are the most reliable path; freestanding WAT/WASM for the full game is still incomplete (terminal imports, control-flow lowering). Smaller WASM demos under `npm run demo:wasm` are closer to working in the browser.
+Status: experimental — libc-linked native builds are the most reliable path. The freestanding WAT/WASM path (`-wasmrc`) now has a reference-counting runtime (free-list heap with `memory.grow`, typedesc-driven recursive object destruction), classes with reference-counted fields, singletons, strings, `[T]`/`[K:V]` collections, and lambdas/closures (function table + `call_indirect`, with value/object capture and mutation); the `gallery/game_engine/games/ranger_autopeli` guest is authored in Ranger and compiles to WASM this way. Terminal-import lowering for the full Space Invaders game is still incomplete. Smaller freestanding demos run under `npm run demo:wasm`.
 
 #### Cross-Compiling the Game
 
@@ -1346,6 +1346,8 @@ this.foo({
     print txt + " = " i
 })
 ```
+
+Lambdas compile on every backend, including the freestanding WASM/WAT path (`-wasmrc`): each body is hoisted to a function-table entry and calls go through `call_indirect`, with the value a reference-counted closure record. Captured variables are copied (values/strings) or retained (objects); a captured object can be mutated through the closure, and a captured value can be shared by boxing it in a heap cell.
 
 # Automatically infixed math support
 

--- a/gallery/game_engine/IDEAL.md
+++ b/gallery/game_engine/IDEAL.md
@@ -238,9 +238,10 @@ The shared ABI is three headers: `wasm/wasm_game_abi.h` (RGW1, world/physics),
 `wasm/wasm_sprite_abi.h` (RGSP1, characters), `wasm/wasm_ui_abi.h` (RGU1, UI).
 
 > **"guest" vs "host" — say it once, precisely.** The **guest is the game itself**,
-> compiled to a WASM module — normally written in **Rust** (`wasm/rust_*/src/lib.rs`)
-> or **AssemblyScript** (`wasm/as_*/assembly/index.ts`), or run through the interpreted
-> `.as` path. The **host** is the Ranger engine (`scripting/` `.rgr` files) that loads
+> compiled to a WASM module — written in **Rust** (`wasm/rust_*/src/lib.rs`),
+> **AssemblyScript** (`wasm/as_*/assembly/index.ts`), the interpreted `.as` path, or
+> in **Ranger** itself (`games/ranger_autopeli/src/*.rgr`, compiled through the WAT
+> backend). The **host** is the Ranger engine (`scripting/` `.rgr` files) that loads
 > that module and drives it each frame. The only thing crossing between them is the
 > shared linear-memory block described by the ABI header — no pointers, no objects.
 >


### PR DESCRIPTION
Root README: update the LLVM/WASM status to state what the freestanding WAT path (-wasmrc) now supports (RC runtime, classes/fields, singletons, strings, collections, lambdas/closures), and add a line to the lambdas section noting they lower to a function table + call_indirect with value/object capture.

game_engine/IDEAL.md: the guest/host callout now lists Ranger (compiled through the WAT backend) alongside Rust and AssemblyScript as a guest-authoring option.


Claude-Session: https://claude.ai/code/session_01PhKhA739wK4UTfc4WurqSS