### PR TITLE
Add game-controller support to Sponza with standard Web Gamepad API

### DIFF
--- a/gallery/game_engine/THREE.md
+++ b/gallery/game_engine/THREE.md
@@ -128,7 +128,11 @@ renders it with WebGL. Editing the shown script hot-reloads the scene.
 - **Sponza** streams the real model + 69 textures at runtime from the Khronos
   sample-assets repo (they are too big to bundle), with a loading progress bar;
   expect a short download + in-browser decode on first open. Controls: WASD /
-  arrows move, drag to look.
+  arrows move, drag to look — or a **game controller** (left stick / d-pad move,
+  right stick looks, LB/RB fly down/up). The scene reads it via the standard
+  `navigator.getGamepads()` from its `update()` loop (the host fills that Web
+  Gamepad API surface — see §9.2 on host-filled runtime, no engine-specific name),
+  and the viewer polls the browser's real gamepad each frame.
 
 ### Native SDL binaries (macOS / Linux / Raspberry Pi)
 ```
@@ -154,7 +158,8 @@ the **Tests** category:
 - `games/teapot` — `render=three` (host = OrbitControls + lil-gui panel + procedural
   env cube / UV texture plumbing).
 - `games/sponza` — `render=sponza` (host = first-person controls + async glTF +
-  the `ThreeSponzaScene` GI-bake plumbing; WASD / arrows move, drag to look).
+  the `ThreeSponzaScene` GI-bake plumbing; WASD / arrows / gamepad move, drag or
+  right-stick to look).
 
 Every example — cube, cubes, teapot, Sponza — reconciles through the **one** generic
 `ThreeTsxBridge`; the hosts are pure plumbing (controls, GUI, async loading, the

--- a/gallery/game_engine/games/sponza/index.tsx
+++ b/gallery/game_engine/games/sponza/index.tsx
@@ -120,3 +120,35 @@ export function setProbeCountX(v) { params.countX = v; probes.countX = v; }
 export function setProbeCountY(v) { params.countY = v; probes.countY = v; }
 export function setProbeCountZ(v) { params.countZ = v; probes.countZ = v; }
 export function setShowProbes(on) { params.showProbes = on; }
+
+// --- game-controller navigation ---------------------------------------------
+// Read the STANDARD Web Gamepad API — the same navigator.getGamepads() call a
+// browser three.js scene makes — from the per-frame update loop, and return a
+// movement/look intent the host folds into the first-person camera alongside WASD
+// and mouse-look. Left stick + d-pad move, right stick looks, shoulder buttons
+// (LB/RB) fly down/up. Nothing here is engine-specific: any pad-reading three.js
+// snippet works because the host fills navigator.getGamepads() like the browser.
+export function update(dt) {
+  const pads = navigator.getGamepads();
+  const p = pads[0];
+  let moveX = 0;
+  let moveZ = 0;
+  let moveY = 0;
+  let lookX = 0;
+  let lookY = 0;
+  if (p) {
+    const ax = p.axes;
+    const b = p.buttons;
+    moveX = ax[0];        // left stick X -> strafe
+    moveZ = 0 - ax[1];    // left stick Y (up = -1) -> forward
+    lookX = ax[2];        // right stick -> look
+    lookY = ax[3];
+    if (b[12] && b[12].pressed) { moveZ = 1; }       // d-pad up
+    if (b[13] && b[13].pressed) { moveZ = 0 - 1; }   // d-pad down
+    if (b[14] && b[14].pressed) { moveX = 0 - 1; }   // d-pad left
+    if (b[15] && b[15].pressed) { moveX = 1; }       // d-pad right
+    if (b[4] && b[4].pressed) { moveY = 0 - 1; }     // LB -> down
+    if (b[5] && b[5].pressed) { moveY = 1; }         // RB -> up
+  }
+  return { moveX: moveX, moveZ: moveZ, moveY: moveY, lookX: lookX, lookY: lookY };
+}

--- a/gallery/game_engine/three/src/run.sh
+++ b/gallery/game_engine/three/src/run.sh
@@ -115,6 +115,10 @@ run_tsx_poc three_teapot_tsx_test
 # scene's params drives the Ranger scene live).
 run_tsx_poc three_sponza_scene_test
 run_tsx_poc three_sponza_tsx_test
+# Sponza game-controller navigation (value-parity path): the scene reads the
+# STANDARD navigator.getGamepads() from its update() loop and returns a movement/
+# look intent the host applies to the first-person camera — no engine-specific name.
+run_tsx_poc three_gamepad_nav_test
 # The teapot's lil-gui panel (demo/host layer): EVG panel rasterise + hit-testing.
 run_tsx_poc three_gui_overlay_test
 

--- a/gallery/game_engine/three/src/three_first_person_controls.rgr
+++ b/gallery/game_engine/three/src/three_first_person_controls.rgr
@@ -32,6 +32,20 @@ class ThreeFirstPersonControls {
     def moveUp:boolean false
     def moveDown:boolean false
 
+    ; analog movement/look intents (host sets these each frame from a gamepad's
+    ; sticks — range −1..1). They ADD to the digital key intents above, so
+    ; keyboard + controller drive the same camera; both default 0 (a scene with no
+    ; pad, or the native SDL runner that only sets the booleans, is unaffected).
+    ; forward = along the look dir, right = strafe, up = world +Y.
+    def axisForward:double 0.0
+    def axisRight:double 0.0
+    def axisUp:double 0.0
+    ; look-stick rate (−1..1); integrated as degrees/sec so it is frame-rate
+    ; independent, unlike handleLook's per-pixel pointer deltas.
+    def lookAxisX:double 0.0
+    def lookAxisY:double 0.0
+    def lookRateDeg:double 120.0
+
     ; reusable scratch so update allocates nothing per frame.
     def _dir:ThreeVector3 (new ThreeVector3)
     def _right:ThreeVector3 (new ThreeVector3)
@@ -54,6 +68,29 @@ class ThreeFirstPersonControls {
         lon = lonDeg
         lat = latDeg
         this.clampLat()
+        return this
+    }
+    ; host: set the per-frame analog movement axes (gamepad sticks, −1..1).
+    fn setMoveAxes:ThreeFirstPersonControls (fwd:double right:double up:double) {
+        axisForward = fwd
+        axisRight = right
+        axisUp = up
+        return this
+    }
+    ; host: set the per-frame analog look axes (right stick, −1..1).
+    fn setLookAxes:ThreeFirstPersonControls (x:double y:double) {
+        lookAxisX = x
+        lookAxisY = y
+        return this
+    }
+    ; host: clear the analog axes (called each frame before re-applying the pad, so
+    ; a released stick stops the camera instead of coasting on last frame's value).
+    fn clearAxes:ThreeFirstPersonControls () {
+        axisForward = 0.0
+        axisRight = 0.0
+        axisUp = 0.0
+        lookAxisX = 0.0
+        lookAxisY = 0.0
         return this
     }
 
@@ -108,47 +145,54 @@ class ThreeFirstPersonControls {
         if (key == "F") { moveDown = on }
     }
 
-    ; integrate one frame: move along look/right/up by speed*delta, then re-aim.
+    ; integrate one frame: apply the look-stick, move along look/right/up by
+    ; speed*delta, then re-aim.
     fn update:void (delta:double) {
         if (hasCamera == false) {
             return
         }
+        ; look stick: rotate lon/lat at lookRateDeg degrees/sec (frame-rate safe),
+        ; before deriving the look direction so this frame's move uses the new aim.
+        if (lookAxisX != 0.0) {
+            lon = (lon - ((lookAxisX * lookRateDeg) * delta))
+        }
+        if (lookAxisY != 0.0) {
+            lat = (lat - ((lookAxisY * lookRateDeg) * delta))
+            this.clampLat()
+        }
+
         def step:double (movementSpeed * delta)
         this.lookDirection()
         ; right = worldUp x dir  (+X when looking +Z)
         _right.crossVectors(_worldUp _dir)
         _right.normalize()
 
+        ; combine digital keys (±1) and analog sticks into one scalar per axis, so
+        ; keyboard and controller drive the same camera. Opposed keys cancel, as
+        ; before (a held w+s nets 0).
+        def fwd:double axisForward
+        if moveForward { fwd = (fwd + 1.0) }
+        if moveBackward { fwd = (fwd - 1.0) }
+        def rgt:double axisRight
+        if moveRight { rgt = (rgt + 1.0) }
+        if moveLeft { rgt = (rgt - 1.0) }
+        def upv:double axisUp
+        if moveUp { upv = (upv + 1.0) }
+        if moveDown { upv = (upv - 1.0) }
+
         def px:double camera.position.x
         def py:double camera.position.y
         def pz:double camera.position.z
 
-        if moveForward {
-            px = (px + (_dir.x * step))
-            py = (py + (_dir.y * step))
-            pz = (pz + (_dir.z * step))
-        }
-        if moveBackward {
-            px = (px - (_dir.x * step))
-            py = (py - (_dir.y * step))
-            pz = (pz - (_dir.z * step))
-        }
-        if moveRight {
-            px = (px + (_right.x * step))
-            py = (py + (_right.y * step))
-            pz = (pz + (_right.z * step))
-        }
-        if moveLeft {
-            px = (px - (_right.x * step))
-            py = (py - (_right.y * step))
-            pz = (pz - (_right.z * step))
-        }
-        if moveUp {
-            py = (py + step)
-        }
-        if moveDown {
-            py = (py - step)
-        }
+        px = (px + ((_dir.x * step) * fwd))
+        py = (py + ((_dir.y * step) * fwd))
+        pz = (pz + ((_dir.z * step) * fwd))
+
+        px = (px + ((_right.x * step) * rgt))
+        py = (py + ((_right.y * step) * rgt))
+        pz = (pz + ((_right.z * step) * rgt))
+
+        py = (py + (step * upv))
 
         camera.position.set(px py pz)
         ; re-aim at position + look direction.

--- a/gallery/game_engine/three/src/three_first_person_controls_test.rgr
+++ b/gallery/game_engine/three/src/three_first_person_controls_test.rgr
@@ -72,6 +72,39 @@ class ThreeFirstPersonControlsTest {
         ck.near("up moves +Y" cam.position.y 1.0)
         fpc.keyUp("r")
 
+        ; --- analog (gamepad) axes: add to the digital keys, drive the same camera ---
+        def cam3:ThreePerspectiveCamera (new ThreePerspectiveCamera)
+        cam3.position.set(0.0 0.0 0.0)
+        def fpc3:ThreeFirstPersonControls (new ThreeFirstPersonControls)
+        fpc3.setCamera(cam3)
+        fpc3.setMovementSpeed(2.0)
+        fpc3.setLook(0.0 0.0)
+        ; full forward on the left stick for 0.5s at speed 2 -> +1 along Z
+        fpc3.setMoveAxes(1.0 0.0 0.0)
+        fpc3.update(0.5)
+        ck.near("analog forward moves +Z" cam3.position.z 1.0)
+        ck.near("analog forward keeps x" cam3.position.x 0.0)
+        ; half strafe right for 0.5s -> +0.5 along X
+        fpc3.clearAxes()
+        fpc3.setMoveAxes(0.0 0.5 0.0)
+        fpc3.update(0.5)
+        ck.near("analog half-strafe moves +0.5 X" cam3.position.x 0.5)
+        ; cleared axes coast to a stop (no further movement)
+        fpc3.clearAxes()
+        fpc3.update(0.5)
+        ck.near("cleared axes stop X" cam3.position.x 0.5)
+        ck.near("cleared axes stop Z" cam3.position.z 1.0)
+
+        ; look stick rotates lon at lookRateDeg deg/sec (default 120): +1 for 0.5s -> -60
+        def cam4:ThreePerspectiveCamera (new ThreePerspectiveCamera)
+        cam4.position.set(0.0 0.0 0.0)
+        def fpc4:ThreeFirstPersonControls (new ThreeFirstPersonControls)
+        fpc4.setCamera(cam4)
+        fpc4.setLook(0.0 0.0)
+        fpc4.setLookAxes(1.0 0.0)
+        fpc4.update(0.5)
+        ck.near("look stick rotates lon -60 in 0.5s" fpc4.lon (0.0 - 60.0))
+
         ; look: pointer dx rotates lon by -dx*lookSpeed
         def fpc2:ThreeFirstPersonControls (new ThreeFirstPersonControls)
         fpc2.setLookSpeed(0.1)

--- a/gallery/game_engine/three/tsx/sponza.tsx
+++ b/gallery/game_engine/three/tsx/sponza.tsx
@@ -120,3 +120,35 @@ export function setProbeCountX(v) { params.countX = v; probes.countX = v; }
 export function setProbeCountY(v) { params.countY = v; probes.countY = v; }
 export function setProbeCountZ(v) { params.countZ = v; probes.countZ = v; }
 export function setShowProbes(on) { params.showProbes = on; }
+
+// --- game-controller navigation ---------------------------------------------
+// Read the STANDARD Web Gamepad API — the same navigator.getGamepads() call a
+// browser three.js scene makes — from the per-frame update loop, and return a
+// movement/look intent the host folds into the first-person camera alongside WASD
+// and mouse-look. Left stick + d-pad move, right stick looks, shoulder buttons
+// (LB/RB) fly down/up. Nothing here is engine-specific: any pad-reading three.js
+// snippet works because the host fills navigator.getGamepads() like the browser.
+export function update(dt) {
+  const pads = navigator.getGamepads();
+  const p = pads[0];
+  let moveX = 0;
+  let moveZ = 0;
+  let moveY = 0;
+  let lookX = 0;
+  let lookY = 0;
+  if (p) {
+    const ax = p.axes;
+    const b = p.buttons;
+    moveX = ax[0];        // left stick X -> strafe
+    moveZ = 0 - ax[1];    // left stick Y (up = -1) -> forward
+    lookX = ax[2];        // right stick -> look
+    lookY = ax[3];
+    if (b[12] && b[12].pressed) { moveZ = 1; }       // d-pad up
+    if (b[13] && b[13].pressed) { moveZ = 0 - 1; }   // d-pad down
+    if (b[14] && b[14].pressed) { moveX = 0 - 1; }   // d-pad left
+    if (b[15] && b[15].pressed) { moveX = 1; }       // d-pad right
+    if (b[4] && b[4].pressed) { moveY = 0 - 1; }     // LB -> down
+    if (b[5] && b[5].pressed) { moveY = 1; }         // RB -> up
+  }
+  return { moveX: moveX, moveZ: moveZ, moveY: moveY, lookX: lookX, lookY: lookY };
+}

--- a/gallery/game_engine/three/tsx/three_gamepad_nav_test.rgr
+++ b/gallery/game_engine/three/tsx/three_gamepad_nav_test.rgr
@@ -1,0 +1,120 @@
+; ==============================================================================
+; three_gamepad_nav_test — the interpreter side of Sponza's controller support.
+; ==============================================================================
+; Proves the value-parity path: the host registers a live __gamepadState global,
+; the navigator prelude exposes the STANDARD navigator.getGamepads() to the scene,
+; and an interpreted update(dt) reads the pad and returns a movement/look intent
+; that the host reads back — with NO engine-specific gamepad name. Compile to ES6
+; and run under Node; prints per-check PASS/FAIL and "ALL PASS".
+; ==============================================================================
+
+Import "../../../pdf_writer/src/jsx/ComponentEngine.rgr"
+Import "../../../pdf_writer/src/jsx/EvalValue.rgr"
+
+class GpCheck {
+    def passed:int 0
+    def failed:int 0
+    fn ok:void (name:string cond:boolean) {
+        if cond {
+            passed = (passed + 1)
+            print ("  PASS " + name)
+        } {
+            failed = (failed + 1)
+            print ("  FAIL " + name)
+        }
+    }
+    fn near:void (name:string got:double want:double) {
+        def d:double (got - want)
+        if (d < 0.0) { d = (0.0 - d) }
+        if (d < 0.000001) {
+            passed = (passed + 1)
+            print ("  PASS " + name + " (" + (to_string got) + ")")
+        } {
+            failed = (failed + 1)
+            print ("  FAIL " + name + " got=" + (to_string got) + " want=" + (to_string want))
+        }
+    }
+}
+
+class GamepadNavTest {
+    ; one standard-shaped pad: axes [lx,ly,rx,ry], 16 buttons, optional d-pad-up.
+    sfn buildPad:EvalValue (lx:double ly:double rx:double ry:double dpadUp:boolean) {
+        def axes:[EvalValue]
+        push axes (EvalValue.number(lx))
+        push axes (EvalValue.number(ly))
+        push axes (EvalValue.number(rx))
+        push axes (EvalValue.number(ry))
+        def buttons:[EvalValue]
+        def i:int 0
+        while (i < 16) {
+            def pressed:boolean false
+            if (i == 12) { pressed = dpadUp }
+            def bk:[string]
+            def bv:[EvalValue]
+            push bk "pressed"
+            push bv (EvalValue.boolean(pressed))
+            push buttons (EvalValue.object(bk bv))
+            i = (i + 1)
+        }
+        def k:[string]
+        def v:[EvalValue]
+        push k "axes"
+        push v (EvalValue.array(axes))
+        push k "buttons"
+        push v (EvalValue.array(buttons))
+        def pads:[EvalValue]
+        push pads (EvalValue.object(k v))
+        return (EvalValue.array(pads))
+    }
+
+    sfn m@(main):void () {
+        def ck:GpCheck (new GpCheck)
+        print "== gamepad nav (interpreter) =="
+
+        def engine:ComponentEngine (new ComponentEngine())
+        engine.quiet = true
+        def emptyPads:[EvalValue]
+        engine.registerGlobal("__gamepadState" (EvalValue.array(emptyPads)))
+
+        ; the exact navigator prelude the Sponza host prepends + the scene's update().
+        def src:string ""
+        src = (src + "const navigator = { getGamepads: () => __gamepadState };\n")
+        src = (src + "export function update(dt) {\n")
+        src = (src + "  const pads = navigator.getGamepads();\n")
+        src = (src + "  const p = pads[0];\n")
+        src = (src + "  let moveX = 0; let moveZ = 0; let moveY = 0; let lookX = 0; let lookY = 0;\n")
+        src = (src + "  if (p) {\n")
+        src = (src + "    const ax = p.axes; const b = p.buttons;\n")
+        src = (src + "    moveX = ax[0]; moveZ = 0 - ax[1]; lookX = ax[2]; lookY = ax[3];\n")
+        src = (src + "    if (b[12] && b[12].pressed) { moveZ = 1; }\n")
+        src = (src + "  }\n")
+        src = (src + "  return { moveX: moveX, moveZ: moveZ, moveY: moveY, lookX: lookX, lookY: lookY };\n")
+        src = (src + "}\n")
+        engine.loadScript(src)
+
+        ; the host gates on scriptHasFunction("update") (engine.getGlobal + isFunction)
+        ; to let the scene drive; assert that gate resolves to the exported update().
+        ck.ok("host sees exported update()" ((engine.getGlobal("update")).isFunction()))
+
+        ; case 1 — no pad connected -> navigator.getGamepads() is [], all zero.
+        def r0:EvalValue (engine.callFunction("update" (EvalValue.number(0.016))))
+        ck.near("no-pad moveX" ((r0.getMember("moveX")).toNumber()) 0.0)
+        ck.near("no-pad moveZ" ((r0.getMember("moveZ")).toNumber()) 0.0)
+
+        ; case 2 — left stick strafe 0.5, forward (y=-1 -> +1), right stick x 0.25.
+        engine.registerGlobal("__gamepadState" (GamepadNavTest.buildPad(0.5 (0.0 - 1.0) 0.25 0.0 false)))
+        def r1:EvalValue (engine.callFunction("update" (EvalValue.number(0.016))))
+        ck.near("stick moveX" ((r1.getMember("moveX")).toNumber()) 0.5)
+        ck.near("stick moveZ (fwd)" ((r1.getMember("moveZ")).toNumber()) 1.0)
+        ck.near("stick lookX" ((r1.getMember("lookX")).toNumber()) 0.25)
+
+        ; case 3 — d-pad up overrides forward to +1 even with a centred stick.
+        engine.registerGlobal("__gamepadState" (GamepadNavTest.buildPad(0.0 0.0 0.0 0.0 true)))
+        def r2:EvalValue (engine.callFunction("update" (EvalValue.number(0.016))))
+        ck.near("dpad-up moveZ" ((r2.getMember("moveZ")).toNumber()) 1.0)
+
+        print "== summary =="
+        print ("passed=" + (to_string ck.passed) + " failed=" + (to_string ck.failed))
+        if (ck.failed == 0) { print "ALL PASS" } { print "SOME FAILED" }
+    }
+}

--- a/gallery/game_engine/web/build.mjs
+++ b/gallery/game_engine/web/build.mjs
@@ -224,7 +224,7 @@ const SPONZA_TSX_SCENES = [
     scriptDir: "gallery/game_engine/three/tsx",
     script: "sponza.tsx",
     facade: "gallery/game_engine/three/tsx/three.tsx",
-    controls: "The light-probe-volume Sponza scene, its code run in the interpreter on the Ranger Three clone + WebGL: WASD / arrows to move, drag to look. Real glTF model + textures stream in from the Khronos sample assets. Sky, cast shadows and per-probe GI. Edit sponza.tsx (sun angle, probe counts) and it hot-reloads.",
+    controls: "The light-probe-volume Sponza scene, its code run in the interpreter on the Ranger Three clone + WebGL: WASD / arrows / game controller to move, drag or right-stick to look. Real glTF model + textures stream in from the Khronos sample assets. Sky, cast shadows and per-probe GI. Edit sponza.tsx (sun angle, probe counts) and it hot-reloads.",
   },
 ];
 

--- a/gallery/game_engine/web/src/sponza-tsx-viewer.js
+++ b/gallery/game_engine/web/src/sponza-tsx-viewer.js
@@ -9,7 +9,8 @@
 // are far too big to bundle): the model bytes go into the engine VFS, and each
 // JPEG/PNG is canvas-decoded and streamed into the host's materials (the Ranger
 // host can't decode JPEG/PNG in the browser). First-person controls: WASD / arrows
-// move, drag to look.
+// move, drag to look; a game controller also navigates — the scene reads the
+// standard navigator.getGamepads() (host-filled) from its update() loop.
 // ============================================================================
 
 (function (root) {
@@ -135,7 +136,7 @@
       }
       this.host.frame();
       this._hideProgress();
-      this.onStatus("Sponza — WASD / arrows to move, drag to look", true);
+      this.onStatus("Sponza — WASD / arrows / gamepad to move, drag or right-stick to look", true);
       this._wireInput();
       this._loaded = true;
       this._resume();
@@ -184,7 +185,31 @@
     setMuted() {}
     stop() { if (this._raf) cancelAnimationFrame(this._raf); this._raf = 0; }
     _resume() { if (!this._raf) this._raf = requestAnimationFrame(this._tick); }
-    _tick() { this.host.frame(); this._raf = requestAnimationFrame(this._tick); }
+    _tick() { this._pollPad(); this.host.frame(); this._raf = requestAnimationFrame(this._tick); }
+
+    // Poll the browser's real navigator.getGamepads() and hand the first connected
+    // pad to the host (standard layout: axes 0/1 = left stick, 2/3 = right stick;
+    // buttons by standard index). The host both exposes this to the scene via its
+    // own navigator.getGamepads() and drives the first-person camera from it. A
+    // small deadzone keeps a centred stick from drifting.
+    _pollPad() {
+      const nav = typeof navigator !== "undefined" ? navigator : null;
+      if (!nav || !nav.getGamepads || !this.host.setPad) return;
+      const pads = nav.getGamepads();
+      let g = null;
+      for (let i = 0; i < pads.length; i++) { if (pads[i]) { g = pads[i]; break; } }
+      if (!g) { this.host.setPad(0, 0, 0, 0, 0, 0); return; }
+      const dz = (v) => (Math.abs(v) < 0.12 ? 0 : v);
+      const ax = g.axes || [];
+      const lx = dz(ax[0] || 0), ly = dz(ax[1] || 0);
+      const rx = dz(ax[2] || 0), ry = dz(ax[3] || 0);
+      let mask = 0;
+      const b = g.buttons || [];
+      for (let i = 0; i < 16; i++) {
+        if (b[i] && (b[i].pressed || b[i].value > 0.5)) mask |= (1 << i);
+      }
+      this.host.setPad(1, lx, ly, rx, ry, mask);
+    }
 
     dispose() {
       this.stop();

--- a/gallery/game_engine/web/web_sponza_tsx_host.rgr
+++ b/gallery/game_engine/web/web_sponza_tsx_host.rgr
@@ -47,6 +47,20 @@ class WebSponzaTsxHost {
     def h:int 500
     def dt:double 0.033
 
+    ; --- gamepad snapshot -----------------------------------------------------
+    ; The viewer polls the browser's navigator.getGamepads() each frame and hands
+    ; the first connected pad here. The host then (a) fills the interpreted scene's
+    ; navigator.getGamepads() from it (so scene code reads the STANDARD Web Gamepad
+    ; API, no engine-specific name), and (b) drives the first-person camera from it.
+    ; buttons is a bitmask keyed by the standard Gamepad button indices
+    ; (0=A,1=B,2=X,3=Y,4=LB,5=RB,8=Back,9=Start,12=up,13=down,14=left,15=right).
+    def padConnected:boolean false
+    def padLX:double 0.0
+    def padLY:double 0.0
+    def padRX:double 0.0
+    def padRY:double 0.0
+    def padButtons:int 0
+
     ; interpreter globals the scene reads (THREE constants + window size).
     fn registerGlobals:void (winW:int winH:int dpr:double) {
         def tk:[string]
@@ -74,6 +88,12 @@ class WebSponzaTsxHost {
         push wk "devicePixelRatio"
         push wv (EvalValue.number(dpr))
         engine.registerGlobal("window" (EvalValue.object(wk wv)))
+
+        ; live gamepad state behind the standard navigator.getGamepads() (see the
+        ; navigator prelude in loadScene). Registered empty so navigator.getGamepads()
+        ; returns [] before the first pad frame instead of an undefined global.
+        def emptyPads:[EvalValue]
+        engine.registerGlobal("__gamepadState" (EvalValue.array(emptyPads)))
     }
 
     fn setupGL:boolean (canvasId:string) {
@@ -133,7 +153,12 @@ class WebSponzaTsxHost {
         renderer.setToneMappingExposure(0.09)
         renderer.setShadowMapEnabled(true)
 
-        def src:string ((facadeSrc + "\n") + sponzaSrc)
+        ; Standard-runtime prelude: expose navigator.getGamepads() to the scene,
+        ; reading the host-filled __gamepadState. The engine holds no gamepad-
+        ; specific name — the scene uses the same Web Gamepad API a browser three.js
+        ; example does, and the host just supplies the live values (as it does window).
+        def navPrelude:string "const navigator = { getGamepads: () => __gamepadState };\n"
+        def src:string (((navPrelude + facadeSrc) + "\n") + sponzaSrc)
         engine.loadScript(src)
         engine.callFunction("init" (EvalValue.null()))
         ; generic bridge reconciles the declared scene graph (sky, sun+shadow, the
@@ -224,6 +249,10 @@ class WebSponzaTsxHost {
         if (ready == false) {
             return
         }
+        ; refresh the scene-visible navigator.getGamepads(), then let the pad drive
+        ; the camera, then integrate the controls (keyboard/mouse + analog pad).
+        this.refreshGamepadGlobal()
+        this.applyPadToControls()
         sponza.update(dt)
         renderer.render(gbridge.scene gbridge.camera)
     }
@@ -244,6 +273,120 @@ class WebSponzaTsxHost {
     }
     fn look:void (dx:double dy:double) {
         sponza.fpc.handleLook(dx dy)
+    }
+
+    ; --- gamepad input (routed from the viewer; standard Gamepad API layout) ----
+    ; connected!=0 with the left/right stick axes (−1..1) and a standard-index
+    ; button bitmask. Called once per frame before frame().
+    fn setPad:void (connected:int lx:double ly:double rx:double ry:double buttons:int) {
+        padConnected = (connected != 0)
+        padLX = lx
+        padLY = ly
+        padRX = rx
+        padRY = ry
+        padButtons = buttons
+    }
+
+    ; is the standard Gamepad button at index `idx` (0-based) set in the mask?
+    fn padBit:boolean (idx:int) {
+        def bit:int 1
+        def i:int 0
+        while (i < idx) {
+            bit = (bit * 2)
+            i = (i + 1)
+        }
+        return ((bit_and padButtons bit) != 0)
+    }
+
+    ; does the interpreted scene export a function of this name?
+    fn scriptHasFunction:boolean (name:string) {
+        def f:EvalValue (engine.getGlobal(name))
+        return (f.isFunction())
+    }
+    fn numOr:double (obj:EvalValue key:string dflt:double) {
+        def v:EvalValue (obj.getMember(key))
+        if (v.isNumber()) {
+            return (v.toNumber())
+        }
+        return dflt
+    }
+
+    ; Build the standard-shaped array navigator.getGamepads() returns for the scene:
+    ; [{connected,index,id,mapping,axes:[lx,ly,rx,ry],buttons:[{pressed,value}×16]}]
+    ; when a pad is connected, else [] — exactly what a browser three.js scene reads.
+    fn buildGamepadState:EvalValue () {
+        def pads:[EvalValue]
+        if padConnected {
+            def axes:[EvalValue]
+            push axes (EvalValue.number(padLX))
+            push axes (EvalValue.number(padLY))
+            push axes (EvalValue.number(padRX))
+            push axes (EvalValue.number(padRY))
+            def buttons:[EvalValue]
+            def i:int 0
+            while (i < 16) {
+                def pressed:boolean (this.padBit(i))
+                def val:double 0.0
+                if pressed { val = 1.0 }
+                def bk:[string]
+                def bv:[EvalValue]
+                push bk "pressed"
+                push bv (EvalValue.boolean(pressed))
+                push bk "value"
+                push bv (EvalValue.number(val))
+                push buttons (EvalValue.object(bk bv))
+                i = (i + 1)
+            }
+            def k:[string]
+            def v:[EvalValue]
+            push k "connected"
+            push v (EvalValue.boolean(true))
+            push k "index"
+            push v (EvalValue.fromInt(0))
+            push k "id"
+            push v (EvalValue.string("gamepad"))
+            push k "mapping"
+            push v (EvalValue.string("standard"))
+            push k "axes"
+            push v (EvalValue.array(axes))
+            push k "buttons"
+            push v (EvalValue.array(buttons))
+            push pads (EvalValue.object(k v))
+        }
+        return (EvalValue.array(pads))
+    }
+    fn refreshGamepadGlobal:void () {
+        engine.registerGlobal("__gamepadState" (this.buildGamepadState()))
+    }
+
+    ; Per frame: let the scene read the pad (navigator.getGamepads()) and return a
+    ; nav intent {moveX,moveZ,moveY,lookX,lookY}, applied to the first-person
+    ; controls (the analog axes ADD to keyboard/mouse). If the scene exports no
+    ; update(), map the raw pad here so a controller navigates any Sponza scene.
+    fn applyPadToControls:void () {
+        sponza.fpc.clearAxes()
+        if (this.scriptHasFunction("update")) {
+            def intent:EvalValue (engine.callFunction("update" (EvalValue.number(dt))))
+            if (intent.isObject()) {
+                sponza.fpc.setMoveAxes((this.numOr(intent "moveZ" 0.0)) (this.numOr(intent "moveX" 0.0)) (this.numOr(intent "moveY" 0.0)))
+                sponza.fpc.setLookAxes((this.numOr(intent "lookX" 0.0)) (this.numOr(intent "lookY" 0.0)))
+                return
+            }
+        }
+        if (padConnected == false) {
+            return
+        }
+        def fwd:double (0.0 - padLY)
+        def rgt:double padLX
+        if (this.padBit(12)) { fwd = 1.0 }
+        if (this.padBit(13)) { fwd = (0.0 - 1.0) }
+        if (this.padBit(14)) { rgt = (0.0 - 1.0) }
+        if (this.padBit(15)) { rgt = 1.0 }
+        def up:double 0.0
+        if (this.padBit(4)) { up = (0.0 - 1.0) }
+        if (this.padBit(5)) { up = 1.0 }
+        sponza.fpc.setMoveAxes(fwd rgt up)
+        sponza.fpc.setLookAxes(padRX padRY)
     }
 
     ; the scene is first-person animated, so every frame may differ.


### PR DESCRIPTION
## Summary
Adds full game-controller navigation support to the Sponza scene using the standard Web Gamepad API. The host polls the browser's `navigator.getGamepads()` each frame and exposes it to the interpreted scene code, allowing controller input to drive both the first-person camera and custom scene logic without any engine-specific gamepad naming.

## Key Changes

- **WebSponzaTsxHost**: Added gamepad state tracking (`padConnected`, `padLX/Y`, `padRX/Y`, `padButtons`) and methods to:
  - `setPad()`: Receive gamepad input from the viewer
  - `buildGamepadState()`: Construct a standard-shaped Gamepad object for the scene
  - `refreshGamepadGlobal()`: Update the `__gamepadState` global each frame
  - `applyPadToControls()`: Apply gamepad input to the first-person camera, with fallback to raw stick mapping if the scene doesn't export an `update()` function
  - Added a navigator prelude that exposes `navigator.getGamepads()` to scene code, reading from the host-filled `__gamepadState` global

- **ThreeFirstPersonControls**: Extended to support analog stick input:
  - Added `axisForward`, `axisRight`, `axisUp` for movement sticks (−1..1 range)
  - Added `lookAxisX`, `lookAxisY` for look stick with configurable `lookRateDeg` (default 120°/sec)
  - Added `setMoveAxes()`, `setLookAxes()`, `clearAxes()` methods
  - Modified `update()` to integrate analog axes with digital keys (both drive the same camera)
  - Look stick rotation is frame-rate independent

- **Sponza scene** (`sponza.tsx` and `index.tsx`): Added `update(dt)` function that:
  - Reads the standard `navigator.getGamepads()` API
  - Maps left stick + d-pad to movement, right stick to look
  - Maps shoulder buttons (LB/RB) to vertical flight
  - Returns a movement/look intent object for the host to apply

- **sponza-tsx-viewer.js**: Added `_pollPad()` method to:
  - Poll the browser's real `navigator.getGamepads()` each frame
  - Apply a small deadzone (0.12) to prevent stick drift
  - Convert button states to a bitmask
  - Pass the gamepad state to the host via `setPad()`

- **Test coverage**: Added `three_gamepad_nav_test.rgr` to verify the value-parity path (scene reads standard API, returns intent, host applies it)

- **Documentation**: Updated THREE.md to document controller support and the standard Web Gamepad API integration

## Implementation Details

The design maintains **no engine-specific gamepad naming**: the scene code uses the exact same `navigator.getGamepads()` call a browser three.js example would use. The host simply fills that standard API surface with live values (as it does for `window`), making any standard gamepad-reading three.js snippet work without modification. The viewer polls the real browser gamepad, the host exposes it to the scene, and optionally applies it to the camera if the scene doesn't provide custom `update()` logic.

https://claude.ai/code/session_0141z2DJN1L8aZDkMfvgGW8Y