### PR TITLE
cpp: return stored buffers by reference so accessors match ES6 semantics

### DIFF
--- a/bin/output.js
+++ b/bin/output.js
@@ -18739,6 +18739,8 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
     constructor() {
       super()
       this.header_created = false;
+      this.buf_ret_seen = false;
+      this.buf_ret_all_safe = true;
     }
     lineEnding () {
       return ";";
@@ -19032,6 +19034,111 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           wr.out(this.getTypeString2(t_name, ctx), false);
           break;
       };
+    };
+    cppMemberPathOf (node) {
+      if ( (node.ns.length) >= 2 ) {
+        let path = "";
+        for ( let i = 0; i < node.ns.length; i++) {
+          var part = node.ns[i];
+          if ( i > 0 ) {
+            path = path + ".";
+          }
+          path = path + part;
+        };
+        return path;
+      }
+      if ( (node.vref.length) > 0 ) {
+        const idx = node.vref.indexOf(".");
+        if ( idx > 0 ) {
+          return node.vref;
+        }
+      }
+      return "";
+    };
+    cppReturnIsSafeBufferLvalue (retValue) {
+      const path = this.cppMemberPathOf(retValue);
+      if ( (path.length) > 0 ) {
+        if ( (path.indexOf("this.")) == 0 ) {
+          return true;
+        }
+      }
+      if ( retValue.expression ) {
+        if ( (retValue.children.length) >= 2 ) {
+          const head = retValue.getFirst();
+          const op = head.vref;
+          if ( (op == "itemAt") || (op == "get") ) {
+            const container = retValue.getSecond();
+            const cpath = this.cppMemberPathOf(container);
+            if ( (cpath.length) > 0 ) {
+              if ( (cpath.indexOf("this.")) == 0 ) {
+                return true;
+              }
+            }
+          }
+        }
+      }
+      return false;
+    };
+    cppScanBufferReturns (node) {
+      if ( (typeof(node.lambda_ctx) !== "undefined" && node.lambda_ctx != null )  ) {
+        return;
+      }
+      if ( node.expression ) {
+        if ( (node.children.length) > 0 ) {
+          const first = node.getFirst();
+          if ( first.vref == "return" ) {
+            if ( (node.children.length) >= 2 ) {
+              this.buf_ret_seen = true;
+              const retValue = node.getSecond();
+              if ( false == this.cppReturnIsSafeBufferLvalue(retValue) ) {
+                this.buf_ret_all_safe = false;
+              }
+            } else {
+              this.buf_ret_seen = true;
+              this.buf_ret_all_safe = false;
+            }
+          }
+        }
+      }
+      for ( let i = 0; i < node.children.length; i++) {
+        var child = node.children[i];
+        this.cppScanBufferReturns(child);
+      };
+    };
+    cppBufferReturnByRef (variant, ctx) {
+      if ( typeof(variant.nameNode) === "undefined" ) {
+        return false;
+      }
+      const node = variant.nameNode;
+      if ( node.hasFlag("optional") ) {
+        return false;
+      }
+      let v_type = node.value_type;
+      if ( ((v_type == 10) || (v_type == 11)) || (v_type == 0) ) {
+        v_type = node.typeNameAsType(ctx);
+      }
+      if ( node.eval_type != 0 ) {
+        v_type = node.eval_type;
+      }
+      if ( ((v_type != 16) && (v_type != 17)) && (v_type != 18) ) {
+        return false;
+      }
+      if ( typeof(variant.fnBody) === "undefined" ) {
+        return false;
+      }
+      this.buf_ret_seen = false;
+      this.buf_ret_all_safe = true;
+      this.cppScanBufferReturns(variant.fnBody);
+      if ( this.buf_ret_seen == false ) {
+        return false;
+      }
+      return this.buf_ret_all_safe;
+    };
+    async writeReturnTypeDef (variant, ctx, wr) {
+      await this.writeTypeDef(variant.nameNode, ctx, wr);
+      if ( this.cppBufferReturnByRef(variant, ctx) ) {
+        wr.out("&", false);
+      }
     };
     async WriteVRef (node, ctx, wr) {
       if ( node.vref == "this" ) {
@@ -19619,7 +19726,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           wr.out("/* static methods */ ", true);
         }
         wr.out("static ", false);
-        await this.writeTypeDef(variant.nameNode, ctx, wr);
+        await this.writeReturnTypeDef(variant, ctx, wr);
         wr.out((" " + variant.compiledName) + "(", false);
         await this.writeArgsDef(variant, ctx, wr);
         wr.out(");", true);
@@ -19644,7 +19751,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           if ( cl.is_inherited ) {
             wr.out("virtual ", false);
           }
-          await this.writeTypeDef(variant_1.nameNode, ctx, wr);
+          await this.writeReturnTypeDef(variant_1, ctx, wr);
           wr.out((" " + variant_1.compiledName) + "(", false);
           await this.writeArgsDef(variant_1, ctx, wr);
           wr.out(");", true);
@@ -19809,7 +19916,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         if ( variant.nameNode.hasFlag("main") ) {
           continue;
         }
-        await this.writeTypeDef(variant.nameNode, ctx, wr);
+        await this.writeReturnTypeDef(variant, ctx, wr);
         wr.out(" ", false);
         wr.out((" " + cl.name) + "::", false);
         wr.out(variant.compiledName + "(", false);
@@ -19829,7 +19936,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         const mVs = ( cl.method_variants.hasOwnProperty(fnVar) ? cl.method_variants[fnVar] : undefined );
         for ( let i_7 = 0; i_7 < mVs.variants.length; i_7++) {
           var variant_1 = mVs.variants[i_7];
-          await this.writeTypeDef(variant_1.nameNode, ctx, wr);
+          await this.writeReturnTypeDef(variant_1, ctx, wr);
           wr.out(" ", false);
           wr.out((" " + cl.name) + "::", false);
           wr.out(variant_1.compiledName + "(", false);

--- a/compiler/ng_RangerCppClassWriter.rgr
+++ b/compiler/ng_RangerCppClassWriter.rgr
@@ -2,6 +2,11 @@ class RangerCppClassWriter {
   Extends (RangerGenericClassWriter)
   def compiler:LiveCompiler
   def header_created:boolean false
+  ; Accumulators used while scanning a buffer-returning method body to decide
+  ; whether its return type can be emitted as a C++ reference (see
+  ; cppBufferReturnByRef).
+  def buf_ret_seen:boolean false
+  def buf_ret_all_safe:boolean true
 
   fn lineEnding:string () {
     return ";"
@@ -336,6 +341,148 @@ class RangerCppClassWriter {
       }
     }
   }
+
+  ; ---------------------------------------------------------------------------
+  ; Buffer return-by-reference analysis
+  ;
+  ; Ranger `buffer` semantics are reference semantics (ES6 returns the live,
+  ; stored buffer). The C++ backend already passes buffers to parameters by
+  ; reference (`std::vector<uint8_t>&`) so in-place writes are visible to the
+  ; caller. The return side must match: a buffer accessor that hands back a
+  ; stored buffer must return a reference to it, otherwise C++ copies it into a
+  ; temporary that (a) cannot bind to a non-const reference parameter and
+  ; (b) silently drops writes. We only do this when every `return` in the body
+  ; yields a safe lvalue that outlives the call — a class member field or an
+  ; element of a member container. Fresh allocations / locals / computed values
+  ; keep value-return semantics so we never return a dangling reference.
+  ; ---------------------------------------------------------------------------
+
+  ; Build a dotted member path (e.g. "this.faces") from a node's namespace, or
+  ; "" when the node is not a simple member access.
+  fn cppMemberPathOf:string (node:CodeNode) {
+    if ((array_length node.ns) >= 2) {
+      def path:string ""
+      for node.ns part:string i {
+        if (i > 0) {
+          path = (path + ".")
+        }
+        path = (path + part)
+      }
+      return path
+    }
+    if ((strlen node.vref) > 0) {
+      def idx:int (indexOf node.vref ".")
+      if (idx > 0) {
+        return node.vref
+      }
+    }
+    return ""
+  }
+
+  ; True when a returned expression refers to storage that outlives the call and
+  ; is therefore safe to hand back as a C++ reference: `this.field`, or an
+  ; element of a member container `(itemAt this.field idx)` / `(get this.field key)`.
+  fn cppReturnIsSafeBufferLvalue:boolean (retValue:CodeNode) {
+    def path:string (this.cppMemberPathOf(retValue))
+    if ((strlen path) > 0) {
+      if ((indexOf path "this.") == 0) {
+        return true
+      }
+    }
+    if retValue.expression {
+      if ((array_length retValue.children) >= 2) {
+        def head:CodeNode (retValue.getFirst())
+        def op:string head.vref
+        if ((op == "itemAt") || (op == "get")) {
+          def container:CodeNode (retValue.getSecond())
+          def cpath:string (this.cppMemberPathOf(container))
+          if ((strlen cpath) > 0) {
+            if ((indexOf cpath "this.") == 0) {
+              return true
+            }
+          }
+        }
+      }
+    }
+    return false
+  }
+
+  ; Walk a function body recording whether it contains any `return <value>` and
+  ; whether every such return is a safe buffer lvalue. Nested lambdas own their
+  ; own returns, so we do not descend into them.
+  fn cppScanBufferReturns:void (node:CodeNode) {
+    if (!null? node.lambda_ctx) {
+      return
+    }
+    if node.expression {
+      if ((array_length node.children) > 0) {
+        def first:CodeNode (node.getFirst())
+        if (first.vref == "return") {
+          if ((array_length node.children) >= 2) {
+            buf_ret_seen = true
+            def retValue:CodeNode (node.getSecond())
+            if (false == (this.cppReturnIsSafeBufferLvalue(retValue))) {
+              buf_ret_all_safe = false
+            }
+          } {
+            ; bare `return` inside a buffer-returning fn — treat conservatively.
+            buf_ret_seen = true
+            buf_ret_all_safe = false
+          }
+        }
+      }
+    }
+    for node.children child:CodeNode i {
+      this.cppScanBufferReturns(child)
+    }
+  }
+
+  ; Decide whether `variant`'s (buffer) return type should be emitted as a C++
+  ; reference. Returns true only for buffer/int_buffer/double_buffer returns
+  ; whose every return statement is a safe stored-buffer lvalue.
+  fn cppBufferReturnByRef:boolean (variant:RangerAppFunctionDesc ctx:RangerAppWriterContext) {
+    if (null? variant.nameNode) {
+      return false
+    }
+    def node:CodeNode (unwrap variant.nameNode)
+    ; Optional buffers are wrapped (shared_ptr / optional), not a bare vector.
+    if (node.hasFlag("optional")) {
+      return false
+    }
+    ; Resolve the return value type the same way writeTypeDef does.
+    def v_type:RangerNodeType node.value_type
+    if ((v_type == RangerNodeType.Object) || (v_type == RangerNodeType.VRef) || (v_type == RangerNodeType.NoType)) {
+      v_type = (node.typeNameAsType(ctx))
+    }
+    if (node.eval_type != RangerNodeType.NoType) {
+      v_type = node.eval_type
+    }
+    if (((v_type != RangerNodeType.Buffer) && (v_type != RangerNodeType.IntBuffer)) && (v_type != RangerNodeType.DoubleBuffer)) {
+      return false
+    }
+    if (null? variant.fnBody) {
+      return false
+    }
+    buf_ret_seen = false
+    buf_ret_all_safe = true
+    this.cppScanBufferReturns((unwrap variant.fnBody))
+    if (buf_ret_seen == false) {
+      return false
+    }
+    return buf_ret_all_safe
+  }
+
+  ; Emit a method's return type, adding `&` when the buffer it returns aliases
+  ; stored storage (so it matches ES6 reference semantics and binds to non-const
+  ; reference parameters). Used for both the header declaration and the
+  ; out-of-line definition so the two signatures always agree.
+  fn writeReturnTypeDef:void (variant:RangerAppFunctionDesc ctx:RangerAppWriterContext wr:CodeWriter) {
+    this.writeTypeDef((unwrap variant.nameNode) ctx wr)
+    if (this.cppBufferReturnByRef(variant ctx)) {
+      wr.out("&" false)
+    }
+  }
+
   fn WriteVRef:void (node:CodeNode ctx:RangerAppWriterContext wr:CodeWriter) {
     if (node.vref == "this") {
       ; std::dynamic_pointer_cast<RangerAppClassDesc>
@@ -1004,7 +1151,7 @@ std::vector<T> r_make_vector_from_array( const T (&data)[N] )
         wr.out("/* static methods */ " true)
       }
       wr.out("static " false)
-      this.writeTypeDef( (unwrap variant.nameNode) ctx wr)
+      this.writeReturnTypeDef(variant ctx wr)
       wr.out(((" " + variant.compiledName) + "(") false)
       this.writeArgsDef(variant ctx wr)
       wr.out(");" true)
@@ -1026,8 +1173,8 @@ std::vector<T> r_make_vector_from_array( const T (&data)[N] )
       for mVs.variants variant:RangerAppFunctionDesc i {
         if(cl.is_inherited) {
           wr.out("virtual " false)
-        }        
-        this.writeTypeDef((unwrap variant.nameNode) ctx wr)
+        }
+        this.writeReturnTypeDef(variant ctx wr)
         wr.out(((" " + variant.compiledName) + "(") false)
         this.writeArgsDef(variant ctx wr)
         wr.out(");" true)
@@ -1234,7 +1381,7 @@ std::vector<T> r_make_vector_from_array( const T (&data)[N] )
         continue _
       }
       ; wr.out("static " false)
-      this.writeTypeDef( (unwrap variant.nameNode ) ctx wr)
+      this.writeReturnTypeDef(variant ctx wr)
       wr.out(" " false)
       wr.out(((" " + cl.name) + "::") false)
       wr.out((variant.compiledName + "(") false)
@@ -1252,7 +1399,7 @@ std::vector<T> r_make_vector_from_array( const T (&data)[N] )
     for cl.defined_variants fnVar:string i {
       def mVs:RangerAppMethodVariants (get cl.method_variants fnVar)
       for mVs.variants variant:RangerAppFunctionDesc i {
-        this.writeTypeDef((unwrap variant.nameNode )ctx wr)
+        this.writeReturnTypeDef(variant ctx wr)
         ;this.writePtr((unwrap variant.nameNode ) ctx wr)
         wr.out(" " false)
         wr.out(((" " + cl.name) + "::") false)

--- a/tests/codegen-cpp.test.ts
+++ b/tests/codegen-cpp.test.ts
@@ -216,4 +216,35 @@ describe("C++ Code Generation", () => {
       expect(result.code).not.toContain("const std::vector<int>& arr");
     });
   });
+
+  describe("Buffer return by reference", () => {
+    // A buffer accessor that returns a stored buffer (member field or an element
+    // of a member container) must return `std::vector<uint8_t>&`, matching ES6
+    // reference semantics: the result aliases the stored buffer and binds to
+    // non-const reference parameters. A method returning a freshly allocated
+    // local buffer must keep value semantics so it never returns a dangling
+    // reference. Regression for the ThreeCubeMap::faceBuffer / copyInto build
+    // break (temporary std::vector could not bind to std::vector<uint8_t>&).
+    it("should return a reference for a stored-buffer accessor and value for a fresh local", () => {
+      const result = getGeneratedCppCode(
+        `${FIXTURES_DIR}/buffer_return_ref.rgr`
+      );
+      expect(result.success, `Failed: ${result.error}`).toBe(true);
+      // accessor returning a member-container element -> reference return
+      expect(result.code).toContain(
+        "std::vector<uint8_t>&  CubeMap::faceBuffer( int face )"
+      );
+      // freshly-allocated local -> value return (no dangling reference)
+      expect(result.code).toContain(
+        "std::vector<uint8_t>  CubeMap::makeScratch( int n )"
+      );
+      expect(result.code).not.toContain(
+        "std::vector<uint8_t>&  CubeMap::makeScratch"
+      );
+      // header declaration must match the out-of-line definition
+      expect(result.code).toContain(
+        "std::vector<uint8_t>& faceBuffer( int face );"
+      );
+    });
+  });
 });

