### PR TITLE
physics: fix native C++ build — 89/89 tests now pass in C++ too

### DIFF
--- a/bin/Lang.rgr
+++ b/bin/Lang.rgr
@@ -1501,12 +1501,16 @@ fn r_read_file(path: &str, filename: &str) -> Option<String> {
         *               cmdMulOp:double         ( left:double right:double ) { templates { * ( (e 1) " * " (e 2) ) } }
         *               cmdMulOp:int            ( left:int right:int ) { templates { * ( (e 1) " * " (e 2) ) } }
 
-        /               cmdDivOp:double         ( left:double right:double ) { templates { * ( (e 1) " / " (e 2) ) } }
-        /               cmdDivOp:double         ( left:int right:int ) { templates { 
+        /               cmdDivOp:double         ( left:double right:double ) { templates {
+            cpp ( "((double)(" (e 1) ") / (double)(" (e 2) "))" )
+            * ( (e 1) " / " (e 2) )
+        } }
+        /               cmdDivOp:double         ( left:int right:int ) { templates {
             go ( "float64(" (e 1) ") / float64(" (e 2) ")" )
             rust ( "(" (e 1) " as f64) / (" (e 2) " as f64)" )
             kotlin ( (e 1) ".toDouble() / " (e 2) ".toDouble()" )
-            * ( (e 1) " / " (e 2) ) 
+            cpp ( "((double)(" (e 1) ") / (double)(" (e 2) "))" )
+            * ( (e 1) " / " (e 2) )
         } }
 
         ; optional string operator...

--- a/compiler/Lang.rgr
+++ b/compiler/Lang.rgr
@@ -1514,12 +1514,16 @@ fn r_read_file(path: &str, filename: &str) -> Option<String> {
         *               cmdMulOp:double         ( left:double right:double ) { templates { * ( (e 1) " * " (e 2) ) } }
         *               cmdMulOp:int            ( left:int right:int ) { templates { * ( (e 1) " * " (e 2) ) } }
 
-        /               cmdDivOp:double         ( left:double right:double ) { templates { * ( (e 1) " / " (e 2) ) } }
-        /               cmdDivOp:double         ( left:int right:int ) { templates { 
+        /               cmdDivOp:double         ( left:double right:double ) { templates {
+            cpp ( "((double)(" (e 1) ") / (double)(" (e 2) "))" )
+            * ( (e 1) " / " (e 2) )
+        } }
+        /               cmdDivOp:double         ( left:int right:int ) { templates {
             go ( "float64(" (e 1) ") / float64(" (e 2) ")" )
             rust ( "(" (e 1) " as f64) / (" (e 2) " as f64)" )
             kotlin ( (e 1) ".toDouble() / " (e 2) ".toDouble()" )
-            * ( (e 1) " / " (e 2) ) 
+            cpp ( "((double)(" (e 1) ") / (double)(" (e 2) "))" )
+            * ( (e 1) " / " (e 2) )
         } }
 
         ; optional string operator...

--- a/gallery/game_engine/physics/src/cannon_mat3.rgr
+++ b/gallery/game_engine/physics/src/cannon_mat3.rgr
@@ -199,11 +199,11 @@ class CannonMat3 {
         def n:int 3
         def k:int 3
         while (k > 0) {
-            i = (k - n)
+            i = (n - k)
             def pivot:double (itemAt eqns (i + (nc * i)))
             if (pivot == 0.0) {
                 def j:int (i + 1)
-                while (j < k) {
+                while (j < n) {
                     def pj:double (itemAt eqns (i + (nc * j)))
                     if (pj != 0.0) {
                         def np:int 4
@@ -226,7 +226,7 @@ class CannonMat3 {
             pivot = (itemAt eqns (i + (nc * i)))
             if (pivot != 0.0) {
                 def j2:int (i + 1)
-                while (j2 < k) {
+                while (j2 < n) {
                     def mult:double (itemAt eqns (i + (nc * j2)))
                     mult = mult / pivot
                     def np2:int 4
@@ -328,11 +328,11 @@ class CannonMat3 {
         def n:int 3
         def k:int 3
         while (k > 0) {
-            i = (k - n)
+            i = (n - k)
             def pivot:double (itemAt eqns (i + (nc * i)))
             if (pivot == 0.0) {
                 def j:int (i + 1)
-                while (j < k) {
+                while (j < n) {
                     def pj:double (itemAt eqns (i + (nc * j)))
                     if (pj != 0.0) {
                         def np:int 6
@@ -352,7 +352,7 @@ class CannonMat3 {
             pivot = (itemAt eqns (i + (nc * i)))
             if (pivot != 0.0) {
                 def j2:int (i + 1)
-                while (j2 < k) {
+                while (j2 < n) {
                     def mult:double (itemAt eqns (i + (nc * j2)))
                     mult = mult / pivot
                     def np2:int 6
@@ -426,7 +426,7 @@ class CannonMat3 {
                 if (this.isBadDouble(pval)) {
                     return false
                 }
-                def dstIdx:int (i + (j3 * 3))
+                def dstIdx:int (j3 + (i * 3))
                 set target.elements dstIdx pval
                 j3 = (j3 - 1)
             }

--- a/gallery/game_engine/physics/src/cannon_narrowphase_test.rgr
+++ b/gallery/game_engine/physics/src/cannon_narrowphase_test.rgr
@@ -44,7 +44,10 @@ class CannonNarrowphaseTest {
         def qi:CannonQuaternion (new CannonQuaternion)
         def qj:CannonQuaternion (new CannonQuaternion)
         this.narrowphase.sphereSphere(1.0 1.0 xi xj bodyA bodyB sphereShape sphereShapeB false)
-        def count:int (array_length result)
+        ; Read the narrowphase's own result member (what sphereSphere pushes to).
+        ; Reading the local `result` assumes JS array aliasing that does not hold in
+        ; C++ (assignment copies), where the local would stay empty.
+        def count:int (array_length this.narrowphase.result)
         h.equal((to_double count) 1.0 "one contact")
         h.finishTest()
     }

--- a/gallery/game_engine/physics/src/cannon_overlap_keeper.rgr
+++ b/gallery/game_engine/physics/src/cannon_overlap_keeper.rgr
@@ -7,8 +7,6 @@ class CannonOverlapKeeper {
     def previous:[int]
     def currentCount:int 0
     def previousCount:int 0
-    def outAdditions:[int]
-    def outRemovals:[int]
 
     fn getKey:int (i:int j:int) {
         if (j < i) {
@@ -68,9 +66,11 @@ class CannonOverlapKeeper {
         push array lo
     }
 
+    ; Push directly into the caller's arrays. Storing them in members first
+    ; (this.outAdditions = additions) relies on JS array-by-reference aliasing,
+    ; which does NOT hold for C++ std::vector (assignment copies) — the caller's
+    ; arrays would stay empty. Pushing to the params keeps them mutable refs.
     fn getDiff:void (additions:[int] removals:[int]) {
-        this.outAdditions = additions
-        this.outRemovals = removals
         def al:int this.currentCount
         def bl:int this.previousCount
         def j 0
@@ -92,7 +92,7 @@ class CannonOverlapKeeper {
                 }
             }
             if (found == false) {
-                this.unpackAndPush(this.outAdditions keyA)
+                this.unpackAndPush(additions keyA)
             }
             i = (i + 1)
         }
@@ -115,7 +115,7 @@ class CannonOverlapKeeper {
                 }
             }
             if (found2 == false) {
-                this.unpackAndPush(this.outRemovals keyB)
+                this.unpackAndPush(removals keyB)
             }
             i = (i + 1)
         }


### PR DESCRIPTION
The Cannon physics port passed all 89 tests under the ES6/JS backend but mis-behaved (and crashed) when compiled to native C++ via -l=cpp — which is what the SDL/native launcher runs. This is why the launcher showed the balls NaN out and vanish ("fall through the floor") while JS was fine.

Four distinct backend-semantics gaps, all now fixed:

1. Lang.rgr `/` operator (the launcher bug): the C++ writer emits a whole-number double literal without its decimal (1.0 -> 1), so `(1.0 / 60.0)` became `1 / 60` = integer division = 0 in C++. That zeroed the SPOOK timestep h, making a = 4/(h*..) = inf and cascading the whole contact solver to NaN. Fixed by casting both `/` operands to (double) in the C++ template, so int/int and whole-double division both yield float division as Ranger specifies. Applied to compiler and bin Lang.rgr.

2. cannon_mat3 solveInto/reverseInto: the Gaussian-elimination loop computed the pivot row as i = (k - n) giving 0,-1,-2, so it indexed eqns[-5]/eqns[-7]. JS returns undefined (silent NaN); C++ throws out_of_range and aborts. The intended pivot is 0,1,2 -> i = (n - k) with inner bounds `< n`. Also fixed reverseInto's extract, which transposed the result. Mat3.invert had been a false pass (NaN >= eps is false, so the check never tripped); it now verifies a real inverse.

3. cannon_overlap_keeper.getDiff wrote results through a member alias (this.outAdditions = additions) then pushed to the member. JS aliases arrays; C++ std::vector assignment copies, so the caller's arrays stayed empty. Now pushes directly into the params (emitted as std::vector<int>&), which propagates in both backends.

4. cannon_narrowphase_test read a local `result` after assigning it to this.narrowphase.result — same JS-only aliasing assumption. Now reads the narrowphase's own member, which is what sphereSphere fills.

Verified: `npm run engine:physics:test` (ES6) = 89/89, and the same suite compiled with -l=cpp + g++ = 89/89 with no crashes. Contact/friction/rest now settle in native C++ instead of NaN.


Claude-Session: https://claude.ai/code/session_015Ze3CPC18WGj9gFW4GW9C8