### PR TITLE
Make Breakout paddle wider for easier ball control

### DIFF
--- a/gallery/game_engine/games/breakout/breakout_bricks.tsx
+++ b/gallery/game_engine/games/breakout/breakout_bricks.tsx
@@ -12,6 +12,14 @@ export const BRICK_GAP = 4;
 export const BRICK_TOP = 52;
 export const BRICK_LEFT = 40;
 
+/** Paddle size — wider than classic breakout for easier ball control. */
+export const PADDLE_W = 88;
+export const PADDLE_H = 10;
+export const PADDLE_HALF = 44;
+export const PLAYFIELD_W = 480;
+export const PADDLE_MIN_X = PADDLE_HALF;
+export const PADDLE_MAX_X = PLAYFIELD_W - PADDLE_HALF;
+
 export const BRICK_COLORS: RgbColor[] = [
   { r: 220, g: 80, b: 90 },
   { r: 255, g: 150, b: 60 },

--- a/gallery/game_engine/games/breakout/index.tsx
+++ b/gallery/game_engine/games/breakout/index.tsx
@@ -17,6 +17,11 @@
 import {
   BRICK_COUNT,
   BRICK_W,
+  PADDLE_H,
+  PADDLE_HALF,
+  PADDLE_MAX_X,
+  PADDLE_MIN_X,
+  PADDLE_W,
   brickId,
   brickX,
   brickY,
@@ -35,7 +40,7 @@ function screens(): string[] {
 function sprites(props) {
   if (props.screen == "play") {
     const list = buildBrickSprites();
-    list.push({ id: "paddle", kind: "rect", w: 64, h: 10, r: 120, g: 220, b: 255 });
+    list.push({ id: "paddle", kind: "rect", w: PADDLE_W, h: PADDLE_H, r: 120, g: 220, b: 255 });
     list.push({ id: "ball", kind: "circle", rad: 5, r: 245, g: 245, b: 130 });
     return list;
   }
@@ -121,8 +126,8 @@ function updatePlay(s: BreakoutState, props: EventProps): BreakoutState {
 
   if (props.left || props.up) { px = px - dt * 0.34; }
   if (props.right || props.down) { px = px + dt * 0.34; }
-  if (px < 40) { px = 40; }
-  if (px > 440) { px = 440; }
+  if (px < PADDLE_MIN_X) { px = PADDLE_MIN_X; }
+  if (px > PADDLE_MAX_X) { px = PADDLE_MAX_X; }
 
   bx = bx + vx * dt;
   by = by + vy * dt;
@@ -132,11 +137,11 @@ function updatePlay(s: BreakoutState, props: EventProps): BreakoutState {
   if (bx > 474) { bx = 474; vx = 0 - vx; events.push(soundEvent("wall")); }
 
   if (by > py - 14) {
-    if (bx > px - 36) {
-      if (bx < px + 36) {
+    if (bx > px - PADDLE_HALF) {
+      if (bx < px + PADDLE_HALF) {
         by = py - 14;
         vy = 0 - vy;
-        const hit = (bx - px) / 36.0;
+        const hit = (bx - px) / PADDLE_HALF;
         vx = vx + hit * 0.06;
         events.push(soundEvent("bounce"));
       }

--- a/gallery/game_engine/scripting/breakout.game.tsx
+++ b/gallery/game_engine/scripting/breakout.game.tsx
@@ -16,6 +16,11 @@
 import {
   BRICK_COUNT,
   BRICK_W,
+  PADDLE_H,
+  PADDLE_HALF,
+  PADDLE_MAX_X,
+  PADDLE_MIN_X,
+  PADDLE_W,
   brickId,
   brickX,
   brickY,
@@ -33,7 +38,7 @@ function screens(): string[] {
 function sprites(props: { screen: string }): SpriteDef[] {
   if (props.screen == "play") {
     const list = buildBrickSprites();
-    list.push({ id: "paddle", kind: "rect", w: 64, h: 10, r: 120, g: 220, b: 255 });
+    list.push({ id: "paddle", kind: "rect", w: PADDLE_W, h: PADDLE_H, r: 120, g: 220, b: 255 });
     list.push({ id: "ball", kind: "circle", rad: 5, r: 245, g: 245, b: 130 });
     return list;
   }
@@ -119,8 +124,8 @@ function updatePlay(s: BreakoutState, props: EventProps): BreakoutState {
 
   if (props.left || props.up) { px = px - dt * 0.34; }
   if (props.right || props.down) { px = px + dt * 0.34; }
-  if (px < 40) { px = 40; }
-  if (px > 440) { px = 440; }
+  if (px < PADDLE_MIN_X) { px = PADDLE_MIN_X; }
+  if (px > PADDLE_MAX_X) { px = PADDLE_MAX_X; }
 
   bx = bx + vx * dt;
   by = by + vy * dt;
@@ -130,11 +135,11 @@ function updatePlay(s: BreakoutState, props: EventProps): BreakoutState {
   if (bx > 474) { bx = 474; vx = 0 - vx; }
 
   if (by > py - 14) {
-    if (bx > px - 36) {
-      if (bx < px + 36) {
+    if (bx > px - PADDLE_HALF) {
+      if (bx < px + PADDLE_HALF) {
         by = py - 14;
         vy = 0 - vy;
-        const hit = (bx - px) / 36.0;
+        const hit = (bx - px) / PADDLE_HALF;
         vx = vx + hit * 0.06;
       }
     }

--- a/gallery/game_engine/scripting/breakout_bricks.tsx
+++ b/gallery/game_engine/scripting/breakout_bricks.tsx
@@ -12,6 +12,14 @@ export const BRICK_GAP = 4;
 export const BRICK_TOP = 52;
 export const BRICK_LEFT = 40;
 
+/** Paddle size — wider than classic breakout for easier ball control. */
+export const PADDLE_W = 88;
+export const PADDLE_H = 10;
+export const PADDLE_HALF = 44;
+export const PLAYFIELD_W = 480;
+export const PADDLE_MIN_X = PADDLE_HALF;
+export const PADDLE_MAX_X = PLAYFIELD_W - PADDLE_HALF;
+
 export const BRICK_COLORS: RgbColor[] = [
   { r: 220, g: 80, b: 90 },
   { r: 255, g: 150, b: 60 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the Breakout paddle noticeably wider so it is easier for children to hit the ball.

- Paddle width increased from **64 → 88** pixels (~37% wider)
- Collision hitbox and movement bounds updated to match the new size
- Constants centralized in `breakout_bricks.tsx` so sprite size, physics, and wall clamping stay in sync

## Files changed

- `gallery/game_engine/games/breakout/breakout_bricks.tsx` — paddle constants
- `gallery/game_engine/games/breakout/index.tsx` — launcher game uses constants
- `gallery/game_engine/scripting/breakout_bricks.tsx` — test fixture constants
- `gallery/game_engine/scripting/breakout.game.tsx` — headless runner fixture uses constants

## Testing

- Breakout runner smoke test reaches `screen=gameOver` with expected entity count (52)
- Audio assertion in `tests/game-runner.test.ts` reports `audioPlays=0` in this environment (pre-existing / unrelated to paddle size)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f74a5-fe80-7251-8a13-7e9dfedfe621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f74a5-fe80-7251-8a13-7e9dfedfe621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

