### PR TITLE
Fix LittleCiv: no split-screen squash, yellow aim tile, HUD

### DIFF
--- a/gallery/game_engine/games/littleciv/README.md
+++ b/gallery/game_engine/games/littleciv/README.md
@@ -31,7 +31,10 @@ npm run engine:game-sdl:launcher
 | Select / ↑ when spent | Cycle units |
 | B / Start | End turn |
 
-Flow: pick direction with arrows → Space to slide.
+Flow: pick direction with arrows → yellow tile shows the target → Space to slide.
+
+`game.info` uses `splitScreen=never` so the 480×270 map is not squeezed into a
+half-width pane (that made tiles look tall and hid HUD text).
 
 ## Art
 

--- a/gallery/game_engine/games/littleciv/game.info
+++ b/gallery/game_engine/games/littleciv/game.info
@@ -1,4 +1,4 @@
 name=LittleCiv
-splitScreen=auto
+splitScreen=never
 category=Games
 icon=assets/image.png

--- a/gallery/game_engine/games/littleciv/index.tsx
+++ b/gallery/game_engine/games/littleciv/index.tsx
@@ -329,8 +329,13 @@ function screenX(worldCol, camCol) {
   return ORIGIN_X + (worldCol - camCol) * TILE + (TILE / 2);
 }
 
+// LPC feet sit inside the tile (not on the grid line under it).
 function screenFeetY(worldRow, camRow) {
-  return ORIGIN_Y + (worldRow - camRow) * TILE + TILE - 1;
+  return ORIGIN_Y + (worldRow - camRow) * TILE + TILE - 6;
+}
+
+function tileTopY(worldRow, camRow) {
+  return ORIGIN_Y + (worldRow - camRow) * TILE;
 }
 
 function inView(worldCol, worldRow, camCol, camRow) {
@@ -404,9 +409,9 @@ function sprites() {
     list.push(tileSheet(tileId(i)));
     i = i + 1;
   }
-  // Bright selection ring + aim marker (rects are easy to see under LPC).
-  list.push({ id: selRingId(), kind: "rect", w: 28, h: 28, r: 255, g: 230, b: 40 });
-  list.push({ id: aimId(), kind: "rect", w: 18, h: 18, r: 80, g: 230, b: 255 });
+  // Full-tile yellow aim highlight + thinner gold selection under the unit.
+  list.push({ id: aimId(), kind: "rect", w: TILE - 2, h: TILE - 2, r: 255, g: 220, b: 40 });
+  list.push({ id: selRingId(), kind: "rect", w: TILE - 6, h: TILE - 6, r: 255, g: 255, b: 180 });
   list.push(pieceSheet(cursorId(), 2, 1));
   i = 0;
   while (i < MAX_CITIES) {
@@ -955,11 +960,10 @@ function buildEntities(units, cities, sel, explored, camCol, camRow, aim, slide)
     if (isExplored(explored, wc, wr) == 1) {
       frame = terrainFrame(cellAt(wc, wr));
     }
-    // Tile sheets are top-left anchored via feet? Sheet uses feet at bottom.
-    // For full-tile art with scale 100 / 24px, place feet at tile bottom.
+    // Sheet sprites are feet-anchored: feet at tile bottom → art fills the cell.
     entities[tileId(i)] = {
       x: ORIGIN_X + vc * TILE + (TILE / 2),
-      y: ORIGIN_Y + vr * TILE + TILE - 1,
+      y: ORIGIN_Y + vr * TILE + TILE,
       p0: frame,
       p1: 0,
       visible: 1
@@ -1073,6 +1077,7 @@ function buildEntities(units, cities, sel, explored, camCol, camRow, aim, slide)
         visible: 1
       };
     }
+    // Destination tile: full yellow square (always when aiming).
     if (aim >= 0 && !(slide && slide.on == 1)) {
       const d = aimDelta(aim);
       const ac = u.col + d.dc;
@@ -1081,6 +1086,22 @@ function buildEntities(units, cities, sel, explored, camCol, camRow, aim, slide)
         entities[aimId()] = {
           x: screenX(ac, camCol),
           y: tileCenterY(ar, camRow),
+          r: 255,
+          g: 220,
+          b: 40,
+          visible: 1
+        };
+      }
+    }
+    // While sliding, keep the destination highlighted.
+    if (slide && slide.on == 1 && slide.unit == sel) {
+      if (inView(slide.tc, slide.tr, camCol, camRow) == 1) {
+        entities[aimId()] = {
+          x: screenX(slide.tc, camCol),
+          y: tileCenterY(slide.tr, camRow),
+          r: 255,
+          g: 220,
+          b: 40,
           visible: 1
         };
       }
@@ -1620,14 +1641,14 @@ function hud(props) {
 
   if (s.screen == "splash") {
     return (
-      <View width="100%" height="100%" flexDirection="column" justifyContent="center" alignItems="center">
-        <Label color="#f0d246" fontSize="38px">LittleCiv</Label>
-        <Label color="#9ec4e8" fontSize="12px">Fogged world · aim then move</Label>
-        <Label color="#ffffff" fontSize="13px">1) Arrows = choose direction</Label>
-        <Label color="#ffffff" fontSize="13px">2) Space = slide into that tile</Label>
-        <Label color="#c8d6e8" fontSize="12px">Select = next unit / found city</Label>
-        <Label color="#c8d6e8" fontSize="12px">B / Start = end turn</Label>
-        <Label color="#ffe98a" fontSize="16px">Space = begin</Label>
+      <View width="100%" height="100%" flexDirection="column" justifyContent="center" alignItems="center" backgroundColor="#101828cc">
+        <Label color="#f0d246" fontSize="42px">LittleCiv</Label>
+        <Label color="#9ec4e8" fontSize="14px">How to play</Label>
+        <Label color="#ffffff" fontSize="16px">Arrows = aim (yellow tile)</Label>
+        <Label color="#ffffff" fontSize="16px">Space = move there</Label>
+        <Label color="#d0d8e8" fontSize="14px">Select = next unit / found city</Label>
+        <Label color="#d0d8e8" fontSize="14px">B / Start = end turn</Label>
+        <Label color="#ffe98a" fontSize="20px">Press Space to begin</Label>
       </View>
     );
   }
