### PR TITLE
Reduce remaining split-screen level-load hitch

### DIFF
--- a/gallery/game_engine/docs/GAME_SCREENS_AND_STORAGE.md
+++ b/gallery/game_engine/docs/GAME_SCREENS_AND_STORAGE.md
@@ -126,9 +126,11 @@ declare function resetGameData(): void;
 |----------|-------|
 | `game_host_native.rgr` | Native bridge: kutsujen käsittely, polkujen ratkaisu |
 | `game_sdl_runner.rgr` | Navigaatiopino, `loadScriptAt`, äänen nollaus; split-modessa `drainSplitScriptNavigation` lataa **vain sen paneelin**, joka kutsui `pushGame`/`loadGame` |
-| `game_split_screen.rgr` | Kaksi bridgeä; `consumePendingNav` + cooperative `beginPaneLoad`/`tickPaneLoad` (sisarus jatkaa frameja latauksen vaiheiden välillä; ei taustasäiettä) |
+| `game_split_screen.rgr` | Kaksi bridgeä; `consumePendingNav` + cooperative `beginPaneLoad`/`tickPaneLoad` (vaiheet: read → parse → prepare → paintBg → entities; sisarus jatkaa frameja vaiheiden välillä; ei taustasäiettä) |
 | `game_persistence.rgr` | JSON luku/kirjoitus `gamedata.json` |
-| `game_runtime.rgr` | `resources()`, `backgroundImage()`, `setupScene()` |
+| `game_runtime.rgr` | `resources()`, `backgroundImage()`, `setupScene()` (`setupScenePrepare` / `setupScenePaintBg` / `setupSceneEntities`) |
+
+`ComponentEngine` pitää importtien AST-välimuistia (`importAstCache`, avain = polku + mtime), joten tasolta toiselle siirryttäessä jaettu `*_shared.tsx` ei mene lexer+parserin läpi uudestaan — `materialize` ajetaan silti uuteen moduleScopeen.
 
 Testit: [`game_host_native_demo.rgr`](../scripting/game_host_native_demo.rgr)
 (persistence + `loadGame`-polku).

--- a/gallery/game_engine/games/ylos3/ylos3_shared.tsx
+++ b/gallery/game_engine/games/ylos3/ylos3_shared.tsx
@@ -881,6 +881,9 @@ function clampByte(v: f64): i32 {
 }
 
 function drawJungleGradient(kind: string) {
+  // Wider bands: ~4x fewer interpreter fillRect calls on tall levels (~2k px).
+  // Banding is soft enough under canopy/mist overlays not to read as stripes.
+  const band = 16;
   let y = 0;
   while (y < bgHeight) {
     const t = y / bgHeight;
@@ -897,8 +900,12 @@ function drawJungleGradient(kind: string) {
       g = 48 + t * 90;
       b = 28 + t * 40;
     }
-    bgFillRect(0, y, bgWidth, 4, clampByte(r), clampByte(g), clampByte(b));
-    y = y + 4;
+    let h = band;
+    if (y + h > bgHeight) {
+      h = bgHeight - y;
+    }
+    bgFillRect(0, y, bgWidth, h, clampByte(r), clampByte(g), clampByte(b));
+    y = y + band;
   }
 }
 
@@ -909,7 +916,8 @@ function drawCanopyBand(cy: i32, depth: i32) {
     const g = 55 + depth * 8;
     bgFillCircle(x, cy, rad, 18, g, 28);
     bgFillCircle(x + 16, cy + 6, rad - 6, 14, g - 10, 24);
-    x = x + 34 + (depth % 5) * 4;
+    // Slightly wider stride — fewer circles, still reads as dense canopy.
+    x = x + 44 + (depth % 5) * 4;
   }
 }
 

--- a/gallery/game_engine/scripting/game_runtime.rgr
+++ b/gallery/game_engine/scripting/game_runtime.rgr
@@ -1081,13 +1081,20 @@ class GameRunner {
         }
     }
 
