### PR TITLE
Fix Ylos 3: load next level after reaching the goal

### DIFF
--- a/gallery/game_engine/docs/GAME_SCREENS_AND_STORAGE.md
+++ b/gallery/game_engine/docs/GAME_SCREENS_AND_STORAGE.md
@@ -125,7 +125,8 @@ declare function resetGameData(): void;
 | Tiedosto | Rooli |
 |----------|-------|
 | `game_host_native.rgr` | Native bridge: kutsujen käsittely, polkujen ratkaisu |
-| `game_sdl_runner.rgr` | Navigaatiopino, `loadScriptAt`, äänen nollaus |
+| `game_sdl_runner.rgr` | Navigaatiopino, `loadScriptAt`, äänen nollaus; split-modessa `drainSplitScriptNavigation` lukee pane-bridgen `pushGame`/`loadGame` |
+| `game_split_screen.rgr` | Kaksi `GameHostNativeBridge`-instanssia; `consumePendingNav` |
 | `game_persistence.rgr` | JSON luku/kirjoitus `gamedata.json` |
 | `game_runtime.rgr` | `resources()`, `backgroundImage()`, `setupScene()` |
 

--- a/gallery/game_engine/games/ylos3/ylos3_shared.tsx
+++ b/gallery/game_engine/games/ylos3/ylos3_shared.tsx
@@ -2035,6 +2035,22 @@ function playerVictoryReady(pl: Player) {
   return pl.done == 1 && pl.finishMs >= FINISH_PHASE_DONE;
 }
 