@@ -1656,17 +1677,17 @@ function hud(props) {
   const theirs = citySummary(s.cities, OWNER_AI);
   const line = statusLine(s);
   let tip = "Arrows aim · Space move · Select found/cycle · B end turn";
-  if (s.help == 1 && s.msgT <= 0) {
-    tip = "Yellow ring = selected · Cyan square = aim · Space slides";
+  if (s.help == 1) {
+    tip = "Yellow tile = where you will move · Space to go";
   }
   if (s.msgT > 0) { tip = s.msg; }
 
   let aimLine = "";
-  if (s.aim == 0) { aimLine = "Aim: UP"; }
-  if (s.aim == 1) { aimLine = "Aim: LEFT"; }
-  if (s.aim == 2) { aimLine = "Aim: DOWN"; }
-  if (s.aim == 3) { aimLine = "Aim: RIGHT"; }
-  if (s.aim < 0) { aimLine = "Aim: —  (pick a direction)"; }
+  if (s.aim == 0) { aimLine = "Aim: UP  (yellow tile)"; }
+  if (s.aim == 1) { aimLine = "Aim: LEFT  (yellow tile)"; }
+  if (s.aim == 2) { aimLine = "Aim: DOWN  (yellow tile)"; }
+  if (s.aim == 3) { aimLine = "Aim: RIGHT  (yellow tile)"; }
+  if (s.aim < 0) { aimLine = "Aim: —  press an arrow first"; }
   if (s.slide && s.slide.on == 1) { aimLine = "Moving…"; }
 
   let cityLine = "";

--- a/gallery/game_engine/tests/littleciv_runner_demo.rgr
+++ b/gallery/game_engine/tests/littleciv_runner_demo.rgr
@@ -51,6 +51,11 @@ class LittlecivRunnerDemo {
         runner.draw()
         buffer_write_file "gallery/game_engine/scripting" "littleciv_frame.rgba" (runner.raw())
 
+        ; Re-aim right so aim marker is visible on the final frame.
+        runner.frame(16 false false false true false false)
+        runner.frame(16 false false false false false false)
+        runner.draw()
+
         def ec:int (runner.entityCount())
         def ringX:int (runner.entityX("selRing"))
         def aimX:int (runner.entityX("aim"))
@@ -69,6 +74,11 @@ class LittlecivRunnerDemo {
             print "select=ok"
         } {
             print "select=missing"
+        }
+        if (aimX > 0) {
+            print "aim=ok"
+        } {
+            print "aim=missing"
         }
         def audio:GameAudio (runner.audioRef())
         print (("audioPlays=" + audio.playCount))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The previous LittleCiv build used `splitScreen=auto`, which scale-blits the 480×270 frame into a **240×270** pane. That squeezed width (tiles looked tall/vertical), crushed HUD text, and made aim/selection hard to read.

### Fixes
- `game.info`: `splitScreen=never` (full 480×270)
- Aim marker = **full yellow tile** on the destination cell
- LPC feet inset into the tile (not standing on the grid line)
- Larger splash “How to play” instructions

### Verify
```bash
npm run engine:littleciv:runner
# aim=ok select=ok tiles=ok entities=181
npm run engine:game-sdl:smoke:littleciv
# entities=181 (was 0 under broken split path)
```

## Test plan
- [x] Headless: `aim=ok`, `select=ok`
- [x] SDL smoke reports `entities=181`
- [ ] Fullscreen: square tiles, readable splash text
- [ ] Arrow → yellow destination tile → Space slides

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-535fe193-c2a4-4d91-94c3-0a9db90478bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-535fe193-c2a4-4d91-94c3-0a9db90478bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