-    ; Build retained entities from sprites() and init state.
-    fn setupScene:void () {
+    ; Split setup for cooperative pane loads: prepare → paint static bg → entities.
+    ; Solo hosts still call setupScene() which runs all three in one go.
+    fn setupScenePrepare:void () {
         this.wireHostAudio()
         this.setupResources()
         this.applyConfig()
         this.applyBackgroundFromScript()
+    }
+
+    fn setupScenePaintBg:void () {
         this.applyCreateStaticBg()
+    }
+
+    fn setupSceneEntities:void () {
         this.applyCamera()
         this.applyPhysics()
         state = (engine.callFunction("initState" (EvalValue.null())))
@@ -1136,6 +1143,13 @@ class GameRunner {
             }
         }
         this.syncFromState()
+    }
+
+    ; Build retained entities from sprites() and init state.
+    fn setupScene:void () {
+        this.setupScenePrepare()
+        this.setupScenePaintBg()
+        this.setupSceneEntities()
     }
 
     fn memInt:int (obj:EvalValue key:string dflt:int) {

--- a/gallery/game_engine/scripting/game_split_screen.rgr
+++ b/gallery/game_engine/scripting/game_split_screen.rgr
@@ -14,8 +14,9 @@
 ; layout itself (e.g. Ylos via bgWidth).
 ;
 ; Per-pane pushGame/loadGame uses a cooperative main-loop load (beginPaneLoad /
-; tickPaneLoad): read → parse → setupScene across frames so the sibling pane
-; keeps updating. Not a background thread — setupScene can still hitch briefly.
+; tickPaneLoad): read → parse → prepare → paintBg → entities across frames so
+; the sibling pane keeps updating. Not a background thread — createStaticBg and
+; first-time TSX parse can still hitch briefly on a single phase.
 ; ==============================================================================
 
 Import "./game_runtime.rgr"
