### PR TITLE
game_engine: show 4 rows of games in the launcher grid

### DIFF
--- a/gallery/game_engine/menu/launcher.tsx
+++ b/gallery/game_engine/menu/launcher.tsx
@@ -35,8 +35,9 @@
 // ============================================================================
 
 const FLASH_MS = 420;
-// 9 games + the pinned Back tile = 10 tiles, laid out 5 x 2 in the panel.
-const GAMES_PER_PAGE = 9;
+// 19 games + the pinned Back tile = 20 tiles, laid out 5 x 4 in the panel
+// so the Games category (currently ~13 titles) fits on one page.
+const GAMES_PER_PAGE = 19;
 // ASCII arrows for labels, built OUTSIDE the JSX: a literal "<" inside JSX
 // children reads as a tag opener to the TSX tokenizer, and typographic arrows
 // ("‹") come out as mojibake on the Latin-1 TTF text path.
@@ -231,7 +232,7 @@ function categoryScreen(s) {
 }
 
 // The page a selection index belongs to: sel 0 is the pinned Back tile (shown
-// on every page, so it borrows page 0); games 1..N map 9-per-page.
+// on every page, so it borrows page 0); games 1..N map GAMES_PER_PAGE-per-page.
 function pageOf(sel) {
   if (sel <= 0) return 0;
   return Math.floor((sel - 1) / GAMES_PER_PAGE);

--- a/gallery/game_engine/scripting/menu_tsx_render_demo.rgr
+++ b/gallery/game_engine/scripting/menu_tsx_render_demo.rgr
@@ -233,20 +233,20 @@ class TsxMenuRenderDemo {
         d.stepBack()
         c.ok(("Back/Quit -> cats (got '" + (d.stateStr("screen")) + "')") ((d.stateStr("screen")) == "cats"))
 
-        ; ---- pagination: a category with more than GAMES_PER_PAGE (9) games
+        ; ---- pagination: a category with more than GAMES_PER_PAGE (19) games
         ; renders as pages; holding right walks straight onto page 2, and the
-        ; page indicator label appears. (The Tests category holds 10+ games.) ----
+        ; page indicator label appears. (The Tests category holds 20+ games.) ----
         d.step(false true false false false)     ; down -> the second category
         d.step(false false false false true)     ; A -> open it
         d.settle()
         c.ok(("opened the second category (got '" + (d.stateStr("screen")) + "')") ((d.stateStr("screen")) == "games"))
         c.ok("page indicator shows on a multi-page grid" (d.anyTextContains(d.root "sivu 1")))
         def w 0
-        while (w < 10) {                          ; right x10: sel 1 -> 11 = page 2
+        while (w < 19) {                          ; right x19: sel 1 -> 20 = page 2
             d.step(false false false true false)
             w = (w + 1)
         }
-        c.ok(("held right onto page 2 (got sel=" + (d.stateStr("sel")) + ")") ((d.stateStr("sel")) == "11"))
+        c.ok(("held right onto page 2 (got sel=" + (d.stateStr("sel")) + ")") ((d.stateStr("sel")) == "20"))
         c.ok("page indicator follows the cursor to page 2" (d.anyTextContains(d.root "sivu 2")))
         d.drawFrame("tsx_menu_3_games_page2.png")
         d.stepBack()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Raise `GAMES_PER_PAGE` from 9 → 19 so the launcher games grid is **5×4** (Back + 19 titles) instead of 5×2. The Games category (~13 titles) now fits on one page with no `sivu 1/2` pager.

[Games grid one page](https://cursor.com/agents/bc-e4e943d9-5299-4ee1-947d-c4a8736efcf0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftsx_menu_2_games.png)

## Test plan
- [x] `menu_tsx_render_demo` — 21/21 pass (pagination still works for Tests with 20+ entries)
- [ ] Launcher Games screen shows all titles without paging


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4e943d9-5299-4ee1-947d-c4a8736efcf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4e943d9-5299-4ee1-947d-c4a8736efcf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

