### PR TITLE
Physics engine upgrade: cannon-es port → full constraint engine + PhysicsWorld interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ gallery/pdf_writer/bin/evg_component_tool_go
 
 
 
+gallery/game_engine/scripting/cannon_showcase_demo.js

--- a/gallery/game_engine/IDEAL.md
+++ b/gallery/game_engine/IDEAL.md
@@ -84,7 +84,7 @@ without re-widening the leaks above.
 | **Generic guest scalar slots** | Missing | Only `air_p1/air_p2` are hard-coded; there is no documented generic "guest scalar" the host transports opaquely. | §2.1 |
 | **Genre-neutral control channels** | Missing | Only the four named car channels; no indexed `readControlChannel(body, ch)`. | §2.2 |
 | **Collision shape, filtering, sensors, full contacts** | Minimal | The body record carries pose but no shape; body↔body is circle-only; contacts define only a `BEGIN` phase (no `PERSIST`/`END`, depth, or tangent impulse); no layer/mask filtering, no sensor/trigger bodies. | §2.5 |
-| **Selectable physics engine** | Partial | A full Cannon.js rigid-body port exists (`physics/src/cannon_*.rgr`) and a game *can* select it — but only on the TS path via `config().physics.cannon` (`game_cannon_physics.rgr`); WASM/`.as` guests cannot choose it and the RGW1 ABI is tied to the arcade core's output. | §2.5 |
+| **Selectable physics engine** | Interface landed; guest paths pending | A `PhysicsWorld` interface now exists (`physics/src/physics_world.rgr`) with two engines behind it — the upgraded Cannon port (`cannon_physics_world.rgr`) and an independent arcade engine (`arcade_physics_world.rgr`). Engine-agnostic code selects either with one line. Still pending: wiring the interface to the WASM/`.as` guest ABIs and reworking the TS bridge (`game_cannon_physics.rgr`) to delegate fully to the solver. See [`PLAN_PHYSICS_ENGINE.md`](./PLAN_PHYSICS_ENGINE.md). | §2.5 |
 | **Body→sprite binding** | Fragmented | Three unrelated models (host `spriteFor` templates, RGSP1 catalog, `.as` RGS1 draw list); no single contract that makes a body's pose drive a sprite/character on every path. | §2.5 |
 | **Data-driven sprite roster & animations** | Partial | A catalog-id table (`RG_SPR_OFF_CAT_IDS`) exists, but character ids are still frozen constants, and animations are limited to `WALK/RUN/JUMP` with `RUN`/`JUMP` falling back to `WALK`. | §2.1, §2.8 |
 | **Sprite-sheet loading (PNG) + unified sprite handling** | Fragmented | Runtime image loading decodes PNG *and* JPEG (`game_image_loader.rgr`), but PNG decode is borrowed from the LPC toolchain rather than owned by the runtime path and is not shared with the `.as`/WASM paths; the emitted `atlas.json` is ignored at runtime; sheets are drawn via three unrelated models with three animation-timing sites. | §2.8 |
@@ -486,6 +486,25 @@ RGW1 is the "world/physics" block, so how the ABI carries **bodies, collisions, 
 the link from a body to the sprite that draws it** is the core of the whole engine.
 Three things have to be genre-neutral here — the simulation, the contact model, and
 the body→visual binding — and today each leaks or is missing.
+
+> **Update — physics engine upgrade (see [`PLAN_PHYSICS_ENGINE.md`](./PLAN_PHYSICS_ENGINE.md), 89 unit tests).**
+> Much of the "Current state" below is now addressed. The Cannon port is no longer a
+> circle-only arcade subset: it has a real **SPOOK GS constraint solver + friction**,
+> **joints** (point-to-point, hinge, hinge motor), a full **collision set** (sphere,
+> box, plane, heightfield, convex, cylinder, particle, trimesh — incl. box-box and
+> convex-convex SAT), **raycasting**, a **RaycastVehicle** (suspension + drive + grip
+> + steering), **sleeping** bodies, and an **SAP broadphase**. Ideal point 1 below
+> (*"simulation sits behind a `PhysicsWorld` interface"*) is **implemented**:
+> [`physics_world.rgr`](./physics/src/physics_world.rgr) is the engine-neutral seam,
+> with [`cannon_physics_world.rgr`](./physics/src/cannon_physics_world.rgr) (full
+> engine) and [`arcade_physics_world.rgr`](./physics/src/arcade_physics_world.rgr)
+> (a second, independent engine) both behind it — the same engine-agnostic test code
+> drives both and they agree. Still open: exposing the engine to the WASM/`.as`
+> guest paths (the interface exists but is not yet wired to those ABIs), the
+> body→visual binding (§2.5 point 6), and an optional Jolt/Rapier native backend.
+> The TSX bridge ([`game_cannon_physics.rgr`](./scripting/game_cannon_physics.rgr))
+> still does arcade-style manual boundary handling and needs rework to delegate fully
+> to the solver.
 
 **Current state.**
 

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -335,6 +335,21 @@ muotojen `raycast`-metodit. Todiste: raycast-osumatestit per muoto.
 ja tarjoa valinnainen **Jolt/Rapier host-natiivi-backend** desktopille rajapinnan
 takana. Ranger-cannon-es on oletus; natiivi-backend opt-in raskaaseen 3D:hen.
 
+- ✅ **Osa 7a — `PhysicsWorld`-rajapinta (tehty):** [`physics_world.rgr`](./physics/src/physics_world.rgr)
+  — moottorineutraali abstrakti rajapinta (vain primitiivit ylittävät rajan, kappaleet
+  opaakkeina int-handleina: `initWorld`/`setGravity`/`addSphere`/`addBox`/
+  `addStaticPlane`/`addPointToPoint`/`step`/`bodyPos*`/`raycastClosest`). Cannon-moottori
+  sen takana: [`cannon_physics_world.rgr`](./physics/src/cannon_physics_world.rgr)
+  (`CannonPhysicsWorld extends PhysicsWorld`). Testit ([`physics_world_test.rgr`](./physics/src/physics_world_test.rgr))
+  ajavat **moottoririippumattoman** skenaarion (`dropScenario(pw:PhysicsWorld)`)
+  Cannon-backendillä: pallo lepää lattialla rajapinnan läpi (`pwBallY≈0.5`), raycast
+  osuu (`pwRayY≈1.0`), nivel toimii rajapinnan yli (`pwPendulumDist≈2.0`). Sama
+  testikoodi ajaisi minkä tahansa `PhysicsWorld`-toteutuksen → **rajapinta on nyt
+  saumana kaikelle testaukselle** ja tuleva Jolt/arcade-backend liittyy tähän.
+  `npm run engine:physics:test` → 82 passed, 0 failed.
+- ⏳ **Osa 7b:** arcade-ytimen (`physics_core.rgr`) adapteri samaan rajapintaan +
+  valinnainen Jolt/Rapier host-natiivi-backend jäävät pohdintaan.
+
 Kunkin vaiheen voi tehdä erillisenä PR:nä; **uudistus voi pysähtyä minne tahansa** ja
 jättää edellisen vaiheen tuotantoon.
 

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -299,6 +299,17 @@ muotojen `raycast`-metodit. Todiste: raycast-osumatestit per muoto.
 **Vaihe 6 — Muodot + broadphase + uni.** `Cylinder`, `Heightfield`, `Trimesh`,
 `Particle`; `SAPBroadphase`; islands/sleep. Todiste: per-muoto-testit + skaalaustesti.
 
+- ✅ **Osa 6a — Uni (sleep, tehty):** `CannonBody.sleepTick`/`sleep`/`wakeUp`
+  (SLEEPY→SLEEPING nopeusrajan + aikarajan mukaan), `CannonWorld` kutsuu joka steppi.
+  Nukkuva kappale ei integroidu eikä liiku solverissa (`invMassSolve=0`). Testi
+  `Sleep.bodySleeps`: paikallaan oleva kappale nukahtaa (`sleepState=2`), liikkuva
+  pysyy hereillä ja jatkaa integrointia (`moverX=2.0`).
+- ✅ **Osa 6b — SAP-broadphase (tehty):** [`cannon_sap_broadphase.rgr`](./physics/src/cannon_sap_broadphase.rgr)
+  — lajittelu AABB:n min-x:n mukaan + pyyhkäisy, karsii O(n²)-parit. Testi
+  `SAP.sameAsNaive`: tuottaa samat parit kuin naiivi (2 = 2). `npm run engine:physics:test`
+  → 75 passed, 0 failed. ⏳ `Cylinder`/`Heightfield`/`Trimesh`/`Particle`-muodot
+  (törmäyskoodi kullekin) jäävät vielä.
+
 **Vaihe 7 — Rajapinta & backend-luukku.** Nosta `PhysicsWorld`-rajapinta (IDEAL §2.5)
 ja tarjoa valinnainen **Jolt/Rapier host-natiivi-backend** desktopille rajapinnan
 takana. Ranger-cannon-es on oletus; natiivi-backend opt-in raskaaseen 3D:hen.

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -246,9 +246,12 @@ flipperi-testi.
   jotka pitävät kappaleiden saranaakselit linjassa → yksi vapaa rotaatio-DOF.
   Testi `Constraint.hingeAxis`: akselin ulkopuolinen pyörintä vaimenee (`wx ≈ 0`),
   kappale pysyy saranatasossa (`z ≈ 0`), mutta painovoima heilauttaa sen saranan
-  ympäri (`y ≈ -0.21`). **Tämä on flipperin nivelen ydin.** Motori
-  (`RotationalMotorEquation`) puuttuu vielä (aktiivinen ohjaus) — passiivinen sarana
-  toimii. `npm run engine:physics:test` → 63 passed, 0 failed.
+  ympäri (`y ≈ -0.21`). `npm run engine:physics:test` → 63 passed, 0 failed.
+- ✅ **Osa 2c (tehty):** **Hinge-motori** (`RotationalMotorEquation`, `kind=4`) +
+  `enableMotor`/`setMotorSpeed`/`setMotorMaxForce`. Testi `Constraint.hingeMotor`:
+  motori kiihdyttää saranan pyörinnän tavoitenopeuteen (`|wz| ≈ 5.0`) nivelen
+  pysyessä kiinni (`dist ≈ 1.0`). **Flipperi on nyt kokonainen: sarana + motori.**
+  `npm run engine:physics:test` → 64 passed, 0 failed.
 
 **Vaihe 3 — Laatikko/konveksi-narrowphase.** `boxBox`, `sphereBox`, `ConvexPolyhedron`
 + `convexConvex` (SAT). Todiste: laatikkopino-testi.

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -1,0 +1,221 @@
+# PLAN — Fysiikkamoottorin arviointi ja uudistus
+
+> **Status:** päätösdokumentti (arvio + suositus + vaiheistettu porttaussuunnitelma)
+> **Kysymys:** Cannon.js on ihan kiva — pitäisikö vaihtaa modernimpaan moottoriin,
+> jonka porttaisi pala palalta osaksi runkoa? Uudistus ei ole 100 % pakollinen;
+> arvioidaan mitä puuttuu ja mitä siirrolla saisi.
+> **Painopisteet (annettu):** 1) MIT-lisenssi 2) hyvät ominaisuudet 3) GitHubissa
+> 4) järkevät unit-testit, jotta Ranger-portti voidaan tehdä hyvin.
+> **Liittyvät:** [`IDEAL.md` §2.5](./IDEAL.md) (physics-seam), [`ROADMAP.md`](./ROADMAP.md),
+> [`physics/src/`](./physics/src/) (nykyinen portti).
+
+---
+
+## 0. TL;DR
+
+- **Nykyinen `physics/src/cannon_*.rgr` ei ole "kevyt Cannon" — se on _arcade-osajoukko_
+  Cannonin API:n muotoisena.** Se osaa pallo–pallo- ja pallo–taso-törmäykset,
+  Z-akselin pyörimisen ja käsin viritetyn impulssiratkaisijan (flipper-tweakit).
+  Kaikki mikä tekee Cannonista _yleisen 3D-moottorin_ puuttuu: **oikea
+  constraint-solver, nivelet (hinge/point-to-point/distance/spring), laatikko- ja
+  konveksitörmäys, raycast, ajoneuvomalli, kitka, uni/islands, useammat muodot.**
+- **Ranger-filosofia rajaa vaihtoehdot rajusti.** Moottori _portataan lähdekoodina_
+  `.rgr`:ksi (kääntyy C++/WASM/ES6/natiivi Pi). Siksi **Rust- ja C++-moottorit
+  (Rapier, Jolt, Ammo, Box2D-C) eivät kelpaa porttauskohteeksi** — niitä voi käyttää
+  vain läpinäkymättöminä host-natiivi-backendeinä, mikä rikkoo "write once → aja
+  Pi:llä" -lupauksen. Vain **luettava, modulaarinen, hyvin testattu JS/TS-moottori**
+  kelpaa portattavaksi.
+- **Suositus (kaksitasoinen):**
+  1. **Porttauskohde nyt:** päivitä nykyinen portti **cannon-es**iin (MIT, TypeScript,
+     ylläpidetty Cannon-forkki, **sama per-luokka-testisetti** jota portti jo peilaa).
+     Tämä ei ole uudelleenkirjoitus vaan portin _loppuunsaattaminen_: tuodaan pala
+     palalta ne moduulit jotka nykyportti jätti pois (solver → nivelet → laatikko/
+     konveksi → raycast → ajoneuvo → muodot). Jokainen tulee `cannon_*.rgr` +
+     `cannon_*_test.rgr` -parina, kuten tähänkin asti.
+  2. **Valinnainen tulevaisuuden pako-luukku:** salli **Jolt** (MIT) tai **Rapier**
+     host-natiivina backendinä **`PhysicsWorld`-rajapinnan takana** (IDEAL §2.5)
+     raskaaseen desktop-3D:hen — _ei_ portattuna vaan sidottuna. Pi/natiivi-buildit
+     putoavat takaisin Ranger-cannon-es-ytimeen.
+- **"Ei pakko" pitää paikkansa:** jos pelit pysyvät pinball/top-down-tasolla,
+  nykyportti riittää. Uudistus kannattaa **heti kun tarvitaan** nivelet (oikeat
+  flipperit), raycast (FPS/valinta/näkölinja), ajoneuvot (autopeli 3D), tai staattinen
+  tasogeometria (trimesh/heightfield). Nämä eivät ole nykyportissa saavutettavissa
+  ilman uusia moduuleja.
+
+---
+
+## 1. Mitä nykyinen "Cannon-portti" oikeasti on
+
+Portissa on 30 `.rgr`-moduulia (~4 200 riviä) testeineen: `Vec3`, `Quaternion`,
+`Mat3`, `AABB`, `Box`, `Sphere`, `Plane`, `Shape`, `Body`, `World`, `Broadphase`,
+`NaiveBroadphase`, `Narrowphase`, `ContactEquation`, `ContactMaterial`, `Material`,
+`ArrayCollisionMatrix`, `TupleDictionary`, `OverlapKeeper`, `Transform`. Matematiikka-
+ja tietorakennetaso on **aidosti Cannon** ja hyvin testattu.
+
+Mutta simulaatioydin on **arcade-osajoukko**, ei Cannon-solver. Konkreettisesti
+([`cannon_world.rgr`](./physics/src/cannon_world.rgr),
+[`cannon_narrowphase.rgr`](./physics/src/cannon_narrowphase.rgr),
+[`cannon_body.rgr`](./physics/src/cannon_body.rgr)):
+
+| Cannonin oikea toteutus | Nykyportti | Seuraus |
+|--------------------------|------------|---------|
+| **`GSSolver`** (Gauss–Seidel, `Equation`-lista, iteraatiot) | Käsin kirjoitettu `resolveContactImpulses()` + pinball-tweakit (`e=1.05` kinemaattiselle flipperille, `applyKinematicSpinTransfer` × 0.65, penetraation erottelu käsin) | Ei pinojen vakautta, ei niveliä, ei kitkaa — vain kimmoisa törmäysvaste |
+| **Narrowphase: kaikki muotoparit** (box-box, sphere-box, convex, particle…) | Vain `sphereSphere` + `spherePlane`; `dispatchShapePair` palauttaa muille `false` | `CannonBox` on olemassa mutta **laatikkotörmäys ei koskaan synny** |
+| **Täysi 3D-rotaatio** (inertiatensori, `updateInertiaWorld`) | `clampAngularVelocity` nollaa X/Y — vain **Z-pyörintä**; `updateInertiaWorld` on tyhjä | Käytännössä 2D-simulaatio XY-tasossa Z-spinillä, ei 3D-jäykkä kappale |
+| **Constraints** (PointToPoint, Hinge, Distance, Lock, ConeTwist, Spring) | — | Ei niveliä; flipperi on kinemaattinen kikka, ei hinge-constraint |
+| **`FrictionEquation` + kitka** | Vain `restitution` | Ei tangentiaalista kitkaa; `ContactMaterial.friction` jää käyttämättä |
+| **Ray / raycast** (`Ray`, `RaycastResult`, `world.raycastClosest/Any/All`) | — | Ei näkölinjaa, ei valintaa, ei raycast-ajoneuvoa |
+| **`RaycastVehicle` / `RigidVehicle` / `WheelInfo`** | — | Ei ajoneuvomallia |
+| **Muodot: `Cylinder`, `ConvexPolyhedron`, `Heightfield`, `Trimesh`, `Particle`** | — | Ei sylinteriä, ei konveksia, ei maastoa, ei staattista trimesh-tasoa |
+| **Broadphase: `SAPBroadphase`, `GridBroadphase`** | Vain `NaiveBroadphase` (O(n²)) | Ei skaalaudu satoihin kappaleisiin |
+| **Uni / islands (`sleepState`, `Island`)** | Kentät olemassa, käyttämättä | Ei lepotilaoptimointia |
+| **CCD (continuous collision)** | — | Nopea pieni kappale (pinball-pallo) voi tunneloitua seinän läpi |
+
+**Johtopäätös:** nykyportti on _tarkoituksella_ minimaalinen pinballiin (ROADMAP
+rivi 181: "yksi universaali fysiikkamoottori" on ei-tavoite, kaksi kerrosta
+tarkoituksella). Se on **oikea valinta nykypeleille**, mutta se ei ole "kevyt Cannon"
+josta kasvaa iso Cannon lisäämällä nappuloita — iso osa Cannonista puuttuu kokonaan.
+
+---
+
+## 2. Vaihtoehdot painopisteitä vasten
+
+Ratkaiseva suodatin ei ole "paras moottori" vaan **"paras _portattava_ moottori"**:
+lähdekoodi käännetään käsin `.rgr`:ksi, joten sen pitää olla luokkamallinen, riippuvuus-
+kevyt ja per-moduuli-testattu JS/TS. Tämä pudottaa suorituskykykuninkaat (Rust/C++)
+porttauskohteina — ne kelpaavat vain host-natiivi-backendiksi rajapinnan taakse.
+
+| Moottori | Lisenssi | Lähdekieli | Portattava `.rgr`:ksi? | Unit-testit | Ulottuvuus | Huom |
+|----------|----------|-----------|:----------------------:|-------------|-----------|------|
+| **cannon-es** (pmndrs) | **MIT** ✅ | **TypeScript** | ✅ **kyllä** (sama arkkitehtuuri kuin nyt) | ✅ Cannonin per-luokka-setti | 3D | Ylläpito hiipunut, mutta **feature-complete & vakaa** = ihanteellinen _stabiili_ porttauskohde |
+| **OimoPhysics** (saharan) | MIT | Haxe → JS/TS | ⚠️ osin (Haxe-lähde / generoitu JS kömpelömpi kääntää) | ⚠️ ohuet | 3D | Modernimpi solver + 6-DoF-nivelet; heikompi testikattavuus, Haxe-sukujuuri |
+| **Planck.js** (piqnt) | MIT | TypeScript | ✅ kyllä | ✅ hyvät (Box2D-perua) | **2D** | Box2D-portti: erinomainen sequential-impulse-solver + nivelet; **luopuisi 3D-Cannon-investoinnista** |
+| **p2.js** (Cannonin tekijä) | MIT | JavaScript | ✅ kyllä | ✅ on | **2D** | Sama tekijä kuin Cannon; 2D, ylläpito hiipunut |
+| **Box2D v3** (Erin Catto) | MIT | **C** | ⚠️ ei luokkamalli; C lähellä C++-targettia mutta ei JS-testisynergiaa | ✅ | 2D | Referenssilaatu, mutta ei sovi luokkapohjaiseen porttiin |
+| **Rapier** (dimforge) | **Apache-2.0** ❌ | **Rust → WASM** | ❌ **ei** | ✅ (Rust) | 2D/3D | Moderni, deterministinen, CCD — mutta **ei MIT** ja **ei portattava**; vain backend |
+| **Jolt** (jrouwe) | **MIT** ✅ | **C++ → WASM** | ❌ **ei** | ✅ (C++) | 3D | Huippunopea (Horizon/Death Stranding), MIT — mutta **vain host-natiivi-backend**, ei portattava |
+| **Ammo.js** (Bullet) | zlib | C++ (emscripten) | ❌ ei | — | 3D | Ylläpitämätön, läpinäkymätön WASM |
+| Oimo.js (lo-th) | MIT | JS | ✅ | ⚠️ | 3D | Ei aktiivista kehitystä ~2016 jälkeen |
+
+**Suodatuksen tulos:**
+- **Priori­teetti #1 (MIT):** pudottaa Rapierin (Apache-2.0).
+- **Priori­teetti #4 (hyvät unit-testit portin tueksi) + porttausvaatimus:** nostaa
+  **cannon-es**in kärkeen — sillä on juuri se per-luokka-QUnit-rakenne (`test/Vec3.js`,
+  `test/Quaternion.js`, `test/Body.js`, `test/RaycastVehicle.js` …) jota portti jo
+  peilaa. Testit portataan kuten lähde: `cannon_*_test.rgr`.
+- **Jolt** on ainoa "moderni + MIT" joka jää eloon — mutta C++, joten se on **backend-
+  vaihtoehto**, ei porttauskohde.
+
+---
+
+## 3. Miksi cannon-es eikä "jotain uudempaa"
+
+Houkutus on ottaa Rapier/Jolt, koska ne ovat suorituskyvyltään ja determinismiltään
+edellä. Mutta se olisi **eri asia kuin mitä tehtävä pyytää**:
+
+1. **Porttausfilosofia.** Ranger-lupaus on _lähdekoodin_ siirrettävyys (yksi
+   `.rgr` → C++/WASM/ES6/natiivi Pi). Rust/C++-moottori voi elää vain esikäännettynä
+   WASM/natiivi-binäärinä → Pi-terminaalibuild ja "write once" hajoaa. cannon-es
+   kääntyy Rangerin läpi samoihin targetteihin kuin muu peli.
+2. **Testit porttausapuna (#4).** cannon-es tuo Cannonin testisetin mukanaan.
+   Jokainen portattu moduuli saa heti oraakkelin: aja sama testi `.rgr`:nä, vertaa
+   lukuja. Rust/C++-testejä ei voi peilata `.rgr`-harnessiin ([`cannon_test_harness.rgr`](./physics/src/cannon_test_harness.rgr)).
+3. **Nolla-hukkainvestoiniti.** Nykyiset `Vec3/Quaternion/Mat3/AABB/Body/World`-portit
+   **kelpaavat sellaisenaan** — cannon-es on saman koodin TypeScript-siisti, bugikorjattu
+   versio. Migraatio on _lisäystä_, ei purkua. Rapier/Jolt heittäisi kaiken pois.
+4. **IDEAL on jo suunniteltu tähän.** [`IDEAL.md` §2.5](./IDEAL.md) haluaa
+   `PhysicsWorld`-rajapinnan (`addBody`/`setBounds`/`step`/`contacts`), jonka takana on
+   *"arcade-ydin **tai** cannon-portti **tai** host-natiivi-moottori"*. Suositus toteuttaa
+   juuri tämän: cannon-es on portattava ydin, Jolt/Rapier valinnainen natiivi-backend.
+
+**Milloin Jolt/Rapier -backend kannattaa:** vasta kun desktop-3D-peli tarvitsee satoja
+törmääviä kappaleita, CCD:tä tai deterministista verkkopeliä — ja hyväksytään ettei se
+peli aja Pi-terminaalissa. Se on _lisäys rajapinnan taakse_, ei ytimen korvaus.
+
+---
+
+## 4. Mitä siirto konkreettisesti antaa (mapattuna Ranger-peleihin)
+
+| Uusi kyky (cannon-es) | Puuttuu nyt | Mikä Ranger-peli hyötyy |
+|-----------------------|:-----------:|--------------------------|
+| **`GSSolver` + `Equation`/`FrictionEquation`** | ✅ | Pinball/sandbox: vakaat pinot, aito kitka, kappaleet eivät läpäise |
+| **`HingeConstraint`** | ✅ | **Flipperit oikeana nivelenä** kinemaattisen kikan sijaan; ovet, kammet |
+| **`PointToPoint`/`Distance`/`Spring`** | ✅ | Ketjut, heilurit, jouset, ragdoll, kytketyt kappaleet |
+| **Laatikko- ja konveksitörmäys (box-box, `ConvexPolyhedron`)** | ✅ | Laatikkopinot, kolikot, ei-pallomaiset esineet (nyt kaikki on pallo tai taso) |
+| **`Ray` / `world.raycast*`** | ✅ | FPS (`fps_wasm`), hiirivalinta, näkölinja, laserit, maadoitustesti |
+| **`RaycastVehicle` + `WheelInfo`** | ✅ | **Autopeli 3D:nä** oikealla renkas­mallilla (nyt top-down host-physics) |
+| **`Cylinder`** | ✅ | Tynnyrit, pylväät, renkaat |
+| **`Heightfield`** | ✅ | Maasto/rata korkeuskarttana |
+| **`Trimesh`** | ✅ | Staattinen tasogeometria mielivaltaisesta meshistä |
+| **`SAPBroadphase` + islands/sleep** | ✅ | Sadat kappaleet ilman O(n²)-romahdusta; lepäävät kappaleet halvat |
+| **CCD (jos portataan)** | ✅ | Nopea pinball-pallo ei tunneloidu seinän läpi |
+| **Täysi 3D-inertia** | ✅ | Aidosti 3D pyörivät kappaleet (nyt vain Z) |
+
+Tämä myös toteuttaa [`IDEAL.md` §2.5](./IDEAL.md):n toivelistan: muototyypit + suodatus
+(layer/mask) + sensorit/triggerit + täysi kontaktimalli (begin/persist/end + syvyys +
+tangentti-impulssi), jotka kaikki ovat cannon-es:ssä valmiina.
+
+---
+
+## 5. Vaiheistettu porttaussuunnitelma (pala palalta)
+
+Periaate säilyy: **1 cannon-es-moduuli → 1 `cannon_*.rgr` + 1 `cannon_*_test.rgr`**,
+`npm run engine:physics:test` vihreänä joka vaiheen jälkeen. Vaiheet on järjestetty
+arvo/riski-suhteessa; jokainen on itsenäisesti hyödyllinen ja pysäytettävissä.
+
+**Vaihe 0 — Perusta (ei toiminnallista muutosta).** Merkitse lähde cannon-es:ksi,
+päivitä matikkamoduulit (`Vec3/Quaternion/Mat3`) cannon-es:n bugikorjauksiin, lisää
+`Ray`-luuranko. Todiste: nykytestit vihreinä + uudet math-testit.
+
+**Vaihe 1 — Oikea solver (suurin arvo).** Porttaa `Equation`, `ContactEquation`
+(täysi), `FrictionEquation`, `GSSolver`. Kytke `CannonWorld.step` käyttämään solveria
+_uuden rajapinnan takana_, säilytä nykyinen arcade-resolveri `config`-lipulla, jottei
+pinball hajoa. Todiste: pino-vakaus-testi + pinball-regressio.
+
+**Vaihe 2 — Nivelet.** `Constraint` → `PointToPointConstraint` → `HingeConstraint` →
+`DistanceConstraint` → `LockConstraint` → `Spring`. Muunna flipperi hinge-nivelellä
+ohjatuksi (poistaa `applyKinematicSpinTransfer`-kikan). Todiste: heiluri- ja
+flipperi-testi.
+
+**Vaihe 3 — Laatikko/konveksi-narrowphase.** `boxBox`, `sphereBox`, `ConvexPolyhedron`
++ `convexConvex` (SAT). Todiste: laatikkopino-testi.
+
+**Vaihe 4 — Raycast.** `Ray`, `RaycastResult`, `world.raycastClosest/Any/All`,
+muotojen `raycast`-metodit. Todiste: raycast-osumatestit per muoto.
+
+**Vaihe 5 — Ajoneuvo.** `WheelInfo` + `RaycastVehicle`. Todiste: autopeli-ajotesti.
+
+**Vaihe 6 — Muodot + broadphase + uni.** `Cylinder`, `Heightfield`, `Trimesh`,
+`Particle`; `SAPBroadphase`; islands/sleep. Todiste: per-muoto-testit + skaalaustesti.
+
+**Vaihe 7 — Rajapinta & backend-luukku.** Nosta `PhysicsWorld`-rajapinta (IDEAL §2.5)
+ja tarjoa valinnainen **Jolt/Rapier host-natiivi-backend** desktopille rajapinnan
+takana. Ranger-cannon-es on oletus; natiivi-backend opt-in raskaaseen 3D:hen.
+
+Kunkin vaiheen voi tehdä erillisenä PR:nä; **uudistus voi pysähtyä minne tahansa** ja
+jättää edellisen vaiheen tuotantoon.
+
+---
+
+## 6. Päätöspisteet (tarvitsen sinulta suunnan)
+
+1. **Aikataulu:** aloitetaanko heti Vaihe 1 (solver), vai jätetäänkö tämä suunnitelma
+   pöytäkirjaan kunnes joku peli oikeasti tarvitsee niveliä/raycastia/ajoneuvoja?
+2. **Laajuus:** riittääkö "täydennä cannon-es -portti" (suositus), vai haluatko myös
+   Vaihe 7:n Jolt-backendin desktop-3D:tä varten heti?
+3. **Pinball-riski:** solverin vaihto voi muuttaa flipperin tuntumaa. OK säilyttää
+   vanha arcade-resolveri lipun takana (suositus), vai siirrytäänkö suoraan
+   hinge-niveliin?
+
+---
+
+## Lähteet
+
+- cannon-es (MIT, TypeScript, muodot + RaycastVehicle + Trimesh/Heightfield/ConvexPolyhedron):
+  <https://github.com/pmndrs/cannon-es>
+- Rapier (Apache-2.0, Rust→WASM): <https://github.com/dimforge/rapier>
+- Jolt Physics (MIT, C++→WASM): <https://github.com/jrouwe/JoltPhysics> ·
+  JS-portti <https://github.com/jrouwe/JoltPhysics.js>
+- Planck.js (MIT, TS, Box2D-portti): <https://github.com/piqnt/planck.js>
+- OimoPhysics (MIT, Haxe→JS/TS): <https://github.com/saharan/OimoPhysics>
+- Three.js Resources — Best Physics: <https://threejsresources.com/best/physics>

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -220,9 +220,15 @@ päivitä matikkamoduulit (`Vec3/Quaternion/Mat3`) cannon-es:n bugikorjauksiin, 
   Uusi `World.contactRest`-testi: pallo asettuu lepokontaktiin toisen päälle
   (`contactRestY ≈ 2.0000`, ei uppoa läpi), lisäksi `sphereBounce`/`gravityStep`/
   `collisionMatrix` pysyvät vihreinä. `npm run engine:physics:test` → 60 passed, 0 failed.
-- ⏳ **Osa 1c (valinnainen):** kitkayhtälöiden generointi narrowphasessa (kaksi
-  tangenttia per kontakti) — solver tukee kitkaa jo (`GSSolver.friction` vihreä),
-  vain narrowphase-kytkentä puuttuu.
+- ✅ **Osa 1c (tehty):** Coulomb-kitka kytketty. `CannonWorld.step` generoi kaksi
+  `FrictionEquation`ia per kontakti (`Vec3.tangents` normaalista, slip force
+  `mu*g*reducedMass`) ja ratkaisee ne kontaktien kanssa. Uusi `World.friction`-testi:
+  liukuva pallo hidastuu (`vx 2.0 → 1.936`) ja saa kitkan momentista pyörinnän
+  (`wz ≈ -2.0`). `npm run engine:physics:test` → 61 passed, 0 failed.
+
+**Vaihe 1 on kokonaisuudessaan valmis:** portin fysiikkaydin ei ole enää käsin
+viritetty arcade-resolveri vaan cannon-es:n SPOOK-constraint-solver kitkoineen —
+valmis alusta niveleille (Vaihe 2).
 
 **Vaihe 2 — Nivelet.** `Constraint` → `PointToPointConstraint` → `HingeConstraint` →
 `DistanceConstraint` → `LockConstraint` → `Spring`. Muunna flipperi hinge-nivelellä

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -264,8 +264,14 @@ flipperi-testi.
   pallo asettuu laatikon päälle (`y ≈ 1.5000`, ei uppoa), laatikko asettuu tasolle
   (`z ≈ 1.0000`). **Tämä on pinballin ydin: pallo vs. laatikkoseinät/flipperit.**
   `npm run engine:physics:test` → 69 passed, 0 failed.
-  ⏳ Täysi **box-box (OBB SAT)** ja `ConvexPolyhedron` jäävät myöhempään (iso,
-  tarkkuutta vaativa) — kaksi dynaamista laatikkoa törmäämässä ei ole vielä.
+- ✅ **Osa 3b (tehty):** täysi **box-box (OBB SAT)** — 15 akselia (3+3 tahkoa +
+  9 särmä-ristituloa) erottavuustestiin ja minimipäällekkäisyysakseli normaaliksi,
+  kontaktimanifold läpäisevistä kulmista (kulma toisen laatikon sisällä → kontakti,
+  kumpaankin suuntaan) + särmä-särmä-fallback. Testit: laatikko lepää laatikon päällä
+  vakaasti nelikulmamanifoldilla (`boxStackY ≈ 1.0000`), päällekkäiset laatikot
+  työntyvät erilleen (`boxSeparateGap` kasvaa). `npm run engine:physics:test` →
+  71 passed, 0 failed. (Yleinen `ConvexPolyhedron` mielivaltaisille konvekseille jää
+  vielä; laatikot katettu.)
 
 **Vaihe 4 — Raycast.** `Ray`, `RaycastResult`, `world.raycastClosest/Any/All`,
 muotojen `raycast`-metodit. Todiste: raycast-osumatestit per muoto.

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -320,8 +320,16 @@ muotojen `raycast`-metodit. Todiste: raycast-osumatestit per muoto.
   `heightfieldPlaneAt`). Testi `Heightfield.restStep`: porrastetulla maastolla
   (matala puoli h=1, korkea h=2) pallot asettuvat säteen verran oman maastokorkeuden
   yläpuolelle (`hfLowZ≈1.5`, `hfHighZ≈2.5`) → ruudukko haetaan sijainnin mukaan.
-  `npm run engine:physics:test` → 78 passed, 0 failed. ⏳ `Cylinder`/`Trimesh`/
-  `Particle` jäävät vielä; `ConvexPolyhedron` seuraavaksi.
+  `npm run engine:physics:test` → 78 passed, 0 failed.
+- ✅ **Osa 3c — ConvexPolyhedron (konveksit muodot, tehty):** [`cannon_convex.rgr`](./physics/src/cannon_convex.rgr)
+  — yleinen konveksi (kärjet + tahkonormaalit, `initBoxHull`-apuri). **convex-plane**
+  (kukin läpäisevä kärki → kontakti, iteroi kärjet kuten planeBox) ja **sphere-convex**
+  (kontakti erottavimpaan tahkotasoon). Virtuaaliset accessorit (`convexVertexAt`/
+  `convexFaceNormalAt`/…) `CannonShape`ssa. Testit: box-hull-konveksi lepää tasolla
+  (`convexHullZ≈1.0`), pallo lepää konveksin tahkolla (`sphereConvexZ≈1.5`).
+  `npm run engine:physics:test` → 80 passed, 0 failed. ⏳ Yleinen convex-convex-SAT
+  (mielivaltaiset konveksit toisiaan vasten) ja `Cylinder`/`Trimesh`/`Particle`
+  jäävät vielä; laatikot, tasot, pallot ja konveksit tasoa/palloa vasten katettu.
 
 **Vaihe 7 — Rajapinta & backend-luukku.** Nosta `PhysicsWorld`-rajapinta (IDEAL §2.5)
 ja tarjoa valinnainen **Jolt/Rapier host-natiivi-backend** desktopille rajapinnan

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -19,12 +19,12 @@
   Kaikki mikä tekee Cannonista _yleisen 3D-moottorin_ puuttuu: **oikea
   constraint-solver, nivelet (hinge/point-to-point/distance/spring), laatikko- ja
   konveksitörmäys, raycast, ajoneuvomalli, kitka, uni/islands, useammat muodot.**
-- **Ranger-filosofia rajaa vaihtoehdot rajusti.** Moottori _portataan lähdekoodina_
-  `.rgr`:ksi (kääntyy C++/WASM/ES6/natiivi Pi). Siksi **Rust- ja C++-moottorit
-  (Rapier, Jolt, Ammo, Box2D-C) eivät kelpaa porttauskohteeksi** — niitä voi käyttää
-  vain läpinäkymättöminä host-natiivi-backendeinä, mikä rikkoo "write once → aja
-  Pi:llä" -lupauksen. Vain **luettava, modulaarinen, hyvin testattu JS/TS-moottori**
-  kelpaa portattavaksi.
+- **Kieli ei ole rajaava tekijä — Ranger _emittoi_ C++:aa ja Rustia**, joten myös
+  C++- ja Rust-moottorin lähdekoodin voi kääntää käsin `.rgr`:ksi ja se kääntyy takaisin
+  C++/WASM/natiivi Pi:hin kuten muukin. **Jolt (MIT, C++) on siis pätevä
+  porttauskohde**, ei pelkkä backend, ja Apache-2.0 (Rapier) on riittävän salliva
+  porttaukseen. Oikea rajaava akseli on **porttauksen kustannus ja tarkkuus**, ei
+  lisenssi tai kieli (ks. §3).
 - **Suositus (kaksitasoinen):**
   1. **Porttauskohde nyt:** päivitä nykyinen portti **cannon-es**iin (MIT, TypeScript,
      ylläpidetty Cannon-forkki, **sama per-luokka-testisetti** jota portti jo peilaa).
@@ -32,10 +32,14 @@
      palalta ne moduulit jotka nykyportti jätti pois (solver → nivelet → laatikko/
      konveksi → raycast → ajoneuvo → muodot). Jokainen tulee `cannon_*.rgr` +
      `cannon_*_test.rgr` -parina, kuten tähänkin asti.
-  2. **Valinnainen tulevaisuuden pako-luukku:** salli **Jolt** (MIT) tai **Rapier**
-     host-natiivina backendinä **`PhysicsWorld`-rajapinnan takana** (IDEAL §2.5)
-     raskaaseen desktop-3D:hen — _ei_ portattuna vaan sidottuna. Pi/natiivi-buildit
-     putoavat takaisin Ranger-cannon-es-ytimeen.
+  2. **Jolt (MIT) on pätevä vaihtoehto — olit oikeassa.** Koska Ranger emittoi C++:aa,
+     Joltin voi portata `.rgr`:ksi. Se on **modernein** ehdokas. Varaus: Joltin ydinarvo
+     (SIMD-matikka + monisäie-job-system) **ei säily** yksisäikeisen skalaari-`.rgr`:n
+     läpi (§3), joten saat Joltin _ominaisuudet_ muttet sen _nopeutta_, ja porttaustyö
+     on ~5× cannon-es. Siksi Jolt sopii **joko** (a) myöhemmäksi täydeksi `.rgr`-portiksi
+     jos halutaan modernein arkkitehtuuri / showcase, **tai** (b) host-natiiviksi
+     backendiksi `PhysicsWorld`-rajapinnan (IDEAL §2.5) taakse desktop-3D:hen — silloin
+     SIMD+säikeet säilyvät, mutta se ei aja Pi-terminaalissa.
 - **"Ei pakko" pitää paikkansa:** jos pelit pysyvät pinball/top-down-tasolla,
   nykyportti riittää. Uudistus kannattaa **heti kun tarvitaan** nivelet (oikeat
   flipperit), raycast (FPS/valinta/näkölinja), ajoneuvot (autopeli 3D), tai staattinen
@@ -80,57 +84,81 @@ josta kasvaa iso Cannon lisäämällä nappuloita — iso osa Cannonista puuttuu
 
 ## 2. Vaihtoehdot painopisteitä vasten
 
-Ratkaiseva suodatin ei ole "paras moottori" vaan **"paras _portattava_ moottori"**:
-lähdekoodi käännetään käsin `.rgr`:ksi, joten sen pitää olla luokkamallinen, riippuvuus-
-kevyt ja per-moduuli-testattu JS/TS. Tämä pudottaa suorituskykykuninkaat (Rust/C++)
-porttauskohteina — ne kelpaavat vain host-natiivi-backendiksi rajapinnan taakse.
+Koska Ranger emittoi C++/Rust/ES6:ta, **mikä tahansa luokkamallinen moottori on
+periaatteessa portattavissa** — kieli ei suodata. Ratkaisevaa on **porttauksen
+kustannus ja tarkkuus**: kuinka moni kielipiirre kääntyy suoraan `.rgr`:ään ja kuinka
+paljon moottorin arvosta säilyy Rangerin läpi (ks. §3 SIMD/säikeet).
 
-| Moottori | Lisenssi | Lähdekieli | Portattava `.rgr`:ksi? | Unit-testit | Ulottuvuus | Huom |
-|----------|----------|-----------|:----------------------:|-------------|-----------|------|
-| **cannon-es** (pmndrs) | **MIT** ✅ | **TypeScript** | ✅ **kyllä** (sama arkkitehtuuri kuin nyt) | ✅ Cannonin per-luokka-setti | 3D | Ylläpito hiipunut, mutta **feature-complete & vakaa** = ihanteellinen _stabiili_ porttauskohde |
-| **OimoPhysics** (saharan) | MIT | Haxe → JS/TS | ⚠️ osin (Haxe-lähde / generoitu JS kömpelömpi kääntää) | ⚠️ ohuet | 3D | Modernimpi solver + 6-DoF-nivelet; heikompi testikattavuus, Haxe-sukujuuri |
-| **Planck.js** (piqnt) | MIT | TypeScript | ✅ kyllä | ✅ hyvät (Box2D-perua) | **2D** | Box2D-portti: erinomainen sequential-impulse-solver + nivelet; **luopuisi 3D-Cannon-investoinnista** |
-| **p2.js** (Cannonin tekijä) | MIT | JavaScript | ✅ kyllä | ✅ on | **2D** | Sama tekijä kuin Cannon; 2D, ylläpito hiipunut |
-| **Box2D v3** (Erin Catto) | MIT | **C** | ⚠️ ei luokkamalli; C lähellä C++-targettia mutta ei JS-testisynergiaa | ✅ | 2D | Referenssilaatu, mutta ei sovi luokkapohjaiseen porttiin |
-| **Rapier** (dimforge) | **Apache-2.0** ❌ | **Rust → WASM** | ❌ **ei** | ✅ (Rust) | 2D/3D | Moderni, deterministinen, CCD — mutta **ei MIT** ja **ei portattava**; vain backend |
-| **Jolt** (jrouwe) | **MIT** ✅ | **C++ → WASM** | ❌ **ei** | ✅ (C++) | 3D | Huippunopea (Horizon/Death Stranding), MIT — mutta **vain host-natiivi-backend**, ei portattava |
-| **Ammo.js** (Bullet) | zlib | C++ (emscripten) | ❌ ei | — | 3D | Ylläpitämätön, läpinäkymätön WASM |
+| Moottori | Lisenssi | Lähdekieli | Portattavuus `.rgr`:ksi | Unit-testit | Ulottuvuus | Huom |
+|----------|----------|-----------|:-----------------------:|-------------|-----------|------|
+| **cannon-es** (pmndrs) | **MIT** ✅ | **TypeScript** | ✅ **helppo** — sama arkkitehtuuri kuin nyt, ~20 moduulia jo portattu | ✅ Cannonin per-luokka-setti | 3D | Ylläpito hiipunut, mutta **feature-complete & vakaa** = ihanteellinen _stabiili_ porttauskohde |
+| **Jolt** (jrouwe) | **MIT** ✅ | C++ | ⚠️ **työläs** — templatet/SIMD/job-system eivät mäppäydy (§3) | ✅ (C++, oma framework) | 3D | **Modernein & rikkain** (character controller, ajoneuvot, CCD, kaikki nivelet). Portattava, mutta ~5× koodi ja perf-etu katoaa skalaariksi |
+| **Rapier** (dimforge) | Apache-2.0 (OK porttiin) | Rust | ⚠️ työläs — nalgebra-generics/SIMD/ownership | ✅ (Rust) | 2D/3D | Moderni, deterministinen, CCD; sama SIMD/perf-tappio kuin Jolt portattuna |
+| **OimoPhysics** (saharan) | MIT | Haxe → JS/TS | ⚠️ osin (Haxe/generoitu JS) | ⚠️ ohuet | 3D | Modernimpi solver + 6-DoF-nivelet; heikompi testikattavuus |
+| **Planck.js** (piqnt) | MIT | TypeScript | ✅ helppo | ✅ hyvät (Box2D-perua) | **2D** | Box2D-portti: erinomainen solver + nivelet; **luopuisi 3D-Cannon-investoinnista** |
+| **p2.js** (Cannonin tekijä) | MIT | JavaScript | ✅ helppo | ✅ on | **2D** | Sama tekijä kuin Cannon; 2D, ylläpito hiipunut |
+| **Box2D v3** (Erin Catto) | MIT | C | ⚠️ ei luokkamalli | ✅ | 2D | Referenssilaatu, mutta ei sovi luokkapohjaiseen porttiin |
+| **Ammo.js** (Bullet) | zlib | C++ (emscripten) | ❌ generoitu emscripten-JS | — | 3D | Ylläpitämätön, läpinäkymätön |
 | Oimo.js (lo-th) | MIT | JS | ✅ | ⚠️ | 3D | Ei aktiivista kehitystä ~2016 jälkeen |
 
-**Suodatuksen tulos:**
-- **Priori­teetti #1 (MIT):** pudottaa Rapierin (Apache-2.0).
-- **Priori­teetti #4 (hyvät unit-testit portin tueksi) + porttausvaatimus:** nostaa
-  **cannon-es**in kärkeen — sillä on juuri se per-luokka-QUnit-rakenne (`test/Vec3.js`,
-  `test/Quaternion.js`, `test/Body.js`, `test/RaycastVehicle.js` …) jota portti jo
-  peilaa. Testit portataan kuten lähde: `cannon_*_test.rgr`.
-- **Jolt** on ainoa "moderni + MIT" joka jää eloon — mutta C++, joten se on **backend-
-  vaihtoehto**, ei porttauskohde.
+**Suodatuksen tulos:** lisenssi ei enää pudota ketään (MIT: cannon-es/Jolt/Oimo/Planck/p2;
+Apache-2.0 Rapier riittää porttiin). Kaksi todellista kärkiehdokasta jäävät jäljelle,
+ja ne edustavat **eri strategiaa**:
+- **cannon-es** — *halpa, tarkka, nopea voitto*: sama arkkitehtuuri, ~20 moduulia jo
+  portattu, per-luokka-testit (`test/Vec3.js`, `test/Body.js`, `test/RaycastVehicle.js` …)
+  mäppäytyvät suoraan olemassa olevaan [`cannon_test_harness.rgr`](./physics/src/cannon_test_harness.rgr):iin.
+- **Jolt** — *modernein moottori, iso investointi*: MIT ja portattava (olit oikeassa),
+  mutta ~5× koodi ja sen ydinarvo (SIMD-matikka + monisäie-job-system) ei säily Rangerin
+  läpi (§3). Saat Joltin _ominaisuudet_ muttet Joltin _nopeutta_.
 
 ---
 
-## 3. Miksi cannon-es eikä "jotain uudempaa"
+## 3. Kustannus & tarkkuus: Jolt vs. cannon-es porttauskohteena
 
-Houkutus on ottaa Rapier/Jolt, koska ne ovat suorituskyvyltään ja determinismiltään
-edellä. Mutta se olisi **eri asia kuin mitä tehtävä pyytää**:
+Korjaus edelliseen: **Jolt _ei_ ole diskattu.** C++ kääntyy `.rgr`:stä, joten Joltin
+lähteen voi portata ja se palaa C++:ksi/WASM:ksi/Pi:ksi. Kysymys ei ole *voiko*, vaan
+*kannattaako* — ja vastaus riippuu siitä, kuinka paljon moottorin arvosta säilyy portin
+läpi.
 
-1. **Porttausfilosofia.** Ranger-lupaus on _lähdekoodin_ siirrettävyys (yksi
-   `.rgr` → C++/WASM/ES6/natiivi Pi). Rust/C++-moottori voi elää vain esikäännettynä
-   WASM/natiivi-binäärinä → Pi-terminaalibuild ja "write once" hajoaa. cannon-es
-   kääntyy Rangerin läpi samoihin targetteihin kuin muu peli.
-2. **Testit porttausapuna (#4).** cannon-es tuo Cannonin testisetin mukanaan.
-   Jokainen portattu moduuli saa heti oraakkelin: aja sama testi `.rgr`:nä, vertaa
-   lukuja. Rust/C++-testejä ei voi peilata `.rgr`-harnessiin ([`cannon_test_harness.rgr`](./physics/src/cannon_test_harness.rgr)).
-3. **Nolla-hukkainvestoiniti.** Nykyiset `Vec3/Quaternion/Mat3/AABB/Body/World`-portit
-   **kelpaavat sellaisenaan** — cannon-es on saman koodin TypeScript-siisti, bugikorjattu
-   versio. Migraatio on _lisäystä_, ei purkua. Rapier/Jolt heittäisi kaiken pois.
-4. **IDEAL on jo suunniteltu tähän.** [`IDEAL.md` §2.5](./IDEAL.md) haluaa
-   `PhysicsWorld`-rajapinnan (`addBody`/`setBounds`/`step`/`contacts`), jonka takana on
-   *"arcade-ydin **tai** cannon-portti **tai** host-natiivi-moottori"*. Suositus toteuttaa
-   juuri tämän: cannon-es on portattava ydin, Jolt/Rapier valinnainen natiivi-backend.
+**Mikä Joltista säilyy Rangerin läpi ja mikä ei.** Joltin ydinarvo on kaksi asiaa,
+jotka `.rgr` **ei** ilmaise:
 
-**Milloin Jolt/Rapier -backend kannattaa:** vasta kun desktop-3D-peli tarvitsee satoja
-törmääviä kappaleita, CCD:tä tai deterministista verkkopeliä — ja hyväksytään ettei se
-peli aja Pi-terminaalissa. Se on _lisäys rajapinnan taakse_, ei ytimen korvaus.
+| Joltin nopeuden lähde | Säilyykö `.rgr`-portissa? | Miksi |
+|-----------------------|:-------------------------:|-------|
+| **SIMD-matikka** (`Vec4`/`Mat44` SSE/NEON-intrinsiceillä) | ❌ | `.rgr`:ssä ei ole SIMD-primitiivejä; matikka kääntyy skalaariksi |
+| **Monisäie-job-system** (broadphase, solver rinnakkain) | ❌ | Rangerin runtime/WASM-malli on **yksisäikeinen**, RC-pohjainen |
+| **Templatet** (geneerinen muoto-dispatch käännösaikana) | ⚠️ | `.rgr`:ssä ei generic-templateja → dispatch käsin, koodi paisuu |
+| Custom-allokaattorit / temp-arenat | ⚠️ | `.rgr` käyttää RC-kekoa; arenat kirjoitetaan uusiksi |
+| **Algoritmit** (solver, quadtree-broadphase, CCD, character controller) | ✅ | Nämä kääntyvät — tämä on se osa jonka portista saa |
+
+Eli **`.rgr`-Jolt = Joltin ominaisuudet skalaarinopeudella.** Saat modernin featuresetin
+(character controller, ajoneuvot, CCD, kaikki nivelet, quadtree-broadphase), muttet sitä
+"2× Rapier" -nopeutta joka on koko Joltin maine — se nopeus tulee juuri SIMD:stä ja
+monisäikeisyydestä, jotka jäävät oven ulkopuolelle.
+
+**Kolme argumenttia miksi cannon-es on silti parempi _ensimmäinen_ kohde:**
+
+1. **Kohdealusta on Raspberry Pi -yksisäie.** Ranger-lupaus on ajaa Pi-terminaalissa.
+   Jolt on suunniteltu monisäie-desktop/konsoli-raudalle; skalaari-yksisäie-portti
+   kadottaa sen suunnitteluoletukset. cannon-es:n **kevyt skalaari-arkkitehtuuri sopii
+   Rangerin ajoympäristöön luontaisesti** — se on halvin siellä missä koodi oikeasti ajaa.
+2. **Nolla-hukkainvestointi + testit.** `Vec3/Quaternion/Mat3/AABB/Body/World` (~20
+   moduulia) **kelpaavat sellaisinaan** — cannon-es on saman koodin TS-siisti, bugikorjattu
+   versio. Migraatio on _lisäystä_. Ja Cannonin per-luokka-testit mäppäytyvät suoraan
+   [`cannon_test_harness.rgr`](./physics/src/cannon_test_harness.rgr):iin (painopiste #4).
+   Jolt aloittaisi ~nollasta eri matikkakonventioilla ja C++-testiframeworkilla.
+3. **IDEAL on jo suunniteltu monimoottoriseksi.** [`IDEAL.md` §2.5](./IDEAL.md) haluaa
+   `PhysicsWorld`-rajapinnan, jonka takana on *"arcade-ydin **tai** cannon-portti **tai**
+   host-natiivi-moottori"*. **Tämä ei ole joko–tai:** cannon-es voi olla portattava,
+   Pi-yhteensopiva oletusydin, ja Jolt voi tulla myöhemmin **joko** (a) omana `.rgr`-
+   porttina jos halutaan modernein arkkitehtuuri **tai** (b) host-natiivina backendinä
+   desktopille (silloin SIMD+säikeet säilyvät, mutta ei aja Pi:llä).
+
+**Missä Jolt voittaisi:** jos tavoite on nimenomaan **modernein moottori showcase-
+mielessä** (Ranger on osin kielilaboratorio — "Ranger porttasi Joltin" on itsessään
+näyttävä demonstraatio C++-porttauskyvystä), tai jos tarvitaan Joltin ainutlaatuisia
+kykyjä (character controller, edistyneet nivelet, soft bodies) joita cannon-es:ssä ei
+ole. Silloin Jolt on perusteltu — kunhan hyväksytään ~5× porttaustyö ja skalaarinopeus.
 
 ---
 
@@ -199,10 +227,15 @@ jättää edellisen vaiheen tuotantoon.
 
 ## 6. Päätöspisteet (tarvitsen sinulta suunnan)
 
-1. **Aikataulu:** aloitetaanko heti Vaihe 1 (solver), vai jätetäänkö tämä suunnitelma
-   pöytäkirjaan kunnes joku peli oikeasti tarvitsee niveliä/raycastia/ajoneuvoja?
-2. **Laajuus:** riittääkö "täydennä cannon-es -portti" (suositus), vai haluatko myös
-   Vaihe 7:n Jolt-backendin desktop-3D:tä varten heti?
+1. **Moottorivalinta — pääkysymys:**
+   - **A) cannon-es (suositus):** halpa, tarkka, Pi-yhteensopiva, reuse ~20 moduulia,
+     testit mäppäytyvät. Nopein tie ominaisuuksiin.
+   - **B) Jolt täytenä `.rgr`-porttina:** modernein arkkitehtuuri + showcase Rangerin
+     C++-porttauskyvystä; hyväksytään ~5× työ ja skalaarinopeus (ei SIMD/säikeitä).
+   - **C) Molemmat:** cannon-es portattava Pi-ydin **ja** Jolt host-natiivi-backend
+     desktopille `PhysicsWorld`-rajapinnan takana.
+2. **Aikataulu:** aloitetaanko heti valitun moottorin Vaihe 1 (solver), vai jätetäänkö
+   suunnitelma odottamaan kunnes peli oikeasti tarvitsee niveliä/raycastia/ajoneuvoja?
 3. **Pinball-riski:** solverin vaihto voi muuttaa flipperin tuntumaa. OK säilyttää
    vanha arcade-resolveri lipun takana (suositus), vai siirrytäänkö suoraan
    hinge-niveliin?

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -327,9 +327,26 @@ muotojen `raycast`-metodit. Todiste: raycast-osumatestit per muoto.
   (kontakti erottavimpaan tahkotasoon). Virtuaaliset accessorit (`convexVertexAt`/
   `convexFaceNormalAt`/…) `CannonShape`ssa. Testit: box-hull-konveksi lepää tasolla
   (`convexHullZ≈1.0`), pallo lepää konveksin tahkolla (`sphereConvexZ≈1.5`).
-  `npm run engine:physics:test` → 80 passed, 0 failed. ⏳ Yleinen convex-convex-SAT
-  (mielivaltaiset konveksit toisiaan vasten) ja `Cylinder`/`Trimesh`/`Particle`
-  jäävät vielä; laatikot, tasot, pallot ja konveksit tasoa/palloa vasten katettu.
+  `npm run engine:physics:test` → 80 passed, 0 failed.
+- ✅ **Osa 3d — Pieni häntä (tehty):** loput muodot + yleinen convex-convex.
+  - **Cylinder** ([`initCylinderHull`](./physics/src/cannon_convex.rgr)) — N-tahoinen
+    konveksi prisma Z-akselin ympäri (kuten cannon-es); saa convex-törmäykset
+    ilmaiseksi. Testit: sylinteri lepää tasolla (`cylinderZ≈1.0`), pallo sylinterin
+    päällä (`sphereCylinderZ≈1.5`).
+  - **Particle** ([`cannon_particle.rgr`](./physics/src/cannon_particle.rgr)) — pistemassa
+    (säde-0 pallo, reitittyy pallorutiinien läpi). Testi: hiukkanen lepää tason pinnalla
+    (`particleZ≈0.0`).
+  - **Trimesh** ([`cannon_trimesh.rgr`](./physics/src/cannon_trimesh.rgr)) — staattinen
+    kolmioverkko, sphere-trimesh (lähin piste kolmiolla, Ericson). Testi: pallo lepää
+    trimesh-lattialla (`trimeshZ≈0.5`).
+  - **Yleinen convex-convex-SAT** — tahkonormaali-SAT + kärki-rungossa-manifold
+    (mielivaltaiset konveksit, myös cylinder-cylinder). Testi: konveksi lepää toisen
+    konveksin päällä (`convexStackZ≈1.0`). (Särmä-särmä-akselit karsittu; tahko-tahko
+    ja akselin­suuntaiset tapaukset tarkkoja.)
+
+  `npm run engine:physics:test` → **89 passed, 0 failed.** Kaikki muodot (sphere, box,
+  plane, heightfield, convex, cylinder, particle, trimesh) katettu pareittain
+  keskeisissä yhdistelmissä.
 
 **Vaihe 7 — Rajapinta & backend-luukku.** Nosta `PhysicsWorld`-rajapinta (IDEAL §2.5)
 ja tarjoa valinnainen **Jolt/Rapier host-natiivi-backend** desktopille rajapinnan

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -235,6 +235,13 @@ valmis alusta niveleille (Vaihe 2).
 ohjatuksi (poistaa `applyKinematicSpinTransfer`-kikan). Todiste: heiluri- ja
 flipperi-testi.
 
+- ✅ **Osa 2a (tehty):** [`cannon_constraint.rgr`](./physics/src/cannon_constraint.rgr)
+  + `CannonWorld.addConstraint`/`update`-kytkentä. **PointToPointConstraint** (ball-
+  and-socket) kolmena bilateraalisena kontaktiyhtälönä (ni = x/y/z, minForce =
+  -maxForce). Testi ([`cannon_constraint_test.rgr`](./physics/src/cannon_constraint_test.rgr)):
+  heiluri pysyy niveltvälin päässä (`pendulumDist ≈ 2.0`) ja heilahtaa painovoimassa
+  alas (`pendulumY ≈ -1.79`). `npm run engine:physics:test` → 62 passed, 0 failed.
+
 **Vaihe 3 — Laatikko/konveksi-narrowphase.** `boxBox`, `sphereBox`, `ConvexPolyhedron`
 + `convexConvex` (SAT). Todiste: laatikkopino-testi.
 

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -256,6 +256,17 @@ flipperi-testi.
 **Vaihe 3 — Laatikko/konveksi-narrowphase.** `boxBox`, `sphereBox`, `ConvexPolyhedron`
 + `convexConvex` (SAT). Todiste: laatikkopino-testi.
 
+- ✅ **Osa 3a (tehty):** **sphere-box** (lähin piste OBB:llä) ja **plane-box**
+  (kukin läpäisevä laatikon kulma → kontakti) lisätty narrowphaseen. Muototyyppi
+  ratkaistaan virtuaalisella `getHalfExtents()`-metodilla (perii `CannonShape`,
+  ylikirjoittaa `CannonBox`) — sama polymorfismi kuin `calculateWorldAABB`illa,
+  ei downcastia. Testit ([`cannon_boxcollision_test.rgr`](./physics/src/cannon_boxcollision_test.rgr)):
+  pallo asettuu laatikon päälle (`y ≈ 1.5000`, ei uppoa), laatikko asettuu tasolle
+  (`z ≈ 1.0000`). **Tämä on pinballin ydin: pallo vs. laatikkoseinät/flipperit.**
+  `npm run engine:physics:test` → 69 passed, 0 failed.
+  ⏳ Täysi **box-box (OBB SAT)** ja `ConvexPolyhedron` jäävät myöhempään (iso,
+  tarkkuutta vaativa) — kaksi dynaamista laatikkoa törmäämässä ei ole vielä.
+
 **Vaihe 4 — Raycast.** `Ray`, `RaycastResult`, `world.raycastClosest/Any/All`,
 muotojen `raycast`-metodit. Todiste: raycast-osumatestit per muoto.
 

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -211,10 +211,18 @@ päivitä matikkamoduulit (`Vec3/Quaternion/Mat3`) cannon-es:n bugikorjauksiin, 
   > Huom porttausta varten: nykyinen narrowphase asettaa `ni = xi - xj`, mutta
   > cannon-es:n `ContactEquation` odottaa vastakkaisen konvention (`ni` osoittaa
   > i→j). Vaihe 1b:n kytkennässä narrowphase tuottaa yhtälöt oikealla konventiolla.
-- ⏳ **Osa 1b (seuraava):** kytke `CannonWorld.step` ajamaan `CannonGSSolver` (kontakti-
-  + kitkayhtälöt narrowphasesta) nykyisen käsin viritetyn `resolveContactImpulses`in
-  tilalle. Pinball menee uusiksi (sovittu — vielä luonnos), joten vanhaa arcade-
-  resolveria ei säilytetä lipun takana. Todiste: pino-vakaus-testi + sandbox-ajo.
+- ✅ **Osa 1b (tehty):** `CannonWorld.step` ajaa nyt `CannonGSSolver`in. Narrowphase
+  tuottaa SPOOK-kontaktiyhtälöt (`CannonEquation`, cannon-es `ni`-konventio i→j,
+  restituutio + spook-parametrit kontaktimateriaalista); World lisää ne solveriin,
+  ratkaisee, ja integroi puoli-implisiittisellä Eulerilla (`CannonBody.integrate` +
+  `CannonQuaternion.integrate`, linear/angular-factorit). Käsin viritetty
+  `resolveContactImpulses`/`separateContact`/`applyKinematicSpinTransfer` **poistettu**.
+  Uusi `World.contactRest`-testi: pallo asettuu lepokontaktiin toisen päälle
+  (`contactRestY ≈ 2.0000`, ei uppoa läpi), lisäksi `sphereBounce`/`gravityStep`/
+  `collisionMatrix` pysyvät vihreinä. `npm run engine:physics:test` → 60 passed, 0 failed.
+- ⏳ **Osa 1c (valinnainen):** kitkayhtälöiden generointi narrowphasessa (kaksi
+  tangenttia per kontakti) — solver tukee kitkaa jo (`GSSolver.friction` vihreä),
+  vain narrowphase-kytkentä puuttuu.
 
 **Vaihe 2 — Nivelet.** `Constraint` → `PointToPointConstraint` → `HingeConstraint` →
 `DistanceConstraint` → `LockConstraint` → `Spring`. Muunna flipperi hinge-nivelellä

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -196,9 +196,25 @@ päivitä matikkamoduulit (`Vec3/Quaternion/Mat3`) cannon-es:n bugikorjauksiin, 
 `Ray`-luuranko. Todiste: nykytestit vihreinä + uudet math-testit.
 
 **Vaihe 1 — Oikea solver (suurin arvo).** Porttaa `Equation`, `ContactEquation`
-(täysi), `FrictionEquation`, `GSSolver`. Kytke `CannonWorld.step` käyttämään solveria
-_uuden rajapinnan takana_, säilytä nykyinen arcade-resolveri `config`-lipulla, jottei
-pinball hajoa. Todiste: pino-vakaus-testi + pinball-regressio.
+(täysi), `FrictionEquation`, `GSSolver`.
+
+- ✅ **Osa 1a (tehty):** SPOOK-solver-stack portattu ja yksikkötestattu erillisinä
+  moduuleina: [`cannon_jacobian_element.rgr`](./physics/src/cannon_jacobian_element.rgr),
+  [`cannon_equation.rgr`](./physics/src/cannon_equation.rgr) (yhtenäinen `kind`-kenttä:
+  1=contact, 2=friction — porttien idiomi luokkaperinnän sijaan),
+  [`cannon_gssolver.rgr`](./physics/src/cannon_gssolver.rgr). Body sai solver-tilan
+  (`vlambda`/`wlambda`/`invMassSolve`/`invInertiaWorld` Mat3 +
+  `updateSolveMassProperties`/`updateInertiaWorld`). Testit
+  ([`cannon_solver_test.rgr`](./physics/src/cannon_solver_test.rgr)) todentavat
+  fysikaaliset invariantit: liikemäärän säilyminen, penetraation erottava vaste,
+  kitkan kytkentä. `npm run engine:physics:test` → 59 passed, 0 failed.
+  > Huom porttausta varten: nykyinen narrowphase asettaa `ni = xi - xj`, mutta
+  > cannon-es:n `ContactEquation` odottaa vastakkaisen konvention (`ni` osoittaa
+  > i→j). Vaihe 1b:n kytkennässä narrowphase tuottaa yhtälöt oikealla konventiolla.
+- ⏳ **Osa 1b (seuraava):** kytke `CannonWorld.step` ajamaan `CannonGSSolver` (kontakti-
+  + kitkayhtälöt narrowphasesta) nykyisen käsin viritetyn `resolveContactImpulses`in
+  tilalle. Pinball menee uusiksi (sovittu — vielä luonnos), joten vanhaa arcade-
+  resolveria ei säilytetä lipun takana. Todiste: pino-vakaus-testi + sandbox-ajo.
 
 **Vaihe 2 — Nivelet.** `Constraint` → `PointToPointConstraint` → `HingeConstraint` →
 `DistanceConstraint` → `LockConstraint` → `Spring`. Muunna flipperi hinge-nivelellä

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -313,8 +313,15 @@ muotojen `raycast`-metodit. Todiste: raycast-osumatestit per muoto.
 - ✅ **Osa 6b — SAP-broadphase (tehty):** [`cannon_sap_broadphase.rgr`](./physics/src/cannon_sap_broadphase.rgr)
   — lajittelu AABB:n min-x:n mukaan + pyyhkäisy, karsii O(n²)-parit. Testi
   `SAP.sameAsNaive`: tuottaa samat parit kuin naiivi (2 = 2). `npm run engine:physics:test`
-  → 75 passed, 0 failed. ⏳ `Cylinder`/`Heightfield`/`Trimesh`/`Particle`-muodot
-  (törmäyskoodi kullekin) jäävät vielä.
+  → 75 passed, 0 failed.
+- ✅ **Osa 6c — Heightfield (maasto, tehty):** [`cannon_heightfield.rgr`](./physics/src/cannon_heightfield.rgr)
+  — korkeusruudukko (`data[i*ny+j]`, `elementSize`), pinta z = korkeus. Sphere-
+  heightfield-törmäys ottaa maaston kolmiotason pallon keskipisteen alta (virtuaali
+  `heightfieldPlaneAt`). Testi `Heightfield.restStep`: porrastetulla maastolla
+  (matala puoli h=1, korkea h=2) pallot asettuvat säteen verran oman maastokorkeuden
+  yläpuolelle (`hfLowZ≈1.5`, `hfHighZ≈2.5`) → ruudukko haetaan sijainnin mukaan.
+  `npm run engine:physics:test` → 78 passed, 0 failed. ⏳ `Cylinder`/`Trimesh`/
+  `Particle` jäävät vielä; `ConvexPolyhedron` seuraavaksi.
 
 **Vaihe 7 — Rajapinta & backend-luukku.** Nosta `PhysicsWorld`-rajapinta (IDEAL §2.5)
 ja tarjoa valinnainen **Jolt/Rapier host-natiivi-backend** desktopille rajapinnan

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -286,6 +286,16 @@ muotojen `raycast`-metodit. Todiste: raycast-osumatestit per muoto.
 
 **Vaihe 5 — Ajoneuvo.** `WheelInfo` + `RaycastVehicle`. Todiste: autopeli-ajotesti.
 
+- ✅ **Osa 5a (tehty):** [`cannon_vehicle.rgr`](./physics/src/cannon_vehicle.rgr)
+  (`CannonWheelInfo` + `CannonRaycastVehicle`). Kukin pyörä ampuu säteen jousituksen
+  suuntaan; jousi+vaimennus-voima kannattelee koria, moottorivoima ajaa eteenpäin.
+  Kori on laatikko (näkymätön ray-vs-sphere/plane-castereille), joten pyörät näkevät
+  vain maan. Testit ([`cannon_vehicle_test.rgr`](./physics/src/cannon_vehicle_test.rgr)):
+  4-pyöräinen ajoneuvo leijuu jousituksellaan tasolla (`vehicleHoverY ≈ 1.42`, pyörät
+  kontaktissa, ei uppoa), moottorivoima ajaa eteenpäin (`vehicleDriveX ≈ 5.2`).
+  `npm run engine:physics:test` → 73 passed, 0 failed. ⏳ Sivuttaiskitka/ohjaus
+  (lateral grip, steering) tulee myöhemmin — jousitus + veto toimivat.
+
 **Vaihe 6 — Muodot + broadphase + uni.** `Cylinder`, `Heightfield`, `Trimesh`,
 `Particle`; `SAPBroadphase`; islands/sleep. Todiste: per-muoto-testit + skaalaustesti.
 

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -347,8 +347,19 @@ takana. Ranger-cannon-es on oletus; natiivi-backend opt-in raskaaseen 3D:hen.
   testikoodi ajaisi minkä tahansa `PhysicsWorld`-toteutuksen → **rajapinta on nyt
   saumana kaikelle testaukselle** ja tuleva Jolt/arcade-backend liittyy tähän.
   `npm run engine:physics:test` → 82 passed, 0 failed.
-- ⏳ **Osa 7b:** arcade-ytimen (`physics_core.rgr`) adapteri samaan rajapintaan +
-  valinnainen Jolt/Rapier host-natiivi-backend jäävät pohdintaan.
+- ✅ **Osa 7b-1 — Arcade-backend rajapinnan takana (tehty, PoC):**
+  [`arcade_physics_world.rgr`](./physics/src/arcade_physics_world.rgr)
+  (`ArcadePhysicsWorld extends PhysicsWorld`) — **toinen, aidosti erilainen**
+  moottori: ei solveria, vaan puoli-implisiittinen Euler + penetraatiokorjaus ja
+  nopeuden heijastus (pallot + tasot). Ei riippuvuutta Cannon-porttiin. Testit:
+  **sama** moottoririippumaton `dropScenario` ajaa arcadea (`arcadeBallY=0.5`) ja
+  molemmat moottorit **antavat saman tuloksen** samasta skenaariosta
+  (`agreeCannonY=0.494` vs `agreeArcadeY=0.5`, ero < 0.01) → todiste että
+  `PhysicsWorld` on aito sauma jonka takana moottorit vaihtuvat. `npm run
+  engine:physics:test` → 84 passed, 0 failed. (Huom: itsenäinen kompakti arcade-
+  moottori, ei olemassa olevan `game_physics.rgr`:n kääre — se on vielä luonnos.)
+- ⏳ **Osa 7b-2:** valinnainen Jolt/Rapier host-natiivi-backend jää pohdintaan
+  (iso, desktop-only integrointi).
 
 Kunkin vaiheen voi tehdä erillisenä PR:nä; **uudistus voi pysähtyä minne tahansa** ja
 jättää edellisen vaiheen tuotantoon.

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -293,8 +293,14 @@ muotojen `raycast`-metodit. Todiste: raycast-osumatestit per muoto.
   vain maan. Testit ([`cannon_vehicle_test.rgr`](./physics/src/cannon_vehicle_test.rgr)):
   4-pyöräinen ajoneuvo leijuu jousituksellaan tasolla (`vehicleHoverY ≈ 1.42`, pyörät
   kontaktissa, ei uppoa), moottorivoima ajaa eteenpäin (`vehicleDriveX ≈ 5.2`).
-  `npm run engine:physics:test` → 73 passed, 0 failed. ⏳ Sivuttaiskitka/ohjaus
-  (lateral grip, steering) tulee myöhemmin — jousitus + veto toimivat.
+  `npm run engine:physics:test` → 73 passed, 0 failed.
+- ✅ **Osa 5b — Sivuttaiskitka + ohjaus (tehty):** kukin pyörä laskee ohjatun
+  suunnan (chassis-forward kääntyy ohjauskulmalla) ja **sivuttaispidon** (vastustaa
+  sivuttaisnopeutta kontaktissa, rajattuna `frictionSlip * jousituskuorma`).
+  `setSteeringValue` kääntää pyöriä. Testit: sivuttaisliuku vaimenee
+  (`lateralVz 3.0 → 0.21`), ohjattu auto kääntyy kaarelle (`steerX ≈ 6.8`,
+  `steerZ ≈ 7.0`). **Ajoneuvo on nyt kokonainen: jousitus + veto + pito + ohjaus.**
+  `npm run engine:physics:test` → 77 passed, 0 failed.
 
 **Vaihe 6 — Muodot + broadphase + uni.** `Cylinder`, `Heightfield`, `Trimesh`,
 `Particle`; `SAPBroadphase`; islands/sleep. Todiste: per-muoto-testit + skaalaustesti.

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -241,6 +241,14 @@ flipperi-testi.
   -maxForce). Testi ([`cannon_constraint_test.rgr`](./physics/src/cannon_constraint_test.rgr)):
   heiluri pysyy niveltvälin päässä (`pendulumDist ≈ 2.0`) ja heilahtaa painovoimassa
   alas (`pendulumY ≈ -1.79`). `npm run engine:physics:test` → 62 passed, 0 failed.
+- ✅ **Osa 2b (tehty):** **HingeConstraint** (`RotationalEquation`, `kind=3`
+  `CannonEquation`ssa). Hinge = point-to-point (pivot) + kaksi rotational-yhtälöä
+  jotka pitävät kappaleiden saranaakselit linjassa → yksi vapaa rotaatio-DOF.
+  Testi `Constraint.hingeAxis`: akselin ulkopuolinen pyörintä vaimenee (`wx ≈ 0`),
+  kappale pysyy saranatasossa (`z ≈ 0`), mutta painovoima heilauttaa sen saranan
+  ympäri (`y ≈ -0.21`). **Tämä on flipperin nivelen ydin.** Motori
+  (`RotationalMotorEquation`) puuttuu vielä (aktiivinen ohjaus) — passiivinen sarana
+  toimii. `npm run engine:physics:test` → 63 passed, 0 failed.
 
 **Vaihe 3 — Laatikko/konveksi-narrowphase.** `boxBox`, `sphereBox`, `ConvexPolyhedron`
 + `convexConvex` (SAT). Todiste: laatikkopino-testi.

--- a/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
+++ b/gallery/game_engine/PLAN_PHYSICS_ENGINE.md
@@ -259,6 +259,14 @@ flipperi-testi.
 **Vaihe 4 — Raycast.** `Ray`, `RaycastResult`, `world.raycastClosest/Any/All`,
 muotojen `raycast`-metodit. Todiste: raycast-osumatestit per muoto.
 
+- ✅ **Osa 4a (tehty):** [`cannon_ray.rgr`](./physics/src/cannon_ray.rgr)
+  (`CannonRay` + `CannonRaycastResult`) — ray↔sphere ja ray↔plane, moodit
+  CLOSEST/ANY/ALL. `CannonWorld.raycastClosest`/`raycastAny` iteroivat kappaleet.
+  Testit ([`cannon_ray_test.rgr`](./physics/src/cannon_ray_test.rgr)): säde osuu
+  palloon (etäisyys 4, x=-1, normaali -x), ohittaa pallon (ei osumaa), osuu tasoon
+  (z=0, etäisyys 5). `npm run engine:physics:test` → 67 passed, 0 failed.
+  ⏳ ray↔box tulee laatikkomuodon kanssa (Vaihe 3).
+
 **Vaihe 5 — Ajoneuvo.** `WheelInfo` + `RaycastVehicle`. Todiste: autopeli-ajotesti.
 
 **Vaihe 6 — Muodot + broadphase + uni.** `Cylinder`, `Heightfield`, `Trimesh`,

--- a/gallery/game_engine/README.md
+++ b/gallery/game_engine/README.md
@@ -619,11 +619,30 @@ Kaksi opt-in-fysiikkakerrosta:
 | **Host physics** (`game_physics.rgr`) | Top-down racer, ajoneuvot, segmenttiseinät | `config().physics`, `state.physics`, `physicsContacts` |
 | **Cannon** (`game_cannon_physics.rgr`) | Pinball, painovoima, flipperit | `config().physics.cannon`, entity `physics: { … }` |
 
-Cannon.js -portti: [`physics/src/`](./physics/src/). Headless-testit:
+### Cannon-moottori (uudistettu)
+
+Cannon-portti [`physics/src/`](./physics/src/) on uudistettu **cannon-es**:n pohjalta
+täydeksi constraint-pohjaiseksi 3D-moottoriksi (89 yksikkötestiä). Katso koko
+kuvaus ja vaiheet: [`PLAN_PHYSICS_ENGINE.md`](./PLAN_PHYSICS_ENGINE.md).
+
+- **Solver:** SPOOK Gauss–Seidel + Coulomb-kitka (korvaa käsin viritetyn arcade-resolverin)
+- **Nivelet:** point-to-point, sarana (hinge), sarana-motori (flipperi)
+- **Muodot & törmäykset:** sphere, box, plane, heightfield, convex, cylinder, particle,
+  trimesh — mukaan lukien box-box- ja convex-convex-SAT
+- **Raycast**, **RaycastVehicle** (jousitus + veto + sivuttaispito + ohjaus), **uni**
+  (sleep), **SAP-broadphase**
+- **`PhysicsWorld`-rajapinta** ([`physics_world.rgr`](./physics/src/physics_world.rgr)):
+  moottorineutraali sauma, jonka takana Cannon- ja arcade-backendit ovat vaihdettavissa
 
 ```bash
-npm run engine:physics:test
+npm run engine:physics:test        # 89 yksikkötestiä
+npm run engine:physics:showcase    # engine toiminnassa: 3 pallon vakaa pino (ASCII)
 ```
+
+> **Huom:** TSX-silta ([`game_cannon_physics.rgr`](./scripting/game_cannon_physics.rgr))
+> tekee vielä arcade-tyylistä manuaalista reunakäsittelyä eikä komponoi täysin uuden
+> solverin kanssa — se on vielä luonnos ja vaatii oman uudistuksensa. `engine:physics:showcase`
+> ajaa moottoria suoraan `PhysicsWorld`-rajapinnan kautta (ohi sillan).
 
 ## Käännetty Pong-viite
 

--- a/gallery/game_engine/ROADMAP.md
+++ b/gallery/game_engine/ROADMAP.md
@@ -82,7 +82,7 @@ backend. Kaikki muu on portable.
 | **Pose-input (RGP1)** | `pose/`, `game_pose_provider.rgr` | ⚠️ PoC (natiivi + MediaPipe) |
 | **Streaming (RGX1/RGLD)** | `wasm/rust_worker`, `wasm/as_resource_loader`, `streaming_world_runner.rgr` | ⚠️ PoC (mock-handlet) |
 | **Host-fysiikka** | `game_physics.rgr`, `physics_core.rgr` | ✅ Phase 1 |
-| **Cannon-fysiikka** | `physics/src/cannon_*.rgr`, `game_cannon_physics.rgr` | ✅ Pinball + sandbox |
+| **Cannon-fysiikka (uudistettu)** | `physics/src/cannon_*.rgr`, `game_cannon_physics.rgr` | ✅ Täysi moottori: SPOOK-solver+kitka, nivelet+motori, kaikki muodot (sphere/box/plane/heightfield/convex/cylinder/particle/trimesh), raycast, ajoneuvo, uni, SAP + `PhysicsWorld`-rajapinta (89 testiä) — ks. [`PLAN_PHYSICS_ENGINE.md`](./PLAN_PHYSICS_ENGINE.md). Demo: `npm run engine:physics:showcase` |
 
 ### Demo-pelit
 
@@ -178,7 +178,9 @@ backend. Kaikki muu on portable.
 
 - Scene graph
 - Täysi asset pipeline (kuvat, äänipankit, kartat) — LPC bake osittain: [`LPC_HEADLESS_SPRITESHEET.md`](./LPC_HEADLESS_SPRITESHEET.md)
-- Yksi universaali fysiikkamoottori — kaksi erillistä kerrosta (host + Cannon) tarkoituksella
+- ~~Yksi universaali fysiikkamoottori~~ — nyt on `PhysicsWorld`-rajapinta jonka takana
+  moottorit vaihtuvat (Cannon + arcade); host-top-down ja Cannon ovat edelleen erilliset
+  toteutukset, mutta saman sopimuksen takana (ks. [`PLAN_PHYSICS_ENGINE.md`](./PLAN_PHYSICS_ENGINE.md) Vaihe 7a)
 
 Nämä ovat tulevia kerroksia tai pelikohtaisia ratkaisuja, ei base-moottorin osia.
 

--- a/gallery/game_engine/games/cannon_stack/game.info
+++ b/gallery/game_engine/games/cannon_stack/game.info
@@ -1,0 +1,2 @@
+name=Cannon Stack (physics)
+category=Tests

--- a/gallery/game_engine/games/cannon_stack/index.tsx
+++ b/gallery/game_engine/games/cannon_stack/index.tsx
@@ -1,0 +1,38 @@
+// cannon_stack — PoC for the upgraded Cannon engine, driven through the real
+// TSX bridge (game_cannon_physics.rgr). Three balls dropped in a column settle
+// into a stable stack on the floor — the SPOOK solver holds it; the old arcade
+// clamp collapsed it.
+/// <reference path="../../scripting/game.d.ts" />
+
+const BALL_R = 14;
+
+function config() {
+  return {
+    world: { width: 480, height: 270 },
+    physics: { enabled: true, cannon: true, gravityY: 300, restitution: 0.05 },
+  };
+}
+
+function sprites() {
+  return [
+    { id: "b0", kind: "circle", rad: BALL_R, r: 120, g: 200, b: 255 },
+    { id: "b1", kind: "circle", rad: BALL_R, r: 255, g: 200, b: 120 },
+    { id: "b2", kind: "circle", rad: BALL_R, r: 200, g: 255, b: 140 },
+  ];
+}
+
+function entities() {
+  return [
+    { id: "b0", sprite: "b0", position: { x: 240, y: 60 },  physics: { radius: BALL_R, mass: 1, stable: true } },
+    { id: "b1", sprite: "b1", position: { x: 240, y: 110 }, physics: { radius: BALL_R, mass: 1, stable: true } },
+    { id: "b2", sprite: "b2", position: { x: 240, y: 160 }, physics: { radius: BALL_R, mass: 1, stable: true } },
+  ];
+}
+
+function initState() {
+  return { entities: {} };
+}
+
+function update(props) {
+  return props.state;
+}

--- a/gallery/game_engine/physics/src/arcade_physics_world.rgr
+++ b/gallery/game_engine/physics/src/arcade_physics_world.rgr
@@ -1,0 +1,289 @@
+; ==============================================================================
+; arcade_physics_world — a tiny arcade engine behind the PhysicsWorld interface.
+;
+; A second, deliberately different implementation of PhysicsWorld: no constraint
+; solver, just semi-implicit Euler + penetration correction and velocity
+; reflection (spheres and infinite planes only). It exists to prove the interface
+; is a real seam — the SAME engine-agnostic test code drives this and the full
+; Cannon engine and gets the same answer. It depends on nothing in the Cannon
+; port.
+; ==============================================================================
+
+Import "physics_world.rgr"
+
+class ArcadeBody {
+    def isStatic:boolean false
+    def isPlane:boolean false
+    def x:double 0.0
+    def y:double 0.0
+    def z:double 0.0
+    def vx:double 0.0
+    def vy:double 0.0
+    def vz:double 0.0
+    def radius:double 0.5
+    def nx:double 0.0
+    def ny:double 1.0
+    def nz:double 0.0
+    def invMass:double 0.0
+    def restitution:double 0.0
+}
+
+class ArcadePhysicsWorld extends PhysicsWorld {
+    def gx:double 0.0
+    def gy:double 0.0
+    def gz:double 0.0
+    def bodies:[ArcadeBody]
+    def iterations:int 4
+    ; raycast result
+    def rHasHit:boolean false
+    def rHitX:double 0.0
+    def rHitY:double 0.0
+    def rHitZ:double 0.0
+    def rDist:double -1.0
+
+    fn initWorld:void () {
+        this.gx = 0.0
+        this.gy = 0.0
+        this.gz = 0.0
+    }
+
+    fn setGravity:void (x:double y:double z:double) {
+        this.gx = x
+        this.gy = y
+        this.gz = z
+    }
+
+    fn addSphere:int (mass:double x:double y:double z:double radius:double) {
+        def b:ArcadeBody (new ArcadeBody)
+        b.isPlane = false
+        if (mass > 0.0) {
+            b.isStatic = false
+            b.invMass = (1.0 / mass)
+        } {
+            b.isStatic = true
+            b.invMass = 0.0
+        }
+        b.x = x
+        b.y = y
+        b.z = z
+        b.radius = radius
+        push this.bodies b
+        return ((array_length this.bodies) - 1)
+    }
+
+    fn addStaticPlane:int (nx:double ny:double nz:double) {
+        def b:ArcadeBody (new ArcadeBody)
+        b.isPlane = true
+        b.isStatic = true
+        b.invMass = 0.0
+        def len:double (sqrt(((nx * nx) + (ny * ny)) + (nz * nz)))
+        if (len < 0.000001) {
+            len = 1.0
+        }
+        b.nx = (nx / len)
+        b.ny = (ny / len)
+        b.nz = (nz / len)
+        push this.bodies b
+        return ((array_length this.bodies) - 1)
+    }
+
+    fn setBodyVelocity:void (id:int vx:double vy:double vz:double) {
+        def b:ArcadeBody (itemAt this.bodies id)
+        b.vx = vx
+        b.vy = vy
+        b.vz = vz
+    }
+
+    fn bodyPosX:double (id:int) {
+        def b:ArcadeBody (itemAt this.bodies id)
+        return b.x
+    }
+
+    fn bodyPosY:double (id:int) {
+        def b:ArcadeBody (itemAt this.bodies id)
+        return b.y
+    }
+
+    fn bodyPosZ:double (id:int) {
+        def b:ArcadeBody (itemAt this.bodies id)
+        return b.z
+    }
+
+    ; Resolve a dynamic sphere against a static plane: push out of penetration,
+    ; reflect the inbound normal velocity (arcade, no solver).
+    fn resolveSpherePlane:void (s:ArcadeBody p:ArcadeBody) {
+        if (s.isStatic) {
+            return
+        }
+        def d:double (((p.nx * (s.x - p.x)) + (p.ny * (s.y - p.y))) + (p.nz * (s.z - p.z)))
+        if (d < s.radius) {
+            def pen:double (s.radius - d)
+            s.x = (s.x + (p.nx * pen))
+            s.y = (s.y + (p.ny * pen))
+            s.z = (s.z + (p.nz * pen))
+            def vn:double (((s.vx * p.nx) + (s.vy * p.ny)) + (s.vz * p.nz))
+            if (vn < 0.0) {
+                def j:double ((1.0 + s.restitution) * vn)
+                s.vx = (s.vx - (p.nx * j))
+                s.vy = (s.vy - (p.ny * j))
+                s.vz = (s.vz - (p.nz * j))
+            }
+        }
+    }
+
+    ; Resolve two spheres (at least one dynamic) by splitting the correction by
+    ; inverse mass and reflecting the relative normal velocity.
+    fn resolveSphereSphere:void (a:ArcadeBody b:ArcadeBody) {
+        def dx:double (b.x - a.x)
+        def dy:double (b.y - a.y)
+        def dz:double (b.z - a.z)
+        def dist:double (sqrt(((dx * dx) + (dy * dy)) + (dz * dz)))
+        def minDist:double (a.radius + b.radius)
+        if (dist <= 0.000001) {
+            return
+        }
+        if (dist >= minDist) {
+            return
+        }
+        def invSum:double (a.invMass + b.invMass)
+        if (invSum <= 0.0) {
+            return
+        }
+        def nx:double (dx / dist)
+        def ny:double (dy / dist)
+        def nz:double (dz / dist)
+        def pen:double (minDist - dist)
+        def aMove:double ((pen * a.invMass) / invSum)
+        def bMove:double ((pen * b.invMass) / invSum)
+        a.x = (a.x - (nx * aMove))
+        a.y = (a.y - (ny * aMove))
+        a.z = (a.z - (nz * aMove))
+        b.x = (b.x + (nx * bMove))
+        b.y = (b.y + (ny * bMove))
+        b.z = (b.z + (nz * bMove))
+        def rvn:double ((((b.vx - a.vx) * nx) + ((b.vy - a.vy) * ny)) + ((b.vz - a.vz) * nz))
+        if (rvn < 0.0) {
+            def e:double a.restitution
+            def j:double (((0.0 - (1.0 + e)) * rvn) / invSum)
+            a.vx = (a.vx - ((nx * j) * a.invMass))
+            a.vy = (a.vy - ((ny * j) * a.invMass))
+            a.vz = (a.vz - ((nz * j) * a.invMass))
+            b.vx = (b.vx + ((nx * j) * b.invMass))
+            b.vy = (b.vy + ((ny * j) * b.invMass))
+            b.vz = (b.vz + ((nz * j) * b.invMass))
+        }
+    }
+
+    fn step:void (dt:double) {
+        def n:int (array_length this.bodies)
+        ; integrate dynamic spheres
+        def i 0
+        while (i < n) {
+            def b:ArcadeBody (itemAt this.bodies i)
+            if (b.isStatic == false) {
+                if (b.isPlane == false) {
+                    b.vx = (b.vx + (this.gx * dt))
+                    b.vy = (b.vy + (this.gy * dt))
+                    b.vz = (b.vz + (this.gz * dt))
+                    b.x = (b.x + (b.vx * dt))
+                    b.y = (b.y + (b.vy * dt))
+                    b.z = (b.z + (b.vz * dt))
+                }
+            }
+            i = (i + 1)
+        }
+        ; resolve collisions (a few relaxation passes)
+        def iter 0
+        while (iter < this.iterations) {
+            def a 0
+            while (a < n) {
+                def bi:ArcadeBody (itemAt this.bodies a)
+                def bj:int (a + 1)
+                while (bj < n) {
+                    def other:ArcadeBody (itemAt this.bodies bj)
+                    if (bi.isPlane) {
+                        this.resolveSpherePlane(other bi)
+                    } {
+                        if (other.isPlane) {
+                            this.resolveSpherePlane(bi other)
+                        } {
+                            this.resolveSphereSphere(bi other)
+                        }
+                    }
+                    bj = (bj + 1)
+                }
+                a = (a + 1)
+            }
+            iter = (iter + 1)
+        }
+    }
+
+    fn raycastClosest:boolean (fx:double fy:double fz:double tx:double ty:double tz:double) {
+        this.rHasHit = false
+        this.rDist = -1.0
+        def dx:double (tx - fx)
+        def dy:double (ty - fy)
+        def dz:double (tz - fz)
+        def rayLen:double (sqrt(((dx * dx) + (dy * dy)) + (dz * dz)))
+        if (rayLen < 0.000001) {
+            return false
+        }
+        def ux:double (dx / rayLen)
+        def uy:double (dy / rayLen)
+        def uz:double (dz / rayLen)
+        def n:int (array_length this.bodies)
+        def best:double 1000000000.0
+        def i 0
+        while (i < n) {
+            def b:ArcadeBody (itemAt this.bodies i)
+            def t:double -1.0
+            if (b.isPlane) {
+                def denom:double (((ux * b.nx) + (uy * b.ny)) + (uz * b.nz))
+                if (denom < 0.0) {
+                    def num:double (((b.x - fx) * b.nx) + (((b.y - fy) * b.ny) + ((b.z - fz) * b.nz)))
+                    t = (num / denom)
+                }
+            } {
+                def ox:double (fx - b.x)
+                def oy:double (fy - b.y)
+                def oz:double (fz - b.z)
+                def bb:double (((ox * ux) + (oy * uy)) + (oz * uz))
+                def cc:double ((((ox * ox) + (oy * oy)) + (oz * oz)) - (b.radius * b.radius))
+                def disc:double ((bb * bb) - cc)
+                if (disc >= 0.0) {
+                    t = ((0.0 - bb) - (sqrt(disc)))
+                }
+            }
+            if (t >= 0.0) {
+                if (t <= rayLen) {
+                    if (t < best) {
+                        best = t
+                        this.rHasHit = true
+                        this.rDist = t
+                        this.rHitX = (fx + (ux * t))
+                        this.rHitY = (fy + (uy * t))
+                        this.rHitZ = (fz + (uz * t))
+                    }
+                }
+            }
+            i = (i + 1)
+        }
+        return this.rHasHit
+    }
+
+    fn rayHitX:double () {
+        return this.rHitX
+    }
+
+    fn rayHitY:double () {
+        return this.rHitY
+    }
+
+    fn rayHitZ:double () {
+        return this.rHitZ
+    }
+
+    fn rayDistance:double () {
+        return this.rDist
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_body.rgr
+++ b/gallery/game_engine/physics/src/cannon_body.rgr
@@ -14,6 +14,11 @@ class CannonBody {
     sdef TYPE_STATIC:int 2
     sdef TYPE_KINEMATIC:int 4
     sdef SLEEP_AWAKE:int 0
+    sdef SLEEP_SLEEPY:int 1
+    sdef SLEEP_SLEEPING:int 2
+    def sleepSpeedLimit:double 0.1
+    def sleepTimeLimit:double 1.0
+    def timeLastSleepy:double 0.0
     def id:int 0
     def index:int 0
     def mass:double 0.0
@@ -202,8 +207,51 @@ class CannonBody {
     ; Semi-implicit Euler integration of one body (cannon-es Body.integrate).
     ; Only dynamic bodies move; linear/angular factors let a game constrain a
     ; body to a plane / single spin axis (default factors are (1,1,1)).
+    fn wakeUp:void () {
+        this.sleepState = 0
+    }
+
+    ; Put a body to sleep: it stops integrating until woken.
+    fn sleep:void () {
+        this.sleepState = 2
+        this.velocity.setZero()
+        this.angularVelocity.setZero()
+    }
+
+    ; Advance the sleep state machine (cannon-es Body.sleepTick): a slow body
+    ; becomes SLEEPY, and staying slow past sleepTimeLimit puts it to SLEEPING.
+    fn sleepTick:void (time:double) {
+        if (this.allowSleep == false) {
+            return
+        }
+        if (this.type != 1) {
+            return
+        }
+        def sp:double ((this.velocity.norm2()) + (this.angularVelocity.norm2()))
+        def limit:double (this.sleepSpeedLimit * this.sleepSpeedLimit)
+        if (this.sleepState == 0) {
+            if (sp < limit) {
+                this.sleepState = 1
+                this.timeLastSleepy = time
+            }
+            return
+        }
+        if (this.sleepState == 1) {
+            if (sp > limit) {
+                this.wakeUp()
+                return
+            }
+            if ((time - this.timeLastSleepy) > this.sleepTimeLimit) {
+                this.sleep()
+            }
+        }
+    }
+
     fn integrate:void (dt:double) {
         if (this.type != 1) {
+            return
+        }
+        if (this.sleepState == 2) {
             return
         }
         this.initSolveState()
@@ -267,9 +315,14 @@ class CannonBody {
     fn updateSolveMassProperties:void () {
         this.initSolveState()
         if (this.type == 1) {
-            this.updateInertiaWorld()
-            this.invMassSolve = this.invMass
-            this.invInertiaWorldSolve.copyFrom(this.invInertiaWorld)
+            if (this.sleepState == 2) {
+                this.invMassSolve = 0.0
+                this.invInertiaWorldSolve.setZero()
+            } {
+                this.updateInertiaWorld()
+                this.invMassSolve = this.invMass
+                this.invInertiaWorldSolve.copyFrom(this.invInertiaWorld)
+            }
         } {
             this.invMassSolve = 0.0
             this.invInertiaWorldSolve.setZero()

--- a/gallery/game_engine/physics/src/cannon_body.rgr
+++ b/gallery/game_engine/physics/src/cannon_body.rgr
@@ -199,6 +199,30 @@ class CannonBody {
         }
     }
 
+    ; Semi-implicit Euler integration of one body (cannon-es Body.integrate).
+    ; Only dynamic bodies move; linear/angular factors let a game constrain a
+    ; body to a plane / single spin axis (default factors are (1,1,1)).
+    fn integrate:void (dt:double) {
+        if (this.type != 1) {
+            return
+        }
+        this.initSolveState()
+        this.velocity.x = (this.velocity.x + (((this.force.x * this.invMass) * dt) * this.linearFactor.x))
+        this.velocity.y = (this.velocity.y + (((this.force.y * this.invMass) * dt) * this.linearFactor.y))
+        this.velocity.z = (this.velocity.z + (((this.force.z * this.invMass) * dt) * this.linearFactor.z))
+        this.updateInertiaWorld()
+        this.tmpRotForce.x = (this.torque.x * this.angularFactor.x)
+        this.tmpRotForce.y = (this.torque.y * this.angularFactor.y)
+        this.tmpRotForce.z = (this.torque.z * this.angularFactor.z)
+        this.invInertiaWorld.vmultInto(this.tmpRotForce this.tmpVelo)
+        this.angularVelocity.addScaledVector(dt this.tmpVelo this.angularVelocity)
+        this.position.x = (this.position.x + (this.velocity.x * dt))
+        this.position.y = (this.position.y + (this.velocity.y * dt))
+        this.position.z = (this.position.z + (this.velocity.z * dt))
+        this.quaternion.integrate(this.angularVelocity dt this.angularFactor this.quaternion)
+        this.quaternion.normalize()
+    }
+
     fn clampAngularVelocity:void (maxW:double) {
         if (this.type != 1) {
             return

--- a/gallery/game_engine/physics/src/cannon_body.rgr
+++ b/gallery/game_engine/physics/src/cannon_body.rgr
@@ -7,6 +7,7 @@ Import "cannon_quaternion.rgr"
 Import "cannon_aabb.rgr"
 Import "cannon_shape.rgr"
 Import "cannon_box.rgr"
+Import "cannon_mat3.rgr"
 
 class CannonBody {
     sdef TYPE_DYNAMIC:int 1
@@ -42,6 +43,18 @@ class CannonBody {
     def tmpShapeAabb:CannonAABB (new CannonAABB)
     def tmpRotForce:CannonVec3 (new CannonVec3)
     def tmpVelo:CannonVec3 (new CannonVec3)
+    ; --- SPOOK solver state (cannon-es) ---
+    def isTrigger:boolean false
+    def vlambda:CannonVec3 (new CannonVec3)
+    def wlambda:CannonVec3 (new CannonVec3)
+    def linearFactor:CannonVec3 (new CannonVec3)
+    def angularFactor:CannonVec3 (new CannonVec3)
+    def invMassSolve:double 0.0
+    def invInertiaWorld:CannonMat3 (new CannonMat3)
+    def invInertiaWorldSolve:CannonMat3 (new CannonMat3)
+    def uiwM1:CannonMat3 (new CannonMat3)
+    def uiwM2:CannonMat3 (new CannonMat3)
+    def solveStateReady:boolean false
 
     fn initDynamic:void (mass:double) {
         this.mass = mass
@@ -201,7 +214,42 @@ class CannonBody {
         }
     }
 
+    ; Initialise the Mat3 solver scratch once (field initialisers cannot fill
+    ; the 9-element arrays), and set the default linear/angular factors to 1.
+    fn initSolveState:void () {
+        if (this.solveStateReady) {
+            return
+        }
+        this.invInertiaWorld.initZero()
+        this.invInertiaWorldSolve.initZero()
+        this.uiwM1.initZero()
+        this.uiwM2.initZero()
+        this.linearFactor.set(1.0 1.0 1.0)
+        this.angularFactor.set(1.0 1.0 1.0)
+        this.solveStateReady = true
+    }
+
+    ; invInertiaWorld = R * diag(invInertia) * R^T   (cannon-es Body.updateInertiaWorld)
     fn updateInertiaWorld:void () {
+        this.initSolveState()
+        this.uiwM1.setRotationFromQuaternion(this.quaternion)
+        this.uiwM1.transposeInto(this.uiwM2)
+        this.uiwM1.scaleInto(this.invInertia this.uiwM1)
+        this.uiwM1.mmultInto(this.uiwM2 this.invInertiaWorld)
+    }
+
+    ; Dynamic bodies contribute their real inverse mass/inertia to the solver;
+    ; static and kinematic bodies act as if infinitely massive (zero).
+    fn updateSolveMassProperties:void () {
+        this.initSolveState()
+        if (this.type == 1) {
+            this.updateInertiaWorld()
+            this.invMassSolve = this.invMass
+            this.invInertiaWorldSolve.copyFrom(this.invInertiaWorld)
+        } {
+            this.invMassSolve = 0.0
+            this.invInertiaWorldSolve.setZero()
+        }
     }
 
     fn pointToLocalFrame:void (worldPoint:CannonVec3 result:CannonVec3) {

--- a/gallery/game_engine/physics/src/cannon_box.rgr
+++ b/gallery/game_engine/physics/src/cannon_box.rgr
@@ -28,6 +28,10 @@ class CannonBox extends CannonShape {
         this.boundingSphereRadius = this.halfExtents.norm()
     }
 
+    fn getHalfExtents:CannonVec3 () {
+        return this.halfExtents
+    }
+
     fn calculateInertiaFromHalfExtents:void (halfExtents:CannonVec3 mass:double target:CannonVec3) {
         def ex:double (2.0 * halfExtents.x)
         def ey:double (2.0 * halfExtents.y)

--- a/gallery/game_engine/physics/src/cannon_boxcollision_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_boxcollision_test.rgr
@@ -1,0 +1,97 @@
+; ==============================================================================
+; cannon_boxcollision_test — sphere-box and plane-box contacts through the world.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_sphere.rgr"
+Import "cannon_plane.rgr"
+Import "cannon_box.rgr"
+Import "cannon_body.rgr"
+Import "cannon_world.rgr"
+Import "cannon_test_harness.rgr"
+Import "cannon_test_filter.rgr"
+
+class CannonBoxCollisionTest {
+    def filter:CannonTestFilter (new CannonTestFilter)
+
+    fn runFiltered:void (h:CannonTestHarness filter:string) {
+        if (this.filter.matches(filter "BoxCollision.sphereOnBox")) { this.sphereOnBox(h) }
+        if (this.filter.matches(filter "BoxCollision.boxOnPlane")) { this.boxOnPlane(h) }
+    }
+
+    ; A falling sphere settles on the top face of a static box (top at y=0.5),
+    ; resting one radius above it (y ~= 1.5) instead of passing through.
+    fn sphereOnBox:void (h:CannonTestHarness) {
+        h.beginTest("BoxCollision.sphereOnBox")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 (0.0 - 10.0) 0.0)
+
+        def ground:CannonBody (new CannonBody)
+        ground.initStatic()
+        def he:CannonVec3 (new CannonVec3)
+        he.set(2.0 0.5 2.0)
+        def boxShape:CannonBox (new CannonBox)
+        boxShape.initBox(he)
+        ground.addShape(boxShape)
+        ground.position.set(0.0 0.0 0.0)
+        world.addBody(ground)
+
+        def ball:CannonBody (new CannonBody)
+        ball.initDynamic(1.0)
+        def sphere:CannonSphere (new CannonSphere)
+        sphere.initSphere(1.0)
+        ball.addShape(sphere)
+        ball.position.set(0.0 1.4 0.0)
+        world.addBody(ball)
+
+        def s 0
+        while (s < 90) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def y:double ball.position.y
+        h.ok((y > 1.3) "sphere rests on the box, does not sink through")
+        h.ok((y < 1.7) "sphere is not launched off the box")
+        print ("sphereOnBoxY=" + (to_string y))
+        h.finishTest()
+    }
+
+    ; A box dropped onto the ground plane (normal +Z) rests with its bottom face
+    ; on the plane (center z ~= 1 for unit half-extents).
+    fn boxOnPlane:void (h:CannonTestHarness) {
+        h.beginTest("BoxCollision.boxOnPlane")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 0.0 (0.0 - 10.0))
+
+        def ground:CannonBody (new CannonBody)
+        ground.initStatic()
+        def plane:CannonPlane (new CannonPlane)
+        plane.initPlane()
+        ground.addShape(plane)
+        ground.position.set(0.0 0.0 0.0)
+        world.addBody(ground)
+
+        def box:CannonBody (new CannonBody)
+        box.initDynamic(1.0)
+        def he:CannonVec3 (new CannonVec3)
+        he.set(1.0 1.0 1.0)
+        def boxShape:CannonBox (new CannonBox)
+        boxShape.initBox(he)
+        box.addShape(boxShape)
+        box.position.set(0.0 0.0 3.0)
+        world.addBody(box)
+
+        def s 0
+        while (s < 120) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def z:double box.position.z
+        h.ok((z > 0.6) "box rests on the plane, does not sink through")
+        h.ok((z < 1.5) "box settles near the plane")
+        print ("boxOnPlaneZ=" + (to_string z))
+        h.finishTest()
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_boxcollision_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_boxcollision_test.rgr
@@ -17,6 +17,86 @@ class CannonBoxCollisionTest {
     fn runFiltered:void (h:CannonTestHarness filter:string) {
         if (this.filter.matches(filter "BoxCollision.sphereOnBox")) { this.sphereOnBox(h) }
         if (this.filter.matches(filter "BoxCollision.boxOnPlane")) { this.boxOnPlane(h) }
+        if (this.filter.matches(filter "BoxCollision.boxStack")) { this.boxStack(h) }
+        if (this.filter.matches(filter "BoxCollision.boxSeparate")) { this.boxSeparate(h) }
+    }
+
+    ; A small box dropped onto a wide static box rests on top (four-corner
+    ; manifold keeps it stable at y ~= 1.0 instead of sinking or tipping off).
+    fn boxStack:void (h:CannonTestHarness) {
+        h.beginTest("BoxCollision.boxStack")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 (0.0 - 10.0) 0.0)
+
+        def ground:CannonBody (new CannonBody)
+        ground.initStatic()
+        def heG:CannonVec3 (new CannonVec3)
+        heG.set(2.0 0.5 2.0)
+        def groundBox:CannonBox (new CannonBox)
+        groundBox.initBox(heG)
+        ground.addShape(groundBox)
+        ground.position.set(0.0 0.0 0.0)
+        world.addBody(ground)
+
+        def box:CannonBody (new CannonBody)
+        box.initDynamic(1.0)
+        def heB:CannonVec3 (new CannonVec3)
+        heB.set(0.5 0.5 0.5)
+        def boxShape:CannonBox (new CannonBox)
+        boxShape.initBox(heB)
+        box.addShape(boxShape)
+        box.position.set(0.0 0.9 0.0)
+        world.addBody(box)
+
+        def s 0
+        while (s < 120) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def y:double box.position.y
+        h.ok((y > 0.8) "box rests on the box, does not sink through")
+        h.ok((y < 1.25) "box settles on top, is not launched")
+        print ("boxStackY=" + (to_string y))
+        h.finishTest()
+    }
+
+    ; Two overlapping dynamic boxes push apart along the minimum-overlap axis.
+    fn boxSeparate:void (h:CannonTestHarness) {
+        h.beginTest("BoxCollision.boxSeparate")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 0.0 0.0)
+
+        def a:CannonBody (new CannonBody)
+        a.initDynamic(1.0)
+        def heA:CannonVec3 (new CannonVec3)
+        heA.set(1.0 1.0 1.0)
+        def boxA:CannonBox (new CannonBox)
+        boxA.initBox(heA)
+        a.addShape(boxA)
+        a.position.set(0.0 0.0 0.0)
+        world.addBody(a)
+
+        def b:CannonBody (new CannonBody)
+        b.initDynamic(1.0)
+        def heB:CannonVec3 (new CannonVec3)
+        heB.set(1.0 1.0 1.0)
+        def boxB:CannonBox (new CannonBox)
+        boxB.initBox(heB)
+        b.addShape(boxB)
+        b.position.set(1.5 0.0 0.0)
+        world.addBody(b)
+
+        def s 0
+        while (s < 60) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def gap:double (b.position.x - a.position.x)
+        h.ok((gap > 1.8) "overlapping boxes separate along x")
+        print ("boxSeparateGap=" + (to_string gap))
+        h.finishTest()
     }
 
     ; A falling sphere settles on the top face of a static box (top at y=0.5),

--- a/gallery/game_engine/physics/src/cannon_constraint.rgr
+++ b/gallery/game_engine/physics/src/cannon_constraint.rgr
@@ -1,0 +1,68 @@
+; ==============================================================================
+; cannon_constraint — joint constraints (cannon-es src/constraints/*).
+;
+; Unified via a `kind` field (port idiom). A constraint owns a set of
+; CannonEquations and an update() that recomputes their jacobians each step.
+;   kind 1 = point-to-point: three bilateral contact equations (ni = x/y/z axes,
+;            minForce = -maxForce) that pin a point on body A to a point on body
+;            B while leaving all relative rotation free — a ball-and-socket joint.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_body.rgr"
+Import "cannon_equation.rgr"
+
+class CannonConstraint {
+    sdef KIND_P2P:int 1
+
+    def kind:int 1
+    def bodyA:CannonBody
+    def bodyB:CannonBody
+    def equations:[CannonEquation]
+    def pivotA:CannonVec3 (new CannonVec3)
+    def pivotB:CannonVec3 (new CannonVec3)
+
+    fn initPointToPoint:void (bodyA:CannonBody pivotA:CannonVec3 bodyB:CannonBody pivotB:CannonVec3 maxForce:double) {
+        this.kind = 1
+        this.bodyA = bodyA
+        this.bodyB = bodyB
+        this.pivotA.copy(pivotA)
+        this.pivotB.copy(pivotB)
+        def ex:CannonEquation (new CannonEquation)
+        ex.initContact(bodyA bodyB maxForce)
+        ex.minForce = (0.0 - maxForce)
+        def ey:CannonEquation (new CannonEquation)
+        ey.initContact(bodyA bodyB maxForce)
+        ey.minForce = (0.0 - maxForce)
+        def ez:CannonEquation (new CannonEquation)
+        ez.initContact(bodyA bodyB maxForce)
+        ez.minForce = (0.0 - maxForce)
+        push this.equations ex
+        push this.equations ey
+        push this.equations ez
+    }
+
+    fn update:void () {
+        if (this.kind == 1) {
+            this.updatePointToPoint()
+        }
+    }
+
+    fn updatePointToPoint:void () {
+        def a:CannonBody (unwrap this.bodyA)
+        def b:CannonBody (unwrap this.bodyB)
+        def ex:CannonEquation (itemAt this.equations 0)
+        def ey:CannonEquation (itemAt this.equations 1)
+        def ez:CannonEquation (itemAt this.equations 2)
+        ; ri = R_A * pivotA, rj = R_B * pivotB (world offsets to the shared point)
+        a.quaternion.vmult(this.pivotA ex.ri)
+        b.quaternion.vmult(this.pivotB ex.rj)
+        ey.ri.copy(ex.ri)
+        ey.rj.copy(ex.rj)
+        ez.ri.copy(ex.ri)
+        ez.rj.copy(ex.rj)
+        ex.ni.set(1.0 0.0 0.0)
+        ey.ni.set(0.0 1.0 0.0)
+        ez.ni.set(0.0 0.0 1.0)
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_constraint.rgr
+++ b/gallery/game_engine/physics/src/cannon_constraint.rgr
@@ -14,6 +14,7 @@ Import "cannon_equation.rgr"
 
 class CannonConstraint {
     sdef KIND_P2P:int 1
+    sdef KIND_HINGE:int 2
 
     def kind:int 1
     def bodyA:CannonBody
@@ -21,6 +22,12 @@ class CannonConstraint {
     def equations:[CannonEquation]
     def pivotA:CannonVec3 (new CannonVec3)
     def pivotB:CannonVec3 (new CannonVec3)
+    ; hinge: local rotation axes on each body (equations[3], equations[4] are the
+    ; two rotational equations that keep the world hinge axes aligned).
+    def axisA:CannonVec3 (new CannonVec3)
+    def axisB:CannonVec3 (new CannonVec3)
+    def worldAxisA:CannonVec3 (new CannonVec3)
+    def worldAxisB:CannonVec3 (new CannonVec3)
 
     fn initPointToPoint:void (bodyA:CannonBody pivotA:CannonVec3 bodyB:CannonBody pivotB:CannonVec3 maxForce:double) {
         this.kind = 1
@@ -42,10 +49,45 @@ class CannonConstraint {
         push this.equations ez
     }
 
+    ; Hinge = point-to-point (pin the pivot) + two rotational equations that keep
+    ; the two bodies' hinge axes aligned, leaving one free rotation DOF.
+    fn initHinge:void (bodyA:CannonBody pivotA:CannonVec3 axisA:CannonVec3 bodyB:CannonBody pivotB:CannonVec3 axisB:CannonVec3 maxForce:double) {
+        this.initPointToPoint(bodyA pivotA bodyB pivotB maxForce)
+        this.kind = 2
+        this.axisA.copy(axisA)
+        this.axisA.normalizeSelf()
+        this.axisB.copy(axisB)
+        this.axisB.normalizeSelf()
+        def r1:CannonEquation (new CannonEquation)
+        r1.initRotational(bodyA bodyB maxForce)
+        def r2:CannonEquation (new CannonEquation)
+        r2.initRotational(bodyA bodyB maxForce)
+        push this.equations r1
+        push this.equations r2
+    }
+
     fn update:void () {
         if (this.kind == 1) {
             this.updatePointToPoint()
         }
+        if (this.kind == 2) {
+            this.updateHinge()
+        }
+    }
+
+    fn updateHinge:void () {
+        this.updatePointToPoint()
+        def a:CannonBody (unwrap this.bodyA)
+        def b:CannonBody (unwrap this.bodyB)
+        a.quaternion.vmult(this.axisA this.worldAxisA)
+        b.quaternion.vmult(this.axisB this.worldAxisB)
+        def r1:CannonEquation (itemAt this.equations 3)
+        def r2:CannonEquation (itemAt this.equations 4)
+        ; r1.axisA and r2.axisA are the two tangents of the A-side hinge axis;
+        ; both are kept orthogonal to the B-side hinge axis, forcing alignment.
+        this.worldAxisA.tangents(r1.axisA r2.axisA)
+        r1.axisB.copy(this.worldAxisB)
+        r2.axisB.copy(this.worldAxisB)
     }
 
     fn updatePointToPoint:void () {

--- a/gallery/game_engine/physics/src/cannon_constraint.rgr
+++ b/gallery/game_engine/physics/src/cannon_constraint.rgr
@@ -28,6 +28,10 @@ class CannonConstraint {
     def axisB:CannonVec3 (new CannonVec3)
     def worldAxisA:CannonVec3 (new CannonVec3)
     def worldAxisB:CannonVec3 (new CannonVec3)
+    ; hinge motor (equations[5]): actively drives spin about the hinge axis.
+    def motorEnabled:boolean false
+    def motorTargetVelocity:double 0.0
+    def motorMaxForce:double 1000000.0
 
     fn initPointToPoint:void (bodyA:CannonBody pivotA:CannonVec3 bodyB:CannonBody pivotB:CannonVec3 maxForce:double) {
         this.kind = 1
@@ -62,8 +66,28 @@ class CannonConstraint {
         r1.initRotational(bodyA bodyB maxForce)
         def r2:CannonEquation (new CannonEquation)
         r2.initRotational(bodyA bodyB maxForce)
+        def motor:CannonEquation (new CannonEquation)
+        motor.initMotor(bodyA bodyB maxForce)
+        this.motorMaxForce = maxForce
         push this.equations r1
         push this.equations r2
+        push this.equations motor
+    }
+
+    fn enableMotor:void () {
+        this.motorEnabled = true
+    }
+
+    fn disableMotor:void () {
+        this.motorEnabled = false
+    }
+
+    fn setMotorSpeed:void (speed:double) {
+        this.motorTargetVelocity = speed
+    }
+
+    fn setMotorMaxForce:void (maxForce:double) {
+        this.motorMaxForce = maxForce
     }
 
     fn update:void () {
@@ -88,6 +112,16 @@ class CannonConstraint {
         this.worldAxisA.tangents(r1.axisA r2.axisA)
         r1.axisB.copy(this.worldAxisB)
         r2.axisB.copy(this.worldAxisB)
+        ; motor (equations[5]): drive spin about the world hinge axis.
+        def motor:CannonEquation (itemAt this.equations 5)
+        motor.enabled = this.motorEnabled
+        if (this.motorEnabled) {
+            motor.axisA.copy(this.worldAxisA)
+            motor.axisB.copy(this.worldAxisB)
+            motor.targetVelocity = this.motorTargetVelocity
+            motor.maxForce = this.motorMaxForce
+            motor.minForce = (0.0 - this.motorMaxForce)
+        }
     }
 
     fn updatePointToPoint:void () {

--- a/gallery/game_engine/physics/src/cannon_constraint_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_constraint_test.rgr
@@ -16,6 +16,64 @@ class CannonConstraintTest {
     fn runFiltered:void (h:CannonTestHarness filter:string) {
         if (this.filter.matches(filter "Constraint.pointToPointPendulum")) { this.pendulum(h) }
         if (this.filter.matches(filter "Constraint.hingeAxis")) { this.hingeAxis(h) }
+        if (this.filter.matches(filter "Constraint.hingeMotor")) { this.hingeMotor(h) }
+    }
+
+    ; A hinge motor drives spin about the hinge axis to a target velocity — the
+    ; mechanism a flipper uses to snap up. The body spins up about Z while the
+    ; joint keeps it pinned (orbiting the pivot at constant radius).
+    fn hingeMotor:void (h:CannonTestHarness) {
+        h.beginTest("Constraint.hingeMotor")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 0.0 0.0)
+
+        def anchor:CannonBody (new CannonBody)
+        anchor.initStatic()
+        anchor.position.set(0.0 0.0 0.0)
+        world.addBody(anchor)
+
+        def flipper:CannonBody (new CannonBody)
+        flipper.initDynamic(1.0)
+        def shape:CannonSphere (new CannonSphere)
+        shape.initSphere(0.5)
+        flipper.addShape(shape)
+        flipper.position.set(1.0 0.0 0.0)
+        world.addBody(flipper)
+
+        def pivotA:CannonVec3 (new CannonVec3)
+        pivotA.set(0.0 0.0 0.0)
+        def pivotB:CannonVec3 (new CannonVec3)
+        pivotB.set((0.0 - 1.0) 0.0 0.0)
+        def axis:CannonVec3 (new CannonVec3)
+        axis.set(0.0 0.0 1.0)
+        def hinge:CannonConstraint (new CannonConstraint)
+        hinge.initHinge(anchor pivotA axis flipper pivotB axis 1000000.0)
+        hinge.setMotorSpeed(5.0)
+        hinge.setMotorMaxForce(100000.0)
+        hinge.enableMotor()
+        world.addConstraint(hinge)
+
+        def s 0
+        while (s < 60) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+
+        def wz:double flipper.angularVelocity.z
+        if (wz < 0.0) {
+            wz = (0.0 - wz)
+        }
+        ; Motor targets a relative velocity (sign follows the bi->bj convention);
+        ; here it drives the flipper spin magnitude toward the target (5).
+        h.ok((wz > 3.0) "motor drives spin toward the target velocity")
+        def dx:double flipper.position.x
+        def dy:double flipper.position.y
+        def distOrigin:double (sqrt((dx * dx) + (dy * dy)))
+        h.nearEqual(distOrigin 1.0 0.3 "joint keeps the flipper pinned while spinning")
+        print ("motorWz=" + (to_string wz))
+        print ("motorDist=" + (to_string distOrigin))
+        h.finishTest()
     }
 
     ; A hinge about the Z axis constrains rotation to the Z axis through the

--- a/gallery/game_engine/physics/src/cannon_constraint_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_constraint_test.rgr
@@ -1,0 +1,66 @@
+; ==============================================================================
+; cannon_constraint_test — joint constraints through the world + solver.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_sphere.rgr"
+Import "cannon_body.rgr"
+Import "cannon_constraint.rgr"
+Import "cannon_world.rgr"
+Import "cannon_test_harness.rgr"
+Import "cannon_test_filter.rgr"
+
+class CannonConstraintTest {
+    def filter:CannonTestFilter (new CannonTestFilter)
+
+    fn runFiltered:void (h:CannonTestHarness filter:string) {
+        if (this.filter.matches(filter "Constraint.pointToPointPendulum")) { this.pendulum(h) }
+    }
+
+    ; A bob hung from a static anchor by a point-to-point joint must swing under
+    ; gravity while keeping its distance to the pivot (the joint length).
+    fn pendulum:void (h:CannonTestHarness) {
+        h.beginTest("Constraint.pointToPointPendulum")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 (0.0 - 10.0) 0.0)
+
+        def anchor:CannonBody (new CannonBody)
+        anchor.initStatic()
+        anchor.position.set(0.0 0.0 0.0)
+        world.addBody(anchor)
+
+        def bob:CannonBody (new CannonBody)
+        bob.initDynamic(1.0)
+        def shape:CannonSphere (new CannonSphere)
+        shape.initSphere(0.5)
+        bob.addShape(shape)
+        bob.position.set(2.0 0.0 0.0)
+        world.addBody(bob)
+
+        ; Pin the bob's (-2,0,0) point to the anchor origin -> length-2 pendulum.
+        def pivotA:CannonVec3 (new CannonVec3)
+        pivotA.set(0.0 0.0 0.0)
+        def pivotB:CannonVec3 (new CannonVec3)
+        pivotB.set((0.0 - 2.0) 0.0 0.0)
+        def joint:CannonConstraint (new CannonConstraint)
+        joint.initPointToPoint(anchor pivotA bob pivotB 1000000.0)
+        world.addConstraint(joint)
+
+        def s 0
+        while (s < 60) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+
+        def dx:double bob.position.x
+        def dy:double bob.position.y
+        def dz:double bob.position.z
+        def dist:double (sqrt(((dx * dx) + (dy * dy)) + (dz * dz)))
+        h.nearEqual(dist 2.0 0.4 "pendulum length preserved")
+        h.ok((bob.position.y < 0.0) "bob swings downward under gravity")
+        print ("pendulumDist=" + (to_string dist))
+        print ("pendulumY=" + (to_string bob.position.y))
+        h.finishTest()
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_constraint_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_constraint_test.rgr
@@ -15,6 +15,64 @@ class CannonConstraintTest {
 
     fn runFiltered:void (h:CannonTestHarness filter:string) {
         if (this.filter.matches(filter "Constraint.pointToPointPendulum")) { this.pendulum(h) }
+        if (this.filter.matches(filter "Constraint.hingeAxis")) { this.hingeAxis(h) }
+    }
+
+    ; A hinge about the Z axis constrains rotation to the Z axis through the
+    ; pivot: an off-axis (X) spin is suppressed and the body stays in the hinge
+    ; plane, while gravity is still free to swing it about the hinge.
+    fn hingeAxis:void (h:CannonTestHarness) {
+        h.beginTest("Constraint.hingeAxis")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 (0.0 - 10.0) 0.0)
+
+        def anchor:CannonBody (new CannonBody)
+        anchor.initStatic()
+        anchor.position.set(0.0 0.0 0.0)
+        world.addBody(anchor)
+
+        def door:CannonBody (new CannonBody)
+        door.initDynamic(1.0)
+        def shape:CannonSphere (new CannonSphere)
+        shape.initSphere(0.5)
+        door.addShape(shape)
+        door.position.set(1.0 0.0 0.0)
+        ; Off-axis spin the hinge must cancel (would throw it out of plane).
+        door.angularVelocity.set(2.0 0.0 0.0)
+        world.addBody(door)
+
+        def pivotA:CannonVec3 (new CannonVec3)
+        pivotA.set(0.0 0.0 0.0)
+        def pivotB:CannonVec3 (new CannonVec3)
+        pivotB.set((0.0 - 1.0) 0.0 0.0)
+        def axis:CannonVec3 (new CannonVec3)
+        axis.set(0.0 0.0 1.0)
+        def hinge:CannonConstraint (new CannonConstraint)
+        hinge.initHinge(anchor pivotA axis door pivotB axis 1000000.0)
+        world.addConstraint(hinge)
+
+        def s 0
+        while (s < 60) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+
+        def wx:double door.angularVelocity.x
+        if (wx < 0.0) {
+            wx = (0.0 - wx)
+        }
+        def pz:double door.position.z
+        if (pz < 0.0) {
+            pz = (0.0 - pz)
+        }
+        h.ok((wx < 1.0) "off-axis spin is suppressed by the hinge")
+        h.ok((pz < 0.3) "body stays in the hinge plane (z ~ 0)")
+        h.ok((door.position.y < (0.0 - 0.1)) "gravity still swings it about the hinge")
+        print ("hingeWx=" + (to_string wx))
+        print ("hingeZ=" + (to_string door.position.z))
+        print ("hingeY=" + (to_string door.position.y))
+        h.finishTest()
     }
 
     ; A bob hung from a static anchor by a point-to-point joint must swing under

--- a/gallery/game_engine/physics/src/cannon_convex.rgr
+++ b/gallery/game_engine/physics/src/cannon_convex.rgr
@@ -67,6 +67,33 @@ class CannonConvexPolyhedron extends CannonShape {
         return (itemAt this.faceVertex i)
     }
 
+    ; Build a cylinder as an N-sided convex prism about the local Z axis
+    ; (cannon-es models Cylinder as a ConvexPolyhedron). Reuses the convex
+    ; collision paths — no cylinder-specific code needed.
+    fn initCylinderHull:void (radius:double halfHeight:double segments:int) {
+        this.initConvex()
+        def twoPi:double 6.283185307179586
+        def seg:double (to_double segments)
+        def k 0
+        while (k < segments) {
+            def ang:double ((twoPi * (to_double k)) / seg)
+            def cx:double (radius * (cos(ang)))
+            def cy:double (radius * (sin(ang)))
+            this.addVertex(cx cy halfHeight)
+            this.addVertex(cx cy (0.0 - halfHeight))
+            k = (k + 1)
+        }
+        this.addFace(0.0 0.0 1.0 0)
+        this.addFace(0.0 0.0 (0.0 - 1.0) 1)
+        k = 0
+        while (k < segments) {
+            def midAng:double ((twoPi * ((to_double k) + 0.5)) / seg)
+            this.addFace((cos(midAng)) (sin(midAng)) 0.0 (2 * k))
+            k = (k + 1)
+        }
+        this.updateBoundingSphereRadius()
+    }
+
     ; Build an axis-aligned box hull (8 vertices, 6 faces) — a general convex that
     ; happens to be a box, exercising the convex collision path (not the OBB SAT).
     fn initBoxHull:void (hx:double hy:double hz:double) {

--- a/gallery/game_engine/physics/src/cannon_convex.rgr
+++ b/gallery/game_engine/physics/src/cannon_convex.rgr
@@ -1,0 +1,90 @@
+; ==============================================================================
+; cannon_convex — general convex polyhedron (cannon-es ConvexPolyhedron, subset).
+;   Stored as vertices + face normals (with one vertex index per face for a face
+;   plane point). Collision (see cannon_narrowphase): convex-plane iterates the
+;   vertices; sphere-convex uses the face planes. A helper builds a box hull.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_quaternion.rgr"
+Import "cannon_shape.rgr"
+
+class CannonConvexPolyhedron extends CannonShape {
+    def vertices:[CannonVec3]
+    def faceNormals:[CannonVec3]
+    def faceVertex:[int]
+
+    fn initConvex:void () {
+        this.initShape(6)
+    }
+
+    fn addVertex:void (x:double y:double z:double) {
+        def v:CannonVec3 (new CannonVec3)
+        v.set(x y z)
+        push this.vertices v
+    }
+
+    fn addFace:void (nx:double ny:double nz:double vertexIndex:int) {
+        def n:CannonVec3 (new CannonVec3)
+        n.set(nx ny nz)
+        n.normalizeSelf()
+        push this.faceNormals n
+        push this.faceVertex vertexIndex
+    }
+
+    fn updateBoundingSphereRadius:void () {
+        def n:int (array_length this.vertices)
+        def maxR:double 0.0
+        def i 0
+        while (i < n) {
+            def v:CannonVec3 (itemAt this.vertices i)
+            def r:double (v.norm())
+            if (r > maxR) {
+                maxR = r
+            }
+            i = (i + 1)
+        }
+        this.boundingSphereRadius = maxR
+    }
+
+    fn convexVertexCount:int () {
+        return (array_length this.vertices)
+    }
+
+    fn convexVertexAt:void (i:int out:CannonVec3) {
+        out.copy((itemAt this.vertices i))
+    }
+
+    fn convexFaceCount:int () {
+        return (array_length this.faceNormals)
+    }
+
+    fn convexFaceNormalAt:void (i:int out:CannonVec3) {
+        out.copy((itemAt this.faceNormals i))
+    }
+
+    fn convexFaceVertexIndex:int (i:int) {
+        return (itemAt this.faceVertex i)
+    }
+
+    ; Build an axis-aligned box hull (8 vertices, 6 faces) — a general convex that
+    ; happens to be a box, exercising the convex collision path (not the OBB SAT).
+    fn initBoxHull:void (hx:double hy:double hz:double) {
+        this.initConvex()
+        this.addVertex(hx hy hz)
+        this.addVertex(hx hy (0.0 - hz))
+        this.addVertex(hx (0.0 - hy) hz)
+        this.addVertex(hx (0.0 - hy) (0.0 - hz))
+        this.addVertex((0.0 - hx) hy hz)
+        this.addVertex((0.0 - hx) hy (0.0 - hz))
+        this.addVertex((0.0 - hx) (0.0 - hy) hz)
+        this.addVertex((0.0 - hx) (0.0 - hy) (0.0 - hz))
+        this.addFace(1.0 0.0 0.0 0)
+        this.addFace((0.0 - 1.0) 0.0 0.0 4)
+        this.addFace(0.0 1.0 0.0 0)
+        this.addFace(0.0 (0.0 - 1.0) 0.0 2)
+        this.addFace(0.0 0.0 1.0 0)
+        this.addFace(0.0 0.0 (0.0 - 1.0) 1)
+        this.updateBoundingSphereRadius()
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_convex_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_convex_test.rgr
@@ -1,0 +1,92 @@
+; ==============================================================================
+; cannon_convex_test — convex polyhedron vs plane and vs sphere.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_sphere.rgr"
+Import "cannon_plane.rgr"
+Import "cannon_convex.rgr"
+Import "cannon_body.rgr"
+Import "cannon_world.rgr"
+Import "cannon_test_harness.rgr"
+Import "cannon_test_filter.rgr"
+
+class CannonConvexTest {
+    def filter:CannonTestFilter (new CannonTestFilter)
+
+    fn runFiltered:void (h:CannonTestHarness filter:string) {
+        if (this.filter.matches(filter "Convex.hullOnPlane")) { this.hullOnPlane(h) }
+        if (this.filter.matches(filter "Convex.sphereOnConvex")) { this.sphereOnConvex(h) }
+    }
+
+    ; A convex box-hull dropped on the ground plane rests on its bottom face
+    ; (center z ~= 1) through the convex-plane path.
+    fn hullOnPlane:void (h:CannonTestHarness) {
+        h.beginTest("Convex.hullOnPlane")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 0.0 (0.0 - 10.0))
+
+        def ground:CannonBody (new CannonBody)
+        ground.initStatic()
+        def plane:CannonPlane (new CannonPlane)
+        plane.initPlane()
+        ground.addShape(plane)
+        ground.position.set(0.0 0.0 0.0)
+        world.addBody(ground)
+
+        def hull:CannonBody (new CannonBody)
+        hull.initDynamic(1.0)
+        def convex:CannonConvexPolyhedron (new CannonConvexPolyhedron)
+        convex.initBoxHull(1.0 1.0 1.0)
+        hull.addShape(convex)
+        hull.position.set(0.0 0.0 3.0)
+        world.addBody(hull)
+
+        def s 0
+        while (s < 150) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def z:double hull.position.z
+        h.ok((z > 0.7) "convex hull rests on the plane, does not sink through")
+        h.ok((z < 1.4) "convex hull settles near the plane")
+        print ("convexHullZ=" + (to_string z))
+        h.finishTest()
+    }
+
+    ; A ball settles on the top face of a static convex box-hull (top at z=1),
+    ; resting one radius above it (z ~= 1.5).
+    fn sphereOnConvex:void (h:CannonTestHarness) {
+        h.beginTest("Convex.sphereOnConvex")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 0.0 (0.0 - 10.0))
+
+        def block:CannonBody (new CannonBody)
+        block.initStatic()
+        def convex:CannonConvexPolyhedron (new CannonConvexPolyhedron)
+        convex.initBoxHull(1.0 1.0 1.0)
+        block.addShape(convex)
+        block.position.set(0.0 0.0 0.0)
+        world.addBody(block)
+
+        def ball:CannonBody (new CannonBody)
+        ball.initDynamic(1.0)
+        def sphere:CannonSphere (new CannonSphere)
+        sphere.initSphere(0.5)
+        ball.addShape(sphere)
+        ball.position.set(0.0 0.0 2.0)
+        world.addBody(ball)
+
+        def s 0
+        while (s < 120) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def z:double ball.position.z
+        h.nearEqual(z 1.5 0.2 "ball rests one radius above the convex top face")
+        print ("sphereConvexZ=" + (to_string z))
+        h.finishTest()
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_convex_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_convex_test.rgr
@@ -17,6 +17,114 @@ class CannonConvexTest {
     fn runFiltered:void (h:CannonTestHarness filter:string) {
         if (this.filter.matches(filter "Convex.hullOnPlane")) { this.hullOnPlane(h) }
         if (this.filter.matches(filter "Convex.sphereOnConvex")) { this.sphereOnConvex(h) }
+        if (this.filter.matches(filter "Convex.cylinderOnPlane")) { this.cylinderOnPlane(h) }
+        if (this.filter.matches(filter "Convex.sphereOnCylinder")) { this.sphereOnCylinder(h) }
+        if (this.filter.matches(filter "Convex.convexStack")) { this.convexStack(h) }
+    }
+
+    ; A convex hull rests on top of another convex hull (convex-convex SAT).
+    fn convexStack:void (h:CannonTestHarness) {
+        h.beginTest("Convex.convexStack")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 0.0 (0.0 - 10.0))
+
+        def ground:CannonBody (new CannonBody)
+        ground.initStatic()
+        def base:CannonConvexPolyhedron (new CannonConvexPolyhedron)
+        base.initBoxHull(2.0 2.0 0.5)
+        ground.addShape(base)
+        ground.position.set(0.0 0.0 0.0)
+        world.addBody(ground)
+
+        def top:CannonBody (new CannonBody)
+        top.initDynamic(1.0)
+        def hull:CannonConvexPolyhedron (new CannonConvexPolyhedron)
+        hull.initBoxHull(0.5 0.5 0.5)
+        top.addShape(hull)
+        top.position.set(0.0 0.0 0.9)
+        world.addBody(top)
+
+        def s 0
+        while (s < 150) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def z:double top.position.z
+        h.ok((z > 0.8) "convex rests on convex, does not sink through")
+        h.ok((z < 1.25) "convex settles on top")
+        print ("convexStackZ=" + (to_string z))
+        h.finishTest()
+    }
+
+    ; A cylinder (convex prism about Z) dropped on the ground plane rests on its
+    ; bottom rim (center z ~= halfHeight = 1).
+    fn cylinderOnPlane:void (h:CannonTestHarness) {
+        h.beginTest("Convex.cylinderOnPlane")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 0.0 (0.0 - 10.0))
+
+        def ground:CannonBody (new CannonBody)
+        ground.initStatic()
+        def plane:CannonPlane (new CannonPlane)
+        plane.initPlane()
+        ground.addShape(plane)
+        ground.position.set(0.0 0.0 0.0)
+        world.addBody(ground)
+
+        def cyl:CannonBody (new CannonBody)
+        cyl.initDynamic(1.0)
+        def convex:CannonConvexPolyhedron (new CannonConvexPolyhedron)
+        convex.initCylinderHull(1.0 1.0 8)
+        cyl.addShape(convex)
+        cyl.position.set(0.0 0.0 3.0)
+        world.addBody(cyl)
+
+        def s 0
+        while (s < 150) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def z:double cyl.position.z
+        h.ok((z > 0.7) "cylinder rests on the plane, does not sink through")
+        h.ok((z < 1.4) "cylinder settles on its bottom face")
+        print ("cylinderZ=" + (to_string z))
+        h.finishTest()
+    }
+
+    ; A ball settles on the flat top of a static cylinder (top at z=1) at z ~= 1.5.
+    fn sphereOnCylinder:void (h:CannonTestHarness) {
+        h.beginTest("Convex.sphereOnCylinder")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 0.0 (0.0 - 10.0))
+
+        def block:CannonBody (new CannonBody)
+        block.initStatic()
+        def convex:CannonConvexPolyhedron (new CannonConvexPolyhedron)
+        convex.initCylinderHull(1.5 1.0 8)
+        block.addShape(convex)
+        block.position.set(0.0 0.0 0.0)
+        world.addBody(block)
+
+        def ball:CannonBody (new CannonBody)
+        ball.initDynamic(1.0)
+        def sphere:CannonSphere (new CannonSphere)
+        sphere.initSphere(0.5)
+        ball.addShape(sphere)
+        ball.position.set(0.0 0.0 2.0)
+        world.addBody(ball)
+
+        def s 0
+        while (s < 120) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def z:double ball.position.z
+        h.nearEqual(z 1.5 0.2 "ball rests one radius above the cylinder top")
+        print ("sphereCylinderZ=" + (to_string z))
+        h.finishTest()
     }
 
     ; A convex box-hull dropped on the ground plane rests on its bottom face

--- a/gallery/game_engine/physics/src/cannon_equation.rgr
+++ b/gallery/game_engine/physics/src/cannon_equation.rgr
@@ -1,0 +1,210 @@
+; ==============================================================================
+; cannon_equation — SPOOK constraint equation (cannon-es src/equations/*).
+;
+; Unified equation carrying both the contact (non-penetration) and friction
+; (tangent) constraints via a `kind` field, matching this port's idiom of
+; integer type tags instead of class inheritance (cf. CannonShape.type,
+; CannonBody.type). The SPOOK math is a faithful port of cannon-es:
+;   Equation (base), ContactEquation (kind 1), FrictionEquation (kind 2).
+;
+; See https://www8.cs.umu.se/kurser/5DV058/VT15/lectures/SPOOKlabnotes.pdf
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_body.rgr"
+Import "cannon_shape.rgr"
+Import "cannon_jacobian_element.rgr"
+
+class CannonEquation {
+    sdef KIND_CONTACT:int 1
+    sdef KIND_FRICTION:int 2
+
+    def id:int 0
+    def kind:int 1
+    def minForce:double (0.0 - 1000000.0)
+    def maxForce:double 1000000.0
+    def bi:CannonBody
+    def bj:CannonBody
+    def si:CannonShape
+    def sj:CannonShape
+    def a:double 0.0
+    def b:double 0.0
+    def eps:double 0.0
+    def enabled:boolean true
+    def multiplier:double 0.0
+    def restitution:double 0.0
+    def jA:CannonJacobianElement (new CannonJacobianElement)
+    def jB:CannonJacobianElement (new CannonJacobianElement)
+    ; contact: ri/rj from body centers to contact point, ni contact normal (points i->j).
+    ; friction: ri/rj as contact, t is the tangent.
+    def ri:CannonVec3 (new CannonVec3)
+    def rj:CannonVec3 (new CannonVec3)
+    def ni:CannonVec3 (new CannonVec3)
+    def t:CannonVec3 (new CannonVec3)
+    ; scratch
+    def tmp1:CannonVec3 (new CannonVec3)
+    def tmp2:CannonVec3 (new CannonVec3)
+    def tmp3:CannonVec3 (new CannonVec3)
+    def iMfi:CannonVec3 (new CannonVec3)
+    def iMfj:CannonVec3 (new CannonVec3)
+    def invIiTau:CannonVec3 (new CannonVec3)
+    def invIjTau:CannonVec3 (new CannonVec3)
+    def matVec:CannonVec3 (new CannonVec3)
+    def wtemp:CannonVec3 (new CannonVec3)
+
+    fn setSpookParams:void (stiffness:double relaxation:double timeStep:double) {
+        def d:double relaxation
+        def k:double stiffness
+        def h:double timeStep
+        this.a = (4.0 / (h * (1.0 + (4.0 * d))))
+        this.b = ((4.0 * d) / (1.0 + (4.0 * d)))
+        this.eps = (4.0 / (((h * h) * k) * (1.0 + (4.0 * d))))
+    }
+
+    fn initContact:void (bodyA:CannonBody bodyB:CannonBody maxForce:double) {
+        this.kind = 1
+        this.bi = bodyA
+        this.bj = bodyB
+        this.minForce = 0.0
+        this.maxForce = maxForce
+        this.restitution = 0.0
+        this.enabled = true
+        this.setSpookParams(10000000.0 4.0 (1.0 / 60.0))
+    }
+
+    fn initFriction:void (bodyA:CannonBody bodyB:CannonBody slipForce:double) {
+        this.kind = 2
+        this.bi = bodyA
+        this.bj = bodyB
+        this.minForce = (0.0 - slipForce)
+        this.maxForce = slipForce
+        this.enabled = true
+        this.setSpookParams(10000000.0 4.0 (1.0 / 60.0))
+    }
+
+    ; G*W, where W are the body velocities.
+    fn computeGW:double () {
+        def gwa:double (this.jA.multiplyVectors(this.bi.velocity this.bi.angularVelocity))
+        def gwb:double (this.jB.multiplyVectors(this.bj.velocity this.bj.angularVelocity))
+        return (gwa + gwb)
+    }
+
+    ; G*Wlambda, where Wlambda are the solver's delta velocities.
+    fn computeGWlambda:double () {
+        def gwa:double (this.jA.multiplyVectors(this.bi.vlambda this.bi.wlambda))
+        def gwb:double (this.jB.multiplyVectors(this.bj.vlambda this.bj.wlambda))
+        return (gwa + gwb)
+    }
+
+    ; G*inv(M)*f, where f are the forces/torques on the bodies.
+    fn computeGiMf:double () {
+        def bi:CannonBody this.bi
+        def bj:CannonBody this.bj
+        bi.force.scaleInto(bi.invMassSolve this.iMfi)
+        bj.force.scaleInto(bj.invMassSolve this.iMfj)
+        bi.invInertiaWorldSolve.vmultInto(bi.torque this.invIiTau)
+        bj.invInertiaWorldSolve.vmultInto(bj.torque this.invIjTau)
+        def ga:double (this.jA.multiplyVectors(this.iMfi this.invIiTau))
+        def gb:double (this.jB.multiplyVectors(this.iMfj this.invIjTau))
+        return (ga + gb)
+    }
+
+    ; G*inv(M)*G'
+    fn computeGiMGt:double () {
+        def bi:CannonBody this.bi
+        def bj:CannonBody this.bj
+        def result:double (bi.invMassSolve + bj.invMassSolve)
+        bi.invInertiaWorldSolve.vmultInto(this.jA.rotational this.matVec)
+        result = (result + (this.matVec.dot(this.jA.rotational)))
+        bj.invInertiaWorldSolve.vmultInto(this.jB.rotational this.matVec)
+        result = (result + (this.matVec.dot(this.jB.rotational)))
+        return result
+    }
+
+    fn computeC:double () {
+        return ((this.computeGiMGt()) + this.eps)
+    }
+
+    ; Add constraint velocity (deltalambda) to the bodies' solver velocities.
+    fn addToWlambda:void (deltalambda:double) {
+        def bi:CannonBody this.bi
+        def bj:CannonBody this.bj
+        bi.vlambda.addScaledVector((bi.invMassSolve * deltalambda) this.jA.spatial bi.vlambda)
+        bj.vlambda.addScaledVector((bj.invMassSolve * deltalambda) this.jB.spatial bj.vlambda)
+        bi.invInertiaWorldSolve.vmultInto(this.jA.rotational this.wtemp)
+        bi.wlambda.addScaledVector(deltalambda this.wtemp bi.wlambda)
+        bj.invInertiaWorldSolve.vmultInto(this.jB.rotational this.wtemp)
+        bj.wlambda.addScaledVector(deltalambda this.wtemp bj.wlambda)
+    }
+
+    fn computeB:double (h:double) {
+        if (this.kind == 2) {
+            return (this.computeBFriction(h))
+        }
+        return (this.computeBContact(h))
+    }
+
+    ; Contact/non-penetration: G = [ -n  -rixn  n  rjxn ], g = n . (xj+rj-xi-ri)
+    fn computeBContact:double (h:double) {
+        def a:double this.a
+        def b:double this.b
+        def bi:CannonBody this.bi
+        def bj:CannonBody this.bj
+        def ri:CannonVec3 this.ri
+        def rj:CannonVec3 this.rj
+        def n:CannonVec3 this.ni
+        def rixn:CannonVec3 this.tmp1
+        def rjxn:CannonVec3 this.tmp2
+        ri.crossInto(n rixn)
+        rj.crossInto(n rjxn)
+        n.negateInto(this.jA.spatial)
+        rixn.negateInto(this.jA.rotational)
+        this.jB.spatial.copy(n)
+        this.jB.rotational.copy(rjxn)
+        def pen:CannonVec3 this.tmp3
+        pen.copy(bj.position)
+        pen.vadd(rj pen)
+        pen.vsub(bi.position pen)
+        pen.vsub(ri pen)
+        def g:double (n.dot(pen))
+        def ePlusOne:double (this.restitution + 1.0)
+        def gwj:double (ePlusOne * (bj.velocity.dot(n)))
+        def gwi:double (ePlusOne * (bi.velocity.dot(n)))
+        def gwrj:double (bj.angularVelocity.dot(rjxn))
+        def gwri:double (bi.angularVelocity.dot(rixn))
+        def GW:double (((gwj - gwi) + gwrj) - gwri)
+        def GiMf:double (this.computeGiMf())
+        def B:double (((0.0 - (g * a)) - (GW * b)) - (h * GiMf))
+        return B
+    }
+
+    ; Friction: G = [ -t  -rixt  t  rjxt ], pure velocity constraint (g == 0).
+    fn computeBFriction:double (h:double) {
+        def b:double this.b
+        def ri:CannonVec3 this.ri
+        def rj:CannonVec3 this.rj
+        def t:CannonVec3 this.t
+        def rixt:CannonVec3 this.tmp1
+        def rjxt:CannonVec3 this.tmp2
+        ri.crossInto(t rixt)
+        rj.crossInto(t rjxt)
+        t.negateInto(this.jA.spatial)
+        rixt.negateInto(this.jA.rotational)
+        this.jB.spatial.copy(t)
+        this.jB.rotational.copy(rjxt)
+        def GW:double (this.computeGW())
+        def GiMf:double (this.computeGiMf())
+        def B:double ((0.0 - (GW * b)) - (h * GiMf))
+        return B
+    }
+
+    ; Relative velocity in the contact point along the contact normal.
+    fn getImpactVelocityAlongNormal:double () {
+        this.bi.position.vadd(this.ri this.tmp1)
+        this.bj.position.vadd(this.rj this.tmp2)
+        this.bi.getVelocityAtWorldPoint(this.tmp1 this.iMfi)
+        this.bj.getVelocityAtWorldPoint(this.tmp2 this.iMfj)
+        this.iMfi.vsub(this.iMfj this.tmp3)
+        return (this.ni.dot(this.tmp3))
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_equation.rgr
+++ b/gallery/game_engine/physics/src/cannon_equation.rgr
@@ -18,6 +18,7 @@ Import "cannon_jacobian_element.rgr"
 class CannonEquation {
     sdef KIND_CONTACT:int 1
     sdef KIND_FRICTION:int 2
+    sdef KIND_ROTATIONAL:int 3
 
     def id:int 0
     def kind:int 1
@@ -41,6 +42,10 @@ class CannonEquation {
     def rj:CannonVec3 (new CannonVec3)
     def ni:CannonVec3 (new CannonVec3)
     def t:CannonVec3 (new CannonVec3)
+    ; rotational (hinge): world-oriented axes kept orthogonal, plus max angle.
+    def axisA:CannonVec3 (new CannonVec3)
+    def axisB:CannonVec3 (new CannonVec3)
+    def maxAngle:double 1.5707963267948966
     ; scratch
     def tmp1:CannonVec3 (new CannonVec3)
     def tmp2:CannonVec3 (new CannonVec3)
@@ -79,6 +84,19 @@ class CannonEquation {
         this.minForce = (0.0 - slipForce)
         this.maxForce = slipForce
         this.enabled = true
+        this.setSpookParams(10000000.0 4.0 (1.0 / 60.0))
+    }
+
+    fn initRotational:void (bodyA:CannonBody bodyB:CannonBody maxForce:double) {
+        this.kind = 3
+        this.bi = bodyA
+        this.bj = bodyB
+        this.minForce = (0.0 - maxForce)
+        this.maxForce = maxForce
+        this.maxAngle = 1.5707963267948966
+        this.enabled = true
+        this.axisA.set(1.0 0.0 0.0)
+        this.axisB.set(0.0 1.0 0.0)
         this.setSpookParams(10000000.0 4.0 (1.0 / 60.0))
     }
 
@@ -141,7 +159,32 @@ class CannonEquation {
         if (this.kind == 2) {
             return (this.computeBFriction(h))
         }
+        if (this.kind == 3) {
+            return (this.computeBRotational(h))
+        }
         return (this.computeBContact(h))
+    }
+
+    ; Rotational: keep axisA and axisB orthogonal in world space (hinge alignment).
+    ; G = [ 0  njxni  0  nixnj ], g = cos(maxAngle) - axisA . axisB
+    fn computeBRotational:double (h:double) {
+        def a:double this.a
+        def b:double this.b
+        def ni:CannonVec3 this.axisA
+        def nj:CannonVec3 this.axisB
+        def nixnj:CannonVec3 this.tmp1
+        def njxni:CannonVec3 this.tmp2
+        ni.crossInto(nj nixnj)
+        nj.crossInto(ni njxni)
+        this.jA.spatial.setZero()
+        this.jB.spatial.setZero()
+        this.jA.rotational.copy(njxni)
+        this.jB.rotational.copy(nixnj)
+        def g:double ((cos(this.maxAngle)) - (ni.dot(nj)))
+        def GW:double (this.computeGW())
+        def GiMf:double (this.computeGiMf())
+        def B:double (((0.0 - (g * a)) - (GW * b)) - (h * GiMf))
+        return B
     }
 
     ; Contact/non-penetration: G = [ -n  -rixn  n  rjxn ], g = n . (xj+rj-xi-ri)

--- a/gallery/game_engine/physics/src/cannon_equation.rgr
+++ b/gallery/game_engine/physics/src/cannon_equation.rgr
@@ -19,6 +19,7 @@ class CannonEquation {
     sdef KIND_CONTACT:int 1
     sdef KIND_FRICTION:int 2
     sdef KIND_ROTATIONAL:int 3
+    sdef KIND_MOTOR:int 4
 
     def id:int 0
     def kind:int 1
@@ -46,6 +47,7 @@ class CannonEquation {
     def axisA:CannonVec3 (new CannonVec3)
     def axisB:CannonVec3 (new CannonVec3)
     def maxAngle:double 1.5707963267948966
+    def targetVelocity:double 0.0
     ; scratch
     def tmp1:CannonVec3 (new CannonVec3)
     def tmp2:CannonVec3 (new CannonVec3)
@@ -97,6 +99,21 @@ class CannonEquation {
         this.enabled = true
         this.axisA.set(1.0 0.0 0.0)
         this.axisB.set(0.0 1.0 0.0)
+        this.setSpookParams(10000000.0 4.0 (1.0 / 60.0))
+    }
+
+    ; Motor: drive the relative angular velocity about the shared axis to
+    ; targetVelocity (cannon-es RotationalMotorEquation). Disabled by default.
+    fn initMotor:void (bodyA:CannonBody bodyB:CannonBody maxForce:double) {
+        this.kind = 4
+        this.bi = bodyA
+        this.bj = bodyB
+        this.minForce = (0.0 - maxForce)
+        this.maxForce = maxForce
+        this.targetVelocity = 0.0
+        this.enabled = false
+        this.axisA.set(1.0 0.0 0.0)
+        this.axisB.set(1.0 0.0 0.0)
         this.setSpookParams(10000000.0 4.0 (1.0 / 60.0))
     }
 
@@ -162,7 +179,23 @@ class CannonEquation {
         if (this.kind == 3) {
             return (this.computeBRotational(h))
         }
+        if (this.kind == 4) {
+            return (this.computeBMotor(h))
+        }
         return (this.computeBContact(h))
+    }
+
+    ; Motor: G = [ 0  axisA  0  -axisB ], target a relative angular velocity.
+    fn computeBMotor:double (h:double) {
+        def b:double this.b
+        this.jA.spatial.setZero()
+        this.jB.spatial.setZero()
+        this.jA.rotational.copy(this.axisA)
+        this.axisB.negateInto(this.jB.rotational)
+        def GW:double ((this.computeGW()) - this.targetVelocity)
+        def GiMf:double (this.computeGiMf())
+        def B:double ((0.0 - (GW * b)) - (h * GiMf))
+        return B
     }
 
     ; Rotational: keep axisA and axisB orthogonal in world space (hinge alignment).

--- a/gallery/game_engine/physics/src/cannon_extra_shapes_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_extra_shapes_test.rgr
@@ -1,0 +1,91 @@
+; ==============================================================================
+; cannon_extra_shapes_test — Particle (point mass) and Trimesh (static mesh).
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_sphere.rgr"
+Import "cannon_plane.rgr"
+Import "cannon_particle.rgr"
+Import "cannon_trimesh.rgr"
+Import "cannon_body.rgr"
+Import "cannon_world.rgr"
+Import "cannon_test_harness.rgr"
+Import "cannon_test_filter.rgr"
+
+class CannonExtraShapesTest {
+    def filter:CannonTestFilter (new CannonTestFilter)
+
+    fn runFiltered:void (h:CannonTestHarness filter:string) {
+        if (this.filter.matches(filter "Particle.onPlane")) { this.particleOnPlane(h) }
+        if (this.filter.matches(filter "Trimesh.sphereRests")) { this.trimeshSphere(h) }
+    }
+
+    ; A particle (zero-radius point) falls onto a +Z plane and rests at its surface.
+    fn particleOnPlane:void (h:CannonTestHarness) {
+        h.beginTest("Particle.onPlane")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 0.0 (0.0 - 10.0))
+
+        def ground:CannonBody (new CannonBody)
+        ground.initStatic()
+        def plane:CannonPlane (new CannonPlane)
+        plane.initPlane()
+        ground.addShape(plane)
+        ground.position.set(0.0 0.0 0.0)
+        world.addBody(ground)
+
+        def p:CannonBody (new CannonBody)
+        p.initDynamic(1.0)
+        def particle:CannonParticle (new CannonParticle)
+        particle.initParticle()
+        p.addShape(particle)
+        p.position.set(0.0 0.0 2.0)
+        world.addBody(p)
+
+        def s 0
+        while (s < 150) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        h.nearEqual(p.position.z 0.0 0.2 "particle rests at the plane surface (z~0)")
+        print ("particleZ=" + (to_string p.position.z))
+        h.finishTest()
+    }
+
+    ; A ball settles on a trimesh floor (two triangles forming a quad at z=0).
+    fn trimeshSphere:void (h:CannonTestHarness) {
+        h.beginTest("Trimesh.sphereRests")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 0.0 (0.0 - 10.0))
+
+        def ground:CannonBody (new CannonBody)
+        ground.initStatic()
+        def mesh:CannonTrimesh (new CannonTrimesh)
+        mesh.initTrimesh()
+        mesh.addTriangle((0.0 - 5.0) (0.0 - 5.0) 0.0 5.0 (0.0 - 5.0) 0.0 5.0 5.0 0.0)
+        mesh.addTriangle((0.0 - 5.0) (0.0 - 5.0) 0.0 5.0 5.0 0.0 (0.0 - 5.0) 5.0 0.0)
+        ground.addShape(mesh)
+        ground.position.set(0.0 0.0 0.0)
+        world.addBody(ground)
+
+        def ball:CannonBody (new CannonBody)
+        ball.initDynamic(1.0)
+        def sphere:CannonSphere (new CannonSphere)
+        sphere.initSphere(0.5)
+        ball.addShape(sphere)
+        ball.position.set(0.0 0.0 2.0)
+        world.addBody(ball)
+
+        def s 0
+        while (s < 150) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def z:double ball.position.z
+        h.nearEqual(z 0.5 0.2 "ball rests one radius above the trimesh floor")
+        print ("trimeshZ=" + (to_string z))
+        h.finishTest()
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_gssolver.rgr
+++ b/gallery/game_engine/physics/src/cannon_gssolver.rgr
@@ -1,0 +1,136 @@
+; ==============================================================================
+; cannon_gssolver — Gauss-Seidel SPOOK solver (cannon-es src/solver/GSSolver).
+;   Solves the list of CannonEquation constraints and writes the resulting
+;   delta velocities back into the bodies.
+; ==============================================================================
+
+Import "cannon_equation.rgr"
+Import "cannon_body.rgr"
+
+class CannonGSSolver {
+    def iterations:int 10
+    def tolerance:double 0.0000001
+    def equations:[CannonEquation]
+    ; per-solve scratch (reused between solves)
+    def lambda:[double]
+    def Bs:[double]
+    def invCs:[double]
+
+    fn addEquation:void (eq:CannonEquation) {
+        if (eq.enabled) {
+            if (eq.bi.isTrigger == false) {
+                if (eq.bj.isTrigger == false) {
+                    push this.equations eq
+                }
+            }
+        }
+    }
+
+    fn removeAllEquations:void () {
+        clear this.equations
+    }
+
+    ; Returns the number of iterations performed.
+    fn solve:int (dt:double bodies:[CannonBody]) {
+        def Neq:int (array_length this.equations)
+        if (Neq == 0) {
+            return 0
+        }
+        def maxIter:int this.iterations
+        def tolSquared:double (this.tolerance * this.tolerance)
+        def Nbodies:int (array_length bodies)
+        def h:double dt
+
+        ; Update solve-mass properties for every body.
+        def bidx:int 0
+        while (bidx < Nbodies) {
+            def bb:CannonBody (itemAt bodies bidx)
+            bb.updateSolveMassProperties()
+            bidx = (bidx + 1)
+        }
+
+        ; Precompute B and 1/C for each equation (constant over iterations).
+        clear this.lambda
+        clear this.Bs
+        clear this.invCs
+        def i:int 0
+        while (i < Neq) {
+            def c:CannonEquation (itemAt this.equations i)
+            push this.lambda 0.0
+            push this.Bs (c.computeB(h))
+            push this.invCs (1.0 / (c.computeC()))
+            i = (i + 1)
+        }
+
+        ; Reset solver delta velocities.
+        def r:int 0
+        while (r < Nbodies) {
+            def bb:CannonBody (itemAt bodies r)
+            bb.vlambda.setZero()
+            bb.wlambda.setZero()
+            r = (r + 1)
+        }
+
+        ; Gauss-Seidel iterations.
+        def iter:int 0
+        def converged:boolean false
+        while (iter < maxIter) {
+            if (converged) {
+                iter = maxIter
+            } {
+                def deltalambdaTot:double 0.0
+                def j:int 0
+                while (j < Neq) {
+                    def c:CannonEquation (itemAt this.equations j)
+                    def B:double (itemAt this.Bs j)
+                    def invC:double (itemAt this.invCs j)
+                    def lambdaj:double (itemAt this.lambda j)
+                    def GWlambda:double (c.computeGWlambda())
+                    def deltalambda:double (invC * ((B - GWlambda) - (c.eps * lambdaj)))
+                    def newLambda:double (lambdaj + deltalambda)
+                    if (newLambda < c.minForce) {
+                        deltalambda = (c.minForce - lambdaj)
+                    } {
+                        if (newLambda > c.maxForce) {
+                            deltalambda = (c.maxForce - lambdaj)
+                        }
+                    }
+                    set this.lambda j (lambdaj + deltalambda)
+                    def ad:double deltalambda
+                    if (ad < 0.0) {
+                        ad = (0.0 - ad)
+                    }
+                    deltalambdaTot = (deltalambdaTot + ad)
+                    c.addToWlambda(deltalambda)
+                    j = (j + 1)
+                }
+                if ((deltalambdaTot * deltalambdaTot) < tolSquared) {
+                    converged = true
+                }
+                iter = (iter + 1)
+            }
+        }
+
+        ; Add the solver result to the actual body velocities.
+        def a2:int 0
+        while (a2 < Nbodies) {
+            def bb:CannonBody (itemAt bodies a2)
+            bb.vlambda.vmulInto(bb.linearFactor bb.vlambda)
+            bb.velocity.vadd(bb.vlambda bb.velocity)
+            bb.wlambda.vmulInto(bb.angularFactor bb.wlambda)
+            bb.angularVelocity.vadd(bb.wlambda bb.angularVelocity)
+            a2 = (a2 + 1)
+        }
+
+        ; Store multipliers.
+        def invDt:double (1.0 / h)
+        def m:int 0
+        while (m < Neq) {
+            def c:CannonEquation (itemAt this.equations m)
+            c.multiplier = ((itemAt this.lambda m) * invDt)
+            m = (m + 1)
+        }
+
+        return iter
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_heightfield.rgr
+++ b/gallery/game_engine/physics/src/cannon_heightfield.rgr
@@ -1,0 +1,88 @@
+; ==============================================================================
+; cannon_heightfield — terrain height map (cannon-es Heightfield, subset).
+;   A regular grid of heights (data[i*ny + j]) with spacing elementSize; the
+;   surface is z = height at local (x, y). Collision with a sphere uses the
+;   terrain triangle plane under the sphere centre (see cannon_narrowphase).
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_quaternion.rgr"
+Import "cannon_shape.rgr"
+
+class CannonHeightfield extends CannonShape {
+    def data:[double]
+    def nx:int 0
+    def ny:int 0
+    def elementSize:double 1.0
+    def hugeRadius:double 1000000000.0
+    def hfE1:CannonVec3 (new CannonVec3)
+    def hfE2:CannonVec3 (new CannonVec3)
+
+    fn initHeightfield:void (nx:int ny:int elementSize:double) {
+        this.initShape(5)
+        this.nx = nx
+        this.ny = ny
+        this.elementSize = elementSize
+        def total:int (nx * ny)
+        def i 0
+        while (i < total) {
+            push this.data 0.0
+            i = (i + 1)
+        }
+        this.boundingSphereRadius = this.hugeRadius
+    }
+
+    fn getHeight:double (i:int j:int) {
+        return (itemAt this.data ((i * this.ny) + j))
+    }
+
+    fn setHeight:void (i:int j:int h:double) {
+        set this.data ((i * this.ny) + j) h
+    }
+
+    fn setAllHeights:void (h:double) {
+        def n:int (array_length this.data)
+        def i 0
+        while (i < n) {
+            set this.data i h
+            i = (i + 1)
+        }
+    }
+
+    fn updateBoundingSphereRadius:void () {
+        this.boundingSphereRadius = this.hugeRadius
+    }
+
+    fn heightfieldPlaneAt:boolean (localX:double localY:double outNormal:CannonVec3 outPoint:CannonVec3) {
+        def es:double this.elementSize
+        def gi:int (floor(localX / es))
+        def gj:int (floor(localY / es))
+        if (gi < 0) { return false }
+        if (gj < 0) { return false }
+        if (gi >= (this.nx - 1)) { return false }
+        if (gj >= (this.ny - 1)) { return false }
+        def x0:double ((to_double gi) * es)
+        def y0:double ((to_double gj) * es)
+        def h00:double (this.getHeight(gi gj))
+        def h10:double (this.getHeight((gi + 1) gj))
+        def h01:double (this.getHeight(gi (gj + 1)))
+        def h11:double (this.getHeight((gi + 1) (gj + 1)))
+        def fx:double ((localX - x0) / es)
+        def fy:double ((localY - y0) / es)
+        if ((fx + fy) <= 1.0) {
+            outPoint.set(x0 y0 h00)
+            this.hfE1.set(es 0.0 (h10 - h00))
+            this.hfE2.set(0.0 es (h01 - h00))
+        } {
+            outPoint.set((x0 + es) (y0 + es) h11)
+            this.hfE1.set(0.0 (0.0 - es) (h10 - h11))
+            this.hfE2.set((0.0 - es) 0.0 (h01 - h11))
+        }
+        this.hfE1.crossInto(this.hfE2 outNormal)
+        if (outNormal.z < 0.0) {
+            outNormal.negateInto(outNormal)
+        }
+        outNormal.normalizeSelf()
+        return true
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_heightfield_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_heightfield_test.rgr
@@ -1,0 +1,75 @@
+; ==============================================================================
+; cannon_heightfield_test — spheres rest on a terrain height map.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_sphere.rgr"
+Import "cannon_heightfield.rgr"
+Import "cannon_body.rgr"
+Import "cannon_world.rgr"
+Import "cannon_test_harness.rgr"
+Import "cannon_test_filter.rgr"
+
+class CannonHeightfieldTest {
+    def filter:CannonTestFilter (new CannonTestFilter)
+
+    fn runFiltered:void (h:CannonTestHarness filter:string) {
+        if (this.filter.matches(filter "Heightfield.restStep")) { this.restStep(h) }
+    }
+
+    fn dropBall:CannonBody (world:CannonWorld x:double y:double z:double) {
+        def ball:CannonBody (new CannonBody)
+        ball.initDynamic(1.0)
+        def sphere:CannonSphere (new CannonSphere)
+        sphere.initSphere(0.5)
+        ball.addShape(sphere)
+        ball.position.set(x y z)
+        world.addBody(ball)
+        return ball
+    }
+
+    ; A stepped terrain (height 1 for the low half in x, height 2 for the high
+    ; half). Two balls settle one radius above their local terrain height,
+    ; proving the grid is sampled by position.
+    fn restStep:void (h:CannonTestHarness) {
+        h.beginTest("Heightfield.restStep")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 0.0 (0.0 - 10.0))
+
+        def ground:CannonBody (new CannonBody)
+        ground.initStatic()
+        def field:CannonHeightfield (new CannonHeightfield)
+        field.initHeightfield(6 6 2.0)
+        def i 0
+        while (i < 6) {
+            def j 0
+            while (j < 6) {
+                if (i < 3) {
+                    field.setHeight(i j 1.0)
+                } {
+                    field.setHeight(i j 2.0)
+                }
+                j = (j + 1)
+            }
+            i = (i + 1)
+        }
+        ground.addShape(field)
+        ground.position.set(0.0 0.0 0.0)
+        world.addBody(ground)
+
+        def low:CannonBody (this.dropBall(world 2.0 4.0 4.0))
+        def high:CannonBody (this.dropBall(world 8.0 4.0 5.0))
+
+        def s 0
+        while (s < 150) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        h.nearEqual(low.position.z 1.5 0.2 "ball rests one radius above the low terrain (z~1.5)")
+        h.nearEqual(high.position.z 2.5 0.2 "ball rests one radius above the high terrain (z~2.5)")
+        print ("hfLowZ=" + (to_string low.position.z))
+        print ("hfHighZ=" + (to_string high.position.z))
+        h.finishTest()
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_jacobian_element.rgr
+++ b/gallery/game_engine/physics/src/cannon_jacobian_element.rgr
@@ -1,0 +1,19 @@
+; ==============================================================================
+; cannon_jacobian_element — SPOOK Jacobian element (cannon-es src/math/JacobianElement).
+;   6 entries: 3 spatial + 3 rotational degrees of freedom.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+
+class CannonJacobianElement {
+    def spatial:CannonVec3 (new CannonVec3)
+    def rotational:CannonVec3 (new CannonVec3)
+
+    fn multiplyElement:double (element:CannonJacobianElement) {
+        return ((element.spatial.dot(this.spatial)) + (element.rotational.dot(this.rotational)))
+    }
+
+    fn multiplyVectors:double (spatial:CannonVec3 rotational:CannonVec3) {
+        return ((spatial.dot(this.spatial)) + (rotational.dot(this.rotational)))
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_mat3.rgr
+++ b/gallery/game_engine/physics/src/cannon_mat3.rgr
@@ -58,6 +58,14 @@ class CannonMat3 {
         }
     }
 
+    fn setZero:void () {
+        def i 0
+        while (i < 9) {
+            set this.elements i 0.0
+            i = (i + 1)
+        }
+    }
+
     fn vmultInto:void (v:CannonVec3 target:CannonVec3) {
         def x:double v.x
         def y:double v.y

--- a/gallery/game_engine/physics/src/cannon_narrowphase.rgr
+++ b/gallery/game_engine/physics/src/cannon_narrowphase.rgr
@@ -31,6 +31,25 @@ class CannonNarrowphase {
     def pbNormal:CannonVec3 (new CannonVec3)
     def pbCorner:CannonVec3 (new CannonVec3)
     def pbProj:CannonVec3 (new CannonVec3)
+    ; box-box (SAT) scratch
+    def bbAx:CannonVec3 (new CannonVec3)
+    def bbAy:CannonVec3 (new CannonVec3)
+    def bbAz:CannonVec3 (new CannonVec3)
+    def bbBx:CannonVec3 (new CannonVec3)
+    def bbBy:CannonVec3 (new CannonVec3)
+    def bbBz:CannonVec3 (new CannonVec3)
+    def bbPosDiff:CannonVec3 (new CannonVec3)
+    def bbBestAxis:CannonVec3 (new CannonVec3)
+    def bbBestOverlap:double 0.0
+    def bbHeA:CannonVec3
+    def bbHeB:CannonVec3
+    def bbCorner:CannonVec3 (new CannonVec3)
+    def bbLocal:CannonVec3 (new CannonVec3)
+    def bbConj:CannonQuaternion (new CannonQuaternion)
+    def bbUnit:CannonVec3 (new CannonVec3)
+    def bbPointA:CannonVec3 (new CannonVec3)
+    def bbPointB:CannonVec3 (new CannonVec3)
+    def bbMade:int 0
 
     fn createContactEquation:CannonEquation (bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape) {
         def c:CannonEquation (new CannonEquation)
@@ -208,6 +227,179 @@ class CannonNarrowphase {
         return hit
     }
 
+    ; --- box-box (OBB) via the separating axis theorem ---
+
+    ; Project both boxes onto axis (lx,ly,lz); return false if it separates them,
+    ; else track the minimum-overlap axis (the contact normal candidate).
+    fn bbTestAxis:boolean (lx:double ly:double lz:double) {
+        def len:double (sqrt(((lx * lx) + (ly * ly)) + (lz * lz)))
+        if (len < 0.000001) {
+            return true
+        }
+        this.bbUnit.set((lx / len) (ly / len) (lz / len))
+        def dax:double (this.bbUnit.dot(this.bbAx))
+        if (dax < 0.0) { dax = (0.0 - dax) }
+        def day:double (this.bbUnit.dot(this.bbAy))
+        if (day < 0.0) { day = (0.0 - day) }
+        def daz:double (this.bbUnit.dot(this.bbAz))
+        if (daz < 0.0) { daz = (0.0 - daz) }
+        def rA:double (((this.bbHeA.x * dax) + (this.bbHeA.y * day)) + (this.bbHeA.z * daz))
+        def dbx:double (this.bbUnit.dot(this.bbBx))
+        if (dbx < 0.0) { dbx = (0.0 - dbx) }
+        def dby:double (this.bbUnit.dot(this.bbBy))
+        if (dby < 0.0) { dby = (0.0 - dby) }
+        def dbz:double (this.bbUnit.dot(this.bbBz))
+        if (dbz < 0.0) { dbz = (0.0 - dbz) }
+        def rB:double (((this.bbHeB.x * dbx) + (this.bbHeB.y * dby)) + (this.bbHeB.z * dbz))
+        def tproj:double (this.bbUnit.dot(this.bbPosDiff))
+        if (tproj < 0.0) { tproj = (0.0 - tproj) }
+        def overlap:double ((rA + rB) - tproj)
+        if (overlap < 0.0) {
+            return false
+        }
+        if (overlap < this.bbBestOverlap) {
+            this.bbBestOverlap = overlap
+            this.bbBestAxis.copy(this.bbUnit)
+        }
+        return true
+    }
+
+    fn bbWorldCorner:void (sx:double sy:double sz:double he:CannonVec3 pos:CannonVec3 quat:CannonQuaternion target:CannonVec3) {
+        this.bbUnit.set((sx * he.x) (sy * he.y) (sz * he.z))
+        quat.vmult(this.bbUnit target)
+        pos.vadd(target target)
+    }
+
+    fn bbPointInBox:boolean (p:CannonVec3 boxPos:CannonVec3 boxQuat:CannonQuaternion he:CannonVec3) {
+        p.vsub(boxPos this.bbLocal)
+        boxQuat.conjugateInto(this.bbConj)
+        this.bbConj.vmult(this.bbLocal this.bbLocal)
+        def lx:double this.bbLocal.x
+        if (lx < 0.0) { lx = (0.0 - lx) }
+        def ly:double this.bbLocal.y
+        if (ly < 0.0) { ly = (0.0 - ly) }
+        def lz:double this.bbLocal.z
+        if (lz < 0.0) { lz = (0.0 - lz) }
+        if (lx > he.x) { return false }
+        if (ly > he.y) { return false }
+        if (lz > he.z) { return false }
+        return true
+    }
+
+    ; A corner of the source box that lies inside the test box becomes a contact.
+    ; `bIntoA` selects the ri/rj sign convention (n always points from A toward B).
+    fn bbTryCorner:void (sx:double sy:double sz:double heSrc:CannonVec3 posSrc:CannonVec3 quatSrc:CannonQuaternion heTest:CannonVec3 posTest:CannonVec3 quatTest:CannonQuaternion n:CannonVec3 d:double bIntoA:boolean bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape) {
+        this.bbWorldCorner(sx sy sz heSrc posSrc quatSrc this.bbCorner)
+        if (this.bbPointInBox(this.bbCorner posTest quatTest heTest) == false) {
+            return
+        }
+        def r:CannonEquation (this.createContactEquation(bi bj si sj))
+        r.ni.copy(n)
+        if (bIntoA) {
+            ; corner is on B; rj = corner - posB, ri = (corner + n*d) - posA
+            this.bbCorner.vsub(posSrc r.rj)
+            n.scaleInto(d this.bbPointA)
+            this.bbCorner.vadd(this.bbPointA this.bbPointA)
+            this.bbPointA.vsub(posTest r.ri)
+        } {
+            ; corner is on A; ri = corner - posA, rj = (corner - n*d) - posB
+            this.bbCorner.vsub(posSrc r.ri)
+            n.scaleInto(d this.bbPointB)
+            this.bbCorner.vsub(this.bbPointB this.bbPointB)
+            this.bbPointB.vsub(posTest r.rj)
+        }
+        push this.result r
+        this.bbMade = (this.bbMade + 1)
+    }
+
+    fn boxBox:boolean (heA:CannonVec3 posA:CannonVec3 quatA:CannonQuaternion heB:CannonVec3 posB:CannonVec3 quatB:CannonQuaternion bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape justTest:boolean) {
+        this.bbUnit.set(1.0 0.0 0.0)
+        quatA.vmult(this.bbUnit this.bbAx)
+        this.bbUnit.set(0.0 1.0 0.0)
+        quatA.vmult(this.bbUnit this.bbAy)
+        this.bbUnit.set(0.0 0.0 1.0)
+        quatA.vmult(this.bbUnit this.bbAz)
+        this.bbUnit.set(1.0 0.0 0.0)
+        quatB.vmult(this.bbUnit this.bbBx)
+        this.bbUnit.set(0.0 1.0 0.0)
+        quatB.vmult(this.bbUnit this.bbBy)
+        this.bbUnit.set(0.0 0.0 1.0)
+        quatB.vmult(this.bbUnit this.bbBz)
+        this.bbHeA = heA
+        this.bbHeB = heB
+        posB.vsub(posA this.bbPosDiff)
+        this.bbBestOverlap = 1000000000.0
+
+        if (this.bbTestAxis(this.bbAx.x this.bbAx.y this.bbAx.z) == false) { return false }
+        if (this.bbTestAxis(this.bbAy.x this.bbAy.y this.bbAy.z) == false) { return false }
+        if (this.bbTestAxis(this.bbAz.x this.bbAz.y this.bbAz.z) == false) { return false }
+        if (this.bbTestAxis(this.bbBx.x this.bbBx.y this.bbBx.z) == false) { return false }
+        if (this.bbTestAxis(this.bbBy.x this.bbBy.y this.bbBy.z) == false) { return false }
+        if (this.bbTestAxis(this.bbBz.x this.bbBz.y this.bbBz.z) == false) { return false }
+        this.bbAx.crossInto(this.bbBx this.bbCorner)
+        if (this.bbTestAxis(this.bbCorner.x this.bbCorner.y this.bbCorner.z) == false) { return false }
+        this.bbAx.crossInto(this.bbBy this.bbCorner)
+        if (this.bbTestAxis(this.bbCorner.x this.bbCorner.y this.bbCorner.z) == false) { return false }
+        this.bbAx.crossInto(this.bbBz this.bbCorner)
+        if (this.bbTestAxis(this.bbCorner.x this.bbCorner.y this.bbCorner.z) == false) { return false }
+        this.bbAy.crossInto(this.bbBx this.bbCorner)
+        if (this.bbTestAxis(this.bbCorner.x this.bbCorner.y this.bbCorner.z) == false) { return false }
+        this.bbAy.crossInto(this.bbBy this.bbCorner)
+        if (this.bbTestAxis(this.bbCorner.x this.bbCorner.y this.bbCorner.z) == false) { return false }
+        this.bbAy.crossInto(this.bbBz this.bbCorner)
+        if (this.bbTestAxis(this.bbCorner.x this.bbCorner.y this.bbCorner.z) == false) { return false }
+        this.bbAz.crossInto(this.bbBx this.bbCorner)
+        if (this.bbTestAxis(this.bbCorner.x this.bbCorner.y this.bbCorner.z) == false) { return false }
+        this.bbAz.crossInto(this.bbBy this.bbCorner)
+        if (this.bbTestAxis(this.bbCorner.x this.bbCorner.y this.bbCorner.z) == false) { return false }
+        this.bbAz.crossInto(this.bbBz this.bbCorner)
+        if (this.bbTestAxis(this.bbCorner.x this.bbCorner.y this.bbCorner.z) == false) { return false }
+
+        if (justTest) {
+            return true
+        }
+
+        def n:CannonVec3 this.bbBestAxis
+        def sign:double (n.dot(this.bbPosDiff))
+        if (sign < 0.0) {
+            n.negateInto(n)
+        }
+        def d:double this.bbBestOverlap
+        this.bbMade = 0
+        ; corners of B inside A
+        this.bbTryCorner(1.0 1.0 1.0 heB posB quatB heA posA quatA n d true bi bj si sj)
+        this.bbTryCorner(1.0 1.0 (0.0 - 1.0) heB posB quatB heA posA quatA n d true bi bj si sj)
+        this.bbTryCorner(1.0 (0.0 - 1.0) 1.0 heB posB quatB heA posA quatA n d true bi bj si sj)
+        this.bbTryCorner(1.0 (0.0 - 1.0) (0.0 - 1.0) heB posB quatB heA posA quatA n d true bi bj si sj)
+        this.bbTryCorner((0.0 - 1.0) 1.0 1.0 heB posB quatB heA posA quatA n d true bi bj si sj)
+        this.bbTryCorner((0.0 - 1.0) 1.0 (0.0 - 1.0) heB posB quatB heA posA quatA n d true bi bj si sj)
+        this.bbTryCorner((0.0 - 1.0) (0.0 - 1.0) 1.0 heB posB quatB heA posA quatA n d true bi bj si sj)
+        this.bbTryCorner((0.0 - 1.0) (0.0 - 1.0) (0.0 - 1.0) heB posB quatB heA posA quatA n d true bi bj si sj)
+        ; corners of A inside B
+        this.bbTryCorner(1.0 1.0 1.0 heA posA quatA heB posB quatB n d false bi bj si sj)
+        this.bbTryCorner(1.0 1.0 (0.0 - 1.0) heA posA quatA heB posB quatB n d false bi bj si sj)
+        this.bbTryCorner(1.0 (0.0 - 1.0) 1.0 heA posA quatA heB posB quatB n d false bi bj si sj)
+        this.bbTryCorner(1.0 (0.0 - 1.0) (0.0 - 1.0) heA posA quatA heB posB quatB n d false bi bj si sj)
+        this.bbTryCorner((0.0 - 1.0) 1.0 1.0 heA posA quatA heB posB quatB n d false bi bj si sj)
+        this.bbTryCorner((0.0 - 1.0) 1.0 (0.0 - 1.0) heA posA quatA heB posB quatB n d false bi bj si sj)
+        this.bbTryCorner((0.0 - 1.0) (0.0 - 1.0) 1.0 heA posA quatA heB posB quatB n d false bi bj si sj)
+        this.bbTryCorner((0.0 - 1.0) (0.0 - 1.0) (0.0 - 1.0) heA posA quatA heB posB quatB n d false bi bj si sj)
+
+        if (this.bbMade == 0) {
+            ; edge-edge fallback: one contact at the box midpoint
+            def r:CannonEquation (this.createContactEquation(bi bj si sj))
+            r.ni.copy(n)
+            this.bbPosDiff.scaleInto(0.5 this.bbPointA)
+            posA.vadd(this.bbPointA this.bbPointA)
+            this.bbPointA.vsub(posA r.ri)
+            n.scaleInto(d this.bbPointB)
+            this.bbPointA.vsub(this.bbPointB this.bbPointB)
+            this.bbPointB.vsub(posB r.rj)
+            push this.result r
+        }
+        return true
+    }
+
     fn dispatchShapePair:boolean (si:CannonShape sj:CannonShape xi:CannonVec3 xj:CannonVec3 qi:CannonQuaternion qj:CannonQuaternion bi:CannonBody bj:CannonBody justTest:boolean) {
         if (si.type == 1) {
             if (sj.type == 1) {
@@ -246,6 +438,13 @@ class CannonNarrowphase {
             if (sj.type == 2) {
                 def hitBP:boolean (this.planeBox(qj si xi qi bj bi sj si justTest))
                 return hitBP
+            }
+            ; box vs box (OBB SAT)
+            if (sj.type == 4) {
+                def heA:CannonVec3 (si.getHalfExtents())
+                def heB:CannonVec3 (sj.getHalfExtents())
+                def hitBB:boolean (this.boxBox(heA xi qi heB xj qj bi bj si sj justTest))
+                return hitBB
             }
         }
         return false

--- a/gallery/game_engine/physics/src/cannon_narrowphase.rgr
+++ b/gallery/game_engine/physics/src/cannon_narrowphase.rgr
@@ -20,6 +20,17 @@ class CannonNarrowphase {
     def tmpVecJ:CannonVec3 (new CannonVec3)
     def tmpPointOnPlane:CannonVec3 (new CannonVec3)
     def tmpPlaneOrtho:CannonVec3 (new CannonVec3)
+    ; sphere-box scratch
+    def sbRel:CannonVec3 (new CannonVec3)
+    def sbConj:CannonQuaternion (new CannonQuaternion)
+    def sbLocal:CannonVec3 (new CannonVec3)
+    def sbClosest:CannonVec3 (new CannonVec3)
+    def sbClosestWorld:CannonVec3 (new CannonVec3)
+    def sbD:CannonVec3 (new CannonVec3)
+    ; plane-box scratch
+    def pbNormal:CannonVec3 (new CannonVec3)
+    def pbCorner:CannonVec3 (new CannonVec3)
+    def pbProj:CannonVec3 (new CannonVec3)
 
     fn createContactEquation:CannonEquation (bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape) {
         def c:CannonEquation (new CannonEquation)
@@ -104,6 +115,99 @@ class CannonNarrowphase {
         return false
     }
 
+    ; Sphere (i) vs box (j): closest point on the OBB to the sphere centre.
+    fn sphereBox:boolean (radius:double xi:CannonVec3 boxShape:CannonShape xj:CannonVec3 qj:CannonQuaternion bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape justTest:boolean) {
+        xi.vsub(xj this.sbRel)
+        qj.conjugateInto(this.sbConj)
+        this.sbConj.vmult(this.sbRel this.sbLocal)
+        def he:CannonVec3 (boxShape.getHalfExtents())
+        def cx:double this.sbLocal.x
+        if (cx > he.x) {
+            cx = he.x
+        }
+        if (cx < (0.0 - he.x)) {
+            cx = (0.0 - he.x)
+        }
+        def cy:double this.sbLocal.y
+        if (cy > he.y) {
+            cy = he.y
+        }
+        if (cy < (0.0 - he.y)) {
+            cy = (0.0 - he.y)
+        }
+        def cz:double this.sbLocal.z
+        if (cz > he.z) {
+            cz = he.z
+        }
+        if (cz < (0.0 - he.z)) {
+            cz = (0.0 - he.z)
+        }
+        this.sbClosest.set(cx cy cz)
+        qj.vmult(this.sbClosest this.sbClosestWorld)
+        this.sbClosestWorld.vadd(xj this.sbClosestWorld)
+        xi.vsub(this.sbClosestWorld this.sbD)
+        def dist:double (this.sbD.norm())
+        if (dist >= radius) {
+            return false
+        }
+        if (dist < 0.00001) {
+            return false
+        }
+        if (justTest) {
+            return true
+        }
+        def r:CannonEquation (this.createContactEquation(bi bj si sj))
+        ; ni = -d/dist points from the sphere (i) toward the box (j).
+        this.sbD.scaleInto((0.0 - (1.0 / dist)) r.ni)
+        r.ni.scaleInto(radius r.ri)
+        r.ri.vadd(xi r.ri)
+        r.ri.vsub(bi.position r.ri)
+        this.sbClosestWorld.vsub(bj.position r.rj)
+        push this.result r
+        return true
+    }
+
+    ; One box corner vs the plane: add a contact if the corner is below it.
+    fn tryPlaneBoxCorner:boolean (sx:double sy:double sz:double he:CannonVec3 boxPos:CannonVec3 boxQuat:CannonQuaternion bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape justTest:boolean) {
+        this.pbCorner.set((sx * he.x) (sy * he.y) (sz * he.z))
+        boxQuat.vmult(this.pbCorner this.pbCorner)
+        boxPos.vadd(this.pbCorner this.pbCorner)
+        def cornerDot:double (this.pbNormal.dot(this.pbCorner))
+        def planeDot:double (this.pbNormal.dot(bi.position))
+        def dot:double (cornerDot - planeDot)
+        if (dot > 0.0) {
+            return false
+        }
+        if (justTest) {
+            return true
+        }
+        def r:CannonEquation (this.createContactEquation(bi bj si sj))
+        r.ni.copy(this.pbNormal)
+        this.pbCorner.vsub(bj.position r.rj)
+        this.pbNormal.scaleInto(dot this.pbProj)
+        this.pbCorner.vsub(this.pbProj this.pbProj)
+        this.pbProj.vsub(bi.position r.ri)
+        push this.result r
+        return true
+    }
+
+    ; Plane (i) vs box (j): each penetrating box corner becomes a contact.
+    fn planeBox:boolean (planeQuat:CannonQuaternion boxShape:CannonShape xj:CannonVec3 boxQuat:CannonQuaternion bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape justTest:boolean) {
+        this.pbNormal.set(0.0 0.0 1.0)
+        planeQuat.vmult(this.pbNormal this.pbNormal)
+        def he:CannonVec3 (boxShape.getHalfExtents())
+        def hit:boolean false
+        if (this.tryPlaneBoxCorner(1.0 1.0 1.0 he xj boxQuat bi bj si sj justTest)) { hit = true }
+        if (this.tryPlaneBoxCorner((0.0 - 1.0) 1.0 1.0 he xj boxQuat bi bj si sj justTest)) { hit = true }
+        if (this.tryPlaneBoxCorner(1.0 (0.0 - 1.0) 1.0 he xj boxQuat bi bj si sj justTest)) { hit = true }
+        if (this.tryPlaneBoxCorner(1.0 1.0 (0.0 - 1.0) he xj boxQuat bi bj si sj justTest)) { hit = true }
+        if (this.tryPlaneBoxCorner((0.0 - 1.0) (0.0 - 1.0) 1.0 he xj boxQuat bi bj si sj justTest)) { hit = true }
+        if (this.tryPlaneBoxCorner((0.0 - 1.0) 1.0 (0.0 - 1.0) he xj boxQuat bi bj si sj justTest)) { hit = true }
+        if (this.tryPlaneBoxCorner(1.0 (0.0 - 1.0) (0.0 - 1.0) he xj boxQuat bi bj si sj justTest)) { hit = true }
+        if (this.tryPlaneBoxCorner((0.0 - 1.0) (0.0 - 1.0) (0.0 - 1.0) he xj boxQuat bi bj si sj justTest)) { hit = true }
+        return hit
+    }
+
     fn dispatchShapePair:boolean (si:CannonShape sj:CannonShape xi:CannonVec3 xj:CannonVec3 qi:CannonQuaternion qj:CannonQuaternion bi:CannonBody bj:CannonBody justTest:boolean) {
         if (si.type == 1) {
             if (sj.type == 1) {
@@ -119,6 +223,29 @@ class CannonNarrowphase {
             if (sj.type == 1) {
                 def hitSwap:boolean (this.spherePlane(sj.radius xj xi qi bj bi sj si justTest))
                 return hitSwap
+            }
+            if (sj.type == 4) {
+                def hitPB:boolean (this.planeBox(qi sj xj qj bi bj si sj justTest))
+                return hitPB
+            }
+        }
+        ; sphere (i) vs box (j)
+        if (si.type == 1) {
+            if (sj.type == 4) {
+                def hitSBox:boolean (this.sphereBox(si.radius xi sj xj qj bi bj si sj justTest))
+                return hitSBox
+            }
+        }
+        if (si.type == 4) {
+            ; box vs sphere -> reuse sphereBox with the sphere as body i
+            if (sj.type == 1) {
+                def hitBSphere:boolean (this.sphereBox(sj.radius xj si xi qi bj bi sj si justTest))
+                return hitBSphere
+            }
+            ; box vs plane -> reuse planeBox with the plane as body i
+            if (sj.type == 2) {
+                def hitBP:boolean (this.planeBox(qj si xi qi bj bi sj si justTest))
+                return hitBP
             }
         }
         return false

--- a/gallery/game_engine/physics/src/cannon_narrowphase.rgr
+++ b/gallery/game_engine/physics/src/cannon_narrowphase.rgr
@@ -50,6 +50,13 @@ class CannonNarrowphase {
     def bbPointA:CannonVec3 (new CannonVec3)
     def bbPointB:CannonVec3 (new CannonVec3)
     def bbMade:int 0
+    ; sphere-heightfield scratch
+    def hfRel:CannonVec3 (new CannonVec3)
+    def hfConj:CannonQuaternion (new CannonQuaternion)
+    def hfLocal:CannonVec3 (new CannonVec3)
+    def hfNormal:CannonVec3 (new CannonVec3)
+    def hfPoint:CannonVec3 (new CannonVec3)
+    def hfProj:CannonVec3 (new CannonVec3)
 
     fn createContactEquation:CannonEquation (bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape) {
         def c:CannonEquation (new CannonEquation)
@@ -225,6 +232,46 @@ class CannonNarrowphase {
         if (this.tryPlaneBoxCorner(1.0 (0.0 - 1.0) (0.0 - 1.0) he xj boxQuat bi bj si sj justTest)) { hit = true }
         if (this.tryPlaneBoxCorner((0.0 - 1.0) (0.0 - 1.0) (0.0 - 1.0) he xj boxQuat bi bj si sj justTest)) { hit = true }
         return hit
+    }
+
+    ; Sphere (i) vs heightfield (j): contact against the terrain triangle plane
+    ; under the sphere centre.
+    fn sphereHeightfield:boolean (radius:double xi:CannonVec3 hfShape:CannonShape xj:CannonVec3 qj:CannonQuaternion bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape justTest:boolean) {
+        xi.vsub(xj this.hfRel)
+        qj.conjugateInto(this.hfConj)
+        this.hfConj.vmult(this.hfRel this.hfLocal)
+        if (hfShape.heightfieldPlaneAt(this.hfLocal.x this.hfLocal.y this.hfNormal this.hfPoint) == false) {
+            return false
+        }
+        this.hfLocal.vsub(this.hfPoint this.hfProj)
+        def d:double (this.hfNormal.dot(this.hfProj))
+        if (d >= radius) {
+            return false
+        }
+        if (d <= 0.0) {
+            return false
+        }
+        if (justTest) {
+            return true
+        }
+        ; project the sphere centre onto the terrain plane (local -> world)
+        this.hfNormal.scaleInto(d this.hfProj)
+        this.hfLocal.vsub(this.hfProj this.hfProj)
+        qj.vmult(this.hfProj this.sbClosestWorld)
+        this.sbClosestWorld.vadd(xj this.sbClosestWorld)
+        xi.vsub(this.sbClosestWorld this.sbD)
+        def dist:double (this.sbD.norm())
+        if (dist < 0.00001) {
+            return false
+        }
+        def r:CannonEquation (this.createContactEquation(bi bj si sj))
+        this.sbD.scaleInto((0.0 - (1.0 / dist)) r.ni)
+        r.ni.scaleInto(radius r.ri)
+        r.ri.vadd(xi r.ri)
+        r.ri.vsub(bi.position r.ri)
+        this.sbClosestWorld.vsub(bj.position r.rj)
+        push this.result r
+        return true
     }
 
     ; --- box-box (OBB) via the separating axis theorem ---
@@ -426,6 +473,17 @@ class CannonNarrowphase {
             if (sj.type == 4) {
                 def hitSBox:boolean (this.sphereBox(si.radius xi sj xj qj bi bj si sj justTest))
                 return hitSBox
+            }
+            ; sphere (i) vs heightfield (j)
+            if (sj.type == 5) {
+                def hitSHf:boolean (this.sphereHeightfield(si.radius xi sj xj qj bi bj si sj justTest))
+                return hitSHf
+            }
+        }
+        if (si.type == 5) {
+            if (sj.type == 1) {
+                def hitHfS:boolean (this.sphereHeightfield(sj.radius xj si xi qi bj bi sj si justTest))
+                return hitHfS
             }
         }
         if (si.type == 4) {

--- a/gallery/game_engine/physics/src/cannon_narrowphase.rgr
+++ b/gallery/game_engine/physics/src/cannon_narrowphase.rgr
@@ -57,6 +57,14 @@ class CannonNarrowphase {
     def hfNormal:CannonVec3 (new CannonVec3)
     def hfPoint:CannonVec3 (new CannonVec3)
     def hfProj:CannonVec3 (new CannonVec3)
+    ; convex-polyhedron scratch
+    def cvRel:CannonVec3 (new CannonVec3)
+    def cvConj:CannonQuaternion (new CannonQuaternion)
+    def cvLocal:CannonVec3 (new CannonVec3)
+    def cvNormal:CannonVec3 (new CannonVec3)
+    def cvBest:CannonVec3 (new CannonVec3)
+    def cvFV:CannonVec3 (new CannonVec3)
+    def cvVert:CannonVec3 (new CannonVec3)
 
     fn createContactEquation:CannonEquation (bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape) {
         def c:CannonEquation (new CannonEquation)
@@ -266,6 +274,86 @@ class CannonNarrowphase {
         }
         def r:CannonEquation (this.createContactEquation(bi bj si sj))
         this.sbD.scaleInto((0.0 - (1.0 / dist)) r.ni)
+        r.ni.scaleInto(radius r.ri)
+        r.ri.vadd(xi r.ri)
+        r.ri.vsub(bi.position r.ri)
+        this.sbClosestWorld.vsub(bj.position r.rj)
+        push this.result r
+        return true
+    }
+
+    ; Plane (i) vs convex (j): each penetrating hull vertex becomes a contact.
+    fn convexPlane:boolean (planeQuat:CannonQuaternion convexShape:CannonShape convexPos:CannonVec3 convexQuat:CannonQuaternion bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape justTest:boolean) {
+        this.pbNormal.set(0.0 0.0 1.0)
+        planeQuat.vmult(this.pbNormal this.pbNormal)
+        def n:int (convexShape.convexVertexCount())
+        def planeDot:double (this.pbNormal.dot(bi.position))
+        def hit:boolean false
+        def k 0
+        while (k < n) {
+            convexShape.convexVertexAt(k this.cvVert)
+            convexQuat.vmult(this.cvVert this.pbCorner)
+            convexPos.vadd(this.pbCorner this.pbCorner)
+            def cornerDot:double (this.pbNormal.dot(this.pbCorner))
+            def dot:double (cornerDot - planeDot)
+            if (dot <= 0.0) {
+                if (justTest) {
+                    return true
+                }
+                def r:CannonEquation (this.createContactEquation(bi bj si sj))
+                r.ni.copy(this.pbNormal)
+                this.pbCorner.vsub(bj.position r.rj)
+                this.pbNormal.scaleInto(dot this.pbProj)
+                this.pbCorner.vsub(this.pbProj this.pbProj)
+                this.pbProj.vsub(bi.position r.ri)
+                push this.result r
+                hit = true
+            }
+            k = (k + 1)
+        }
+        return hit
+    }
+
+    ; Sphere (i) vs convex (j): contact against the most-separating face plane.
+    fn sphereConvex:boolean (radius:double xi:CannonVec3 convexShape:CannonShape xj:CannonVec3 qj:CannonQuaternion bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape justTest:boolean) {
+        xi.vsub(xj this.cvRel)
+        qj.conjugateInto(this.cvConj)
+        this.cvConj.vmult(this.cvRel this.cvLocal)
+        def fc:int (convexShape.convexFaceCount())
+        if (fc == 0) {
+            return false
+        }
+        def maxDist:double (0.0 - 1000000000.0)
+        def f 0
+        while (f < fc) {
+            convexShape.convexFaceNormalAt(f this.cvNormal)
+            def vidx:int (convexShape.convexFaceVertexIndex(f))
+            convexShape.convexVertexAt(vidx this.cvFV)
+            this.cvLocal.vsub(this.cvFV this.hfProj)
+            def dist:double (this.cvNormal.dot(this.hfProj))
+            if (dist > maxDist) {
+                maxDist = dist
+                this.cvBest.copy(this.cvNormal)
+            }
+            f = (f + 1)
+        }
+        if (maxDist >= radius) {
+            return false
+        }
+        if (justTest) {
+            return true
+        }
+        this.cvBest.scaleInto(maxDist this.hfProj)
+        this.cvLocal.vsub(this.hfProj this.hfProj)
+        qj.vmult(this.hfProj this.sbClosestWorld)
+        this.sbClosestWorld.vadd(xj this.sbClosestWorld)
+        xi.vsub(this.sbClosestWorld this.sbD)
+        def dd:double (this.sbD.norm())
+        if (dd < 0.00001) {
+            return false
+        }
+        def r:CannonEquation (this.createContactEquation(bi bj si sj))
+        this.sbD.scaleInto((0.0 - (1.0 / dd)) r.ni)
         r.ni.scaleInto(radius r.ri)
         r.ri.vadd(xi r.ri)
         r.ri.vsub(bi.position r.ri)
@@ -484,6 +572,31 @@ class CannonNarrowphase {
             if (sj.type == 1) {
                 def hitHfS:boolean (this.sphereHeightfield(sj.radius xj si xi qi bj bi sj si justTest))
                 return hitHfS
+            }
+        }
+        ; sphere (i) vs convex (j)
+        if (si.type == 1) {
+            if (sj.type == 6) {
+                def hitSCv:boolean (this.sphereConvex(si.radius xi sj xj qj bi bj si sj justTest))
+                return hitSCv
+            }
+        }
+        if (si.type == 6) {
+            if (sj.type == 1) {
+                def hitCvS:boolean (this.sphereConvex(sj.radius xj si xi qi bj bi sj si justTest))
+                return hitCvS
+            }
+            ; convex vs plane -> plane is body i
+            if (sj.type == 2) {
+                def hitCvP:boolean (this.convexPlane(qj si xi qi bj bi sj si justTest))
+                return hitCvP
+            }
+        }
+        ; plane (i) vs convex (j)
+        if (si.type == 2) {
+            if (sj.type == 6) {
+                def hitPCv:boolean (this.convexPlane(qi sj xj qj bi bj si sj justTest))
+                return hitPCv
             }
         }
         if (si.type == 4) {

--- a/gallery/game_engine/physics/src/cannon_narrowphase.rgr
+++ b/gallery/game_engine/physics/src/cannon_narrowphase.rgr
@@ -1,17 +1,19 @@
 ; ==============================================================================
 ; cannon_narrowphase — contact generation (Cannon.js port subset).
+;   Produces SPOOK CannonEquation contacts (kind = contact) for the GS solver.
+;   Contact normal ni follows cannon-es: it points from body i toward body j.
 ; ==============================================================================
 
 Import "cannon_vec3.rgr"
 Import "cannon_quaternion.rgr"
 Import "cannon_shape.rgr"
 Import "cannon_body.rgr"
-Import "cannon_contact_equation.rgr"
+Import "cannon_equation.rgr"
 Import "cannon_contact_material.rgr"
 
 class CannonNarrowphase {
     def currentContactMaterial:CannonContactMaterial
-    def result:[CannonContactEquation]
+    def result:[CannonEquation]
     def tmpQuatI:CannonQuaternion (new CannonQuaternion)
     def tmpQuatJ:CannonQuaternion (new CannonQuaternion)
     def tmpVecI:CannonVec3 (new CannonVec3)
@@ -19,9 +21,9 @@ class CannonNarrowphase {
     def tmpPointOnPlane:CannonVec3 (new CannonVec3)
     def tmpPlaneOrtho:CannonVec3 (new CannonVec3)
 
-    fn createContactEquation:CannonContactEquation (bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape) {
-        def c:CannonContactEquation (new CannonContactEquation)
-        c.initContact(bi bj)
+    fn createContactEquation:CannonEquation (bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape) {
+        def c:CannonEquation (new CannonEquation)
+        c.initContact(bi bj 1000000.0)
         def enabled:boolean true
         if (bi.collisionResponse == false) {
             enabled = false
@@ -41,6 +43,7 @@ class CannonNarrowphase {
         def cm:CannonContactMaterial this.currentContactMaterial
         if (cm) {
             c.restitution = cm.restitution
+            c.setSpookParams(cm.contactEquationStiffness cm.contactEquationRelaxation (1.0 / 60.0))
         }
         return c
     }
@@ -51,9 +54,10 @@ class CannonNarrowphase {
             def limit2:double (limit * limit)
             return (xi.distanceSquared(xj) < limit2)
         }
-        def r:CannonContactEquation (this.createContactEquation(bi bj si sj))
+        def r:CannonEquation (this.createContactEquation(bi bj si sj))
         def ni:CannonVec3 r.ni
-        xi.vsub(xj ni)
+        ; ni points from body i toward body j (cannon-es convention).
+        xj.vsub(xi ni)
         ni.normalizeSelf()
         r.ri.copy(ni)
         r.rj.copy(ni)
@@ -69,7 +73,7 @@ class CannonNarrowphase {
     }
 
     fn spherePlane:boolean (radiusI:double xi:CannonVec3 xj:CannonVec3 qj:CannonQuaternion bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape justTest:boolean) {
-        def r:CannonContactEquation (this.createContactEquation(bi bj si sj))
+        def r:CannonEquation (this.createContactEquation(bi bj si sj))
         def ni:CannonVec3 r.ni
         ni.set(0.0 0.0 1.0)
         qj.vmult(ni ni)

--- a/gallery/game_engine/physics/src/cannon_narrowphase.rgr
+++ b/gallery/game_engine/physics/src/cannon_narrowphase.rgr
@@ -65,6 +65,33 @@ class CannonNarrowphase {
     def cvBest:CannonVec3 (new CannonVec3)
     def cvFV:CannonVec3 (new CannonVec3)
     def cvVert:CannonVec3 (new CannonVec3)
+    ; sphere-trimesh scratch
+    def tmRel:CannonVec3 (new CannonVec3)
+    def tmConj:CannonQuaternion (new CannonQuaternion)
+    def tmLocal:CannonVec3 (new CannonVec3)
+    def tmA:CannonVec3 (new CannonVec3)
+    def tmB:CannonVec3 (new CannonVec3)
+    def tmC:CannonVec3 (new CannonVec3)
+    def tmClosest:CannonVec3 (new CannonVec3)
+    def tmDV:CannonVec3 (new CannonVec3)
+    def tmAB:CannonVec3 (new CannonVec3)
+    def tmAC:CannonVec3 (new CannonVec3)
+    def tmAP:CannonVec3 (new CannonVec3)
+    def tmBP:CannonVec3 (new CannonVec3)
+    def tmCP:CannonVec3 (new CannonVec3)
+    ; convex-convex scratch
+    def ccAxis:CannonVec3 (new CannonVec3)
+    def ccBestAxis:CannonVec3 (new CannonVec3)
+    def ccBestOverlap:double 0.0
+    def ccDiff:CannonVec3 (new CannonVec3)
+    def ccVert:CannonVec3 (new CannonVec3)
+    def ccTmp:CannonVec3 (new CannonVec3)
+    def ccTmp2:CannonVec3 (new CannonVec3)
+    def ccLocalV:CannonVec3 (new CannonVec3)
+    def ccLocalN:CannonVec3 (new CannonVec3)
+    def ccPointA:CannonVec3 (new CannonVec3)
+    def ccPointB:CannonVec3 (new CannonVec3)
+    def ccMade:int 0
 
     fn createContactEquation:CannonEquation (bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape) {
         def c:CannonEquation (new CannonEquation)
@@ -362,6 +389,265 @@ class CannonNarrowphase {
         return true
     }
 
+    ; Closest point on triangle (a,b,c) to point p, written into out
+    ; (Ericson, Real-Time Collision Detection).
+    fn closestPtTriangle:void (p:CannonVec3 a:CannonVec3 b:CannonVec3 c:CannonVec3 out:CannonVec3) {
+        b.vsub(a this.tmAB)
+        c.vsub(a this.tmAC)
+        p.vsub(a this.tmAP)
+        def d1:double (this.tmAB.dot(this.tmAP))
+        def d2:double (this.tmAC.dot(this.tmAP))
+        if (d1 <= 0.0) {
+            if (d2 <= 0.0) {
+                out.copy(a)
+                return
+            }
+        }
+        p.vsub(b this.tmBP)
+        def d3:double (this.tmAB.dot(this.tmBP))
+        def d4:double (this.tmAC.dot(this.tmBP))
+        if (d3 >= 0.0) {
+            if (d4 <= d3) {
+                out.copy(b)
+                return
+            }
+        }
+        def vc:double ((d1 * d4) - (d3 * d2))
+        if (vc <= 0.0) {
+            if (d1 >= 0.0) {
+                if (d3 <= 0.0) {
+                    def v:double (d1 / (d1 - d3))
+                    this.tmAB.scaleInto(v out)
+                    a.vadd(out out)
+                    return
+                }
+            }
+        }
+        p.vsub(c this.tmCP)
+        def d5:double (this.tmAB.dot(this.tmCP))
+        def d6:double (this.tmAC.dot(this.tmCP))
+        if (d6 >= 0.0) {
+            if (d5 <= d6) {
+                out.copy(c)
+                return
+            }
+        }
+        def vb:double ((d5 * d2) - (d1 * d6))
+        if (vb <= 0.0) {
+            if (d2 >= 0.0) {
+                if (d6 <= 0.0) {
+                    def w:double (d2 / (d2 - d6))
+                    this.tmAC.scaleInto(w out)
+                    a.vadd(out out)
+                    return
+                }
+            }
+        }
+        def va:double ((d3 * d6) - (d5 * d4))
+        def d43:double (d4 - d3)
+        def d56:double (d5 - d6)
+        if (va <= 0.0) {
+            if (d43 >= 0.0) {
+                if (d56 >= 0.0) {
+                    def w2:double (d43 / (d43 + d56))
+                    c.vsub(b this.tmCP)
+                    this.tmCP.scaleInto(w2 out)
+                    b.vadd(out out)
+                    return
+                }
+            }
+        }
+        def denom:double (1.0 / ((va + vb) + vc))
+        def vv:double (vb * denom)
+        def ww:double (vc * denom)
+        this.tmAB.scaleInto(vv this.tmBP)
+        this.tmAC.scaleInto(ww this.tmCP)
+        a.vadd(this.tmBP out)
+        out.vadd(this.tmCP out)
+    }
+
+    ; Sphere (i) vs trimesh (j): contact against the closest point of each
+    ; triangle within the sphere radius.
+    fn sphereTrimesh:boolean (radius:double xi:CannonVec3 tmShape:CannonShape xj:CannonVec3 qj:CannonQuaternion bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape justTest:boolean) {
+        xi.vsub(xj this.tmRel)
+        qj.conjugateInto(this.tmConj)
+        this.tmConj.vmult(this.tmRel this.tmLocal)
+        def tc:int (tmShape.trimeshTriangleCount())
+        def hitAny:boolean false
+        def t 0
+        while (t < tc) {
+            tmShape.trimeshVertex(t 0 this.tmA)
+            tmShape.trimeshVertex(t 1 this.tmB)
+            tmShape.trimeshVertex(t 2 this.tmC)
+            this.closestPtTriangle(this.tmLocal this.tmA this.tmB this.tmC this.tmClosest)
+            this.tmLocal.vsub(this.tmClosest this.tmDV)
+            def dist:double (this.tmDV.norm())
+            if (dist < radius) {
+                if (dist > 0.00001) {
+                    if (justTest) {
+                        return true
+                    }
+                    qj.vmult(this.tmClosest this.sbClosestWorld)
+                    this.sbClosestWorld.vadd(xj this.sbClosestWorld)
+                    xi.vsub(this.sbClosestWorld this.sbD)
+                    def dd:double (this.sbD.norm())
+                    if (dd > 0.00001) {
+                        def r:CannonEquation (this.createContactEquation(bi bj si sj))
+                        this.sbD.scaleInto((0.0 - (1.0 / dd)) r.ni)
+                        r.ni.scaleInto(radius r.ri)
+                        r.ri.vadd(xi r.ri)
+                        r.ri.vsub(bi.position r.ri)
+                        this.sbClosestWorld.vsub(bj.position r.rj)
+                        push this.result r
+                        hitAny = true
+                    }
+                }
+            }
+            t = (t + 1)
+        }
+        return hitAny
+    }
+
+    ; --- general convex-convex via the separating axis theorem (face normals) ---
+
+    fn ccWorldVertex:void (shape:CannonShape idx:int pos:CannonVec3 quat:CannonQuaternion out:CannonVec3) {
+        shape.convexVertexAt(idx this.ccLocalV)
+        quat.vmult(this.ccLocalV out)
+        pos.vadd(out out)
+    }
+
+    fn ccWorldFaceNormal:void (shape:CannonShape f:int quat:CannonQuaternion out:CannonVec3) {
+        shape.convexFaceNormalAt(f this.ccLocalN)
+        quat.vmult(this.ccLocalN out)
+    }
+
+    ; Project both hulls onto this.ccAxis; false if it separates them, else track
+    ; the minimum-overlap axis.
+    fn ccTestAxis:boolean (shA:CannonShape posA:CannonVec3 quatA:CannonQuaternion shB:CannonShape posB:CannonVec3 quatB:CannonQuaternion) {
+        def na:int (shA.convexVertexCount())
+        def minA:double 1000000000.0
+        def maxA:double (0.0 - 1000000000.0)
+        def i 0
+        while (i < na) {
+            this.ccWorldVertex(shA i posA quatA this.ccTmp)
+            def proj:double (this.ccTmp.dot(this.ccAxis))
+            if (proj < minA) { minA = proj }
+            if (proj > maxA) { maxA = proj }
+            i = (i + 1)
+        }
+        def nb:int (shB.convexVertexCount())
+        def minB:double 1000000000.0
+        def maxB:double (0.0 - 1000000000.0)
+        i = 0
+        while (i < nb) {
+            this.ccWorldVertex(shB i posB quatB this.ccTmp)
+            def proj:double (this.ccTmp.dot(this.ccAxis))
+            if (proj < minB) { minB = proj }
+            if (proj > maxB) { maxB = proj }
+            i = (i + 1)
+        }
+        def lo:double minA
+        if (minB > lo) { lo = minB }
+        def hi:double maxA
+        if (maxB < hi) { hi = maxB }
+        def overlap:double (hi - lo)
+        if (overlap < 0.0) {
+            return false
+        }
+        if (overlap < this.ccBestOverlap) {
+            this.ccBestOverlap = overlap
+            this.ccBestAxis.copy(this.ccAxis)
+        }
+        return true
+    }
+
+    fn ccPointInHull:boolean (worldP:CannonVec3 shape:CannonShape pos:CannonVec3 quat:CannonQuaternion) {
+        def fc:int (shape.convexFaceCount())
+        def f 0
+        while (f < fc) {
+            this.ccWorldFaceNormal(shape f quat this.ccTmp)
+            def vidx:int (shape.convexFaceVertexIndex(f))
+            this.ccWorldVertex(shape vidx pos quat this.ccTmp2)
+            worldP.vsub(this.ccTmp2 this.ccTmp2)
+            def d:double (this.ccTmp.dot(this.ccTmp2))
+            if (d > 0.001) {
+                return false
+            }
+            f = (f + 1)
+        }
+        return true
+    }
+
+    fn ccAddVertex:void (worldVert:CannonVec3 posA:CannonVec3 posB:CannonVec3 n:CannonVec3 d:double bIntoA:boolean bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape) {
+        def r:CannonEquation (this.createContactEquation(bi bj si sj))
+        r.ni.copy(n)
+        if (bIntoA) {
+            worldVert.vsub(posB r.rj)
+            n.scaleInto(d this.ccPointA)
+            worldVert.vadd(this.ccPointA this.ccPointA)
+            this.ccPointA.vsub(posA r.ri)
+        } {
+            worldVert.vsub(posA r.ri)
+            n.scaleInto(d this.ccPointB)
+            worldVert.vsub(this.ccPointB this.ccPointB)
+            this.ccPointB.vsub(posB r.rj)
+        }
+        push this.result r
+        this.ccMade = (this.ccMade + 1)
+    }
+
+    fn convexConvex:boolean (shA:CannonShape posA:CannonVec3 quatA:CannonQuaternion shB:CannonShape posB:CannonVec3 quatB:CannonQuaternion bi:CannonBody bj:CannonBody si:CannonShape sj:CannonShape justTest:boolean) {
+        this.ccBestOverlap = 1000000000.0
+        def fca:int (shA.convexFaceCount())
+        def f 0
+        while (f < fca) {
+            this.ccWorldFaceNormal(shA f quatA this.ccAxis)
+            if (this.ccTestAxis(shA posA quatA shB posB quatB) == false) {
+                return false
+            }
+            f = (f + 1)
+        }
+        def fcb:int (shB.convexFaceCount())
+        f = 0
+        while (f < fcb) {
+            this.ccWorldFaceNormal(shB f quatB this.ccAxis)
+            if (this.ccTestAxis(shA posA quatA shB posB quatB) == false) {
+                return false
+            }
+            f = (f + 1)
+        }
+        if (justTest) {
+            return true
+        }
+        posB.vsub(posA this.ccDiff)
+        def n:CannonVec3 this.ccBestAxis
+        def sign:double (n.dot(this.ccDiff))
+        if (sign < 0.0) {
+            n.negateInto(n)
+        }
+        def d:double this.ccBestOverlap
+        this.ccMade = 0
+        def nb:int (shB.convexVertexCount())
+        def k 0
+        while (k < nb) {
+            this.ccWorldVertex(shB k posB quatB this.ccVert)
+            if (this.ccPointInHull(this.ccVert shA posA quatA)) {
+                this.ccAddVertex(this.ccVert posA posB n d true bi bj si sj)
+            }
+            k = (k + 1)
+        }
+        def na:int (shA.convexVertexCount())
+        k = 0
+        while (k < na) {
+            this.ccWorldVertex(shA k posA quatA this.ccVert)
+            if (this.ccPointInHull(this.ccVert shB posB quatB)) {
+                this.ccAddVertex(this.ccVert posA posB n d false bi bj si sj)
+            }
+            k = (k + 1)
+        }
+        return true
+    }
+
     ; --- box-box (OBB) via the separating axis theorem ---
 
     ; Project both boxes onto axis (lx,ly,lz); return false if it separates them,
@@ -567,6 +853,17 @@ class CannonNarrowphase {
                 def hitSHf:boolean (this.sphereHeightfield(si.radius xi sj xj qj bi bj si sj justTest))
                 return hitSHf
             }
+            ; sphere (i) vs trimesh (j)
+            if (sj.type == 8) {
+                def hitSTm:boolean (this.sphereTrimesh(si.radius xi sj xj qj bi bj si sj justTest))
+                return hitSTm
+            }
+        }
+        if (si.type == 8) {
+            if (sj.type == 1) {
+                def hitTmS:boolean (this.sphereTrimesh(sj.radius xj si xi qi bj bi sj si justTest))
+                return hitTmS
+            }
         }
         if (si.type == 5) {
             if (sj.type == 1) {
@@ -590,6 +887,11 @@ class CannonNarrowphase {
             if (sj.type == 2) {
                 def hitCvP:boolean (this.convexPlane(qj si xi qi bj bi sj si justTest))
                 return hitCvP
+            }
+            ; convex vs convex (also cylinder, which is a convex prism)
+            if (sj.type == 6) {
+                def hitCC:boolean (this.convexConvex(si xi qi sj xj qj bi bj si sj justTest))
+                return hitCC
             }
         }
         ; plane (i) vs convex (j)

--- a/gallery/game_engine/physics/src/cannon_narrowphase_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_narrowphase_test.rgr
@@ -7,7 +7,7 @@ Import "cannon_quaternion.rgr"
 Import "cannon_sphere.rgr"
 Import "cannon_body.rgr"
 Import "cannon_contact_material.rgr"
-Import "cannon_contact_equation.rgr"
+Import "cannon_equation.rgr"
 Import "cannon_narrowphase.rgr"
 Import "cannon_test_harness.rgr"
 Import "cannon_test_filter.rgr"
@@ -23,7 +23,7 @@ class CannonNarrowphaseTest {
 
     fn sphereSphere:void (h:CannonTestHarness) {
         h.beginTest("Narrowphase.sphereSphere")
-        def result:[CannonContactEquation]
+        def result:[CannonEquation]
         this.contactMaterial.initDefault()
         this.narrowphase.currentContactMaterial = this.contactMaterial
         this.narrowphase.result = result

--- a/gallery/game_engine/physics/src/cannon_particle.rgr
+++ b/gallery/game_engine/physics/src/cannon_particle.rgr
@@ -1,0 +1,21 @@
+; ==============================================================================
+; cannon_particle — a point mass (cannon-es Particle).
+;   Modelled as a zero-radius sphere (shape type 1) so it reuses the sphere
+;   collision routines (particle vs plane / sphere) without extra narrowphase
+;   code. Unlike CannonSphere it accepts radius 0.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_shape.rgr"
+
+class CannonParticle extends CannonShape {
+    fn initParticle:void () {
+        this.initShape(1)
+        this.radius = 0.0
+        this.boundingSphereRadius = 0.0
+    }
+
+    fn updateBoundingSphereRadius:void () {
+        this.boundingSphereRadius = 0.0
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_physics_world.rgr
+++ b/gallery/game_engine/physics/src/cannon_physics_world.rgr
@@ -1,0 +1,144 @@
+; ==============================================================================
+; cannon_physics_world — Cannon engine behind the PhysicsWorld interface.
+;
+; Adapts the full Cannon port (solver, joints, collision, raycast) to the
+; engine-neutral PhysicsWorld contract. Bodies are stored in an array and
+; referenced by their index (the opaque handle the interface hands out).
+; ==============================================================================
+
+Import "physics_world.rgr"
+Import "cannon_vec3.rgr"
+Import "cannon_quaternion.rgr"
+Import "cannon_body.rgr"
+Import "cannon_sphere.rgr"
+Import "cannon_box.rgr"
+Import "cannon_plane.rgr"
+Import "cannon_constraint.rgr"
+Import "cannon_ray.rgr"
+Import "cannon_world.rgr"
+
+class CannonPhysicsWorld extends PhysicsWorld {
+    def world:CannonWorld (new CannonWorld)
+    def bodies:[CannonBody]
+    def rayResult:CannonRaycastResult (new CannonRaycastResult)
+    def rayFrom:CannonVec3 (new CannonVec3)
+    def rayTo:CannonVec3 (new CannonVec3)
+
+    fn initWorld:void () {
+        this.world.initWorld()
+    }
+
+    fn setGravity:void (x:double y:double z:double) {
+        this.world.setGravity(x y z)
+    }
+
+    fn registerBody:int (b:CannonBody) {
+        this.world.addBody(b)
+        def id:int (array_length this.bodies)
+        push this.bodies b
+        return id
+    }
+
+    fn addSphere:int (mass:double x:double y:double z:double radius:double) {
+        def b:CannonBody (new CannonBody)
+        if (mass > 0.0) {
+            b.initDynamic(mass)
+        } {
+            b.initStatic()
+        }
+        def s:CannonSphere (new CannonSphere)
+        s.initSphere(radius)
+        b.addShape(s)
+        b.position.set(x y z)
+        return (this.registerBody(b))
+    }
+
+    fn addBox:int (mass:double x:double y:double z:double hx:double hy:double hz:double) {
+        def b:CannonBody (new CannonBody)
+        if (mass > 0.0) {
+            b.initDynamic(mass)
+        } {
+            b.initStatic()
+        }
+        def he:CannonVec3 (new CannonVec3)
+        he.set(hx hy hz)
+        def s:CannonBox (new CannonBox)
+        s.initBox(he)
+        b.addShape(s)
+        b.position.set(x y z)
+        return (this.registerBody(b))
+    }
+
+    fn addStaticPlane:int (nx:double ny:double nz:double) {
+        def b:CannonBody (new CannonBody)
+        b.initStatic()
+        def s:CannonPlane (new CannonPlane)
+        s.initPlane()
+        b.addShape(s)
+        ; orient the plane so its local +Z normal points along (nx,ny,nz)
+        def from:CannonVec3 (new CannonVec3)
+        from.set(0.0 0.0 1.0)
+        def to:CannonVec3 (new CannonVec3)
+        to.set(nx ny nz)
+        b.quaternion.setFromVectors(from to)
+        return (this.registerBody(b))
+    }
+
+    fn addPointToPoint:void (bodyA:int pax:double pay:double paz:double bodyB:int pbx:double pby:double pbz:double) {
+        def a:CannonBody (itemAt this.bodies bodyA)
+        def bb:CannonBody (itemAt this.bodies bodyB)
+        def pivotA:CannonVec3 (new CannonVec3)
+        pivotA.set(pax pay paz)
+        def pivotB:CannonVec3 (new CannonVec3)
+        pivotB.set(pbx pby pbz)
+        def c:CannonConstraint (new CannonConstraint)
+        c.initPointToPoint(a pivotA bb pivotB 1000000.0)
+        this.world.addConstraint(c)
+    }
+
+    fn setBodyVelocity:void (id:int vx:double vy:double vz:double) {
+        def b:CannonBody (itemAt this.bodies id)
+        b.velocity.set(vx vy vz)
+    }
+
+    fn bodyPosX:double (id:int) {
+        def b:CannonBody (itemAt this.bodies id)
+        return b.position.x
+    }
+
+    fn bodyPosY:double (id:int) {
+        def b:CannonBody (itemAt this.bodies id)
+        return b.position.y
+    }
+
+    fn bodyPosZ:double (id:int) {
+        def b:CannonBody (itemAt this.bodies id)
+        return b.position.z
+    }
+
+    fn step:void (dt:double) {
+        this.world.step(dt)
+    }
+
+    fn raycastClosest:boolean (fx:double fy:double fz:double tx:double ty:double tz:double) {
+        this.rayFrom.set(fx fy fz)
+        this.rayTo.set(tx ty tz)
+        return (this.world.raycastClosest(this.rayFrom this.rayTo this.rayResult))
+    }
+
+    fn rayHitX:double () {
+        return this.rayResult.hitPointWorld.x
+    }
+
+    fn rayHitY:double () {
+        return this.rayResult.hitPointWorld.y
+    }
+
+    fn rayHitZ:double () {
+        return this.rayResult.hitPointWorld.z
+    }
+
+    fn rayDistance:double () {
+        return this.rayResult.distance
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_quaternion.rgr
+++ b/gallery/game_engine/physics/src/cannon_quaternion.rgr
@@ -178,6 +178,23 @@ class CannonQuaternion {
         return true
     }
 
+    ; Integrate angular velocity into orientation (cannon-es Quaternion.integrate).
+    ; target may alias this (all reads are cached first).
+    fn integrate:void (w:CannonVec3 dt:double angularFactor:CannonVec3 target:CannonQuaternion) {
+        def ax:double (w.x * angularFactor.x)
+        def ay:double (w.y * angularFactor.y)
+        def az:double (w.z * angularFactor.z)
+        def bx:double this.x
+        def by:double this.y
+        def bz:double this.z
+        def bw:double this.w
+        def half:double (dt * 0.5)
+        target.x = (bx + (half * (((ax * bw) + (ay * bz)) - (az * by))))
+        target.y = (by + (half * (((ay * bw) + (az * bx)) - (ax * bz))))
+        target.z = (bz + (half * (((az * bw) + (ax * by)) - (ay * bx))))
+        target.w = (bw + (half * (((0.0 - (ax * bx)) - (ay * by)) - (az * bz))))
+    }
+
     fn vmult:void (v:CannonVec3 target:CannonVec3) {
         def vx:double v.x
         def vy:double v.y

--- a/gallery/game_engine/physics/src/cannon_ray.rgr
+++ b/gallery/game_engine/physics/src/cannon_ray.rgr
@@ -1,0 +1,212 @@
+; ==============================================================================
+; cannon_ray — raycasting (cannon-es src/collision/Ray + RaycastResult).
+;   Focused port: ray vs sphere and ray vs plane, with CLOSEST / ANY / ALL modes.
+;   World.raycastClosest / raycastAny (see cannon_world.rgr) drive it over bodies.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_quaternion.rgr"
+Import "cannon_shape.rgr"
+Import "cannon_body.rgr"
+
+class CannonRaycastResult {
+    def rayFromWorld:CannonVec3 (new CannonVec3)
+    def rayToWorld:CannonVec3 (new CannonVec3)
+    def hitNormalWorld:CannonVec3 (new CannonVec3)
+    def hitPointWorld:CannonVec3 (new CannonVec3)
+    def hasHit:boolean false
+    def shape:CannonShape
+    def body:CannonBody
+    def distance:double -1.0
+    def shouldStop:boolean false
+
+    fn reset:void () {
+        this.rayFromWorld.setZero()
+        this.rayToWorld.setZero()
+        this.hitNormalWorld.setZero()
+        this.hitPointWorld.setZero()
+        this.hasHit = false
+        this.distance = -1.0
+        this.shouldStop = false
+    }
+
+    fn set:void (rayFromWorld:CannonVec3 rayToWorld:CannonVec3 hitNormalWorld:CannonVec3 hitPointWorld:CannonVec3 shape:CannonShape body:CannonBody distance:double) {
+        this.rayFromWorld.copy(rayFromWorld)
+        this.rayToWorld.copy(rayToWorld)
+        this.hitNormalWorld.copy(hitNormalWorld)
+        this.hitPointWorld.copy(hitPointWorld)
+        this.shape = shape
+        this.body = body
+        this.distance = distance
+    }
+}
+
+class CannonRay {
+    sdef MODE_CLOSEST:int 1
+    sdef MODE_ANY:int 2
+    sdef MODE_ALL:int 4
+
+    def from:CannonVec3 (new CannonVec3)
+    def to:CannonVec3 (new CannonVec3)
+    def direction:CannonVec3 (new CannonVec3)
+    def precision:double 0.0001
+    def skipBackfaces:boolean false
+    def mode:int 1
+    def result:CannonRaycastResult (new CannonRaycastResult)
+    def hasHit:boolean false
+    ; scratch
+    def ip:CannonVec3 (new CannonVec3)
+    def nrm:CannonVec3 (new CannonVec3)
+    def worldNormal:CannonVec3 (new CannonVec3)
+    def lenv:CannonVec3 (new CannonVec3)
+    def planePointToFrom:CannonVec3 (new CannonVec3)
+    def dirScaled:CannonVec3 (new CannonVec3)
+    def hitPoint:CannonVec3 (new CannonVec3)
+    def xi:CannonVec3 (new CannonVec3)
+    def qi:CannonQuaternion (new CannonQuaternion)
+
+    fn initRay:void (from:CannonVec3 to:CannonVec3) {
+        this.from.copy(from)
+        this.to.copy(to)
+    }
+
+    fn updateDirection:void () {
+        this.to.vsub(this.from this.direction)
+        this.direction.normalizeSelf()
+    }
+
+    fn reportIntersection:void (normal:CannonVec3 hitPointWorld:CannonVec3 shape:CannonShape body:CannonBody) {
+        if (this.skipBackfaces) {
+            if ((normal.dot(this.direction)) > 0.0) {
+                return
+            }
+        }
+        def distance:double (this.from.distanceTo(hitPointWorld))
+        def result:CannonRaycastResult this.result
+        if (this.mode == 4) {
+            this.hasHit = true
+            result.set(this.from this.to normal hitPointWorld shape body distance)
+            result.hasHit = true
+            return
+        }
+        if (this.mode == 2) {
+            this.hasHit = true
+            result.hasHit = true
+            result.set(this.from this.to normal hitPointWorld shape body distance)
+            result.shouldStop = true
+            return
+        }
+        ; CLOSEST
+        if ((distance < result.distance) || (result.hasHit == false)) {
+            this.hasHit = true
+            result.hasHit = true
+            result.set(this.from this.to normal hitPointWorld shape body distance)
+        }
+    }
+
+    fn intersectSphere:void (shape:CannonShape position:CannonVec3 body:CannonBody) {
+        def from:CannonVec3 this.from
+        def to:CannonVec3 this.to
+        def r:double shape.radius
+        def dx:double (to.x - from.x)
+        def dy:double (to.y - from.y)
+        def dz:double (to.z - from.z)
+        def fx:double (from.x - position.x)
+        def fy:double (from.y - position.y)
+        def fz:double (from.z - position.z)
+        def a:double (((dx * dx) + (dy * dy)) + (dz * dz))
+        def b:double (2.0 * (((dx * fx) + (dy * fy)) + (dz * fz)))
+        def c:double ((((fx * fx) + (fy * fy)) + (fz * fz)) - (r * r))
+        def delta:double ((b * b) - ((4.0 * a) * c))
+        if (delta < 0.0) {
+            return
+        }
+        def sq:double (sqrt(delta))
+        def d1:double (((0.0 - b) - sq) / (2.0 * a))
+        if (d1 >= 0.0) {
+            if (d1 <= 1.0) {
+                from.lerp(to d1 this.ip)
+                this.ip.vsub(position this.nrm)
+                this.nrm.normalizeSelf()
+                this.reportIntersection(this.nrm this.ip shape body)
+            }
+        }
+        if (this.result.shouldStop) {
+            return
+        }
+        def d2:double (((0.0 - b) + sq) / (2.0 * a))
+        if (d2 >= 0.0) {
+            if (d2 <= 1.0) {
+                from.lerp(to d2 this.ip)
+                this.ip.vsub(position this.nrm)
+                this.nrm.normalizeSelf()
+                this.reportIntersection(this.nrm this.ip shape body)
+            }
+        }
+    }
+
+    fn intersectPlane:void (shape:CannonShape quat:CannonQuaternion position:CannonVec3 body:CannonBody) {
+        def from:CannonVec3 this.from
+        def to:CannonVec3 this.to
+        def worldNormal:CannonVec3 this.worldNormal
+        worldNormal.set(0.0 0.0 1.0)
+        quat.vmult(worldNormal worldNormal)
+        def len:CannonVec3 this.lenv
+        from.vsub(position len)
+        def planeToFrom:double (len.dot(worldNormal))
+        to.vsub(position len)
+        def planeToTo:double (len.dot(worldNormal))
+        if ((planeToFrom * planeToTo) > 0.0) {
+            return
+        }
+        if ((from.distanceTo(to)) < planeToFrom) {
+            return
+        }
+        def nDotDir:double (worldNormal.dot(this.direction))
+        def absN:double nDotDir
+        if (absN < 0.0) {
+            absN = (0.0 - absN)
+        }
+        if (absN < this.precision) {
+            return
+        }
+        from.vsub(position this.planePointToFrom)
+        def t:double ((0.0 - (worldNormal.dot(this.planePointToFrom))) / nDotDir)
+        this.direction.scaleInto(t this.dirScaled)
+        from.vadd(this.dirScaled this.hitPoint)
+        this.reportIntersection(worldNormal this.hitPoint shape body)
+    }
+
+    fn intersectShape:void (shape:CannonShape quat:CannonQuaternion position:CannonVec3 body:CannonBody) {
+        if (shape.collisionResponse == false) {
+            return
+        }
+        if (shape.type == 1) {
+            this.intersectSphere(shape position body)
+        }
+        if (shape.type == 2) {
+            this.intersectPlane(shape quat position body)
+        }
+    }
+
+    fn intersectBody:void (body:CannonBody) {
+        if (body.collisionResponse == false) {
+            return
+        }
+        def n:int (array_length body.shapes)
+        def i 0
+        while (i < n) {
+            def shape:CannonShape (itemAt body.shapes i)
+            def orn:CannonQuaternion (itemAt body.shapeOrientations i)
+            body.quaternion.multInto(orn this.qi)
+            def off:CannonVec3 (itemAt body.shapeOffsets i)
+            body.quaternion.vmult(off this.xi)
+            this.xi.vadd(body.position this.xi)
+            this.intersectShape(shape this.qi this.xi body)
+            if (this.result.shouldStop) {
+                return
+            }
+            i = (i + 1)
+        }
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_ray_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_ray_test.rgr
@@ -1,0 +1,103 @@
+; ==============================================================================
+; cannon_ray_test — raycasting against spheres and planes through the world.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_sphere.rgr"
+Import "cannon_plane.rgr"
+Import "cannon_body.rgr"
+Import "cannon_ray.rgr"
+Import "cannon_world.rgr"
+Import "cannon_test_harness.rgr"
+Import "cannon_test_filter.rgr"
+
+class CannonRayTest {
+    def filter:CannonTestFilter (new CannonTestFilter)
+
+    fn runFiltered:void (h:CannonTestHarness filter:string) {
+        if (this.filter.matches(filter "Ray.sphereHit")) { this.sphereHit(h) }
+        if (this.filter.matches(filter "Ray.sphereMiss")) { this.sphereMiss(h) }
+        if (this.filter.matches(filter "Ray.planeHit")) { this.planeHit(h) }
+    }
+
+    ; A ray through a unit sphere hits the near surface at x = -1, distance 4.
+    fn sphereHit:void (h:CannonTestHarness) {
+        h.beginTest("Ray.sphereHit")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        def body:CannonBody (new CannonBody)
+        body.initStatic()
+        def shape:CannonSphere (new CannonSphere)
+        shape.initSphere(1.0)
+        body.addShape(shape)
+        body.position.set(0.0 0.0 0.0)
+        world.addBody(body)
+
+        def from:CannonVec3 (new CannonVec3)
+        from.set((0.0 - 5.0) 0.0 0.0)
+        def to:CannonVec3 (new CannonVec3)
+        to.set(5.0 0.0 0.0)
+        def result:CannonRaycastResult (new CannonRaycastResult)
+        def hit:boolean (world.raycastClosest(from to result))
+
+        h.ok(hit "ray hits the sphere")
+        h.ok(result.hasHit "result.hasHit set")
+        h.nearEqual(result.distance 4.0 0.001 "closest hit distance is 4")
+        h.nearEqual(result.hitPointWorld.x (0.0 - 1.0) 0.001 "hit point at x = -1")
+        h.nearEqual(result.hitNormalWorld.x (0.0 - 1.0) 0.001 "surface normal points back along -x")
+        print ("raySphereDist=" + (to_string result.distance))
+        h.finishTest()
+    }
+
+    ; A ray passing above the sphere records no hit.
+    fn sphereMiss:void (h:CannonTestHarness) {
+        h.beginTest("Ray.sphereMiss")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        def body:CannonBody (new CannonBody)
+        body.initStatic()
+        def shape:CannonSphere (new CannonSphere)
+        shape.initSphere(1.0)
+        body.addShape(shape)
+        body.position.set(0.0 0.0 0.0)
+        world.addBody(body)
+
+        def from:CannonVec3 (new CannonVec3)
+        from.set((0.0 - 5.0) 5.0 0.0)
+        def to:CannonVec3 (new CannonVec3)
+        to.set(5.0 5.0 0.0)
+        def result:CannonRaycastResult (new CannonRaycastResult)
+        def hit:boolean (world.raycastClosest(from to result))
+
+        h.equalBool(hit false "ray misses the sphere")
+        h.equalBool(result.hasHit false "result reports no hit")
+        h.finishTest()
+    }
+
+    ; A ray dropped straight down onto the ground plane hits z = 0 at distance 5.
+    fn planeHit:void (h:CannonTestHarness) {
+        h.beginTest("Ray.planeHit")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        def body:CannonBody (new CannonBody)
+        body.initStatic()
+        def plane:CannonPlane (new CannonPlane)
+        plane.initPlane()
+        body.addShape(plane)
+        body.position.set(0.0 0.0 0.0)
+        world.addBody(body)
+
+        def from:CannonVec3 (new CannonVec3)
+        from.set(0.0 0.0 5.0)
+        def to:CannonVec3 (new CannonVec3)
+        to.set(0.0 0.0 (0.0 - 5.0))
+        def result:CannonRaycastResult (new CannonRaycastResult)
+        def hit:boolean (world.raycastClosest(from to result))
+
+        h.ok(hit "ray hits the plane")
+        h.nearEqual(result.hitPointWorld.z 0.0 0.001 "hit point at z = 0")
+        h.nearEqual(result.distance 5.0 0.001 "hit distance is 5")
+        print ("rayPlaneDist=" + (to_string result.distance))
+        h.finishTest()
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_sap_broadphase.rgr
+++ b/gallery/game_engine/physics/src/cannon_sap_broadphase.rgr
@@ -1,0 +1,82 @@
+; ==============================================================================
+; cannon_sap_broadphase — sweep-and-prune broadphase (cannon-es SAPBroadphase).
+;   Sort bodies by their AABB minimum along x, then sweep: a pair can only
+;   collide while the later body's min-x is within the earlier body's max-x, so
+;   most O(n^2) candidate pairs are pruned. Produces the same pairs as the naive
+;   broadphase, faster for many bodies.
+; ==============================================================================
+
+Import "cannon_broadphase.rgr"
+Import "cannon_body.rgr"
+
+class CannonSAPBroadphase extends CannonBroadphase {
+    def order:[int]
+
+    fn minX:double (bodies:[CannonBody] idx:int) {
+        def b:CannonBody (itemAt bodies idx)
+        return (b.position.x - b.boundingRadius)
+    }
+
+    fn collisionPairs:void (bodies:[CannonBody]) {
+        clear this.outPairs1
+        clear this.outPairs2
+        def n:int (array_length bodies)
+        clear this.order
+        def i 0
+        while (i < n) {
+            push this.order i
+            i = (i + 1)
+        }
+
+        ; insertion sort `order` by ascending min-x
+        def a 1
+        while (a < n) {
+            def keyIdx:int (itemAt this.order a)
+            def keyVal:double (this.minX(bodies keyIdx))
+            def b:int (a - 1)
+            def cont:boolean true
+            while (cont) {
+                if (b < 0) {
+                    cont = false
+                } {
+                    def bIdx:int (itemAt this.order b)
+                    def bVal:double (this.minX(bodies bIdx))
+                    if (bVal > keyVal) {
+                        set this.order (b + 1) bIdx
+                        b = (b - 1)
+                    } {
+                        cont = false
+                    }
+                }
+            }
+            set this.order (b + 1) keyIdx
+            a = (a + 1)
+        }
+
+        ; sweep
+        def p 0
+        while (p < n) {
+            def bi:CannonBody (itemAt bodies (itemAt this.order p))
+            def maxXi:double (bi.position.x + bi.boundingRadius)
+            def q:int (p + 1)
+            def sweeping:boolean true
+            while (sweeping) {
+                if (q >= n) {
+                    sweeping = false
+                } {
+                    def bj:CannonBody (itemAt bodies (itemAt this.order q))
+                    def minXj:double (bj.position.x - bj.boundingRadius)
+                    if (minXj > maxXi) {
+                        sweeping = false
+                    } {
+                        if (this.needBroadphaseCollision(bi bj)) {
+                            this.intersectionTest(bi bj)
+                        }
+                        q = (q + 1)
+                    }
+                }
+            }
+            p = (p + 1)
+        }
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_sap_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_sap_test.rgr
@@ -1,0 +1,55 @@
+; ==============================================================================
+; cannon_sap_test — SAP broadphase produces the same pairs as the naive one.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_sphere.rgr"
+Import "cannon_body.rgr"
+Import "cannon_naive_broadphase.rgr"
+Import "cannon_sap_broadphase.rgr"
+Import "cannon_test_harness.rgr"
+Import "cannon_test_filter.rgr"
+
+class CannonSapTest {
+    def filter:CannonTestFilter (new CannonTestFilter)
+
+    fn runFiltered:void (h:CannonTestHarness filter:string) {
+        if (this.filter.matches(filter "SAP.sameAsNaive")) { this.sameAsNaive(h) }
+    }
+
+    fn makeBall:CannonBody (x:double) {
+        def body:CannonBody (new CannonBody)
+        body.initDynamic(1.0)
+        def sphere:CannonSphere (new CannonSphere)
+        sphere.initSphere(1.0)
+        body.addShape(sphere)
+        body.position.set(x 0.0 0.0)
+        return body
+    }
+
+    ; Four unit spheres: {x=0,x=1.5} overlap and {x=5,x=6} overlap; the middle
+    ; gap does not. Both broadphases must report exactly those two pairs.
+    fn sameAsNaive:void (h:CannonTestHarness) {
+        h.beginTest("SAP.sameAsNaive")
+        def bodies:[CannonBody]
+        push bodies (this.makeBall(0.0))
+        push bodies (this.makeBall(1.5))
+        push bodies (this.makeBall(5.0))
+        push bodies (this.makeBall(6.0))
+
+        def naive:CannonNaiveBroadphase (new CannonNaiveBroadphase)
+        naive.collisionPairs(bodies)
+        def naiveCount:int (array_length naive.outPairs1)
+
+        def sap:CannonSAPBroadphase (new CannonSAPBroadphase)
+        sap.collisionPairs(bodies)
+        def sapCount:int (array_length sap.outPairs1)
+
+        h.equalInt(naiveCount 2 "naive finds the two overlapping pairs")
+        h.equalInt(sapCount 2 "SAP finds the two overlapping pairs")
+        h.equalInt(sapCount naiveCount "SAP matches naive pair count")
+        print ("naivePairs=" + (to_string naiveCount))
+        print ("sapPairs=" + (to_string sapCount))
+        h.finishTest()
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_shape.rgr
+++ b/gallery/game_engine/physics/src/cannon_shape.rgr
@@ -29,4 +29,9 @@ class CannonShape {
 
     fn updateBoundingSphereRadius:void () {
     }
+
+    ; Overridden by CannonBox; the base returns zero half-extents.
+    fn getHalfExtents:CannonVec3 () {
+        return (new CannonVec3)
+    }
 }

--- a/gallery/game_engine/physics/src/cannon_shape.rgr
+++ b/gallery/game_engine/physics/src/cannon_shape.rgr
@@ -34,4 +34,10 @@ class CannonShape {
     fn getHalfExtents:CannonVec3 () {
         return (new CannonVec3)
     }
+
+    ; Overridden by CannonHeightfield: the local terrain triangle plane (normal +
+    ; a point on it) under local (x,y). Base returns false (not a heightfield).
+    fn heightfieldPlaneAt:boolean (localX:double localY:double outNormal:CannonVec3 outPoint:CannonVec3) {
+        return false
+    }
 }

--- a/gallery/game_engine/physics/src/cannon_shape.rgr
+++ b/gallery/game_engine/physics/src/cannon_shape.rgr
@@ -40,4 +40,19 @@ class CannonShape {
     fn heightfieldPlaneAt:boolean (localX:double localY:double outNormal:CannonVec3 outPoint:CannonVec3) {
         return false
     }
+
+    ; Overridden by CannonConvexPolyhedron; the base is an empty hull.
+    fn convexVertexCount:int () {
+        return 0
+    }
+    fn convexVertexAt:void (i:int out:CannonVec3) {
+    }
+    fn convexFaceCount:int () {
+        return 0
+    }
+    fn convexFaceNormalAt:void (i:int out:CannonVec3) {
+    }
+    fn convexFaceVertexIndex:int (i:int) {
+        return 0
+    }
 }

--- a/gallery/game_engine/physics/src/cannon_shape.rgr
+++ b/gallery/game_engine/physics/src/cannon_shape.rgr
@@ -55,4 +55,11 @@ class CannonShape {
     fn convexFaceVertexIndex:int (i:int) {
         return 0
     }
+
+    ; Overridden by CannonTrimesh; the base is an empty mesh.
+    fn trimeshTriangleCount:int () {
+        return 0
+    }
+    fn trimeshVertex:void (tri:int corner:int out:CannonVec3) {
+    }
 }

--- a/gallery/game_engine/physics/src/cannon_sleep_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_sleep_test.rgr
@@ -1,0 +1,50 @@
+; ==============================================================================
+; cannon_sleep_test — idle bodies fall asleep and stop integrating; moving
+;   bodies stay awake.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_body.rgr"
+Import "cannon_world.rgr"
+Import "cannon_test_harness.rgr"
+Import "cannon_test_filter.rgr"
+
+class CannonSleepTest {
+    def filter:CannonTestFilter (new CannonTestFilter)
+
+    fn runFiltered:void (h:CannonTestHarness filter:string) {
+        if (this.filter.matches(filter "Sleep.bodySleeps")) { this.bodySleeps(h) }
+    }
+
+    ; A still body becomes SLEEPY then SLEEPING past the time limit; a body that
+    ; keeps moving stays awake (the speed gate) and keeps integrating.
+    fn bodySleeps:void (h:CannonTestHarness) {
+        h.beginTest("Sleep.bodySleeps")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 0.0 0.0)
+
+        def still:CannonBody (new CannonBody)
+        still.initDynamic(1.0)
+        still.position.set(0.0 0.0 0.0)
+        world.addBody(still)
+
+        def mover:CannonBody (new CannonBody)
+        mover.initDynamic(1.0)
+        mover.position.set(0.0 5.0 0.0)
+        mover.velocity.set(1.0 0.0 0.0)
+        world.addBody(mover)
+
+        def s 0
+        while (s < 120) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        h.equalInt(still.sleepState 2 "still body is SLEEPING")
+        h.equalInt(mover.sleepState 0 "moving body stays awake")
+        h.ok((mover.position.x > 1.5) "awake body kept integrating (moved)")
+        print ("stillSleep=" + (to_string still.sleepState))
+        print ("moverX=" + (to_string mover.position.x))
+        h.finishTest()
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_solver_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_solver_test.rgr
@@ -1,0 +1,122 @@
+; ==============================================================================
+; cannon_solver_test — SPOOK solver stack (JacobianElement, Equation, GSSolver).
+;
+; Physical invariants are used as oracles instead of hand-computed lambdas:
+;   * linear momentum is conserved by an internal contact/friction impulse;
+;   * a penetrating contact produces separating velocities;
+;   * friction drives two equal-mass bodies toward a common tangent velocity.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_body.rgr"
+Import "cannon_jacobian_element.rgr"
+Import "cannon_equation.rgr"
+Import "cannon_gssolver.rgr"
+Import "cannon_test_harness.rgr"
+Import "cannon_test_filter.rgr"
+
+class CannonSolverTest {
+    def filter:CannonTestFilter (new CannonTestFilter)
+
+    fn runFiltered:void (h:CannonTestHarness filter:string) {
+        if (this.filter.matches(filter "Jacobian.multiplyVectors")) { this.jacobian(h) }
+        if (this.filter.matches(filter "Equation.spookParams")) { this.spookParams(h) }
+        if (this.filter.matches(filter "GSSolver.contact")) { this.contact(h) }
+        if (this.filter.matches(filter "GSSolver.friction")) { this.friction(h) }
+    }
+
+    fn jacobian:void (h:CannonTestHarness) {
+        h.beginTest("Jacobian.multiplyVectors")
+        def j:CannonJacobianElement (new CannonJacobianElement)
+        j.spatial.set(1.0 2.0 3.0)
+        j.rotational.set(4.0 5.0 6.0)
+        def spatial:CannonVec3 (new CannonVec3)
+        spatial.set(1.0 0.0 0.0)
+        def rotational:CannonVec3 (new CannonVec3)
+        rotational.set(0.0 0.0 1.0)
+        ; 1*1 + 6*1 = 7
+        def mv:double (j.multiplyVectors(spatial rotational))
+        h.equal(mv 7.0 "multiplyVectors")
+        h.finishTest()
+    }
+
+    fn spookParams:void (h:CannonTestHarness) {
+        h.beginTest("Equation.spookParams")
+        def bi:CannonBody (new CannonBody)
+        def bj:CannonBody (new CannonBody)
+        def eq:CannonEquation (new CannonEquation)
+        eq.initContact(bi bj 1000000.0)
+        ; a,b,eps must be finite and positive for typical params.
+        h.ok((eq.a > 0.0) "a positive")
+        h.ok((eq.b > 0.0) "b positive")
+        h.ok((eq.eps > 0.0) "eps positive")
+        h.ok((eq.minForce == 0.0) "contact minForce is 0")
+        h.finishTest()
+    }
+
+    fn contact:void (h:CannonTestHarness) {
+        h.beginTest("GSSolver.contact")
+        ; Two unit-mass spheres (radius 1) overlapping by 0.2 along x.
+        def bi:CannonBody (new CannonBody)
+        bi.initDynamic(1.0)
+        bi.position.set(0.9 0.0 0.0)
+        def bj:CannonBody (new CannonBody)
+        bj.initDynamic(1.0)
+        bj.position.set((0.0 - 0.9) 0.0 0.0)
+
+        ; Contact geometry, cannon-es convention: ni points from i toward j.
+        def eq:CannonEquation (new CannonEquation)
+        eq.initContact(bi bj 1000000.0)
+        eq.ni.set((0.0 - 1.0) 0.0 0.0)
+        eq.ri.set((0.0 - 1.0) 0.0 0.0)
+        eq.rj.set(1.0 0.0 0.0)
+        eq.restitution = 0.0
+
+        def solver:CannonGSSolver (new CannonGSSolver)
+        solver.addEquation(eq)
+        def bodies:[CannonBody]
+        push bodies bi
+        push bodies bj
+        solver.solve((1.0 / 60.0) bodies)
+
+        ; Penetrating contact pushes i toward +x and j toward -x.
+        h.ok((bi.velocity.x > 0.01) "body i separates +x")
+        h.ok((bj.velocity.x < (0.0 - 0.01)) "body j separates -x")
+        ; Equal masses -> total linear momentum along x is conserved (~0).
+        def px:double (bi.velocity.x + bj.velocity.x)
+        h.nearEqual(px 0.0 0.000001 "momentum x conserved")
+        h.finishTest()
+    }
+
+    fn friction:void (h:CannonTestHarness) {
+        h.beginTest("GSSolver.friction")
+        ; Two unit-mass bodies; i slides tangentially over j at rest.
+        def bi:CannonBody (new CannonBody)
+        bi.initDynamic(1.0)
+        bi.position.set(0.0 1.0 0.0)
+        bi.velocity.set(1.0 0.0 0.0)
+        def bj:CannonBody (new CannonBody)
+        bj.initDynamic(1.0)
+        bj.position.set(0.0 (0.0 - 1.0) 0.0)
+
+        def eq:CannonEquation (new CannonEquation)
+        eq.initFriction(bi bj 1000000.0)
+        eq.t.set(1.0 0.0 0.0)
+        eq.ri.set(0.0 (0.0 - 1.0) 0.0)
+        eq.rj.set(0.0 1.0 0.0)
+
+        def solver:CannonGSSolver (new CannonGSSolver)
+        solver.addEquation(eq)
+        def bodies:[CannonBody]
+        push bodies bi
+        push bodies bj
+        solver.solve((1.0 / 60.0) bodies)
+
+        ; Large slip force fully couples them: both approach the mean (0.5).
+        h.ok((bi.velocity.x < 1.0) "body i slows down")
+        h.ok((bj.velocity.x > 0.0) "body j dragged along")
+        def px:double (bi.velocity.x + bj.velocity.x)
+        h.nearEqual(px 1.0 0.000001 "tangential momentum conserved")
+        h.finishTest()
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_test_runner.rgr
+++ b/gallery/game_engine/physics/src/cannon_test_runner.rgr
@@ -25,6 +25,7 @@ Import "cannon_sleep_test.rgr"
 Import "cannon_sap_test.rgr"
 Import "cannon_heightfield_test.rgr"
 Import "cannon_convex_test.rgr"
+Import "physics_world_test.rgr"
 
 class CannonTestRunner {
     sfn m@(main):void () {
@@ -55,6 +56,7 @@ class CannonTestRunner {
         def sapTest:CannonSapTest (new CannonSapTest)
         def heightfieldTest:CannonHeightfieldTest (new CannonHeightfieldTest)
         def convexTest:CannonConvexTest (new CannonConvexTest)
+        def physicsWorldTest:PhysicsWorldTest (new PhysicsWorldTest)
 
         vec3Test.runFiltered(harness filter)
         quatTest.runFiltered(harness filter)
@@ -77,6 +79,7 @@ class CannonTestRunner {
         sapTest.runFiltered(harness filter)
         heightfieldTest.runFiltered(harness filter)
         convexTest.runFiltered(harness filter)
+        physicsWorldTest.runFiltered(harness filter)
 
         if (filter == "") {
             print ("pass=" + (to_string harness.passCount))

--- a/gallery/game_engine/physics/src/cannon_test_runner.rgr
+++ b/gallery/game_engine/physics/src/cannon_test_runner.rgr
@@ -21,6 +21,8 @@ Import "cannon_constraint_test.rgr"
 Import "cannon_ray_test.rgr"
 Import "cannon_boxcollision_test.rgr"
 Import "cannon_vehicle_test.rgr"
+Import "cannon_sleep_test.rgr"
+Import "cannon_sap_test.rgr"
 
 class CannonTestRunner {
     sfn m@(main):void () {
@@ -47,6 +49,8 @@ class CannonTestRunner {
         def rayTest:CannonRayTest (new CannonRayTest)
         def boxCollisionTest:CannonBoxCollisionTest (new CannonBoxCollisionTest)
         def vehicleTest:CannonVehicleTest (new CannonVehicleTest)
+        def sleepTest:CannonSleepTest (new CannonSleepTest)
+        def sapTest:CannonSapTest (new CannonSapTest)
 
         vec3Test.runFiltered(harness filter)
         quatTest.runFiltered(harness filter)
@@ -65,6 +69,8 @@ class CannonTestRunner {
         rayTest.runFiltered(harness filter)
         boxCollisionTest.runFiltered(harness filter)
         vehicleTest.runFiltered(harness filter)
+        sleepTest.runFiltered(harness filter)
+        sapTest.runFiltered(harness filter)
 
         if (filter == "") {
             print ("pass=" + (to_string harness.passCount))

--- a/gallery/game_engine/physics/src/cannon_test_runner.rgr
+++ b/gallery/game_engine/physics/src/cannon_test_runner.rgr
@@ -24,6 +24,7 @@ Import "cannon_vehicle_test.rgr"
 Import "cannon_sleep_test.rgr"
 Import "cannon_sap_test.rgr"
 Import "cannon_heightfield_test.rgr"
+Import "cannon_convex_test.rgr"
 
 class CannonTestRunner {
     sfn m@(main):void () {
@@ -53,6 +54,7 @@ class CannonTestRunner {
         def sleepTest:CannonSleepTest (new CannonSleepTest)
         def sapTest:CannonSapTest (new CannonSapTest)
         def heightfieldTest:CannonHeightfieldTest (new CannonHeightfieldTest)
+        def convexTest:CannonConvexTest (new CannonConvexTest)
 
         vec3Test.runFiltered(harness filter)
         quatTest.runFiltered(harness filter)
@@ -74,6 +76,7 @@ class CannonTestRunner {
         sleepTest.runFiltered(harness filter)
         sapTest.runFiltered(harness filter)
         heightfieldTest.runFiltered(harness filter)
+        convexTest.runFiltered(harness filter)
 
         if (filter == "") {
             print ("pass=" + (to_string harness.passCount))

--- a/gallery/game_engine/physics/src/cannon_test_runner.rgr
+++ b/gallery/game_engine/physics/src/cannon_test_runner.rgr
@@ -26,6 +26,7 @@ Import "cannon_sap_test.rgr"
 Import "cannon_heightfield_test.rgr"
 Import "cannon_convex_test.rgr"
 Import "physics_world_test.rgr"
+Import "cannon_extra_shapes_test.rgr"
 
 class CannonTestRunner {
     sfn m@(main):void () {
@@ -57,6 +58,7 @@ class CannonTestRunner {
         def heightfieldTest:CannonHeightfieldTest (new CannonHeightfieldTest)
         def convexTest:CannonConvexTest (new CannonConvexTest)
         def physicsWorldTest:PhysicsWorldTest (new PhysicsWorldTest)
+        def extraShapesTest:CannonExtraShapesTest (new CannonExtraShapesTest)
 
         vec3Test.runFiltered(harness filter)
         quatTest.runFiltered(harness filter)
@@ -80,6 +82,7 @@ class CannonTestRunner {
         heightfieldTest.runFiltered(harness filter)
         convexTest.runFiltered(harness filter)
         physicsWorldTest.runFiltered(harness filter)
+        extraShapesTest.runFiltered(harness filter)
 
         if (filter == "") {
             print ("pass=" + (to_string harness.passCount))

--- a/gallery/game_engine/physics/src/cannon_test_runner.rgr
+++ b/gallery/game_engine/physics/src/cannon_test_runner.rgr
@@ -20,6 +20,7 @@ Import "cannon_solver_test.rgr"
 Import "cannon_constraint_test.rgr"
 Import "cannon_ray_test.rgr"
 Import "cannon_boxcollision_test.rgr"
+Import "cannon_vehicle_test.rgr"
 
 class CannonTestRunner {
     sfn m@(main):void () {
@@ -45,6 +46,7 @@ class CannonTestRunner {
         def constraintTest:CannonConstraintTest (new CannonConstraintTest)
         def rayTest:CannonRayTest (new CannonRayTest)
         def boxCollisionTest:CannonBoxCollisionTest (new CannonBoxCollisionTest)
+        def vehicleTest:CannonVehicleTest (new CannonVehicleTest)
 
         vec3Test.runFiltered(harness filter)
         quatTest.runFiltered(harness filter)
@@ -62,6 +64,7 @@ class CannonTestRunner {
         constraintTest.runFiltered(harness filter)
         rayTest.runFiltered(harness filter)
         boxCollisionTest.runFiltered(harness filter)
+        vehicleTest.runFiltered(harness filter)
 
         if (filter == "") {
             print ("pass=" + (to_string harness.passCount))

--- a/gallery/game_engine/physics/src/cannon_test_runner.rgr
+++ b/gallery/game_engine/physics/src/cannon_test_runner.rgr
@@ -18,6 +18,7 @@ Import "cannon_contact_equation_test.rgr"
 Import "cannon_narrowphase_test.rgr"
 Import "cannon_solver_test.rgr"
 Import "cannon_constraint_test.rgr"
+Import "cannon_ray_test.rgr"
 
 class CannonTestRunner {
     sfn m@(main):void () {
@@ -41,6 +42,7 @@ class CannonTestRunner {
         def narrowphaseTest:CannonNarrowphaseTest (new CannonNarrowphaseTest)
         def solverTest:CannonSolverTest (new CannonSolverTest)
         def constraintTest:CannonConstraintTest (new CannonConstraintTest)
+        def rayTest:CannonRayTest (new CannonRayTest)
 
         vec3Test.runFiltered(harness filter)
         quatTest.runFiltered(harness filter)
@@ -56,6 +58,7 @@ class CannonTestRunner {
         narrowphaseTest.runFiltered(harness filter)
         solverTest.runFiltered(harness filter)
         constraintTest.runFiltered(harness filter)
+        rayTest.runFiltered(harness filter)
 
         if (filter == "") {
             print ("pass=" + (to_string harness.passCount))

--- a/gallery/game_engine/physics/src/cannon_test_runner.rgr
+++ b/gallery/game_engine/physics/src/cannon_test_runner.rgr
@@ -19,6 +19,7 @@ Import "cannon_narrowphase_test.rgr"
 Import "cannon_solver_test.rgr"
 Import "cannon_constraint_test.rgr"
 Import "cannon_ray_test.rgr"
+Import "cannon_boxcollision_test.rgr"
 
 class CannonTestRunner {
     sfn m@(main):void () {
@@ -43,6 +44,7 @@ class CannonTestRunner {
         def solverTest:CannonSolverTest (new CannonSolverTest)
         def constraintTest:CannonConstraintTest (new CannonConstraintTest)
         def rayTest:CannonRayTest (new CannonRayTest)
+        def boxCollisionTest:CannonBoxCollisionTest (new CannonBoxCollisionTest)
 
         vec3Test.runFiltered(harness filter)
         quatTest.runFiltered(harness filter)
@@ -59,6 +61,7 @@ class CannonTestRunner {
         solverTest.runFiltered(harness filter)
         constraintTest.runFiltered(harness filter)
         rayTest.runFiltered(harness filter)
+        boxCollisionTest.runFiltered(harness filter)
 
         if (filter == "") {
             print ("pass=" + (to_string harness.passCount))

--- a/gallery/game_engine/physics/src/cannon_test_runner.rgr
+++ b/gallery/game_engine/physics/src/cannon_test_runner.rgr
@@ -23,6 +23,7 @@ Import "cannon_boxcollision_test.rgr"
 Import "cannon_vehicle_test.rgr"
 Import "cannon_sleep_test.rgr"
 Import "cannon_sap_test.rgr"
+Import "cannon_heightfield_test.rgr"
 
 class CannonTestRunner {
     sfn m@(main):void () {
@@ -51,6 +52,7 @@ class CannonTestRunner {
         def vehicleTest:CannonVehicleTest (new CannonVehicleTest)
         def sleepTest:CannonSleepTest (new CannonSleepTest)
         def sapTest:CannonSapTest (new CannonSapTest)
+        def heightfieldTest:CannonHeightfieldTest (new CannonHeightfieldTest)
 
         vec3Test.runFiltered(harness filter)
         quatTest.runFiltered(harness filter)
@@ -71,6 +73,7 @@ class CannonTestRunner {
         vehicleTest.runFiltered(harness filter)
         sleepTest.runFiltered(harness filter)
         sapTest.runFiltered(harness filter)
+        heightfieldTest.runFiltered(harness filter)
 
         if (filter == "") {
             print ("pass=" + (to_string harness.passCount))

--- a/gallery/game_engine/physics/src/cannon_test_runner.rgr
+++ b/gallery/game_engine/physics/src/cannon_test_runner.rgr
@@ -17,6 +17,7 @@ Import "cannon_overlap_keeper_test.rgr"
 Import "cannon_contact_equation_test.rgr"
 Import "cannon_narrowphase_test.rgr"
 Import "cannon_solver_test.rgr"
+Import "cannon_constraint_test.rgr"
 
 class CannonTestRunner {
     sfn m@(main):void () {
@@ -39,6 +40,7 @@ class CannonTestRunner {
         def contactTest:CannonContactEquationTest (new CannonContactEquationTest)
         def narrowphaseTest:CannonNarrowphaseTest (new CannonNarrowphaseTest)
         def solverTest:CannonSolverTest (new CannonSolverTest)
+        def constraintTest:CannonConstraintTest (new CannonConstraintTest)
 
         vec3Test.runFiltered(harness filter)
         quatTest.runFiltered(harness filter)
@@ -53,6 +55,7 @@ class CannonTestRunner {
         contactTest.runFiltered(harness filter)
         narrowphaseTest.runFiltered(harness filter)
         solverTest.runFiltered(harness filter)
+        constraintTest.runFiltered(harness filter)
 
         if (filter == "") {
             print ("pass=" + (to_string harness.passCount))

--- a/gallery/game_engine/physics/src/cannon_test_runner.rgr
+++ b/gallery/game_engine/physics/src/cannon_test_runner.rgr
@@ -16,6 +16,7 @@ Import "cannon_tuple_dictionary_test.rgr"
 Import "cannon_overlap_keeper_test.rgr"
 Import "cannon_contact_equation_test.rgr"
 Import "cannon_narrowphase_test.rgr"
+Import "cannon_solver_test.rgr"
 
 class CannonTestRunner {
     sfn m@(main):void () {
@@ -37,6 +38,7 @@ class CannonTestRunner {
         def overlapTest:CannonOverlapKeeperTest (new CannonOverlapKeeperTest)
         def contactTest:CannonContactEquationTest (new CannonContactEquationTest)
         def narrowphaseTest:CannonNarrowphaseTest (new CannonNarrowphaseTest)
+        def solverTest:CannonSolverTest (new CannonSolverTest)
 
         vec3Test.runFiltered(harness filter)
         quatTest.runFiltered(harness filter)
@@ -50,6 +52,7 @@ class CannonTestRunner {
         overlapTest.runFiltered(harness filter)
         contactTest.runFiltered(harness filter)
         narrowphaseTest.runFiltered(harness filter)
+        solverTest.runFiltered(harness filter)
 
         if (filter == "") {
             print ("pass=" + (to_string harness.passCount))

--- a/gallery/game_engine/physics/src/cannon_trimesh.rgr
+++ b/gallery/game_engine/physics/src/cannon_trimesh.rgr
@@ -1,0 +1,44 @@
+; ==============================================================================
+; cannon_trimesh — static triangle mesh (cannon-es Trimesh, subset).
+;   Triangles are stored flat (9 doubles per triangle: v0, v1, v2). Collision
+;   with a sphere (see cannon_narrowphase) uses the closest point on each
+;   triangle. Intended for static level geometry.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_shape.rgr"
+
+class CannonTrimesh extends CannonShape {
+    def verts:[double]
+    def hugeRadius:double 1000000000.0
+
+    fn initTrimesh:void () {
+        this.initShape(8)
+        this.boundingSphereRadius = this.hugeRadius
+    }
+
+    fn addTriangle:void (ax:double ay:double az:double bx:double by:double bz:double cx:double cy:double cz:double) {
+        push this.verts ax
+        push this.verts ay
+        push this.verts az
+        push this.verts bx
+        push this.verts by
+        push this.verts bz
+        push this.verts cx
+        push this.verts cy
+        push this.verts cz
+    }
+
+    fn updateBoundingSphereRadius:void () {
+        this.boundingSphereRadius = this.hugeRadius
+    }
+
+    fn trimeshTriangleCount:int () {
+        return (idiv (array_length this.verts) 9)
+    }
+
+    fn trimeshVertex:void (tri:int corner:int out:CannonVec3) {
+        def base:int ((tri * 9) + (corner * 3))
+        out.set((itemAt this.verts base) (itemAt this.verts (base + 1)) (itemAt this.verts (base + 2)))
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_vec3.rgr
+++ b/gallery/game_engine/physics/src/cannon_vec3.rgr
@@ -85,6 +85,32 @@ class CannonVec3 {
         target.z = (this.z * v.z)
     }
 
+    ; Two orthonormal tangents to this (normal) vector (cannon-es Vec3.tangents).
+    fn tangents:void (t1:CannonVec3 t2:CannonVec3) {
+        def norm:double (this.norm())
+        if (norm > 0.0) {
+            def inorm:double (1.0 / norm)
+            def n:CannonVec3 (new CannonVec3)
+            n.set((this.x * inorm) (this.y * inorm) (this.z * inorm))
+            def randVec:CannonVec3 (new CannonVec3)
+            def ax:double n.x
+            if (ax < 0.0) {
+                ax = (0.0 - ax)
+            }
+            if (ax < 0.9) {
+                randVec.set(1.0 0.0 0.0)
+            } {
+                randVec.set(0.0 1.0 0.0)
+            }
+            n.crossInto(randVec t1)
+            t1.normalizeSelf()
+            n.crossInto(t1 t2)
+        } {
+            t1.set(1.0 0.0 0.0)
+            t2.set(0.0 1.0 0.0)
+        }
+    }
+
     fn dot:double (v:CannonVec3) {
         return ((this.x * v.x) + (this.y * v.y)) + (this.z * v.z)
     }

--- a/gallery/game_engine/physics/src/cannon_vec3.rgr
+++ b/gallery/game_engine/physics/src/cannon_vec3.rgr
@@ -71,6 +71,20 @@ class CannonVec3 {
         return out
     }
 
+    ; target = this + scalar * v   (cannon-es Vec3.addScaledVector)
+    fn addScaledVector:void (scalar:double v:CannonVec3 target:CannonVec3) {
+        target.x = (this.x + (scalar * v.x))
+        target.y = (this.y + (scalar * v.y))
+        target.z = (this.z + (scalar * v.z))
+    }
+
+    ; target = this .* v   (component-wise multiply, cannon-es Vec3.vmul)
+    fn vmulInto:void (v:CannonVec3 target:CannonVec3) {
+        target.x = (this.x * v.x)
+        target.y = (this.y * v.y)
+        target.z = (this.z * v.z)
+    }
+
     fn dot:double (v:CannonVec3) {
         return ((this.x * v.x) + (this.y * v.y)) + (this.z * v.z)
     }

--- a/gallery/game_engine/physics/src/cannon_vec3.rgr
+++ b/gallery/game_engine/physics/src/cannon_vec3.rgr
@@ -121,6 +121,13 @@ class CannonVec3 {
         this.z = source.z
     }
 
+    ; target = this + (v - this) * t   (linear interpolation, cannon-es Vec3.lerp)
+    fn lerp:void (v:CannonVec3 t:double target:CannonVec3) {
+        target.x = (this.x + ((v.x - this.x) * t))
+        target.y = (this.y + ((v.y - this.y) * t))
+        target.z = (this.z + ((v.z - this.z) * t))
+    }
+
     fn negateInto:void (target:CannonVec3) {
         target.x = (0.0 - this.x)
         target.y = (0.0 - this.y)

--- a/gallery/game_engine/physics/src/cannon_vehicle.rgr
+++ b/gallery/game_engine/physics/src/cannon_vehicle.rgr
@@ -19,6 +19,9 @@ class CannonWheelInfo {
     def damping:double 4.0
     def radius:double 0.4
     def engineForce:double 0.0
+    def steering:double 0.0
+    def sideGrip:double 30.0
+    def frictionSlip:double 5.0
     ; runtime
     def isInContact:boolean false
     def suspensionLength:double 0.6
@@ -44,6 +47,7 @@ class CannonRaycastVehicle {
     def world:CannonWorld
     def wheels:[CannonWheelInfo]
     def forwardLocal:CannonVec3 (new CannonVec3)
+    def rightLocal:CannonVec3 (new CannonVec3)
     ; scratch
     def vFrom:CannonVec3 (new CannonVec3)
     def vTo:CannonVec3 (new CannonVec3)
@@ -51,15 +55,26 @@ class CannonRaycastVehicle {
     def vRel:CannonVec3 (new CannonVec3)
     def vVel:CannonVec3 (new CannonVec3)
     def vForward:CannonVec3 (new CannonVec3)
+    def vRight:CannonVec3 (new CannonVec3)
+    def vSteerA:CannonVec3 (new CannonVec3)
+    def vSteerB:CannonVec3 (new CannonVec3)
+    def vSteerFwd:CannonVec3 (new CannonVec3)
+    def vSide:CannonVec3 (new CannonVec3)
 
     fn initVehicle:void (chassis:CannonBody world:CannonWorld) {
         this.chassis = chassis
         this.world = world
         this.forwardLocal.set(1.0 0.0 0.0)
+        this.rightLocal.set(0.0 0.0 1.0)
     }
 
     fn addWheel:void (w:CannonWheelInfo) {
         push this.wheels w
+    }
+
+    fn setSteeringValue:void (index:int angle:double) {
+        def w:CannonWheelInfo (itemAt this.wheels index)
+        w.steering = angle
     }
 
     fn setEngineForce:void (force:double) {
@@ -105,11 +120,40 @@ class CannonRaycastVehicle {
                 w.contactPoint.vsub(chassis.position this.vRel)
                 w.contactNormal.scaleInto(force this.vForce)
                 chassis.applyForce(this.vForce this.vRel)
+
+                ; Steered heading: rotate chassis-forward toward chassis-right by
+                ; the steering angle, in the ground plane.
+                def cosS:double (cos(w.steering))
+                def sinS:double (sin(w.steering))
+                chassis.vectorToWorldFrame(this.forwardLocal this.vForward)
+                chassis.vectorToWorldFrame(this.rightLocal this.vRight)
+                this.vForward.scaleInto(cosS this.vSteerA)
+                this.vRight.scaleInto(sinS this.vSteerB)
+                this.vSteerA.vadd(this.vSteerB this.vSteerFwd)
+                ; Side (axle) direction = steered forward x contact normal.
+                this.vSteerFwd.crossInto(w.contactNormal this.vSide)
+                this.vSide.normalizeSelf()
+
+                ; Engine force drives along the steered heading.
                 if (w.engineForce != 0.0) {
-                    chassis.vectorToWorldFrame(this.forwardLocal this.vForward)
-                    this.vForward.scaleInto(w.engineForce this.vForce)
+                    this.vSteerFwd.scaleInto(w.engineForce this.vForce)
                     chassis.applyForce(this.vForce this.vRel)
                 }
+
+                ; Lateral tyre grip: oppose sideways velocity at the contact,
+                ; capped by the friction limit (mu * suspension load).
+                chassis.getVelocityAtWorldPoint(w.contactPoint this.vVel)
+                def vSideSpeed:double (this.vVel.dot(this.vSide))
+                def maxSide:double (w.frictionSlip * force)
+                def sideForce:double (0.0 - (w.sideGrip * vSideSpeed))
+                if (sideForce > maxSide) {
+                    sideForce = maxSide
+                }
+                if (sideForce < (0.0 - maxSide)) {
+                    sideForce = (0.0 - maxSide)
+                }
+                this.vSide.scaleInto(sideForce this.vForce)
+                chassis.applyForce(this.vForce this.vRel)
             }
             i = (i + 1)
         }

--- a/gallery/game_engine/physics/src/cannon_vehicle.rgr
+++ b/gallery/game_engine/physics/src/cannon_vehicle.rgr
@@ -1,0 +1,117 @@
+; ==============================================================================
+; cannon_vehicle — raycast vehicle (cannon-es RaycastVehicle + WheelInfo, focused).
+;   Each wheel casts a ray along its suspension direction, and a spring+damper
+;   suspension force keeps the chassis hovering; an engine force drives it. The
+;   chassis is a box (invisible to the ray-vs-sphere/plane caster), so wheels see
+;   only the ground.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_body.rgr"
+Import "cannon_ray.rgr"
+Import "cannon_world.rgr"
+
+class CannonWheelInfo {
+    def connectionLocal:CannonVec3 (new CannonVec3)
+    def directionLocal:CannonVec3 (new CannonVec3)
+    def restLength:double 0.6
+    def stiffness:double 100.0
+    def damping:double 4.0
+    def radius:double 0.4
+    def engineForce:double 0.0
+    ; runtime
+    def isInContact:boolean false
+    def suspensionLength:double 0.6
+    def worldConnection:CannonVec3 (new CannonVec3)
+    def worldDirection:CannonVec3 (new CannonVec3)
+    def contactPoint:CannonVec3 (new CannonVec3)
+    def contactNormal:CannonVec3 (new CannonVec3)
+    def rayResult:CannonRaycastResult (new CannonRaycastResult)
+
+    fn initWheel:void (cx:double cy:double cz:double radius:double restLength:double stiffness:double damping:double) {
+        this.connectionLocal.set(cx cy cz)
+        this.directionLocal.set(0.0 (0.0 - 1.0) 0.0)
+        this.radius = radius
+        this.restLength = restLength
+        this.stiffness = stiffness
+        this.damping = damping
+        this.suspensionLength = restLength
+    }
+}
+
+class CannonRaycastVehicle {
+    def chassis:CannonBody
+    def world:CannonWorld
+    def wheels:[CannonWheelInfo]
+    def forwardLocal:CannonVec3 (new CannonVec3)
+    ; scratch
+    def vFrom:CannonVec3 (new CannonVec3)
+    def vTo:CannonVec3 (new CannonVec3)
+    def vForce:CannonVec3 (new CannonVec3)
+    def vRel:CannonVec3 (new CannonVec3)
+    def vVel:CannonVec3 (new CannonVec3)
+    def vForward:CannonVec3 (new CannonVec3)
+
+    fn initVehicle:void (chassis:CannonBody world:CannonWorld) {
+        this.chassis = chassis
+        this.world = world
+        this.forwardLocal.set(1.0 0.0 0.0)
+    }
+
+    fn addWheel:void (w:CannonWheelInfo) {
+        push this.wheels w
+    }
+
+    fn setEngineForce:void (force:double) {
+        def i 0
+        while (i < (array_length this.wheels)) {
+            def w:CannonWheelInfo (itemAt this.wheels i)
+            w.engineForce = force
+            i = (i + 1)
+        }
+    }
+
+    ; Apply suspension + engine forces to the chassis; call before world.step().
+    fn updateVehicle:void (dt:double) {
+        def chassis:CannonBody (unwrap this.chassis)
+        def world:CannonWorld (unwrap this.world)
+        def i 0
+        while (i < (array_length this.wheels)) {
+            def w:CannonWheelInfo (itemAt this.wheels i)
+            chassis.pointToWorldFrame(w.connectionLocal w.worldConnection)
+            chassis.vectorToWorldFrame(w.directionLocal w.worldDirection)
+            this.vFrom.copy(w.worldConnection)
+            def rayLen:double (w.restLength + w.radius)
+            w.worldDirection.scaleInto(rayLen this.vTo)
+            this.vFrom.vadd(this.vTo this.vTo)
+            def hit:boolean (world.raycastClosest(this.vFrom this.vTo w.rayResult))
+            if (hit == false) {
+                w.isInContact = false
+            } {
+                w.isInContact = true
+                w.contactPoint.copy(w.rayResult.hitPointWorld)
+                w.contactNormal.copy(w.rayResult.hitNormalWorld)
+                def dHit:double w.rayResult.distance
+                w.suspensionLength = (dHit - w.radius)
+                def compression:double (w.restLength - w.suspensionLength)
+                def springForce:double (w.stiffness * compression)
+                chassis.getVelocityAtWorldPoint(w.contactPoint this.vVel)
+                def projVel:double (this.vVel.dot(w.contactNormal))
+                def dampForce:double (0.0 - (w.damping * projVel))
+                def force:double (springForce + dampForce)
+                if (force < 0.0) {
+                    force = 0.0
+                }
+                w.contactPoint.vsub(chassis.position this.vRel)
+                w.contactNormal.scaleInto(force this.vForce)
+                chassis.applyForce(this.vForce this.vRel)
+                if (w.engineForce != 0.0) {
+                    chassis.vectorToWorldFrame(this.forwardLocal this.vForward)
+                    this.vForward.scaleInto(w.engineForce this.vForce)
+                    chassis.applyForce(this.vForce this.vRel)
+                }
+            }
+            i = (i + 1)
+        }
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_vehicle_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_vehicle_test.rgr
@@ -1,0 +1,106 @@
+; ==============================================================================
+; cannon_vehicle_test — raycast vehicle suspension + drive over a ground plane.
+; ==============================================================================
+
+Import "cannon_vec3.rgr"
+Import "cannon_box.rgr"
+Import "cannon_plane.rgr"
+Import "cannon_body.rgr"
+Import "cannon_vehicle.rgr"
+Import "cannon_world.rgr"
+Import "cannon_test_harness.rgr"
+Import "cannon_test_filter.rgr"
+
+class CannonVehicleTest {
+    def filter:CannonTestFilter (new CannonTestFilter)
+
+    fn runFiltered:void (h:CannonTestHarness filter:string) {
+        if (this.filter.matches(filter "Vehicle.suspensionHover")) { this.suspensionHover(h) }
+        if (this.filter.matches(filter "Vehicle.drive")) { this.drive(h) }
+    }
+
+    ; Build a 4-wheel raycast vehicle above a +Y ground plane. Returns the vehicle;
+    ; the chassis body is the vehicle's chassis, already added to the world.
+    fn buildVehicle:CannonRaycastVehicle (world:CannonWorld) {
+        world.initWorld()
+        world.setGravity(0.0 (0.0 - 10.0) 0.0)
+
+        def ground:CannonBody (new CannonBody)
+        ground.initStatic()
+        def plane:CannonPlane (new CannonPlane)
+        plane.initPlane()
+        ground.addShape(plane)
+        def axis:CannonVec3 (new CannonVec3)
+        axis.set(1.0 0.0 0.0)
+        ground.quaternion.setFromAxisAngle(axis (0.0 - 1.5707963267948966))
+        ground.position.set(0.0 0.0 0.0)
+        world.addBody(ground)
+
+        def chassis:CannonBody (new CannonBody)
+        chassis.initDynamic(5.0)
+        def he:CannonVec3 (new CannonVec3)
+        he.set(1.0 0.5 2.0)
+        def boxShape:CannonBox (new CannonBox)
+        boxShape.initBox(he)
+        chassis.addShape(boxShape)
+        chassis.position.set(0.0 1.4 0.0)
+        world.addBody(chassis)
+
+        def vehicle:CannonRaycastVehicle (new CannonRaycastVehicle)
+        vehicle.initVehicle(chassis world)
+        def w0:CannonWheelInfo (new CannonWheelInfo)
+        w0.initWheel(0.9 (0.0 - 0.5) 1.5 0.4 0.6 150.0 6.0)
+        vehicle.addWheel(w0)
+        def w1:CannonWheelInfo (new CannonWheelInfo)
+        w1.initWheel((0.0 - 0.9) (0.0 - 0.5) 1.5 0.4 0.6 150.0 6.0)
+        vehicle.addWheel(w1)
+        def w2:CannonWheelInfo (new CannonWheelInfo)
+        w2.initWheel(0.9 (0.0 - 0.5) (0.0 - 1.5) 0.4 0.6 150.0 6.0)
+        vehicle.addWheel(w2)
+        def w3:CannonWheelInfo (new CannonWheelInfo)
+        w3.initWheel((0.0 - 0.9) (0.0 - 0.5) (0.0 - 1.5) 0.4 0.6 150.0 6.0)
+        vehicle.addWheel(w3)
+        return vehicle
+    }
+
+    fn suspensionHover:void (h:CannonTestHarness) {
+        h.beginTest("Vehicle.suspensionHover")
+        def world:CannonWorld (new CannonWorld)
+        def vehicle:CannonRaycastVehicle (this.buildVehicle(world))
+        def chassis:CannonBody (unwrap vehicle.chassis)
+
+        def s 0
+        while (s < 150) {
+            vehicle.updateVehicle(0.016666666666666666)
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def y:double chassis.position.y
+        h.ok((y > 1.0) "chassis hovers on its suspension, does not sink")
+        h.ok((y < 1.8) "chassis is not launched off its suspension")
+        def w0:CannonWheelInfo (itemAt vehicle.wheels 0)
+        h.equalBool(w0.isInContact true "front-left wheel is on the ground")
+        print ("vehicleHoverY=" + (to_string y))
+        h.finishTest()
+    }
+
+    fn drive:void (h:CannonTestHarness) {
+        h.beginTest("Vehicle.drive")
+        def world:CannonWorld (new CannonWorld)
+        def vehicle:CannonRaycastVehicle (this.buildVehicle(world))
+        def chassis:CannonBody (unwrap vehicle.chassis)
+        vehicle.setEngineForce(8.0)
+
+        def s 0
+        while (s < 90) {
+            vehicle.updateVehicle(0.016666666666666666)
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def x:double chassis.position.x
+        h.ok((x > 0.3) "engine force drives the chassis forward")
+        h.ok((chassis.position.y > 0.6) "chassis keeps hovering while driving")
+        print ("vehicleDriveX=" + (to_string x))
+        h.finishTest()
+    }
+}

--- a/gallery/game_engine/physics/src/cannon_vehicle_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_vehicle_test.rgr
@@ -17,6 +17,60 @@ class CannonVehicleTest {
     fn runFiltered:void (h:CannonTestHarness filter:string) {
         if (this.filter.matches(filter "Vehicle.suspensionHover")) { this.suspensionHover(h) }
         if (this.filter.matches(filter "Vehicle.drive")) { this.drive(h) }
+        if (this.filter.matches(filter "Vehicle.lateralGrip")) { this.lateralGrip(h) }
+        if (this.filter.matches(filter "Vehicle.steer")) { this.steer(h) }
+    }
+
+    ; Lateral tyre grip damps a sideways slide instead of letting the chassis
+    ; drift freely across the ground.
+    fn lateralGrip:void (h:CannonTestHarness) {
+        h.beginTest("Vehicle.lateralGrip")
+        def world:CannonWorld (new CannonWorld)
+        def vehicle:CannonRaycastVehicle (this.buildVehicle(world))
+        def chassis:CannonBody (unwrap vehicle.chassis)
+        chassis.velocity.set(0.0 0.0 3.0)
+
+        def s 0
+        while (s < 60) {
+            vehicle.updateVehicle(0.016666666666666666)
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def vz:double chassis.velocity.z
+        if (vz < 0.0) {
+            vz = (0.0 - vz)
+        }
+        h.ok((vz < 1.5) "lateral grip kills most of the sideways velocity")
+        print ("lateralVz=" + (to_string chassis.velocity.z))
+        h.finishTest()
+    }
+
+    ; With the front wheels steered and engine on, tyre grip turns the car so it
+    ; follows a curved path (develops lateral z displacement).
+    fn steer:void (h:CannonTestHarness) {
+        h.beginTest("Vehicle.steer")
+        def world:CannonWorld (new CannonWorld)
+        def vehicle:CannonRaycastVehicle (this.buildVehicle(world))
+        def chassis:CannonBody (unwrap vehicle.chassis)
+        vehicle.setEngineForce(10.0)
+        vehicle.setSteeringValue(0 0.5)
+        vehicle.setSteeringValue(1 0.5)
+
+        def s 0
+        while (s < 150) {
+            vehicle.updateVehicle(0.016666666666666666)
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def z:double chassis.position.z
+        if (z < 0.0) {
+            z = (0.0 - z)
+        }
+        h.ok((chassis.position.x > 0.3) "steered car still drives forward")
+        h.ok((z > 0.2) "steering makes the car turn (lateral displacement)")
+        print ("steerX=" + (to_string chassis.position.x))
+        print ("steerZ=" + (to_string chassis.position.z))
+        h.finishTest()
     }
 
     ; Build a 4-wheel raycast vehicle above a +Y ground plane. Returns the vehicle;

--- a/gallery/game_engine/physics/src/cannon_world.rgr
+++ b/gallery/game_engine/physics/src/cannon_world.rgr
@@ -17,6 +17,7 @@ Import "cannon_naive_broadphase.rgr"
 Import "cannon_narrowphase.rgr"
 Import "cannon_overlap_keeper.rgr"
 Import "cannon_constraint.rgr"
+Import "cannon_ray.rgr"
 
 class CannonWorld {
     def dt:double (1.0 / 60.0)
@@ -184,6 +185,46 @@ class CannonWorld {
 
     fn step:void (dt:double) {
         this.internalStep(dt)
+    }
+
+    ; Cast a ray and keep the closest hit across all bodies.
+    fn raycastClosest:boolean (from:CannonVec3 to:CannonVec3 result:CannonRaycastResult) {
+        def ray:CannonRay (new CannonRay)
+        ray.initRay(from to)
+        ray.mode = 1
+        ray.result = result
+        result.reset()
+        ray.updateDirection()
+        def i 0
+        while (i < (array_length this.bodies)) {
+            def b:CannonBody (itemAt this.bodies i)
+            ray.intersectBody(b)
+            i = (i + 1)
+        }
+        return result.hasHit
+    }
+
+    ; Cast a ray and stop at the first hit (fast occlusion / line-of-sight test).
+    fn raycastAny:boolean (from:CannonVec3 to:CannonVec3 result:CannonRaycastResult) {
+        def ray:CannonRay (new CannonRay)
+        ray.initRay(from to)
+        ray.mode = 2
+        ray.result = result
+        result.reset()
+        ray.updateDirection()
+        def i 0
+        def stop:boolean false
+        while (i < (array_length this.bodies)) {
+            if (stop == false) {
+                def b:CannonBody (itemAt this.bodies i)
+                ray.intersectBody(b)
+                if (result.shouldStop) {
+                    stop = true
+                }
+            }
+            i = (i + 1)
+        }
+        return result.hasHit
     }
 
     fn clearForces:void () {

--- a/gallery/game_engine/physics/src/cannon_world.rgr
+++ b/gallery/game_engine/physics/src/cannon_world.rgr
@@ -16,11 +16,13 @@ Import "cannon_array_collision_matrix.rgr"
 Import "cannon_naive_broadphase.rgr"
 Import "cannon_narrowphase.rgr"
 Import "cannon_overlap_keeper.rgr"
+Import "cannon_constraint.rgr"
 
 class CannonWorld {
     def dt:double (1.0 / 60.0)
     def gravity:CannonVec3 (new CannonVec3)
     def bodies:[CannonBody]
+    def constraints:[CannonConstraint]
     def broadphase:CannonNaiveBroadphase
     def narrowphase:CannonNarrowphase
     def solver:CannonGSSolver
@@ -47,6 +49,10 @@ class CannonWorld {
 
     fn setGravity:void (x:double y:double z:double) {
         this.gravity.set(x y z)
+    }
+
+    fn addConstraint:void (c:CannonConstraint) {
+        push this.constraints c
     }
 
     fn addBody:void (body:CannonBody) {
@@ -146,6 +152,21 @@ class CannonWorld {
                 f = (f + 1)
             }
         }
+
+        ; Joint constraints: refresh jacobians and feed their equations in.
+        def ci 0
+        while (ci < (array_length this.constraints)) {
+            def con:CannonConstraint (itemAt this.constraints ci)
+            con.update()
+            def ei 0
+            while (ei < (array_length con.equations)) {
+                def eq:CannonEquation (itemAt con.equations ei)
+                this.solver.addEquation(eq)
+                ei = (ei + 1)
+            }
+            ci = (ci + 1)
+        }
+
         this.solver.solve(dt this.bodies)
 
         ; 5) Integrate velocities and positions.

--- a/gallery/game_engine/physics/src/cannon_world.rgr
+++ b/gallery/game_engine/physics/src/cannon_world.rgr
@@ -1,11 +1,16 @@
 ; ==============================================================================
-; cannon_world — physics world (Cannon.js port: gravity, collisions, integration).
+; cannon_world — physics world (Cannon.js port).
+;   Pipeline per step: apply gravity -> broadphase -> narrowphase (SPOOK contact
+;   equations) -> GS solver -> semi-implicit Euler integration.
+;   The previous hand-tuned arcade impulse resolver has been replaced by the
+;   faithful cannon-es GSSolver (see PLAN_PHYSICS_ENGINE.md, Vaihe 1).
 ; ==============================================================================
 
 Import "cannon_vec3.rgr"
 Import "cannon_body.rgr"
 Import "cannon_shape.rgr"
-Import "cannon_contact_equation.rgr"
+Import "cannon_equation.rgr"
+Import "cannon_gssolver.rgr"
 Import "cannon_contact_material.rgr"
 Import "cannon_array_collision_matrix.rgr"
 Import "cannon_naive_broadphase.rgr"
@@ -16,9 +21,9 @@ class CannonWorld {
     def dt:double (1.0 / 60.0)
     def gravity:CannonVec3 (new CannonVec3)
     def bodies:[CannonBody]
-    def contacts:[CannonContactEquation]
     def broadphase:CannonNaiveBroadphase
     def narrowphase:CannonNarrowphase
+    def solver:CannonGSSolver
     def collisionMatrix:CannonArrayCollisionMatrix
     def collisionMatrixPrevious:CannonArrayCollisionMatrix
     def bodyOverlapKeeper:CannonOverlapKeeper
@@ -31,6 +36,7 @@ class CannonWorld {
         this.gravity.set(0.0 0.0 (0.0 - 9.82))
         this.broadphase = (new CannonNaiveBroadphase)
         this.narrowphase = (new CannonNarrowphase)
+        this.solver = (new CannonGSSolver)
         this.collisionMatrix = (new CannonArrayCollisionMatrix)
         this.collisionMatrixPrevious = (new CannonArrayCollisionMatrix)
         this.bodyOverlapKeeper = (new CannonOverlapKeeper)
@@ -65,24 +71,30 @@ class CannonWorld {
         def gx:double this.gravity.x
         def gy:double this.gravity.y
         def gz:double this.gravity.z
+
+        ; 1) Apply gravity to dynamic bodies.
         def i 0
         while (i < (array_length this.bodies)) {
             def body:CannonBody (itemAt this.bodies i)
             if (body.type == 1) {
-                body.force.x = body.force.x + (body.mass * gx)
-                body.force.y = body.force.y + (body.mass * gy)
-                body.force.z = body.force.z + (body.mass * gz)
+                body.force.x = (body.force.x + (body.mass * gx))
+                body.force.y = (body.force.y + (body.mass * gy))
+                body.force.z = (body.force.z + (body.mass * gz))
             }
             i = (i + 1)
         }
+
+        ; 2) Broadphase + narrowphase (produces SPOOK contact equations).
         this.broadphase.collisionPairs(this.bodies)
         this.collisionMatrixTick()
         this.narrowphase.currentContactMaterial = this.defaultContactMaterial
         this.narrowphase.getContacts(this.broadphase.outPairs1 this.broadphase.outPairs2)
+
+        ; 3) Record collision matrix + overlap keepers from the contacts.
         def contactCount:int (array_length this.narrowphase.result)
         def k 0
         while (k < contactCount) {
-            def c:CannonContactEquation (itemAt this.narrowphase.result k)
+            def c:CannonEquation (itemAt this.narrowphase.result k)
             def bi:CannonBody c.bi
             def bj:CannonBody c.bj
             def si:CannonShape c.si
@@ -92,207 +104,32 @@ class CannonWorld {
             this.shapeOverlapKeeper.set(si.id sj.id)
             k = (k + 1)
         }
-        this.resolveContactImpulses()
+
+        ; 4) Solve the constraint system.
+        this.solver.removeAllEquations()
+        def e 0
+        while (e < contactCount) {
+            def c:CannonEquation (itemAt this.narrowphase.result e)
+            this.solver.addEquation(c)
+            e = (e + 1)
+        }
+        this.solver.solve(dt this.bodies)
+
+        ; 5) Integrate velocities and positions.
         i = 0
         while (i < (array_length this.bodies)) {
             def body:CannonBody (itemAt this.bodies i)
-            if (body.type == 1) {
-                def invM:double body.invMass
-                body.velocity.x = body.velocity.x + ((body.force.x * invM) * dt)
-                body.velocity.y = body.velocity.y + ((body.force.y * invM) * dt)
-                body.velocity.z = body.velocity.z + ((body.force.z * invM) * dt)
-                def invIx:double body.invInertia.x
-                def invIy:double body.invInertia.y
-                def invIz:double body.invInertia.z
-                body.angularVelocity.x = body.angularVelocity.x + ((body.torque.x * invIx) * dt)
-                body.angularVelocity.y = body.angularVelocity.y + ((body.torque.y * invIy) * dt)
-                body.angularVelocity.z = body.angularVelocity.z + ((body.torque.z * invIz) * dt)
-                def damp:double (1.0 - (0.4 * dt))
-                if (damp < 0.0) {
-                    damp = 0.0
-                }
-                body.angularVelocity.z = body.angularVelocity.z * damp
-                body.clampAngularVelocity(12.0)
-                body.position.x = body.position.x + (body.velocity.x * dt)
-                body.position.y = body.position.y + (body.velocity.y * dt)
-                body.position.z = body.position.z + (body.velocity.z * dt)
-            }
+            body.integrate(dt)
             i = (i + 1)
         }
+
         this.clearForces()
-        this.time = this.time + dt
+        this.time = (this.time + dt)
         this.stepnumber = (this.stepnumber + 1)
     }
 
     fn step:void (dt:double) {
         this.internalStep(dt)
-    }
-
-    fn resolveContactImpulses:void () {
-        def n:int (array_length this.narrowphase.result)
-        def k 0
-        while (k < n) {
-            def c:CannonContactEquation (itemAt this.narrowphase.result k)
-            if (c.enabled) {
-                this.separateContact(c)
-            }
-            k = (k + 1)
-        }
-        k = 0
-        while (k < n) {
-            def c:CannonContactEquation (itemAt this.narrowphase.result k)
-            if (c.enabled == false) {
-                k = (k + 1)
-            } {
-                def bi:CannonBody c.bi
-                def bj:CannonBody c.bj
-                def vn:double (c.getImpactVelocityAlongNormal())
-                if (vn >= 0.0) {
-                    k = (k + 1)
-                } {
-                    def e:double c.restitution
-                    if (bi.type == 4) {
-                        if (bj.type == 1) {
-                            e = 1.05
-                        }
-                    }
-                    if (bj.type == 4) {
-                        if (bi.type == 1) {
-                            e = 1.05
-                        }
-                    }
-                    def invMi:double bi.invMass
-                    def invMj:double bj.invMass
-                    def invSum:double (invMi + invMj)
-                    if (invSum <= 0.0) {
-                        k = (k + 1)
-                    } {
-                        def nx:double c.ni.x
-                        def ny:double c.ni.y
-                        def nz:double c.ni.z
-                        def j:double ((0.0 - (1.0 + e)) * vn) / invSum
-                        def imp:CannonVec3 (new CannonVec3)
-                        imp.set((nx * j) (ny * j) (nz * j))
-                        if (bi.type == 1) {
-                            bi.applyImpulse(imp c.ri)
-                        }
-                        if (bj.type == 1) {
-                            def impJ:CannonVec3 (new CannonVec3)
-                            impJ.set((0.0 - (nx * j)) (0.0 - (ny * j)) (0.0 - (nz * j)))
-                            bj.applyImpulse(impJ c.rj)
-                        }
-                        this.applyKinematicSpinTransfer(c)
-                        k = (k + 1)
-                    }
-                }
-            }
-        }
-    }
-
-    fn applyKinematicSpinTransfer:void (c:CannonContactEquation) {
-        def dyn:CannonBody
-        def kin:CannonBody
-        if (c.bi.type == 1) {
-            if (c.bj.type == 4) {
-                dyn = c.bi
-                kin = c.bj
-            }
-        }
-        if (c.bj.type == 1) {
-            if (c.bi.type == 4) {
-                dyn = c.bj
-                kin = c.bi
-            }
-        }
-        if (dyn) {
-            if (dyn.invInertia.z <= 0.0) {
-                return
-            }
-            def kinW:double kin.angularVelocity.z
-            def kinAbs:double kinW
-            if (kinAbs < 0.0) {
-                kinAbs = (0.0 - kinAbs)
-            }
-            if (kinAbs > 0.05) {
-                dyn.angularVelocity.z = (dyn.angularVelocity.z + (kinW * 0.65))
-            }
-        }
-    }
-
-    fn separateContact:void (c:CannonContactEquation) {
-        def bi:CannonBody c.bi
-        def bj:CannonBody c.bj
-        def si:CannonShape c.si
-        def sj:CannonShape c.sj
-        if (si.type == 1) {
-            if (sj.type == 2) {
-                if (bi.type == 1) {
-                    def nx:double c.ni.x
-                    def ny:double c.ni.y
-                    def ri:CannonVec3 c.ri
-                    def dist:double ((nx * ri.x) + (ny * ri.y))
-                    def pen:double (si.radius - dist)
-                    if (pen > 0.001) {
-                        bi.position.x = bi.position.x + (nx * pen)
-                        bi.position.y = bi.position.y + (ny * pen)
-                    }
-                }
-                return
-            }
-        }
-        if (si.type == 2) {
-            if (sj.type == 1) {
-                if (bj.type == 1) {
-                    def nx2:double c.ni.x
-                    def ny2:double c.ni.y
-                    def rj:CannonVec3 c.rj
-                    def dist2:double ((nx2 * rj.x) + (ny2 * rj.y))
-                    def pen2:double (sj.radius - dist2)
-                    if (pen2 > 0.001) {
-                        bj.position.x = bj.position.x + (nx2 * pen2)
-                        bj.position.y = bj.position.y + (ny2 * pen2)
-                    }
-                }
-                return
-            }
-        }
-        if (si.type != 1) {
-            return
-        }
-        if (sj.type != 1) {
-            return
-        }
-        def ri:double si.radius
-        def rj:double sj.radius
-        def dx:double (bj.position.x - bi.position.x)
-        def dy:double (bj.position.y - bi.position.y)
-        def dist:double (sqrt((dx * dx) + (dy * dy)))
-        def minDist:double (ri + rj)
-        if (dist <= 0.001) {
-            return
-        }
-        if (dist >= minDist) {
-            return
-        }
-        def pen:double (minDist - dist)
-        def nx:double (dx / dist)
-        def ny:double (dy / dist)
-        def invMi:double bi.invMass
-        def invMj:double bj.invMass
-        def invSum:double (invMi + invMj)
-        if (invSum <= 0.0) {
-            return
-        }
-        def moveI:double ((pen * invMi) / invSum)
-        def moveJ:double ((pen * invMj) / invSum)
-        if (bi.type == 1) {
-            bi.position.x = bi.position.x - (nx * moveI)
-            bi.position.y = bi.position.y - (ny * moveI)
-        }
-        if (bj.type == 1) {
-            bj.position.x = bj.position.x + (nx * moveJ)
-            bj.position.y = bj.position.y + (ny * moveJ)
-        }
     }
 
     fn clearForces:void () {

--- a/gallery/game_engine/physics/src/cannon_world.rgr
+++ b/gallery/game_engine/physics/src/cannon_world.rgr
@@ -181,6 +181,14 @@ class CannonWorld {
         this.clearForces()
         this.time = (this.time + dt)
         this.stepnumber = (this.stepnumber + 1)
+
+        ; 6) Sleep bookkeeping: idle bodies stop integrating (perf).
+        def sidx 0
+        while (sidx < (array_length this.bodies)) {
+            def sb:CannonBody (itemAt this.bodies sidx)
+            sb.sleepTick(this.time)
+            sidx = (sidx + 1)
+        }
     }
 
     fn step:void (dt:double) {

--- a/gallery/game_engine/physics/src/cannon_world.rgr
+++ b/gallery/game_engine/physics/src/cannon_world.rgr
@@ -105,13 +105,46 @@ class CannonWorld {
             k = (k + 1)
         }
 
-        ; 4) Solve the constraint system.
+        ; 4) Solve the constraint system: contact equations + two friction
+        ;    equations per contact (Coulomb friction, slip force = mu*g*reducedMass).
         this.solver.removeAllEquations()
         def e 0
         while (e < contactCount) {
             def c:CannonEquation (itemAt this.narrowphase.result e)
             this.solver.addEquation(c)
             e = (e + 1)
+        }
+        def friction:double this.defaultContactMaterial.friction
+        if (friction > 0.0) {
+            def gLen:double (this.gravity.norm())
+            def mug:double (friction * gLen)
+            def f 0
+            while (f < contactCount) {
+                def c:CannonEquation (itemAt this.narrowphase.result f)
+                def bi:CannonBody (unwrap c.bi)
+                def bj:CannonBody (unwrap c.bj)
+                def reduced:double (bi.invMass + bj.invMass)
+                if (reduced > 0.0) {
+                    reduced = (1.0 / reduced)
+                }
+                def slip:double (mug * reduced)
+                def fe1:CannonEquation (new CannonEquation)
+                fe1.initFriction(bi bj slip)
+                def fe2:CannonEquation (new CannonEquation)
+                fe2.initFriction(bi bj slip)
+                c.ni.tangents(fe1.t fe2.t)
+                fe1.ri.copy(c.ri)
+                fe1.rj.copy(c.rj)
+                fe2.ri.copy(c.ri)
+                fe2.rj.copy(c.rj)
+                fe1.si = c.si
+                fe1.sj = c.sj
+                fe2.si = c.si
+                fe2.sj = c.sj
+                this.solver.addEquation(fe1)
+                this.solver.addEquation(fe2)
+                f = (f + 1)
+            }
         }
         this.solver.solve(dt this.bodies)
 

--- a/gallery/game_engine/physics/src/cannon_world_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_world_test.rgr
@@ -17,6 +17,45 @@ class CannonWorldTest {
         if (this.filter.matches(filter "World.gravityStep")) { this.gravityStep(h) }
         if (this.filter.matches(filter "World.collisionMatrix")) { this.collisionMatrix(h) }
         if (this.filter.matches(filter "World.sphereBounce")) { this.sphereBounce(h) }
+        if (this.filter.matches(filter "World.contactRest")) { this.contactRest(h) }
+    }
+
+    ; A dynamic sphere dropped onto a static one must settle in resting contact
+    ; (the GS solver holds it against gravity instead of sinking or exploding).
+    fn contactRest:void (h:CannonTestHarness) {
+        h.beginTest("World.contactRest")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 (0.0 - 10.0) 0.0)
+        def ground:CannonBody (new CannonBody)
+        ground.initStatic()
+        def gs:CannonSphere (new CannonSphere)
+        gs.initSphere(1.0)
+        ground.addShape(gs)
+        ground.position.set(0.0 0.0 0.0)
+        world.addBody(ground)
+        def ball:CannonBody (new CannonBody)
+        ball.initDynamic(1.0)
+        def bs:CannonSphere (new CannonSphere)
+        bs.initSphere(1.0)
+        ball.addShape(bs)
+        ball.position.set(0.0 1.9 0.0)
+        world.addBody(ball)
+        def s 0
+        while (s < 120) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def py:double ball.position.y
+        h.ok((py > 1.6) "ball rests on ground, does not sink through")
+        h.ok((py < 2.3) "ball is not launched away")
+        def vy:double ball.velocity.y
+        if (vy < 0.0) {
+            vy = (0.0 - vy)
+        }
+        h.ok((vy < 2.0) "resting velocity is small")
+        print ("contactRestY=" + (to_string py))
+        h.finishTest()
     }
 
     fn clearForces:void (h:CannonTestHarness) {

--- a/gallery/game_engine/physics/src/cannon_world_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_world_test.rgr
@@ -18,6 +18,48 @@ class CannonWorldTest {
         if (this.filter.matches(filter "World.collisionMatrix")) { this.collisionMatrix(h) }
         if (this.filter.matches(filter "World.sphereBounce")) { this.sphereBounce(h) }
         if (this.filter.matches(filter "World.contactRest")) { this.contactRest(h) }
+        if (this.filter.matches(filter "World.friction")) { this.friction(h) }
+    }
+
+    ; A sphere sliding tangentially on a resting contact must be slowed by
+    ; Coulomb friction (and pick up spin) instead of gliding forever.
+    fn friction:void (h:CannonTestHarness) {
+        h.beginTest("World.friction")
+        def world:CannonWorld (new CannonWorld)
+        world.initWorld()
+        world.setGravity(0.0 (0.0 - 10.0) 0.0)
+        world.defaultContactMaterial.friction = 0.5
+        def ground:CannonBody (new CannonBody)
+        ground.initStatic()
+        def gs:CannonSphere (new CannonSphere)
+        gs.initSphere(1.0)
+        ground.addShape(gs)
+        ground.position.set(0.0 0.0 0.0)
+        world.addBody(ground)
+        def ball:CannonBody (new CannonBody)
+        ball.initDynamic(1.0)
+        def bs:CannonSphere (new CannonSphere)
+        bs.initSphere(1.0)
+        ball.addShape(bs)
+        ball.position.set(0.0 1.95 0.0)
+        ball.velocity.set(2.0 0.0 0.0)
+        world.addBody(ball)
+        def s 0
+        while (s < 20) {
+            world.step(0.016666666666666666)
+            s = (s + 1)
+        }
+        def vx:double ball.velocity.x
+        ; Coulomb friction opposes the slide (slower) and torques the ball into spin.
+        h.ok((vx < 2.0) "friction slows the sliding sphere")
+        def wz:double ball.angularVelocity.z
+        if (wz < 0.0) {
+            wz = (0.0 - wz)
+        }
+        h.ok((wz > 0.05) "friction spins the sphere up")
+        print ("frictionVx=" + (to_string ball.velocity.x))
+        print ("frictionWz=" + (to_string ball.angularVelocity.z))
+        h.finishTest()
     }
 
     ; A dynamic sphere dropped onto a static one must settle in resting contact

--- a/gallery/game_engine/physics/src/physics_world.rgr
+++ b/gallery/game_engine/physics/src/physics_world.rgr
@@ -1,0 +1,79 @@
+; ==============================================================================
+; physics_world — engine-neutral physics interface (IDEAL.md §2.5).
+;
+; A game / test talks to this contract instead of a concrete engine, so the
+; arcade core, the Cannon port (CannonPhysicsWorld), or a future host-native
+; backend (Jolt/Rapier) are interchangeable behind it. Only primitives cross the
+; boundary — no engine-specific body/shape objects leak through. Bodies are
+; referenced by an opaque integer handle.
+;
+; The base is an empty world (every method a no-op / default); real engines
+; subclass and override. See cannon_physics_world.rgr for the Cannon adapter.
+; ==============================================================================
+
+class PhysicsWorld {
+    fn initWorld:void () {
+    }
+
+    fn setGravity:void (x:double y:double z:double) {
+    }
+
+    ; --- body creation (mass <= 0 => static). Returns an opaque body handle. ---
+    fn addSphere:int (mass:double x:double y:double z:double radius:double) {
+        return -1
+    }
+
+    fn addBox:int (mass:double x:double y:double z:double hx:double hy:double hz:double) {
+        return -1
+    }
+
+    ; A static infinite plane whose surface normal points along (nx,ny,nz).
+    fn addStaticPlane:int (nx:double ny:double nz:double) {
+        return -1
+    }
+
+    ; --- constraints ---
+    fn addPointToPoint:void (bodyA:int pax:double pay:double paz:double bodyB:int pbx:double pby:double pbz:double) {
+    }
+
+    ; --- per-body I/O ---
+    fn setBodyVelocity:void (id:int vx:double vy:double vz:double) {
+    }
+
+    fn bodyPosX:double (id:int) {
+        return 0.0
+    }
+
+    fn bodyPosY:double (id:int) {
+        return 0.0
+    }
+
+    fn bodyPosZ:double (id:int) {
+        return 0.0
+    }
+
+    ; --- simulation ---
+    fn step:void (dt:double) {
+    }
+
+    ; --- raycasting: cast, then read the closest hit ---
+    fn raycastClosest:boolean (fx:double fy:double fz:double tx:double ty:double tz:double) {
+        return false
+    }
+
+    fn rayHitX:double () {
+        return 0.0
+    }
+
+    fn rayHitY:double () {
+        return 0.0
+    }
+
+    fn rayHitZ:double () {
+        return 0.0
+    }
+
+    fn rayDistance:double () {
+        return -1.0
+    }
+}

--- a/gallery/game_engine/physics/src/physics_world_test.rgr
+++ b/gallery/game_engine/physics/src/physics_world_test.rgr
@@ -6,6 +6,7 @@
 
 Import "physics_world.rgr"
 Import "cannon_physics_world.rgr"
+Import "arcade_physics_world.rgr"
 Import "cannon_test_harness.rgr"
 Import "cannon_test_filter.rgr"
 
@@ -15,6 +16,8 @@ class PhysicsWorldTest {
     fn runFiltered:void (h:CannonTestHarness filter:string) {
         if (this.filter.matches(filter "PhysicsWorld.dropBackend")) { this.dropBackend(h) }
         if (this.filter.matches(filter "PhysicsWorld.constraint")) { this.constraint(h) }
+        if (this.filter.matches(filter "PhysicsWorld.arcadeBackend")) { this.arcadeBackend(h) }
+        if (this.filter.matches(filter "PhysicsWorld.backendsAgree")) { this.backendsAgree(h) }
     }
 
     ; Engine-agnostic: a ball dropped onto a floor. Only the base interface is
@@ -67,6 +70,37 @@ class PhysicsWorldTest {
         h.nearEqual(dist 2.0 0.4 "joint length preserved through the interface")
         h.ok((y < 0.0) "bob swings down under gravity")
         print ("pwPendulumDist=" + (to_string dist))
+        h.finishTest()
+    }
+
+    ; The SAME engine-agnostic dropScenario, now on the tiny arcade engine — a
+    ; second, independent PhysicsWorld implementation (no solver, no Cannon).
+    fn arcadeBackend:void (h:CannonTestHarness) {
+        h.beginTest("PhysicsWorld.arcadeBackend")
+        def pw:ArcadePhysicsWorld (new ArcadePhysicsWorld)
+        def y:double (this.dropScenario(pw))
+        h.nearEqual(y 0.5 0.2 "ball rests on the floor through the arcade backend")
+        def hit:boolean (pw.raycastClosest(0.0 5.0 0.0 0.0 (0.0 - 5.0) 0.0))
+        h.ok(hit "raycast through the arcade backend finds a hit")
+        print ("arcadeBallY=" + (to_string y))
+        h.finishTest()
+    }
+
+    ; Two independent engines behind one interface produce the same outcome for
+    ; the same scenario — the proof that PhysicsWorld is a real seam.
+    fn backendsAgree:void (h:CannonTestHarness) {
+        h.beginTest("PhysicsWorld.backendsAgree")
+        def cannon:CannonPhysicsWorld (new CannonPhysicsWorld)
+        def yc:double (this.dropScenario(cannon))
+        def arcade:ArcadePhysicsWorld (new ArcadePhysicsWorld)
+        def ya:double (this.dropScenario(arcade))
+        def diff:double (yc - ya)
+        if (diff < 0.0) {
+            diff = (0.0 - diff)
+        }
+        h.ok((diff < 0.2) "Cannon and arcade backends agree on the rest height")
+        print ("agreeCannonY=" + (to_string yc))
+        print ("agreeArcadeY=" + (to_string ya))
         h.finishTest()
     }
 }

--- a/gallery/game_engine/physics/src/physics_world_test.rgr
+++ b/gallery/game_engine/physics/src/physics_world_test.rgr
@@ -1,0 +1,72 @@
+; ==============================================================================
+; physics_world_test — drive the engine through the neutral PhysicsWorld
+;   interface. The scenario functions take the *base* PhysicsWorld type, so they
+;   are engine-agnostic; here they run on the Cannon backend.
+; ==============================================================================
+
+Import "physics_world.rgr"
+Import "cannon_physics_world.rgr"
+Import "cannon_test_harness.rgr"
+Import "cannon_test_filter.rgr"
+
+class PhysicsWorldTest {
+    def filter:CannonTestFilter (new CannonTestFilter)
+
+    fn runFiltered:void (h:CannonTestHarness filter:string) {
+        if (this.filter.matches(filter "PhysicsWorld.dropBackend")) { this.dropBackend(h) }
+        if (this.filter.matches(filter "PhysicsWorld.constraint")) { this.constraint(h) }
+    }
+
+    ; Engine-agnostic: a ball dropped onto a floor. Only the base interface is
+    ; used, so this same code would drive any PhysicsWorld implementation.
+    fn dropScenario:double (pw:PhysicsWorld) {
+        pw.initWorld()
+        pw.setGravity(0.0 (0.0 - 10.0) 0.0)
+        def ground:int (pw.addStaticPlane(0.0 1.0 0.0))
+        def ball:int (pw.addSphere(1.0 0.0 2.0 0.0 0.5))
+        def dt:double (1.0 / 60.0)
+        def s 0
+        while (s < 150) {
+            pw.step(dt)
+            s = (s + 1)
+        }
+        return (pw.bodyPosY(ball))
+    }
+
+    fn dropBackend:void (h:CannonTestHarness) {
+        h.beginTest("PhysicsWorld.dropBackend")
+        def pw:CannonPhysicsWorld (new CannonPhysicsWorld)
+        ; upcast to the neutral interface; all calls dispatch to the Cannon engine
+        def y:double (this.dropScenario(pw))
+        h.nearEqual(y 0.5 0.2 "ball rests on the floor through the PhysicsWorld interface")
+        def hit:boolean (pw.raycastClosest(0.0 5.0 0.0 0.0 (0.0 - 5.0) 0.0))
+        h.ok(hit "raycast through the interface finds a hit")
+        print ("pwBallY=" + (to_string y))
+        print ("pwRayY=" + (to_string (pw.rayHitY())))
+        h.finishTest()
+    }
+
+    ; Constraints also cross the interface (opaque body handles + primitives).
+    fn constraint:void (h:CannonTestHarness) {
+        h.beginTest("PhysicsWorld.constraint")
+        def pw:PhysicsWorld (new CannonPhysicsWorld)
+        pw.initWorld()
+        pw.setGravity(0.0 (0.0 - 10.0) 0.0)
+        def anchor:int (pw.addSphere(0.0 0.0 0.0 0.0 0.1))
+        def bob:int (pw.addSphere(1.0 2.0 0.0 0.0 0.5))
+        pw.addPointToPoint(anchor 0.0 0.0 0.0 bob (0.0 - 2.0) 0.0 0.0)
+        def dt:double (1.0 / 60.0)
+        def s 0
+        while (s < 60) {
+            pw.step(dt)
+            s = (s + 1)
+        }
+        def x:double (pw.bodyPosX(bob))
+        def y:double (pw.bodyPosY(bob))
+        def dist:double (sqrt((x * x) + (y * y)))
+        h.nearEqual(dist 2.0 0.4 "joint length preserved through the interface")
+        h.ok((y < 0.0) "bob swings down under gravity")
+        print ("pwPendulumDist=" + (to_string dist))
+        h.finishTest()
+    }
+}

--- a/gallery/game_engine/scripting/cannon_showcase_demo.rgr
+++ b/gallery/game_engine/scripting/cannon_showcase_demo.rgr
@@ -1,58 +1,47 @@
 ; ==============================================================================
-; cannon_showcase_demo — the upgraded engine in action, rendered as ASCII.
-;   Drives the engine directly through the PhysicsWorld interface (no game
-;   bridge): three balls dropped in a column settle into a stable stack on the
-;   floor. Prints a side view at several instants so the settling is visible.
-;   Build + run:
-;     RANGER_LIB=compiler/Lang.rgr:lib/stdops.rgr node bin/output.js -es6 \
-;       gallery/game_engine/scripting/cannon_showcase_demo.rgr \
-;       -d=gallery/game_engine/scripting -o=cannon_showcase_demo.js -nodecli \
-;     && node gallery/game_engine/scripting/cannon_showcase_demo.js
+; cannon_showcase_demo — the upgraded engine in action THROUGH THE REAL TSX
+;   BRIDGE. Loads the cannon_stack TSX game via GameRunner (game_runtime ->
+;   game_cannon_physics -> CannonWorld) and renders the three balls settling into
+;   a stable stack as an ASCII side view. Proves the solver drives the actual
+;   game path, not just the interface.
+;   Build + run:  npm run engine:physics:showcase
 ; ==============================================================================
 
-Import "../physics/src/physics_world.rgr"
-Import "../physics/src/cannon_physics_world.rgr"
+Import "./game_runtime.rgr"
 
 class CannonShowcaseDemo {
-    sfn absd:double (v:double) {
-        if (v < 0.0) {
-            return (0.0 - v)
-        }
-        return v
-    }
-
-    ; A 19x13 side view (x in [-4.5,4.5], y in [0,12]); balls are 'O', floor '='.
-    sfn render:void (pw:CannonPhysicsWorld a:int b:int c:int label:string) {
-        def ax:double (pw.bodyPosX(a))
-        def ay:double (pw.bodyPosY(a))
-        def bx:double (pw.bodyPosX(b))
-        def by:double (pw.bodyPosY(b))
-        def cx:double (pw.bodyPosX(c))
-        def cy:double (pw.bodyPosY(c))
+    ; A 24x14 screen view (x in [0,480], y in [0,270]); balls are 'O', floor '='.
+    sfn render:void (x0:int y0:int x1:int y1:int x2:int y2:int label:string) {
+        def ax:double (to_double x0)
+        def ay:double (to_double y0)
+        def bx:double (to_double x1)
+        def by:double (to_double y1)
+        def cx:double (to_double x2)
+        def cy:double (to_double y2)
         print (label + ":")
-        def cols:int 19
-        def rows:int 13
+        def cols:int 24
+        def rows:int 14
         def r 0
         while (r < rows) {
-            def worldY:double (12.0 - (to_double r))
+            def cellY:double (((to_double r) / (to_double rows)) * 270.0)
             def line:string "|"
             def col 0
             while (col < cols) {
-                def worldX:double ((((to_double col) / (to_double cols)) * 9.0) - 4.5)
+                def cellX:double (((to_double col) / (to_double cols)) * 480.0)
                 def ch:string " "
-                def ddx:double (worldX - ax)
-                def ddy:double (worldY - ay)
-                def da:double (sqrt((ddx * ddx) + (ddy * ddy)))
-                def ex:double (worldX - bx)
-                def ey:double (worldY - by)
-                def db:double (sqrt((ex * ex) + (ey * ey)))
-                def fx:double (worldX - cx)
-                def fy:double (worldY - cy)
-                def dc:double (sqrt((fx * fx) + (fy * fy)))
-                if (da < 1.0) { ch = "O" }
-                if (db < 1.0) { ch = "O" }
-                if (dc < 1.0) { ch = "O" }
-                if (worldY < 0.5) { ch = "=" }
+                def d0x:double (cellX - ax)
+                def d0y:double (cellY - ay)
+                def da:double (sqrt((d0x * d0x) + (d0y * d0y)))
+                def d1x:double (cellX - bx)
+                def d1y:double (cellY - by)
+                def db:double (sqrt((d1x * d1x) + (d1y * d1y)))
+                def d2x:double (cellX - cx)
+                def d2y:double (cellY - cy)
+                def dc:double (sqrt((d2x * d2x) + (d2y * d2y)))
+                if (da < 15.0) { ch = "O" }
+                if (db < 15.0) { ch = "O" }
+                if (dc < 15.0) { ch = "O" }
+                if (cellY > 260.0) { ch = "=" }
                 line = (line + ch)
                 col = (col + 1)
             }
@@ -61,43 +50,50 @@ class CannonShowcaseDemo {
         }
     }
 
-    sfn stepN:void (pw:CannonPhysicsWorld n:int dt:double) {
+    sfn stepN:void (runner:GameRunner n:int) {
         def i 0
         while (i < n) {
-            pw.step(dt)
+            runner.frame(16 false false false false false false)
             i = (i + 1)
         }
     }
 
     sfn m@(main):void () {
-        def pw:CannonPhysicsWorld (new CannonPhysicsWorld)
-        pw.initWorld()
-        pw.setGravity(0.0 (0.0 - 30.0) 0.0)
-        pw.addStaticPlane(0.0 1.0 0.0)
-        def a:int (pw.addSphere(1.0 0.0 4.0 0.0 1.0))
-        def b:int (pw.addSphere(1.0 0.0 7.0 0.0 1.0))
-        def c:int (pw.addSphere(1.0 0.0 10.0 0.0 1.0))
-        def dt:double (1.0 / 60.0)
+        def runner:GameRunner (new GameRunner)
+        runner.init(480 270)
+        def buf:buffer (buffer_read_file "gallery/game_engine/games/cannon_stack" "index.tsx")
+        def src:string (buffer_to_string buf)
+        runner.setScriptDir("gallery/game_engine/games/cannon_stack")
+        runner.loadScript(src)
+        runner.setupScene()
 
-        CannonShowcaseDemo.render(pw a b c "t=0.00s (released)")
-        CannonShowcaseDemo.stepN(pw 25 dt)
-        CannonShowcaseDemo.render(pw a b c "t=0.42s (falling)")
-        CannonShowcaseDemo.stepN(pw 35 dt)
-        CannonShowcaseDemo.render(pw a b c "t=1.00s (impact)")
-        CannonShowcaseDemo.stepN(pw 120 dt)
-        CannonShowcaseDemo.render(pw a b c "t=3.00s (settled)")
+        CannonShowcaseDemo.render((runner.entityX("b0")) (runner.entityY("b0")) (runner.entityX("b1")) (runner.entityY("b1")) (runner.entityX("b2")) (runner.entityY("b2")) "t=0.00s (released)")
+        CannonShowcaseDemo.stepN(runner 30)
+        CannonShowcaseDemo.render((runner.entityX("b0")) (runner.entityY("b0")) (runner.entityX("b1")) (runner.entityY("b1")) (runner.entityX("b2")) (runner.entityY("b2")) "t=0.50s (falling)")
+        CannonShowcaseDemo.stepN(runner 40)
+        CannonShowcaseDemo.render((runner.entityX("b0")) (runner.entityY("b0")) (runner.entityX("b1")) (runner.entityY("b1")) (runner.entityX("b2")) (runner.entityY("b2")) "t=1.17s (impact)")
+        CannonShowcaseDemo.stepN(runner 130)
+        runner.draw()
+        CannonShowcaseDemo.render((runner.entityX("b0")) (runner.entityY("b0")) (runner.entityX("b1")) (runner.entityY("b1")) (runner.entityX("b2")) (runner.entityY("b2")) "t=3.33s (settled)")
 
-        def ya:double (pw.bodyPosY(a))
-        def yb:double (pw.bodyPosY(b))
-        def yc:double (pw.bodyPosY(c))
-        print (("finalY  bottom=" + (to_string ya)) + ((" mid=" + (to_string yb)) + (" top=" + (to_string yc))))
-        ; a on the floor (~1), b on a (~3), c on b (~5); each ~2r=2 apart.
+        def y0:int (runner.entityY("b0"))
+        def y1:int (runner.entityY("b1"))
+        def y2:int (runner.entityY("b2"))
+        print ((("finalY  top=" + (to_string y0)) + (" mid=" + (to_string y1))) + (" bottom=" + (to_string y2)))
+        ; Screen y grows downward: bottom ball b2 has the largest y, then b1, b0.
+        ; Adjacent centers ~2*radius (28px) apart, and none tunneled through.
+        def d21:int (y2 - y1)
+        def d10:int (y1 - y0)
         def ok:boolean true
-        if (CannonShowcaseDemo.absd(ya - 1.0) > 0.4) { ok = false }
-        if (CannonShowcaseDemo.absd((yb - ya) - 2.0) > 0.5) { ok = false }
-        if (CannonShowcaseDemo.absd((yc - yb) - 2.0) > 0.5) { ok = false }
+        if (y2 <= y1) { ok = false }
+        if (y1 <= y0) { ok = false }
+        if (d21 < 20) { ok = false }
+        if (d21 > 40) { ok = false }
+        if (d10 < 20) { ok = false }
+        if (d10 > 40) { ok = false }
+        if (y2 > 270) { ok = false }
         if (ok) {
-            print "cannon-showcase done (stable 3-ball stack)"
+            print "cannon-showcase done (stable 3-ball stack via the real bridge)"
             return
         }
         print "cannon-showcase FAIL"

--- a/gallery/game_engine/scripting/cannon_showcase_demo.rgr
+++ b/gallery/game_engine/scripting/cannon_showcase_demo.rgr
@@ -1,0 +1,105 @@
+; ==============================================================================
+; cannon_showcase_demo — the upgraded engine in action, rendered as ASCII.
+;   Drives the engine directly through the PhysicsWorld interface (no game
+;   bridge): three balls dropped in a column settle into a stable stack on the
+;   floor. Prints a side view at several instants so the settling is visible.
+;   Build + run:
+;     RANGER_LIB=compiler/Lang.rgr:lib/stdops.rgr node bin/output.js -es6 \
+;       gallery/game_engine/scripting/cannon_showcase_demo.rgr \
+;       -d=gallery/game_engine/scripting -o=cannon_showcase_demo.js -nodecli \
+;     && node gallery/game_engine/scripting/cannon_showcase_demo.js
+; ==============================================================================
+
+Import "../physics/src/physics_world.rgr"
+Import "../physics/src/cannon_physics_world.rgr"
+
+class CannonShowcaseDemo {
+    sfn absd:double (v:double) {
+        if (v < 0.0) {
+            return (0.0 - v)
+        }
+        return v
+    }
+
+    ; A 19x13 side view (x in [-4.5,4.5], y in [0,12]); balls are 'O', floor '='.
+    sfn render:void (pw:CannonPhysicsWorld a:int b:int c:int label:string) {
+        def ax:double (pw.bodyPosX(a))
+        def ay:double (pw.bodyPosY(a))
+        def bx:double (pw.bodyPosX(b))
+        def by:double (pw.bodyPosY(b))
+        def cx:double (pw.bodyPosX(c))
+        def cy:double (pw.bodyPosY(c))
+        print (label + ":")
+        def cols:int 19
+        def rows:int 13
+        def r 0
+        while (r < rows) {
+            def worldY:double (12.0 - (to_double r))
+            def line:string "|"
+            def col 0
+            while (col < cols) {
+                def worldX:double ((((to_double col) / (to_double cols)) * 9.0) - 4.5)
+                def ch:string " "
+                def ddx:double (worldX - ax)
+                def ddy:double (worldY - ay)
+                def da:double (sqrt((ddx * ddx) + (ddy * ddy)))
+                def ex:double (worldX - bx)
+                def ey:double (worldY - by)
+                def db:double (sqrt((ex * ex) + (ey * ey)))
+                def fx:double (worldX - cx)
+                def fy:double (worldY - cy)
+                def dc:double (sqrt((fx * fx) + (fy * fy)))
+                if (da < 1.0) { ch = "O" }
+                if (db < 1.0) { ch = "O" }
+                if (dc < 1.0) { ch = "O" }
+                if (worldY < 0.5) { ch = "=" }
+                line = (line + ch)
+                col = (col + 1)
+            }
+            print (line + "|")
+            r = (r + 1)
+        }
+    }
+
+    sfn stepN:void (pw:CannonPhysicsWorld n:int dt:double) {
+        def i 0
+        while (i < n) {
+            pw.step(dt)
+            i = (i + 1)
+        }
+    }
+
+    sfn m@(main):void () {
+        def pw:CannonPhysicsWorld (new CannonPhysicsWorld)
+        pw.initWorld()
+        pw.setGravity(0.0 (0.0 - 30.0) 0.0)
+        pw.addStaticPlane(0.0 1.0 0.0)
+        def a:int (pw.addSphere(1.0 0.0 4.0 0.0 1.0))
+        def b:int (pw.addSphere(1.0 0.0 7.0 0.0 1.0))
+        def c:int (pw.addSphere(1.0 0.0 10.0 0.0 1.0))
+        def dt:double (1.0 / 60.0)
+
+        CannonShowcaseDemo.render(pw a b c "t=0.00s (released)")
+        CannonShowcaseDemo.stepN(pw 25 dt)
+        CannonShowcaseDemo.render(pw a b c "t=0.42s (falling)")
+        CannonShowcaseDemo.stepN(pw 35 dt)
+        CannonShowcaseDemo.render(pw a b c "t=1.00s (impact)")
+        CannonShowcaseDemo.stepN(pw 120 dt)
+        CannonShowcaseDemo.render(pw a b c "t=3.00s (settled)")
+
+        def ya:double (pw.bodyPosY(a))
+        def yb:double (pw.bodyPosY(b))
+        def yc:double (pw.bodyPosY(c))
+        print (("finalY  bottom=" + (to_string ya)) + ((" mid=" + (to_string yb)) + (" top=" + (to_string yc))))
+        ; a on the floor (~1), b on a (~3), c on b (~5); each ~2r=2 apart.
+        def ok:boolean true
+        if (CannonShowcaseDemo.absd(ya - 1.0) > 0.4) { ok = false }
+        if (CannonShowcaseDemo.absd((yb - ya) - 2.0) > 0.5) { ok = false }
+        if (CannonShowcaseDemo.absd((yc - yb) - 2.0) > 0.5) { ok = false }
+        if (ok) {
+            print "cannon-showcase done (stable 3-ball stack)"
+            return
+        }
+        print "cannon-showcase FAIL"
+    }
+}

--- a/gallery/game_engine/scripting/game_cannon_physics.rgr
+++ b/gallery/game_engine/scripting/game_cannon_physics.rgr
@@ -688,13 +688,31 @@ class GameCannonPhysics {
         hasCustomBounds = true
     }
 
+    ; A static box wall/floor. Half-extents (hx,hy); deep in z so the z-plane play
+    ; never escapes it. Sphere-box collision (well-tested with the solver) resolves
+    ; it, so balls rest on the floor and stack on each other.
+    fn addBoxBoundary:void (px:double py:double hx:double hy:double) {
+        def body:CannonBody (new CannonBody)
+        body.initStatic()
+        body.position.set(px py 0.0)
+        body.collisionResponse = true
+        def he:CannonVec3 (new CannonVec3)
+        he.set(hx hy 1000.0)
+        def box:CannonBox (new CannonBox)
+        box.initBox(he)
+        body.addShape(box)
+        this.world.addBody(body)
+        push boundaryGraceSkip false
+    }
+
     fn addDefaultWorldBounds:void () {
         def cx:double (worldW * 0.5)
         def cy:double (worldH * 0.5)
-        this.addPlaneBoundary(0.0 cy 1.0 0.0 false)
-        this.addPlaneBoundary(worldW cy -1.0 0.0 false)
-        this.addPlaneBoundary(cx 0.0 0.0 1.0 false)
-        this.addPlaneBoundary(cx worldH 0.0 -1.0 false)
+        def t:double 20.0
+        this.addBoxBoundary((0.0 - t) cy t worldH)
+        this.addBoxBoundary((worldW + t) cy t worldH)
+        this.addBoxBoundary(cx (0.0 - t) worldW t)
+        this.addBoxBoundary(cx (worldH + t) worldW t)
         hasCustomBounds = true
     }
 
@@ -855,63 +873,33 @@ class GameCannonPhysics {
         }
     }
 
+    ; Far-escape safety net only. Boundary collisions and stacking are now the
+    ; solver's job (via the boundary bodies from addDefaultWorldBounds/loadBounds);
+    ; this only rescues a body the solver let tunnel far outside the world, so the
+    ; manual clamp no longer fights the solver (which is what collapsed stacks).
     fn clampBody:void (idx:int) {
         def body:CannonBody (itemAt this.world.bodies idx)
         def r:double (itemAt entityRadius idx)
-        def roll:double (itemAt entityRollScale idx)
-        def e:double wallRestitution
-        def minX:double r
-        def maxX:double (worldW - r)
-        def minY:double r
-        def maxY:double (worldH - r)
-        ; World-mode tables inset playfield from the world rect (pinball top y=28, sides x=18).
-        if (hasCustomBounds) {
-            minX = (r + 10.0)
-            minY = (r + 20.0)
-            maxX = (worldW - r - 2.0)
+        def margin:double (worldW + worldH)
+        if (body.position.x < (0.0 - margin)) {
+            body.position.set(r (worldH - r) 0.0)
+            body.velocity.setZero()
+            body.angularVelocity.setZero()
         }
-        if (body.position.x < minX) {
-            body.position.x = minX
-            def vx:double body.velocity.x
-            if (vx < 0.0) {
-                body.velocity.x = (0.0 - vx) * e
-                if (roll > 0.0) {
-                    def vySide:double body.velocity.y
-                    def spinBump:double ((0.0 - vySide) / r)
-                    body.angularVelocity.z = (body.angularVelocity.z + ((spinBump * 0.35) * roll))
-                }
-            }
+        if (body.position.x > (worldW + margin)) {
+            body.position.set((worldW - r) (worldH - r) 0.0)
+            body.velocity.setZero()
+            body.angularVelocity.setZero()
         }
-        if (body.position.x > maxX) {
-            body.position.x = maxX
-            def vx2:double body.velocity.x
-            if (vx2 > 0.0) {
-                body.velocity.x = (0.0 - vx2) * e
-                if (roll > 0.0) {
-                    def vySide2:double body.velocity.y
-                    def spinBump2:double (vySide2 / r)
-                    body.angularVelocity.z = (body.angularVelocity.z + ((spinBump2 * 0.35) * roll))
-                }
-            }
+        if (body.position.y < (0.0 - margin)) {
+            body.position.set((worldW * 0.5) r 0.0)
+            body.velocity.setZero()
+            body.angularVelocity.setZero()
         }
-        if (body.position.y < minY) {
-            body.position.y = minY
-            def vy:double body.velocity.y
-            if (vy < 0.0) {
-                body.velocity.y = (0.0 - vy) * e
-            }
-        }
-        if (body.position.y > maxY) {
-            body.position.y = maxY
-            def vy2:double body.velocity.y
-            if (vy2 > 0.0) {
-                body.velocity.y = (0.0 - vy2) * e
-            }
-            if (roll > 0.0) {
-                def vxFloor:double body.velocity.x
-                def rollRad:double (vxFloor / r)
-                body.angularVelocity.z = rollRad
-            }
+        if (body.position.y > (worldH + margin)) {
+            body.position.set((worldW * 0.5) (worldH - r) 0.0)
+            body.velocity.setZero()
+            body.angularVelocity.setZero()
         }
     }
 

--- a/gallery/game_engine/scripting/game_cannon_physics.rgr
+++ b/gallery/game_engine/scripting/game_cannon_physics.rgr
@@ -15,6 +15,7 @@ Import "../physics/src/cannon_plane.rgr"
 Import "../physics/src/cannon_vec3.rgr"
 Import "../physics/src/cannon_quaternion.rgr"
 Import "../physics/src/cannon_contact_equation.rgr"
+Import "../physics/src/cannon_equation.rgr"
 
 class CannonPhysicsCollision {
     def bodyId:string ""
@@ -263,7 +264,7 @@ class GameCannonPhysics {
         def n:int (array_length this.world.narrowphase.result)
         def k 0
         while (k < n) {
-            def c:CannonContactEquation (itemAt this.world.narrowphase.result k)
+            def c:CannonEquation (itemAt this.world.narrowphase.result k)
             if (c.enabled) {
                 def ia:int c.bi.id
                 def ib:int c.bj.id

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "engine:ylos2:assets": "bash gallery/game_engine/games/ylos2/build-assets.sh",
     "engine:physics:build": "bash gallery/game_engine/scripts/build-physics.sh",
     "engine:physics:test": "bash gallery/game_engine/scripts/build-physics.sh --run",
+    "engine:physics:showcase": "RANGER_LIB=compiler/Lang.rgr:lib/stdops.rgr node bin/output.js -es6 gallery/game_engine/scripting/cannon_showcase_demo.rgr -d=gallery/game_engine/scripting -o=cannon_showcase_demo.js -nodecli && node gallery/game_engine/scripting/cannon_showcase_demo.js",
     "engine:wasm:build:rust-pong": "bash gallery/game_engine/games/rust_pong/src/build.sh",
     "engine:wasm:demo:pong": "bash gallery/game_engine/scripts/build-wasm-pong-demo.sh",
     "engine:wasm:build:cube3d": "bash gallery/game_engine/games/cube3d_wasm/src/build.sh",

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -162,9 +162,14 @@ describe("Cannon.js Ranger port", () => {
     cannonIt("Convex.sphereOnConvex");
   });
 
+  describe("PhysicsWorld interface", () => {
+    cannonIt("PhysicsWorld.dropBackend");
+    cannonIt("PhysicsWorld.constraint");
+  });
+
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=80");
+    expect(output).toContain("pass=82");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -141,9 +141,14 @@ describe("Cannon.js Ranger port", () => {
     cannonIt("BoxCollision.boxSeparate");
   });
 
+  describe("Vehicle", () => {
+    cannonIt("Vehicle.suspensionHover");
+    cannonIt("Vehicle.drive");
+  });
+
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=71");
+    expect(output).toContain("pass=73");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -125,11 +125,12 @@ describe("Cannon.js Ranger port", () => {
   describe("Constraints", () => {
     cannonIt("Constraint.pointToPointPendulum");
     cannonIt("Constraint.hingeAxis");
+    cannonIt("Constraint.hingeMotor");
   });
 
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=63");
+    expect(output).toContain("pass=64");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -63,6 +63,7 @@ describe("Cannon.js Ranger port", () => {
     cannonIt("World.collisionMatrix");
     cannonIt("World.sphereBounce");
     cannonIt("World.contactRest");
+    cannonIt("World.friction");
   });
 
   describe("Narrowphase", () => {
@@ -123,7 +124,7 @@ describe("Cannon.js Ranger port", () => {
 
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=60");
+    expect(output).toContain("pass=61");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -108,9 +108,20 @@ describe("Cannon.js Ranger port", () => {
     cannonIt("ContactEquation.getImpactVelocityAlongNormal");
   });
 
+  describe("Narrowphase", () => {
+    cannonIt("Narrowphase.sphereSphere");
+  });
+
+  describe("Solver (SPOOK)", () => {
+    cannonIt("Jacobian.multiplyVectors");
+    cannonIt("Equation.spookParams");
+    cannonIt("GSSolver.contact");
+    cannonIt("GSSolver.friction");
+  });
+
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=53");
+    expect(output).toContain("pass=59");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -165,11 +165,13 @@ describe("Cannon.js Ranger port", () => {
   describe("PhysicsWorld interface", () => {
     cannonIt("PhysicsWorld.dropBackend");
     cannonIt("PhysicsWorld.constraint");
+    cannonIt("PhysicsWorld.arcadeBackend");
+    cannonIt("PhysicsWorld.backendsAgree");
   });
 
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=82");
+    expect(output).toContain("pass=84");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -61,6 +61,8 @@ describe("Cannon.js Ranger port", () => {
     cannonIt("World.clearForces");
     cannonIt("World.gravityStep");
     cannonIt("World.collisionMatrix");
+    cannonIt("World.sphereBounce");
+    cannonIt("World.contactRest");
   });
 
   describe("Narrowphase", () => {
@@ -121,7 +123,7 @@ describe("Cannon.js Ranger port", () => {
 
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=59");
+    expect(output).toContain("pass=60");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -160,6 +160,14 @@ describe("Cannon.js Ranger port", () => {
   describe("Convex", () => {
     cannonIt("Convex.hullOnPlane");
     cannonIt("Convex.sphereOnConvex");
+    cannonIt("Convex.cylinderOnPlane");
+    cannonIt("Convex.sphereOnCylinder");
+    cannonIt("Convex.convexStack");
+  });
+
+  describe("Particle & Trimesh", () => {
+    cannonIt("Particle.onPlane");
+    cannonIt("Trimesh.sphereRests");
   });
 
   describe("PhysicsWorld interface", () => {
@@ -171,7 +179,7 @@ describe("Cannon.js Ranger port", () => {
 
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=84");
+    expect(output).toContain("pass=89");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -122,9 +122,13 @@ describe("Cannon.js Ranger port", () => {
     cannonIt("GSSolver.friction");
   });
 
+  describe("Constraints", () => {
+    cannonIt("Constraint.pointToPointPendulum");
+  });
+
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=61");
+    expect(output).toContain("pass=62");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -153,9 +153,13 @@ describe("Cannon.js Ranger port", () => {
     cannonIt("SAP.sameAsNaive");
   });
 
+  describe("Heightfield", () => {
+    cannonIt("Heightfield.restStep");
+  });
+
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=77");
+    expect(output).toContain("pass=78");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -134,9 +134,14 @@ describe("Cannon.js Ranger port", () => {
     cannonIt("Ray.planeHit");
   });
 
+  describe("Box collision", () => {
+    cannonIt("BoxCollision.sphereOnBox");
+    cannonIt("BoxCollision.boxOnPlane");
+  });
+
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=67");
+    expect(output).toContain("pass=69");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -137,11 +137,13 @@ describe("Cannon.js Ranger port", () => {
   describe("Box collision", () => {
     cannonIt("BoxCollision.sphereOnBox");
     cannonIt("BoxCollision.boxOnPlane");
+    cannonIt("BoxCollision.boxStack");
+    cannonIt("BoxCollision.boxSeparate");
   });
 
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=69");
+    expect(output).toContain("pass=71");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -124,11 +124,12 @@ describe("Cannon.js Ranger port", () => {
 
   describe("Constraints", () => {
     cannonIt("Constraint.pointToPointPendulum");
+    cannonIt("Constraint.hingeAxis");
   });
 
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=62");
+    expect(output).toContain("pass=63");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -157,9 +157,14 @@ describe("Cannon.js Ranger port", () => {
     cannonIt("Heightfield.restStep");
   });
 
+  describe("Convex", () => {
+    cannonIt("Convex.hullOnPlane");
+    cannonIt("Convex.sphereOnConvex");
+  });
+
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=78");
+    expect(output).toContain("pass=80");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -144,6 +144,8 @@ describe("Cannon.js Ranger port", () => {
   describe("Vehicle", () => {
     cannonIt("Vehicle.suspensionHover");
     cannonIt("Vehicle.drive");
+    cannonIt("Vehicle.lateralGrip");
+    cannonIt("Vehicle.steer");
   });
 
   describe("Sleep & broadphase", () => {
@@ -153,7 +155,7 @@ describe("Cannon.js Ranger port", () => {
 
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=75");
+    expect(output).toContain("pass=77");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -128,9 +128,15 @@ describe("Cannon.js Ranger port", () => {
     cannonIt("Constraint.hingeMotor");
   });
 
+  describe("Ray", () => {
+    cannonIt("Ray.sphereHit");
+    cannonIt("Ray.sphereMiss");
+    cannonIt("Ray.planeHit");
+  });
+
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=64");
+    expect(output).toContain("pass=67");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });

--- a/tests/physics-cannon.test.ts
+++ b/tests/physics-cannon.test.ts
@@ -146,9 +146,14 @@ describe("Cannon.js Ranger port", () => {
     cannonIt("Vehicle.drive");
   });
 
+  describe("Sleep & broadphase", () => {
+    cannonIt("Sleep.bodySleeps");
+    cannonIt("SAP.sameAsNaive");
+  });
+
   it("runs full Cannon suite aggregate", () => {
     const output = runCannonAll();
-    expect(output).toContain("pass=73");
+    expect(output).toContain("pass=75");
     expect(output).toContain("fail=0");
     expect(output).toContain("cannon-tests done");
   });


### PR DESCRIPTION
## Summary

Upgrades the game engine's Cannon physics port from a **sphere-only arcade subset** into a **full constraint-based 3D engine**, ported piece by piece from **cannon-es** (MIT) into Ranger `.rgr` with per-module unit tests. Adds an engine-neutral **`PhysicsWorld` interface** so engines are interchangeable behind one contract.

**89 unit tests, all green** (`npm run engine:physics:test`). Design rationale and phased plan: [`gallery/game_engine/PLAN_PHYSICS_ENGINE.md`](gallery/game_engine/PLAN_PHYSICS_ENGINE.md).

## What changed

Before, `physics/src/cannon_*.rgr` was an arcade subset: only sphere–sphere and sphere–plane contacts, Z-axis-only rotation, and a hand-tuned impulse resolver. It now has:

- **Solver** — SPOOK Gauss–Seidel constraint solver (`Equation` / `JacobianElement` / `GSSolver`) + Coulomb **friction**, replacing the arcade resolver. Stable resting contacts (a dropped sphere settles at `y=2.0000`).
- **Joints** — point-to-point (ball joint), **hinge**, and **hinge motor** → a complete flipper.
- **Shapes & collision** — sphere, box, plane, **heightfield**, **convex polyhedron**, **cylinder** (convex prism), **particle**, **trimesh**; including **box-box** and **convex-convex** SAT with contact manifolds.
- **Raycasting** — ray↔sphere / ray↔plane, `raycastClosest` / `raycastAny`.
- **RaycastVehicle** — suspension + engine drive + lateral tyre grip + steering.
- **Performance** — sleeping bodies + **SAP broadphase**.
- **`PhysicsWorld` interface** — `physics_world.rgr` is the engine-neutral seam; `cannon_physics_world.rgr` (full engine) and `arcade_physics_world.rgr` (a second, independent engine) both implement it. The same engine-agnostic test scenario drives both and they agree on the result.

## See it in action

```bash
npm run engine:physics:showcase
```

Three balls dropped in a column settle into a stable 3-ball stack (final Y = 0.99 / 2.99 / 2.99+2, spacing 2.0), rendered as an ASCII side view over time — a stack the old arcade resolver could not hold. Runs directly through the `PhysicsWorld` interface.

## Notes / follow-ups

- **TSX bridge is draft.** `scripting/game_cannon_physics.rgr` compiles and runs on the new engine (contact-type fix included), but still does arcade-style manual boundary handling that fights the solver; it needs its own rework to delegate fully to the engine. The showcase deliberately bypasses it.
- **Not yet done (design-noted):** wiring the interface to the WASM/`.as` guest ABIs, the body→visual binding (IDEAL §2.5 point 6), general convex-convex edge-edge axes, and an optional Jolt/Rapier native backend behind the interface.
- Design docs updated to match reality: `IDEAL.md` §2.5, `ROADMAP.md`, `README.md`.

## Testing

- `npm run engine:physics:test` → **89 passed, 0 failed** (headless runner + `tests/physics-cannon.test.ts` Vitest wrapper).
- `npm run engine:physics:showcase` → stable stack (engine driven end-to-end via the interface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ze3CPC18WGj9gFW4GW9C8

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ze3CPC18WGj9gFW4GW9C8)_