@@ -51,7 +52,8 @@ class SplitScreenHost {
     def leftPrevPath:string ""
     def rightPrevPath:string ""
     ; Cooperative per-pane load (no threads): while one pane reloads, the
-    ; sibling keeps receiving frames. Phases: 0=idle 1=read 2=parse 3=setup.
+    ; sibling keeps receiving frames.
+    ; Phases: 0=idle 1=read 2=parse 3=prepare 4=paintBg 5=entities.
     def loadPane:int -1
     def loadPath:string ""
     def loadPhase:int 0
@@ -420,7 +422,7 @@ class SplitScreenHost {
     }
 
     ; Advance one load phase. Call at most once per host frame so the sibling
-    ; pane can update + present between read / parse / setupScene.
+    ; pane can update + present between read / parse / prepare / paintBg / entities.
     fn tickPaneLoad:void () {
         if (loadPhase <= 0) {
             return
@@ -450,7 +452,17 @@ class SplitScreenHost {
             return
         }
         if (loadPhase == 3) {
-            runner.setupScene()
+            runner.setupScenePrepare()
+            loadPhase = 4
+            return
+        }
+        if (loadPhase == 4) {
+            runner.setupScenePaintBg()
+            loadPhase = 5
+            return
+        }
+        if (loadPhase == 5) {
+            runner.setupSceneEntities()
             runner.enableGpuSheetOverlay()
             runner.trackScriptFile(loadPath)
             if (loadPane == 0) {

--- a/gallery/game_engine/scripting/import_ast_cache_demo.rgr
+++ b/gallery/game_engine/scripting/import_ast_cache_demo.rgr
@@ -1,0 +1,37 @@
+; Regression: import AST cache reuses parse across loadScript() when mtime
+; is unchanged. Second load of the same entry must still resolve imports.
+
+Import "../../pdf_writer/src/jsx/ComponentEngine.rgr"
+Import "../../pdf_writer/src/jsx/EvalValue.rgr"
+
+class ImportAstCacheDemo {
+    sfn m@(main):void () {
+        def engine (new ComponentEngine())
+        engine.quiet = true
+        engine.setBasePath("gallery/game_engine/games/ylos3/")
+        engine.addAssetPath("gallery/game_engine/scripting/")
+
+        def buf:buffer (buffer_read_file "gallery/game_engine/games/ylos3" "level2.tsx")
+        def src:string (buffer_to_string buf)
+
+        engine.loadScript(src)
+        def h1:EvalValue (engine.callFunction("staticLevelHeight" (EvalValue.null())))
+        def n1:int (to_int h1.numberValue)
+
+        ; Same engine, same file — shared imports should hit importAstCache.
+        engine.loadScript(src)
+        def h2:EvalValue (engine.callFunction("staticLevelHeight" (EvalValue.null())))
+        def n2:int (to_int h2.numberValue)
+
+        if (n1 <= 270) {
+            print ("importAstCache FAIL height1=" + n1)
+            return
+        }
+        if (n2 != n1) {
+            print ((("importAstCache FAIL height mismatch " + n1) + " vs ") + n2)
+            return
+        }
+        print (("importAstCache ok height=" + n1))
+        print "import-ast-cache-demo done"
+    }
+}

--- a/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
+++ b/gallery/pdf_writer/src/jsx/ComponentEngine.rgr
@@ -25,6 +25,17 @@ class ImportedSymbol {
     def helperFunctions:[TSNode] ; Helper functions defined in the same file
 }
 
+; Parsed import AST retained across loadScript() so shared modules (e.g. a
+; game's *_shared.tsx) are not re-lexed/re-parsed on every level transition.
+; Keyed by absolute path + mtime; materialize still runs into the new moduleScope.
+class CachedImportAst {
+    def path:string ""
+    def mtime:int 0
+    def ast:TSNode (new TSNode())
+    def dirPath:string ""
+    def relativePath:string ""
+}
+
 ; =============================================================================
 ; EvalContext - Variable scope for expression evaluation
 ; =============================================================================
@@ -177,6 +188,8 @@ class ComponentEngine {
     ; Canonical import paths currently loading / fully materialized (cycle guard).
     def importLoading:[string]
     def importLoaded:[string]
+    ; Survives loadScript(): skip tokenize+parse when path mtime is unchanged.
+    def importAstCache:[CachedImportAst]
     
     ; Evaluation context
     def context:EvalContext
@@ -250,6 +263,8 @@ class ComponentEngine {
         importLoading = il
         def id:[string]
         importLoaded = id
+        def iac:[CachedImportAst]
+        importAstCache = iac
         def host:EvalContext (new EvalContext())
         host.moduleRoot = host
         hostScope = host
@@ -945,41 +960,58 @@ class ComponentEngine {
             return
         }
 
-        print ("Loading import: " + dirPath + fullPath)
-
         ; Track loaded file for file watching
         def loadedFilePath:string (dirPath + fullPath)
         loadedFiles = (this.listWithStringIfMissing(loadedFiles loadedFilePath))
-        
-        ; Parse the imported file
-        def lexer (new TSLexer(src))
-        def tokens:[Token] (lexer.tokenize())
-        def importParser:TSParserSimple (new TSParserSimple())
-        importParser.initParser(tokens)
-        importParser.tsxMode = jsxParsing
-        def importAst:TSNode (importParser.parseProgram())
+
+        ; Reuse a previous parse of this module when mtime is unchanged. Level
+        ; transitions that re-import a large shared.tsx skip lexer+parser work.
+        ; mtime must use foundDir+fullPath (same pair as the successful read) —
+        ; dirPath is the module directory after resolving relative segments and
+        ; is not a valid file_mtime prefix when fullPath still contains "../".
+        def cacheKey:string ((this.normalizeDirPath(foundDir)) + fullPath)
+        def fileMtime:int (file_mtime foundDir fullPath)
+        def cacheIdx:int (this.findCachedImportIndex(cacheKey fileMtime))
+        def cacheHit:boolean (cacheIdx >= 0)
+        def importAstNode:TSNode (new TSNode())
+        if (cacheHit) {
+            def hit:CachedImportAst (itemAt importAstCache cacheIdx)
+            importAstNode = hit.ast
+            this.trace("Import cache hit: " + cacheKey)
+        } {
+            print ("Loading import: " + dirPath + fullPath)
+            def lexer (new TSLexer(src))
+            def tokens:[Token] (lexer.tokenize())
+            def importParser:TSParserSimple (new TSParserSimple())
+            importParser.initParser(tokens)
+            importParser.tsxMode = jsxParsing
+            importAstNode = (importParser.parseProgram())
+            this.storeCachedImportAst(cacheKey fileMtime importAstNode dirPath fullPath)
+        }
         
         ; Resolve transitive imports using this module's directory as basePath.
         def savedBasePath:string basePath
         basePath = dirPath
-        this.processImports(importAst)
+        this.processImports(importAstNode)
         basePath = savedBasePath
         
         ; Register all top-level bindings from the imported module so script
         ; code can call imported functions and read imported constants.
-        this.materializeImportedModule(importAst)
+        this.materializeImportedModule(importAstNode)
         
         ; Collect all non-exported helper functions from the file
         def helperFns:[TSNode]
         def hk:int 0
-        while (hk < (array_length importAst.children)) {
-            def hstmt:TSNode (itemAt importAst.children hk)
+        while (hk < (array_length importAstNode.children)) {
+            def hstmt:TSNode (itemAt importAstNode.children hk)
             ; Collect non-exported function declarations as helpers
             if (hstmt.nodeType == "FunctionDeclaration") {
                 def hfnName:string hstmt.name
                 if ((this.isInList(hfnName importExportNames)) == false) {
                     push helperFns hstmt
-                    print ("  Found helper function: " + hfnName)
+                    if (cacheHit == false) {
+                        print ("  Found helper function: " + hfnName)
+                    }
                 }
             }
             hk = hk + 1
@@ -987,8 +1019,8 @@ class ComponentEngine {
         
         ; Find exported functions that match imported names
         def k:int 0
-        while (k < (array_length importAst.children)) {
-            def stmt:TSNode (itemAt importAst.children k)
+        while (k < (array_length importAstNode.children)) {
+            def stmt:TSNode (itemAt importAstNode.children k)
             
             ; Check for exported function declarations
             if (stmt.nodeType == "ExportNamedDeclaration") {
@@ -1070,6 +1102,44 @@ class ComponentEngine {
     
     ; Directory where the last successful readImportSource() found its module.
     def resolvedImportDir:string "./"
+
+    ; Index into importAstCache, or -1 on miss / stale mtime.
+    fn findCachedImportIndex:int (path:string mtime:int) {
+        def i:int 0
+        while (i < (array_length importAstCache)) {
+            def entry:CachedImportAst (itemAt importAstCache i)
+            if (entry.path == path) {
+                if (entry.mtime == mtime) {
+                    return i
+                }
+                return -1
+            }
+            i = i + 1
+        }
+        return -1
+    }
+
+    fn storeCachedImportAst:void (path:string mtime:int ast:TSNode dirPath:string relativePath:string) {
+        def i:int 0
+        while (i < (array_length importAstCache)) {
+            def entry:CachedImportAst (itemAt importAstCache i)
+            if (entry.path == path) {
+                entry.mtime = mtime
+                entry.ast = ast
+                entry.dirPath = dirPath
+                entry.relativePath = relativePath
+                return
+            }
+            i = i + 1
+        }
+        def fresh:CachedImportAst (new CachedImportAst())
+        fresh.path = path
+        fresh.mtime = mtime
+        fresh.ast = ast
+        fresh.dirPath = dirPath
+        fresh.relativePath = relativePath
+        push importAstCache fresh
+    }
 
     ; Read an import file from basePath, falling back to assetPaths.
     fn readImportSource:string (dirPath:string fullPath:string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cooperative per-pane load (#343) helped, but a visible gap remained. Two causes:

1. **TSX parse** — each `loadScript` re-lexed/re-parsed `ylos3_shared.tsx` (~58KB) and helpers with no cache
2. **`createStaticBg`** — tall jungle buffer + many interpreter `bgFillRect`/`bgFillCircle` calls in one `setupScene` phase

### Changes
- **`ComponentEngine` import AST cache** (`importAstCache`, key = resolved path + mtime): level transitions skip lexer+parser for unchanged shared modules; `materialize` still runs into the new moduleScope
- **Split `setupScene`** into `setupScenePrepare` / `setupScenePaintBg` / `setupSceneEntities`; split-screen coop load advances these across frames (read → parse → prepare → paintBg → entities)
- **Cheaper ylos3 bg**: gradient band 4→16px, slightly sparser canopy

### Tests
- `import_chain_demo` / `import_ast_cache_demo` (level2 load twice on same engine)
- `ylos3_runner_demo`

First-time parse of a cold shared module can still hitch briefly; paintBg can too on Pi if the static bg is still heavy — cache mainly helps level2/level3 transitions on an already-warm pane engine.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6f5c-9fd4-7dc0-b3a6-7fb5985dca81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6f5c-9fd4-7dc0-b3a6-7fb5985dca81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