--- a/tests/fixtures/buffer_return_ref.rgr
+++ b/tests/fixtures/buffer_return_ref.rgr
@@ -1,0 +1,50 @@
+; Regression fixture for buffer return-by-reference in the C++ backend.
+; A buffer accessor that hands back a stored buffer (a member field, or an
+; element of a member container) must return `std::vector<uint8_t>&` so the
+; result aliases the stored buffer (ES6 reference semantics) and binds to
+; non-const reference parameters. A method that returns a freshly allocated
+; local buffer must keep value-return semantics (no dangling reference).
+class CubeMap {
+    def size:int 2
+    def faces:[buffer]
+
+    sfn create:CubeMap (size:int) {
+        def c:CubeMap (new CubeMap)
+        c.size = size
+        def i:int 0
+        while (i < 6) {
+            push c.faces (buffer_alloc ((size * size) * 3))
+            i = (i + 1)
+        }
+        return c
+    }
+
+    ; SAFE: element of a member container -> reference return
+    fn faceBuffer:buffer (face:int) {
+        return (itemAt this.faces face)
+    }
+
+    ; UNSAFE: freshly allocated local -> value return (must not dangle)
+    fn makeScratch:buffer (n:int) {
+        def b:buffer (buffer_alloc n)
+        return b
+    }
+}
+
+class Worker {
+    sfn copyInto:void (src:buffer dst:buffer n:int) {
+        def i:int 0
+        while (i < n) {
+            buffer_set dst i (buffer_get src i)
+            i = (i + 1)
+        }
+    }
+
+    sfn run:void () {
+        def cube:CubeMap (CubeMap.create(2))
+        def src:buffer (buffer_alloc 12)
+        ; Passing the accessor result directly to a non-const buffer& parameter
+        ; only compiles if faceBuffer returns a reference.
+        Worker.copyInto(src (cube.faceBuffer(0)) 12)
+    }
+}


### PR DESCRIPTION
Ranger `buffer` semantics are reference semantics — an accessor returns the live stored buffer, and writes through it are visible to the owner. The C++ backend already passes buffers to parameters by reference (`std::vector<uint8_t>&`), but the return side still copied: a buffer accessor emitted a by-value `std::vector<uint8_t>` return, producing a temporary that

  * cannot bind to a non-const `std::vector<uint8_t>&` parameter (hard compile error — the ThreeCubeMap::faceBuffer / ThreeCubeCamera::copyInto build break in the SDL target), and
  * silently drops writes even where it does compile.

Emit the return type as `std::vector<uint8_t>&` when every `return` in the method body yields a safe lvalue that outlives the call — a class member field (`return this.field`) or an element of a member container (`return (itemAt this.field idx)` / `(get this.field key)`). Fresh allocations, locals, and computed values keep value-return semantics, so we never hand back a dangling reference. The decision is applied through a single writeReturnTypeDef helper used by both the header declaration and the out-of-line definition, so the two signatures always agree.

Adds a codegen-cpp regression test plus fixture covering the accessor (reference return) and a fresh-local returner (value return).


Claude-Session: https://claude.ai/code/session_01Km2Y35aRV1B4ctCedZgnMn