### PR TITLE
Split-screen: load next level only for the pane that finished

### DIFF
--- a/gallery/game_engine/docs/GAME_SCREENS_AND_STORAGE.md
+++ b/gallery/game_engine/docs/GAME_SCREENS_AND_STORAGE.md
@@ -125,8 +125,8 @@ declare function resetGameData(): void;
 | Tiedosto | Rooli |
 |----------|-------|
 | `game_host_native.rgr` | Native bridge: kutsujen käsittely, polkujen ratkaisu |
-| `game_sdl_runner.rgr` | Navigaatiopino, `loadScriptAt`, äänen nollaus; split-modessa `drainSplitScriptNavigation` lukee pane-bridgen `pushGame`/`loadGame` |
-| `game_split_screen.rgr` | Kaksi `GameHostNativeBridge`-instanssia; `consumePendingNav` |
+| `game_sdl_runner.rgr` | Navigaatiopino, `loadScriptAt`, äänen nollaus; split-modessa `drainSplitScriptNavigation` lataa **vain sen paneelin**, joka kutsui `pushGame`/`loadGame` |
+| `game_split_screen.rgr` | Kaksi `GameHostNativeBridge`-instanssia; `consumePendingNav` + `reloadPane` |
 | `game_persistence.rgr` | JSON luku/kirjoitus `gamedata.json` |
 | `game_runtime.rgr` | `resources()`, `backgroundImage()`, `setupScene()` |
 

--- a/gallery/game_engine/scripting/game_sdl_runner.rgr
+++ b/gallery/game_engine/scripting/game_sdl_runner.rgr
@@ -951,20 +951,15 @@ class GameSdlRunner {
     }
 
     ; Split-screen panes each have their own GameHostNativeBridge. pushGame /
