### PR TITLE
Pac-Man: slower mouth chomp and tunnel teleport

### DIFF
--- a/gallery/game_engine/games/pacman/pacman_shared.tsx
+++ b/gallery/game_engine/games/pacman/pacman_shared.tsx
@@ -214,9 +214,28 @@ function tryMove(col, row, dir) {
   return { ok: 0, col: col, row: row };
 }
 
+function isTunnelWrap(col, row, dir) {
+  if (isTunnelRow(row) == 0) {
+    return 0;
+  }
+  const d = dirDelta(dir);
+  const rawCol = col + d.dc;
+  if (rawCol < 0) {
+    return 1;
+  }
+  if (rawCol >= COLS()) {
+    return 1;
+  }
+  return 0;
+}
+
 function lerpTile(col, row, frac, dir) {
   const cx = tileX(col);
   const cy = tileY(row);
+  // Tunnel wrap must teleport — never lerp across the full screen width.
+  if (isTunnelWrap(col, row, dir) == 1) {
+    return { x: cx, y: cy };
+  }
   const d = dirDelta(dir);
   const nc = wrapCol(col + d.dc, row + d.dr);
   const nr = row + d.dr;
@@ -432,7 +451,25 @@ function pacMouth(frameSeed, moving) {
   if (moving == 0) {
     return 0;
   }
-  return 1 + (frameSeed % 3);
+  // Slow chomp: ~8 ticks per mouth frame, bounce 0→3→0 (no per-frame flicker).
+  const step = (frameSeed / 8) | 0;
+  const phase = step % 6;
+  if (phase == 0) {
+    return 0;
+  }
+  if (phase == 1) {
+    return 1;
+  }
+  if (phase == 2) {
+    return 2;
+  }
+  if (phase == 3) {
+    return 3;
+  }
+  if (phase == 4) {
+    return 2;
+  }
+  return 1;
 }
 
 function placePacDeath(entities, col, row, frac, dir, frameSeed) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #348: fix two animation glitches.

### Fixes
- **Mouth flicker** — chomp now cycles 0→3→0 over ~8 ticks per frame instead of changing every update
- **Tunnel wrap** — wrapping no longer lerps across the full screen; Pac-Man/ghosts hold position then jump to the far side

### Test
- `npm test -- tests/game-runner.test.ts -t pacman` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7c884a9-d281-43ad-b3ba-624199c72e5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7c884a9-d281-43ad-b3ba-624199c72e5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

