### PR TITLE
Fix chess: capture enemy under cursor with Space

### DIFF
--- a/gallery/game_engine/games/chess/README.md
+++ b/gallery/game_engine/games/chess/README.md
@@ -16,7 +16,7 @@ Two-player or vs-computer chess for the Ranger game engine (480×270).
 | Input | Action |
 |-------|--------|
 | Arrows | Move cursor (after select: jump between legal squares only) |
-| Space / Action | Select piece / move |
+| Space / Action | Select own piece, move, or capture enemy under cursor |
 | B / Select | Cancel selection |
 
 ## Run

--- a/gallery/game_engine/games/chess/chess_rules.tsx
+++ b/gallery/game_engine/games/chess/chess_rules.tsx
@@ -36,16 +36,18 @@ export function pieceColor(p) {
   return 0;
 }
 
+// Keep board indices as integers — `/` is real division in the TSX interpreter
+// (use Math.floor; there is no `idiv` in game scripts).
 export function sq(col, row) {
-  return row * 8 + col;
+  return Math.floor(row) * 8 + Math.floor(col);
 }
 
 export function sqCol(s) {
-  return s % 8;
+  return Math.floor(s) % 8;
 }
 
 export function sqRow(s) {
-  return (s - (s % 8)) / 8;
+  return Math.floor(Math.floor(s) / 8);
 }
 
 export function cloneBoard(board) {
@@ -450,7 +452,7 @@ export function applyMoveRaw(board, move, color, ep) {
 
   let newEp = -1;
   if (flags == 4) {
-    newEp = (srcSq + to) / 2;
+    newEp = Math.floor((srcSq + to) / 2);
   }
 
   return { board: b, ep: newEp };

--- a/gallery/game_engine/games/chess/index.tsx
+++ b/gallery/game_engine/games/chess/index.tsx
@@ -65,10 +65,13 @@ function markId(i) {
 
 function sprites() {
   const list = [];
-  list.push({ id: "cursor", kind: "rect", w: TILE - 2, h: TILE - 2, r: 255, g: 230, b: 80 });
-  list.push({ id: "sel", kind: "rect", w: TILE - 2, h: TILE - 2, r: 80, g: 200, b: 255 });
+  // Draw order = sprites() order. Last-move must sit under cursor/selection,
+  // otherwise a muted lastTo square hides the bright yellow cursor (e.g. when
+  // targeting the square the opponent just moved to).
   list.push({ id: "lastFrom", kind: "rect", w: TILE - 2, h: TILE - 2, r: 200, g: 180, b: 60 });
   list.push({ id: "lastTo", kind: "rect", w: TILE - 2, h: TILE - 2, r: 200, g: 180, b: 60 });
+  list.push({ id: "sel", kind: "rect", w: TILE - 2, h: TILE - 2, r: 80, g: 200, b: 255 });
+  list.push({ id: "cursor", kind: "rect", w: TILE - 2, h: TILE - 2, r: 255, g: 230, b: 80 });
   let i = 0;
   while (i < MAX_MARKS) {
     list.push({ id: markId(i), kind: "circle", rad: 5, r: 70, g: 220, b: 120 });
@@ -207,7 +210,10 @@ function buildEntities(s) {
     entities.sel = { x: -40, y: -40, visible: 0 };
   }
 
-  if (s.lastFrom >= 0) {
+  // Hide last-move tint on the square under the cursor (or selection) so the
+  // bright yellow / cyan highlight always reads clearly.
+  const curSq = sq(s.cursorCol, s.cursorRow);
+  if (s.lastFrom >= 0 && s.lastFrom != curSq && s.lastFrom != s.selSq) {
     entities.lastFrom = {
       x: tileX(sqCol(s.lastFrom)),
       y: tileY(sqRow(s.lastFrom)),
@@ -219,7 +225,7 @@ function buildEntities(s) {
   } else {
     entities.lastFrom = { x: -40, y: -40, visible: 0 };
   }
-  if (s.lastTo >= 0) {
+  if (s.lastTo >= 0 && s.lastTo != curSq && s.lastTo != s.selSq) {
     entities.lastTo = {
       x: tileX(sqCol(s.lastTo)),
       y: tileY(sqRow(s.lastTo)),

--- a/gallery/game_engine/games/chess/index.tsx
+++ b/gallery/game_engine/games/chess/index.tsx
@@ -361,6 +361,32 @@ function findLegalTo(s, toSq) {
   return null;
 }
 
+// Pieces of `turn` that can legally capture/move to `toSq`.
+function findCapturersOf(board, turn, ep, rights, toSq) {
+  const out = [];
+  let srcSq = 0;
+  while (srcSq < 64) {
+    const p = board[srcSq];
+    if (p != 0) {
+      let pc = 0;
+      if (p > 0) { pc = 1; }
+      if (p < 0) { pc = -1; }
+      if (pc == turn) {
+        const moves = legalMovesFrom(board, srcSq, turn, ep, rights);
+        let i = 0;
+        while (i < moves.length) {
+          if (moves[i].to == toSq) {
+            out.push(moves[i]);
+          }
+          i = i + 1;
+        }
+      }
+    }
+    srcSq = srcSq + 1;
+  }
+  return out;
+}
+
 function playerCanAct(s) {
   if (s.status == "mate") { return 0; }
   if (s.status == "stalemate") { return 0; }
@@ -751,11 +777,50 @@ function update(props) {
           if (p > 0) { pc = 1; }
           if (p < 0) { pc = -1; }
           if (pc == turn) {
-            selSq = target;
-            // Snap onto the piece; next arrows visit only legal squares.
-            cursorCol = sqCol(target);
-            cursorRow = sqRow(target);
-            ev = [{ kind: "playSound", id: "blip" }];
+            // Only select pieces that have at least one legal move.
+            const ownMoves = legalMovesFrom(board, target, turn, ep, rights);
+            if (ownMoves.length > 0) {
+              selSq = target;
+              cursorCol = sqCol(target);
+              cursorRow = sqRow(target);
+              ev = [{ kind: "playSound", id: "blip" }];
+            }
+          } else {
+            // Space on enemy: capture with the first legal capturer.
+            // (Pick a specific own piece first if you want a different taker.)
+            const caps = findCapturersOf(board, turn, ep, rights, target);
+            if (caps.length > 0) {
+              const moved = doMove({
+                screen: "play",
+                mode: s.mode,
+                board: board,
+                turn: turn,
+                ep: ep,
+                rights: rights,
+                cursorCol: cursorCol,
+                cursorRow: cursorRow,
+                selSq: caps[0].from,
+                status: status,
+                history: history,
+                lastFrom: lastFrom,
+                lastTo: lastTo,
+                seed: seed,
+                aiWait: 0,
+                msg: msg,
+                score1: score1,
+                score2: score2,
+                showNet: 0,
+                pUp: pUp,
+                pDown: pDown,
+                pLeft: pLeft,
+                pRight: pRight,
+                pAct: pAct,
+                pB: bHeld
+              }, caps[0]);
+              moved.entities = buildEntities(moved);
+              moved.events = [{ kind: "playSound", id: "blip" }];
+              return moved;
+            }
           }
         }
       } else {
@@ -803,15 +868,55 @@ function update(props) {
             moved.events = [{ kind: "playSound", id: "blip" }];
             return moved;
           } else {
-            // Re-select if own piece
+            // Selected piece cannot go here — try any capturer, or re-select.
             const p = board[target];
             let pc = 0;
             if (p > 0) { pc = 1; }
             if (p < 0) { pc = -1; }
             if (pc == turn) {
-              selSq = target;
+              const ownMoves = legalMovesFrom(board, target, turn, ep, rights);
+              if (ownMoves.length > 0) {
+                selSq = target;
+              }
             } else {
-              selSq = -1;
+              if (p != 0 && pc != turn) {
+                const caps = findCapturersOf(board, turn, ep, rights, target);
+                if (caps.length > 0) {
+                  const moved = doMove({
+                    screen: "play",
+                    mode: s.mode,
+                    board: board,
+                    turn: turn,
+                    ep: ep,
+                    rights: rights,
+                    cursorCol: cursorCol,
+                    cursorRow: cursorRow,
+                    selSq: caps[0].from,
+                    status: status,
+                    history: history,
+                    lastFrom: lastFrom,
+                    lastTo: lastTo,
+                    seed: seed,
+                    aiWait: 0,
+                    msg: msg,
+                    score1: score1,
+                    score2: score2,
+                    showNet: 0,
+                    pUp: pUp,
+                    pDown: pDown,
+                    pLeft: pLeft,
+                    pRight: pRight,
+                    pAct: pAct,
+                    pB: bHeld
+                  }, caps[0]);
+                  moved.entities = buildEntities(moved);
+                  moved.events = [{ kind: "playSound", id: "blip" }];
+                  return moved;
+                }
+                selSq = -1;
+              } else {
+                selSq = -1;
+              }
             }
           }
         }

--- a/gallery/game_engine/tests/chess_runner_demo.rgr
+++ b/gallery/game_engine/tests/chess_runner_demo.rgr
@@ -69,11 +69,12 @@ class ChessRunnerDemo {
         print (("entities=" + ec))
         print (("pc0=" + pc0x) + ("," + pc0y))
         print (("cursor=" + curx) + ("," + cury))
-        ; After e2e4 the last-move highlight should sit on e4 (col 4, row 4).
-        def ltx:int (runner.entityX("lastTo"))
-        def lty:int (runner.entityY("lastTo"))
-        print (("lastTo=" + ltx) + ("," + lty))
-        if (ltx > 0) {
+        ; After e2e4 lastFrom is e2. lastTo may be hidden while the cursor
+        ; still sits on e4 (cursor wins over last-move tint).
+        def lfx:int (runner.entityX("lastFrom"))
+        def lfy:int (runner.entityY("lastFrom"))
+        print (("lastFrom=" + lfx) + ("," + lfy))
+        if (lfx > 0) {
             print "moved=ok"
         } {
             print "moved=missing"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Two related issues when capturing on the square the opponent just moved to (e.g. black bishop landing on c3 giving check):

1. **UI:** The muted last-move highlight was drawn *on top of* the bright yellow cursor, so targeting that square looked like the selection “wasn’t there”.
2. **Input:** Space on an enemy square did nothing unless a capturer was already selected.

## Changes
- Draw `lastFrom` / `lastTo` under selection and cursor; hide last-move tint on the square under the cursor (or selected piece).
- Space on an enemy plays the first legal capture to that square.
- Do not select own pieces with zero legal moves.
- Harden board index math with `Math.floor`.

## Test plan
- [ ] Opponent moves a piece to a square; move cursor onto that square — cursor should be bright yellow, not muted last-move tint.
- [ ] Select pawn that can capture that piece; arrow to the square — yellow cursor + capture mark visible; Space captures.
- [ ] Space directly on a capturable enemy (no selection) also captures.
- [ ] `npm run engine:chess:runner`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c037464-66e1-49d3-9028-ed3dbd3fc089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c037464-66e1-49d3-9028-ed3dbd3fc089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

