### PR TITLE
fix(deploy-pi): install and link libcurl for game_sdl

### DIFF
--- a/gallery/game_engine/README.md
+++ b/gallery/game_engine/README.md
@@ -746,7 +746,7 @@ npm run build:raspberry
 # → dist/raspberry-pi5/ (pong + games/menu/scripting + lib + compiler + DEPLOY.md)
 ```
 
-Kopioi `pong` Pi:lle ja aja HDMI-konsolissa. SDL-pelit (`engine:game-sdl`) vaativat Pi:llä `libsdl2-dev` ja käännöksen laitteella tai vastaavan cross-buildin. GPU-present (GLES2) on oletus SDL-hostissa; sheet-spritet voidaan renderöidä GPU-overlayna.
+Kopioi `pong` Pi:lle ja aja HDMI-konsolissa. SDL-pelit (`engine:game-sdl`) vaativat Pi:llä `libsdl2-dev` + `libcurl4-openssl-dev` (Sponza / `three_http`) ja käännöksen laitteella tai vastaavan cross-buildin. GPU-present (GLES2) on oletus SDL-hostissa; sheet-spritet voidaan renderöidä GPU-overlayna.
 
 ## LPC-spritesheet-compositor
 

--- a/gallery/game_engine/scripts/build-game-sdl.sh
+++ b/gallery/game_engine/scripts/build-game-sdl.sh
@@ -7,6 +7,8 @@
 # Requirements:
 #   * a C++17 compiler (clang++ or g++)
 #   * SDL2 development libraries
+#   * libcurl (three_http / Sponza glTF fetch). macOS: brew install curl
+#     Debian/Pi: sudo apt-get install libcurl4-openssl-dev
 #
 # Usage:
 #   ./gallery/game_engine/scripts/build-game-sdl.sh [--run [tsx] [frames]]
@@ -62,6 +64,16 @@ elif command -v sdl2-config >/dev/null 2>&1; then
   SDL_FLAGS="$(sdl2-config --cflags --libs)"
 else
   echo "error: SDL2 not found. Install libsdl2-dev (or brew install sdl2 on macOS)" >&2
+  exit 1
+fi
+
+# libcurl: game_sdl_runner imports three_gltf_* → three_http (Sponza over HTTPS).
+if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists libcurl; then
+  CURL_FLAGS="$(pkg-config --cflags --libs libcurl)"
+elif command -v curl-config >/dev/null 2>&1; then
+  CURL_FLAGS="$(curl-config --cflags --libs)"
+else
+  echo "error: libcurl not found. Install libcurl4-openssl-dev (or brew install curl on macOS)" >&2
   exit 1
 fi
 
@@ -123,7 +135,7 @@ for src in "$WASM_BRIDGE" "${WASM3_SOURCES[@]}"; do
   WASM3_OBJS+=("$obj")
 done
 # shellcheck disable=SC2086
-"$CXX" $CXX_OPT -std=c++17 "${WASM3_CFLAGS[@]}" "$CPP_FILE" "${WASM3_OBJS[@]}" -o "$BIN_FILE" $SDL_FLAGS $GL_FLAGS -lm
+"$CXX" $CXX_OPT -std=c++17 "${WASM3_CFLAGS[@]}" "$CPP_FILE" "${WASM3_OBJS[@]}" -o "$BIN_FILE" $SDL_FLAGS $GL_FLAGS $CURL_FLAGS -lm
 
 echo "==> 3/3 Ready: $BIN_FILE"
 

--- a/gallery/game_engine/scripts/deploy-pi.sh
+++ b/gallery/game_engine/scripts/deploy-pi.sh
@@ -23,8 +23,9 @@
 #   ~/initservice.sh  — wires lxsession / labwc / crontab -> ~/start.sh
 #   ~/start.sh        — launch game (manual or from autostart)
 #
-# Copies the local repo (excl. node_modules/tmp), installs deps on the Pi,
-# runs npm install + compile + engine:game-sdl build (-O3).
+# Copies the local repo (excl. node_modules/tmp), installs deps on the Pi
+# (incl. libcurl4-openssl-dev for three_http / Sponza), runs npm install +
+# compile + engine:game-sdl build (-O3).
 
 set -euo pipefail
 
@@ -145,8 +146,9 @@ CAMEOF
 echo "==> 1/$TOTAL_STEPS Test SSH: $TARGET"
 ssh -o ConnectTimeout=10 -o BatchMode=yes "$TARGET" 'echo ok; uname -m'
 
-echo "==> 2/$TOTAL_STEPS Install Pi packages (clang, SDL2, GLES2, alsa-utils, x11-utils, node, npm)"
-ssh "$TARGET" 'sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git clang pkg-config libsdl2-dev libgles2-mesa-dev alsa-utils x11-utils nodejs npm v4l-utils'
+echo "==> 2/$TOTAL_STEPS Install Pi packages (clang, SDL2, GLES2, libcurl, alsa-utils, x11-utils, node, npm)"
+# libcurl4-openssl-dev: game_sdl pulls three_http (Sponza glTF fetch) which #includes <curl/curl.h>
+ssh "$TARGET" 'sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git clang pkg-config libsdl2-dev libgles2-mesa-dev libcurl4-openssl-dev alsa-utils x11-utils nodejs npm v4l-utils'
 
 echo "==> Check USB camera (pose game input)"
 if check_usb_camera; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`bash gallery/game_engine/scripts/deploy-pi.sh pelit` failed on the Pi at the native g++ step:

```text
game_sdl.cpp:21:11: fatal error: curl/curl.h: No such file or directory
```

## Cause

The Sponza launcher path (`render=sponza`) imports `three_gltf_*` → `three_http`, which emits `#include <curl/curl.h>` into `game_sdl`. Deploy installed SDL2/GLES2 but not the libcurl headers, and `build-game-sdl.sh` did not link `-lcurl`.

## Fix

- Install `libcurl4-openssl-dev` in `deploy-pi.sh` apt packages
- Resolve and link `CURL_FLAGS` in `build-game-sdl.sh` (same pattern as `build-sponza-sdl.sh`)
- Note the dependency in the game-engine README

## Workaround (without this PR)

On the Pi:

```bash
sudo apt-get install -y libcurl4-openssl-dev
```

Then re-run deploy (or `cd ~/ranger && npm run engine:game-sdl`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f175f055-95ed-42a5-8cd5-0eda91004442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f175f055-95ed-42a5-8cd5-0eda91004442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

