### PR TITLE
fix(three): CubeCamera C++ temp vector binding for capture

### DIFF
--- a/gallery/game_engine/three/src/three_cube_camera.rgr
+++ b/gallery/game_engine/three/src/three_cube_camera.rgr
@@ -38,14 +38,26 @@ class ThreeCubeCamera {
         return v
     }
 
+    ; Copy n bytes src→dst. Callers must pass locals (not call results): C++ emits
+    ; buffer params as non-const std::vector& and rejects temporaries.
+    sfn copyInto:void (src:buffer dst:buffer n:int) {
+        def i:int 0
+        while (i < n) {
+            buffer_set dst i (buffer_get src i)
+            i = (i + 1)
+        }
+    }
+
     ; capture the scene at (px,py,pz) into a faceSize² cube using `renderer`.
-    ; Bind renderer.raw() to a local before storing — C++ emits buffer params as
-    ; non-const std::vector& and rejects temporaries (cannot bind lvalue ref).
-    ; setFace stores that copy so the next face's render cannot overwrite it.
+    ; Bind raw()/faceBuffer() to locals before copyInto (C++ temp-ref rule).
+    ; Byte-copy into the face buffer, then setFace so C++ value-return from
+    ; faceBuffer is written back; ES6 needs the copy because raw() aliases the
+    ; renderer color buffer (storing it would let the next face overwrite all).
     sfn capture:ThreeCubeMap (renderer:ThreeWebGLRenderer scene:ThreeScene px:double py:double pz:double faceSize:int) {
         def cube:ThreeCubeMap (ThreeCubeMap.create(faceSize))
         def cam:ThreePerspectiveCamera (new ThreePerspectiveCamera)
         cam.setPerspective(90.0 1.0 0.1 100000.0)
+        def bytes:int ((faceSize * faceSize) * 3)
         def face:int 0
         while (face < 6) {
             def fwd:ThreeVector3 (ThreeCubeCamera.faceForward(face))
@@ -56,7 +68,9 @@ class ThreeCubeCamera {
             renderer.setSize(faceSize faceSize)
             renderer.render(scene cam)
             def src:buffer (renderer.raw())
-            cube.setFace(face src)
+            def dst:buffer (cube.faceBuffer(face))
+            ThreeCubeCamera.copyInto(src dst bytes)
+            cube.setFace(face dst)
             face = (face + 1)
         }
         return cube

--- a/gallery/game_engine/three/src/three_cube_camera.rgr
+++ b/gallery/game_engine/three/src/three_cube_camera.rgr
@@ -38,20 +38,14 @@ class ThreeCubeCamera {
         return v
     }
 
-    sfn copyInto:void (src:buffer dst:buffer n:int) {
-        def i:int 0
-        while (i < n) {
-            buffer_set dst i (buffer_get src i)
-            i = (i + 1)
-        }
-    }
-
     ; capture the scene at (px,py,pz) into a faceSize² cube using `renderer`.
+    ; Bind renderer.raw() to a local before storing — C++ emits buffer params as
+    ; non-const std::vector& and rejects temporaries (cannot bind lvalue ref).
+    ; setFace stores that copy so the next face's render cannot overwrite it.
     sfn capture:ThreeCubeMap (renderer:ThreeWebGLRenderer scene:ThreeScene px:double py:double pz:double faceSize:int) {
         def cube:ThreeCubeMap (ThreeCubeMap.create(faceSize))
         def cam:ThreePerspectiveCamera (new ThreePerspectiveCamera)
         cam.setPerspective(90.0 1.0 0.1 100000.0)
-        def bytes:int ((faceSize * faceSize) * 3)
         def face:int 0
         while (face < 6) {
             def fwd:ThreeVector3 (ThreeCubeCamera.faceForward(face))
@@ -61,7 +55,8 @@ class ThreeCubeCamera {
             cam.lookAt((px + fwd.x) (py + fwd.y) (pz + fwd.z))
             renderer.setSize(faceSize faceSize)
             renderer.render(scene cam)
-            ThreeCubeCamera.copyInto((renderer.raw()) (cube.faceBuffer(face)) bytes)
+            def src:buffer (renderer.raw())
+            cube.setFace(face src)
             face = (face + 1)
         }
         return cube

--- a/gallery/game_engine/three/src/three_gl.rgr
+++ b/gallery/game_engine/three/src/three_gl.rgr
@@ -103,7 +103,9 @@ function __rglEnd(){ }
                   (imp "<vector>") (imp "<string>") (imp "<cstdint>") (imp "<cmath>")
 (create_polyfill "
 #if defined(__APPLE__)
+#ifndef GL_SILENCE_DEPRECATION
 #define GL_SILENCE_DEPRECATION
+#endif
 #include <OpenGL/gl3.h>
 #elif defined(__arm__) || defined(__aarch64__)
 #include <GLES2/gl2.h>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Native `game_sdl` / Sponza SDL builds fail in `ThreeCubeCamera::capture` with:

```
non-const lvalue reference to type 'vector<...>' cannot bind to a temporary
ThreeCubeCamera::copyInto(renderer->raw(), cube->faceBuffer(face), bytes);
```

Ranger emits buffer parameters as `std::vector<uint8_t>&`, so call-site temporaries from `raw()` / `faceBuffer()` are illegal in C++.

## Fix

- Bind `renderer.raw()` and `cube.faceBuffer(face)` to locals before `copyInto`.
- Call `cube.setFace(face dst)` after the copy so C++ value-return from `faceBuffer` is written back.
- Keep the byte-copy (needed on ES6: `raw()` aliases the renderer color buffer; storing it would let later faces overwrite earlier ones).
- Guard `#define GL_SILENCE_DEPRECATION` with `#ifndef` (macOS `-DGL_SILENCE_DEPRECATION` macro-redefine warning).

## Verification

- [x] ES6 `three_cube_camera_test` — 5/5 ALL PASS
- [x] C++ `three_cube_camera_test` — compiles with g++ and 5/5 ALL PASS
- [x] Full `./gallery/game_engine/scripts/build-game-sdl.sh` — succeeds (no temp-ref error; `#ifndef GL_SILENCE_DEPRECATION` in generated cpp)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5583a760-4c22-417c-8076-5898bbad3536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5583a760-4c22-417c-8076-5898bbad3536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