+// Level is cleared as soon as the required player(s) touch the goal — do not
+// wait for the long finish walk (FINISH_PHASE_DONE). Invaders uses the same
+// "clear → short celebrate → pushGame" pattern.
+function levelCleared(slots: i32, p1: Player, p2: Player) {
+  if (slots == 1) {
+    return p1.done == 1;
+  }
+  if (p1.done == 0) {
+    return false;
+  }
+  if (p2.done == 0) {
+    return false;
+  }
+  return true;
+}
+
 function showVictoryBanner(s: GameSnapshot) {
   if (s.playerSlots == 1) {
     return playerVictoryReady(s.p1);
@@ -2148,17 +2164,19 @@ function tickFinishPlayer(pl: Player, dt: f64, events: GameEvent[]): Player {
 
 export function playHud(props) {
   const s = props.state;
+  const slots = playerSlots();
+  const cleared = levelCleared(slots, s.p1, s.p2);
   const victory = showVictoryBanner(s);
   const localSlot = localPlayerSlot();
   let msg = "Ylos 3 — Viidakko! Kerää timantteja = supervoima.";
-  if (victory == 0) {
+  if (cleared == 0) {
     if (isSplitPane()) {
       if (paneIndex == 0) {
         msg = "Vasen — tyttö (P1). Pääse maaliin!";
       } else {
         msg = "Oikea — poika (P2). Pääse maaliin!";
       }
-    } else if (s.playerSlots == 2) {
+    } else if (slots == 2) {
       msg = msg + " Ensimmäinen maaliin juhlii — toinen jatkaa!";
     } else {
       msg = cfg().label + " — pääse temppeliin!";
@@ -2170,7 +2188,7 @@ export function playHud(props) {
         msg = "P1 MAALISSA!";
       }
     }
-    if (s.playerSlots == 2) {
+    if (slots == 2) {
       if (s.p2.done == 1) {
         if (s.p1.done == 1) {
           msg = "MOLEMMAT MAALISSA!";
@@ -2181,7 +2199,7 @@ export function playHud(props) {
     }
   }
   let scoreLine = "Hedelmät: " + s.score1;
-  if (s.playerSlots == 2) {
+  if (slots == 2) {
     scoreLine = "Hedelmät P1:" + s.score1 + "  P2:" + s.score2;
   }
   let superLine = "";
@@ -2192,7 +2210,7 @@ export function playHud(props) {
       superLine = "P1 SUPER!";
     }
   }
-  if (s.playerSlots == 2) {
+  if (slots == 2) {
     if (s.p2.superMs > 0) {
       if (superLine.length > 0) {
         superLine = superLine + "  ";
@@ -2201,10 +2219,14 @@ export function playHud(props) {
     }
   }
   let victoryLine = "";
-if (victory == 1) {
+  if (cleared == 1) {
     if (cfg().isFinal) {
       victoryLine = "Viidakko valloittettu!";
-      msg = "Paina Space — pelaa uudelleen";
+      if (victory == 1) {
+        msg = "Paina Space — pelaa uudelleen";
+      } else {
+        msg = "Juhli huipulla…";
+      }
     } else {
       victoryLine = "Taso selvitetty!";
       msg = "Seuraava taso latautuu…";
@@ -2256,7 +2278,8 @@ export function runUpdate(props) {
     }
   }
 
-  if (showVictoryBanner({ playerSlots: slots, p1: p1, p2: p2 })) {
+  // Invaders-style: once the goal is reached, celebrate briefly then pushGame.
+  if (levelCleared(slots, p1, p2)) {
     let levelLoadQueued = s.levelLoadQueued;
     if (levelLoadQueued == null) {
       levelLoadQueued = 0;
@@ -2267,10 +2290,12 @@ export function runUpdate(props) {
     }
     if (levelLoadQueued == 0) {
       if (cfg().isFinal) {
-        if (wantsRestart(props, dual)) {
-          resetGameData();
-          loadGame("index.tsx");
-          return s;
+        if (showVictoryBanner({ playerSlots: slots, p1: p1, p2: p2 })) {
+          if (wantsRestart(props, dual)) {
+            resetGameData();
+            loadGame("index.tsx");
+            return s;
+          }
         }
       } else {
         celebrateMs = celebrateMs - dt;

--- a/gallery/game_engine/games/ylos3/ylos3_shared.tsx
+++ b/gallery/game_engine/games/ylos3/ylos3_shared.tsx
@@ -2220,7 +2220,7 @@ export function playHud(props) {
   }
   let victoryLine = "";
   if (cleared == 1) {
-    if (cfg().isFinal) {
+    if (cfg().nextLevel == "") {
       victoryLine = "Viidakko valloittettu!";
       if (victory == 1) {
         msg = "Paina Space — pelaa uudelleen";
@@ -2289,7 +2289,9 @@ export function runUpdate(props) {
       celebrateMs = LEVEL_LOAD_MS;
     }
     if (levelLoadQueued == 0) {
-      if (cfg().isFinal) {
+      // Prefer nextLevel string (Invaders-style) over boolean isFinal — more
+      // reliable across the TSX evaluator than truthiness of `false`.
+      if (cfg().nextLevel == "") {
         if (showVictoryBanner({ playerSlots: slots, p1: p1, p2: p2 })) {
           if (wantsRestart(props, dual)) {
             resetGameData();

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -950,6 +950,55 @@ class GameSdlRunner {
         }
     }
 
+    ; Split-screen panes each have their own GameHostNativeBridge. pushGame /
+    ; loadGame from a pane script lands on leftBridge/rightBridge — not the
+    ; solo nativeBridge — so the solo drainScriptNavigation never saw them
+    ; (Ylos 3 / Invaders level advance was a no-op in split). Reload both panes.
+    fn reloadSplitPanes:void (tsxPath:string) {
+        gfx_audio_clear
+        splitHost.clearPendingNav()
+        currentGamePath = tsxPath
+        currentScriptPath = tsxPath
+        splitHost.loadPanes(tsxPath tsxPath)
+        inMenu = false
+        inGame = true
+        this.syncInputEdges()
+        gfx_clear_should_close
+        print ("[split-screen] nav reload both panes: " + tsxPath)
+    }
+
+    fn drainSplitScriptNavigation:void () {
+        if (false == (splitHost.consumePendingNav())) {
+            return
+        }
+        def op:string splitHost.lastNavOp
+        def path:string splitHost.lastNavPath
+        if (op == "load") {
+            if ((strlen path) > 0) {
+                this.clearNavStack()
+                this.reloadSplitPanes(path)
+            }
+            return
+        }
+        if (op == "push") {
+            if ((strlen path) > 0) {
+                this.pushNavStack(currentScriptPath)
+                this.reloadSplitPanes(path)
+            }
+            return
+        }
+        if (op == "pop") {
+            def prev:string (this.popNavStack())
+            if ((strlen prev) == 0) {
+                inGame = false
+                splitScreenActive = false
+                return
+            }
+            this.reloadSplitPanes(prev)
+            return
+        }
+    }
+
     fn maybePollCatalog:void () {
         def now:int (gfx_ticks_ms)
         if ((now - lastCatalogPoll) < catalogPollMs) {
@@ -1880,6 +1929,7 @@ class GameSdlRunner {
                         wasmSplitHost.frame(dtMs)
                     } {
                         splitHost.frameWithInput(dtMs)
+                        this.drainSplitScriptNavigation()
                     }
                 }
             } {

--- a/gallery/game_engine/scripting/game_split_nav_demo.rgr
+++ b/gallery/game_engine/scripting/game_split_nav_demo.rgr
@@ -1,0 +1,65 @@
+; ==============================================================================
+; game_split_nav_demo — self-check for pane-bridge pushGame/loadGame pending ops.
+; ==============================================================================
+;
+; Split-screen panes each own a GameHostNativeBridge. pushGame from a game
+; script lands on that bridge; the SDL host must drain it (see
+; drainSplitScriptNavigation). This demo checks the bridge queue + path resolve
+; that consumePendingNav relies on — without pulling the full SplitScreenHost
+; (SdlGameHost) graph.
+
+Import "./game_host_native.rgr"
+
+class GameSplitNavDemo {
+    sfn consumeFrom:boolean (primary:GameHostNativeBridge other:GameHostNativeBridge expectOp:string needle:string) {
+        if (false == (primary.hasPendingNav())) {
+            print ("FAIL: expected pending on primary for " + expectOp)
+            return false
+        }
+        def op:string (primary.takePendingNavOp())
+        def path:string (primary.takePendingNavPath())
+        primary.takePendingPopToMenu()
+        other.clearPendingNav()
+        if (op != expectOp) {
+            print ((("FAIL: expected op " + expectOp) + ", got ") + op)
+            return false
+        }
+        if ((indexOf path needle) < 0) {
+            print ((("FAIL: path missing " + needle) + ": ") + path)
+            return false
+        }
+        return true
+    }
+
+    sfn m@(main):void () {
+        def leftBridge:GameHostNativeBridge (new GameHostNativeBridge)
+        def rightBridge:GameHostNativeBridge (new GameHostNativeBridge)
+        leftBridge.setGameDir("gallery/game_engine/games/ylos3")
+        rightBridge.setGameDir("gallery/game_engine/games/ylos3")
+
+        def pushArgs:[EvalValue]
+        push pushArgs (EvalValue.string("level2.tsx"))
+        leftBridge.invoke("pushGame" pushArgs)
+        if (false == (GameSplitNavDemo.consumeFrom(leftBridge rightBridge "push" "level2.tsx"))) {
+            return
+        }
+
+        def loadArgs:[EvalValue]
+        push loadArgs (EvalValue.string("index.tsx"))
+        rightBridge.invoke("loadGame" loadArgs)
+        if (false == (GameSplitNavDemo.consumeFrom(rightBridge leftBridge "load" "index.tsx"))) {
+            return
+        }
+
+        if (leftBridge.hasPendingNav()) {
+            print "FAIL: left still pending"
+            return
+        }
+        if (rightBridge.hasPendingNav()) {
+            print "FAIL: right still pending"
+            return
+        }
+
+        print "split-nav OK"
+    }
+}

--- a/gallery/game_engine/scripting/game_split_screen.rgr
+++ b/gallery/game_engine/scripting/game_split_screen.rgr
@@ -39,6 +39,9 @@ class SplitScreenHost {
     def profFrames:int 0
     def leftScriptPath:string ""
     def rightScriptPath:string ""
+    ; Filled by consumePendingNav() for the SDL host to apply once per frame.
+    def lastNavOp:string ""
+    def lastNavPath:string ""
 
     fn half:int (n:int) {
         def result 0
@@ -298,5 +301,34 @@ class SplitScreenHost {
             return true
         }
         return false
+    }
+
+    ; Consume pushGame/loadGame/popGame from either pane bridge (left wins if
+    ; both fired the same frame). Clears the other bridge so nav is applied once.
+    ; Returns true when an op was pending; read it via lastNavOp / lastNavPath.
+    fn consumePendingNav:boolean () {
+        lastNavOp = ""
+        lastNavPath = ""
+        if (leftBridge.hasPendingNav()) {
+            lastNavOp = (leftBridge.takePendingNavOp())
+            lastNavPath = (leftBridge.takePendingNavPath())
+            leftBridge.takePendingPopToMenu()
+            rightBridge.clearPendingNav()
+            return true
+        }
+        if (rightBridge.hasPendingNav()) {
+            lastNavOp = (rightBridge.takePendingNavOp())
+            lastNavPath = (rightBridge.takePendingNavPath())
+            rightBridge.takePendingPopToMenu()
+            return true
+        }
+        return false
+    }
+
+    fn clearPendingNav:void () {
+        leftBridge.clearPendingNav()
+        rightBridge.clearPendingNav()
+        lastNavOp = ""
+        lastNavPath = ""
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause (not the 7.5s celebrate)

Ylos 3 runs in **split-screen** (`splitScreen=auto`). Each pane has its own `GameHostNativeBridge`. `pushGame("level2.tsx")` was queued on `leftBridge` / `rightBridge`, but the SDL host only drained the **solo** `nativeBridge` after non-split frames.

So the next level **never loaded**, no matter how long you waited. The earlier FINISH_PHASE_DONE timing was a red herring.

## Fix

1. **`SplitScreenHost.consumePendingNav`** — read pending push/load/pop from either pane bridge
2. **`drainSplitScriptNavigation`** — after each split frame, reload **both** panes on nav
3. **Ylos 3** — still advances shortly after `done==1` (Invaders-style), using `nextLevel` string

## Verify

```bash
npm run engine:game-sdl:run:ylos3
```

Reach the goal in split-screen; after ~2s both panes should load level 2 (köysisillat).

Headless bridge check:
```bash
RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -es6 \
  ./gallery/game_engine/scripting/game_split_nav_demo.rgr \
  -d=./tests/.output -o=game_split_nav_demo.js -nodecli \
&& node ./tests/.output/game_split_nav_demo.js
# → split-nav OK
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6f5c-9fd4-7dc0-b3a6-7fb5985dca81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6f5c-9fd4-7dc0-b3a6-7fb5985dca81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