-    ; loadGame from a pane script lands on leftBridge/rightBridge — not the
-    ; solo nativeBridge — so the solo drainScriptNavigation never saw them
-    ; (Ylos 3 / Invaders level advance was a no-op in split). Reload both panes.
-    fn reloadSplitPanes:void (tsxPath:string) {
-        gfx_audio_clear
-        splitHost.clearPendingNav()
-        currentGamePath = tsxPath
-        currentScriptPath = tsxPath
-        splitHost.loadPanes(tsxPath tsxPath)
+    ; loadGame from a pane lands on leftBridge/rightBridge. Reload only the
+    ; pane that requested nav so the other player's session keeps running.
+    fn reloadSplitPane:void (pane:int tsxPath:string) {
+        splitHost.reloadPane(pane tsxPath)
         inMenu = false
         inGame = true
         this.syncInputEdges()
         gfx_clear_should_close
-        print ("[split-screen] nav reload both panes: " + tsxPath)
+        print ((("[split-screen] nav reload pane " + pane) + ": ") + tsxPath)
     }
 
     fn drainSplitScriptNavigation:void () {
@@ -973,28 +968,32 @@ class GameSdlRunner {
         }
         def op:string splitHost.lastNavOp
         def path:string splitHost.lastNavPath
+        def pane:int splitHost.lastNavPane
         if (op == "load") {
             if ((strlen path) > 0) {
-                this.clearNavStack()
-                this.reloadSplitPanes(path)
+                ; loadGame replaces that pane's screen and drops its push history.
+                splitHost.clearPanePrev(pane)
+                this.reloadSplitPane(pane path)
             }
             return
         }
         if (op == "push") {
             if ((strlen path) > 0) {
-                this.pushNavStack(currentScriptPath)
-                this.reloadSplitPanes(path)
+                splitHost.pushPanePath(pane)
+                this.reloadSplitPane(pane path)
             }
             return
         }
         if (op == "pop") {
-            def prev:string (this.popNavStack())
+            def prev:string (splitHost.popPanePath(pane))
             if ((strlen prev) == 0) {
+                ; No per-pane history — leave split and return to launcher,
+                ; same as solo pop with an empty stack.
                 inGame = false
                 splitScreenActive = false
                 return
             }
-            this.reloadSplitPanes(prev)
+            this.reloadSplitPane(pane prev)
             return
         }
     }

--- a/gallery/game_engine/scripting/game_split_nav_demo.rgr
+++ b/gallery/game_engine/scripting/game_split_nav_demo.rgr
@@ -1,36 +1,10 @@
 ; ==============================================================================
-; game_split_nav_demo — self-check for pane-bridge pushGame/loadGame pending ops.
+; game_split_nav_demo — pane bridges keep independent pushGame/loadGame queues.
 ; ==============================================================================
-;
-; Split-screen panes each own a GameHostNativeBridge. pushGame from a game
-; script lands on that bridge; the SDL host must drain it (see
-; drainSplitScriptNavigation). This demo checks the bridge queue + path resolve
-; that consumePendingNav relies on — without pulling the full SplitScreenHost
-; (SdlGameHost) graph.
 
 Import "./game_host_native.rgr"
 
 class GameSplitNavDemo {
-    sfn consumeFrom:boolean (primary:GameHostNativeBridge other:GameHostNativeBridge expectOp:string needle:string) {
-        if (false == (primary.hasPendingNav())) {
-            print ("FAIL: expected pending on primary for " + expectOp)
-            return false
-        }
-        def op:string (primary.takePendingNavOp())
-        def path:string (primary.takePendingNavPath())
-        primary.takePendingPopToMenu()
-        other.clearPendingNav()
-        if (op != expectOp) {
-            print ((("FAIL: expected op " + expectOp) + ", got ") + op)
-            return false
-        }
-        if ((indexOf path needle) < 0) {
-            print ((("FAIL: path missing " + needle) + ": ") + path)
-            return false
-        }
-        return true
-    }
-
     sfn m@(main):void () {
         def leftBridge:GameHostNativeBridge (new GameHostNativeBridge)
         def rightBridge:GameHostNativeBridge (new GameHostNativeBridge)
@@ -40,23 +14,41 @@ class GameSplitNavDemo {
         def pushArgs:[EvalValue]
         push pushArgs (EvalValue.string("level2.tsx"))
         leftBridge.invoke("pushGame" pushArgs)
-        if (false == (GameSplitNavDemo.consumeFrom(leftBridge rightBridge "push" "level2.tsx"))) {
-            return
-        }
 
         def loadArgs:[EvalValue]
-        push loadArgs (EvalValue.string("index.tsx"))
+        push loadArgs (EvalValue.string("level3.tsx"))
         rightBridge.invoke("loadGame" loadArgs)
-        if (false == (GameSplitNavDemo.consumeFrom(rightBridge leftBridge "load" "index.tsx"))) {
+
+        ; Consume left only — right must still be pending (per-pane sessions).
+        if (false == (leftBridge.hasPendingNav())) {
+            print "FAIL: left pushGame not pending"
+            return
+        }
+        def opL:string (leftBridge.takePendingNavOp())
+        def pathL:string (leftBridge.takePendingNavPath())
+        leftBridge.takePendingPopToMenu()
+        if (opL != "push") {
+            print ("FAIL: left op " + opL)
+            return
+        }
+        if ((indexOf pathL "level2.tsx") < 0) {
+            print ("FAIL: left path " + pathL)
+            return
+        }
+        if (false == (rightBridge.hasPendingNav())) {
+            print "FAIL: right pending was lost when left consumed"
             return
         }
 
-        if (leftBridge.hasPendingNav()) {
-            print "FAIL: left still pending"
+        def opR:string (rightBridge.takePendingNavOp())
+        def pathR:string (rightBridge.takePendingNavPath())
+        rightBridge.takePendingPopToMenu()
+        if (opR != "load") {
+            print ("FAIL: right op " + opR)
             return
         }
-        if (rightBridge.hasPendingNav()) {
-            print "FAIL: right still pending"
+        if ((indexOf pathR "level3.tsx") < 0) {
+            print ("FAIL: right path " + pathR)
             return
         }
 

--- a/gallery/game_engine/scripting/game_split_screen.rgr
+++ b/gallery/game_engine/scripting/game_split_screen.rgr
@@ -42,6 +42,10 @@ class SplitScreenHost {
     ; Filled by consumePendingNav() for the SDL host to apply once per frame.
     def lastNavOp:string ""
     def lastNavPath:string ""
+    def lastNavPane:int -1
+    ; One-deep prev path per pane so popGame can restore that pane only.
+    def leftPrevPath:string ""
+    def rightPrevPath:string ""
 
     fn half:int (n:int) {
         def result 0
@@ -303,23 +307,26 @@ class SplitScreenHost {
         return false
     }
 
-    ; Consume pushGame/loadGame/popGame from either pane bridge (left wins if
-    ; both fired the same frame). Clears the other bridge so nav is applied once.
-    ; Returns true when an op was pending; read it via lastNavOp / lastNavPath.
+    ; Consume pushGame/loadGame/popGame from one pane bridge (left first if
+    ; both pending — right is handled next frame). Does NOT clear the other
+    ; pane: each session advances independently.
+    ; Returns true when an op was pending; read lastNavOp / lastNavPath / lastNavPane.
     fn consumePendingNav:boolean () {
         lastNavOp = ""
         lastNavPath = ""
+        lastNavPane = -1
         if (leftBridge.hasPendingNav()) {
             lastNavOp = (leftBridge.takePendingNavOp())
             lastNavPath = (leftBridge.takePendingNavPath())
             leftBridge.takePendingPopToMenu()
-            rightBridge.clearPendingNav()
+            lastNavPane = 0
             return true
         }
         if (rightBridge.hasPendingNav()) {
             lastNavOp = (rightBridge.takePendingNavOp())
             lastNavPath = (rightBridge.takePendingNavPath())
             rightBridge.takePendingPopToMenu()
+            lastNavPane = 1
             return true
         }
         return false
@@ -330,5 +337,54 @@ class SplitScreenHost {
         rightBridge.clearPendingNav()
         lastNavOp = ""
         lastNavPath = ""
+        lastNavPane = -1
+    }
+
+    ; Reload a single pane's script. The other pane's runner/state is untouched.
+    fn reloadPane:void (pane:int tsxPath:string) {
+        if (pane == 0) {
+            this.loadScriptAt(left leftBridge tsxPath 0)
+            leftScriptPath = tsxPath
+            return
+        }
+        if (pane == 1) {
+            this.loadScriptAt(right rightBridge tsxPath 1)
+            rightScriptPath = tsxPath
+            return
+        }
+    }
+
+    fn pushPanePath:void (pane:int) {
+        if (pane == 0) {
+            leftPrevPath = leftScriptPath
+            return
+        }
+        if (pane == 1) {
+            rightPrevPath = rightScriptPath
+        }
+    }
+
+    fn popPanePath:string (pane:int) {
+        if (pane == 0) {
+            def p:string leftPrevPath
+            leftPrevPath = ""
+            return p
+        }
+        if (pane == 1) {
+            def p2:string rightPrevPath
+            rightPrevPath = ""
+            return p2
+        }
+        return ""
+    }
+
+    fn clearPanePrev:void (pane:int) {
+        if (pane == 0) {
+            leftPrevPath = ""
+            return
+        }
+        if (pane == 1) {
+            rightPrevPath = ""
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After #341, `pushGame` worked in split-screen — but reloaded **both** panes. If P1 finished while P2 was still mid-level, P2’s session was wiped.

## Fix (host, minimal)

- `consumePendingNav` records **which pane** requested nav and does **not** clear the other bridge
- `reloadSplitPane(pane, path)` reloads only that runner
- One-deep per-pane prev path for `popGame`
- Other player’s runner/state/audio session stays intact

No game-script changes required (Ylos 3 / Invaders keep calling `pushGame` as before).

## Verify

```bash
npm run engine:game-sdl:run:ylos3
```

In split: finish on the left → only left should move to level 2; right continues.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6f5c-9fd4-7dc0-b3a6-7fb5985dca81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6f5c-9fd4-7dc0-b3a6-7fb5985dca81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

