### PR TITLE
docs(game_engine): sketch v2 game rewrites on ranger:* APIs

### DIFF
--- a/gallery/game_engine/v2/games/README.md
+++ b/gallery/game_engine/v2/games/README.md
@@ -1,64 +1,67 @@
 # games — selected titles on the v2 API
 
-Re-implemented (or lightly copied) games that run **only** against the v2
-engine (`ranger:core` / `ranger:three` / `ranger:cannon` or `ranger_wasm`).
+Re-implemented sketches that target **only** v2 modules:
 
-**Plan phase:** 12 (smoke ports may start once modules exist) — see
+`ranger:core` / `ranger:2d` / `ranger:three` / `ranger:cannon`  
+(or `ranger_wasm::{core,two_d,three,cannon}`).
+
+They are **not expected to compile** until the registry and façades exist.
+Comments mark `MISSING` / `TODO` / `HACK` where the API or content is incomplete.
+
+**Plan phase:** 12 (sketches may land earlier) — see
 [`CODE_CLEANUP_PLAN.md`](../../CODE_CLEANUP_PLAN.md).
 
-## Binding decisions
+## Policy
 
-- D-MODULES
-- D-SYNC (live objects — no reconciler)
+1. **New folder, old tree kept.** Ports live under `v2/games/<name>/`.
+   Top-level [`../../games/`](../../games/) is **not deleted**.
+2. **Select, don’t bulk-move.** Prefer small high-signal titles.
+3. **Copy or rewrite by maturity.** These ports are mostly **rewrites** onto
+   `runtime.start(Game)` (v1 used GameRunner `sprites()` / Three `window` loops).
+4. **No v1 engine imports.**
 
-## Policy (read this first)
-
-1. **New folder, old tree kept.** Ports live here under `v2/games/<name>/`.
-   The top-level [`../../games/`](../../games/) tree is **not deleted**.
-2. **Select, don’t bulk-move.** Games are still small — pick titles that
-   exercise the API; do not dump every v1 game in at once.
-3. **Copy or rewrite by maturity.**
-   - **Copy + adapt** when the old game is already close to the target API.
-   - **Rewrite** a thin version when the old code depends on the reconciler,
-     `three/tsx` private trees, or other v1 bridges.
-4. **No v1 engine imports.** v1 sources are a gameplay reference only.
-
-## To implement
-
-- Maintain a short selection list below as titles are chosen
-- One subdirectory per game: `v2/games/<name>/` with its own README
-- Prefer `runtime.start(Game)` / `ranger_wasm::export_game!` shapes from
-  CODE_CLEANUP worked examples
-
-## Candidate selection (fill in as ports start)
+## Selection
 
 | v1 source | v2 path | Strategy | Status |
 |-----------|---------|----------|--------|
-| *(none yet)* | | copy / rewrite | pending |
+| `games/pong` | [`pong/`](./pong/) | rewrite → `ranger:2d` shapes + action maps | sketch |
+| `games/breakout` | [`breakout/`](./breakout/) | rewrite → retained bricks | sketch |
+| `games/invaders` | [`invaders/`](./invaders/) | thin rewrite; bitmap art TODO | sketch |
+| `games/pacman` | [`pacman/`](./pacman/) | thin maze only (not full level pack) | sketch |
+| `games/sprite_char` | [`sprite_char/`](./sprite_char/) | atlas/AnimationPlayer (TS + Rust); not RGSP1 | sketch |
+| `games/cube` | [`cube/`](./cube/) | rewrite → `ranger:three` + `runtime.start` | sketch |
+| `games/teapot` | [`teapot/`](./teapot/) | slim lit teapot; GUI/OrbitControls TODO | sketch |
+| `games/cannon_stack` | [`cannon_stack/`](./cannon_stack/) | `ranger:2d` + `ranger:cannon` dual handles | sketch |
 
-Suggested early picks (small, high signal):
+## Conventions used in sketches
 
-- **3D:** rotating cube, teapot, one Cannon stack / sandbox
-- **2D (`ranger:2d`):** Pac-Man or Breakout class title; one LPC / character
-  sample via `SpriteAtlas` + `AnimationPlayer2D` (not RGSP1 slots)
-- **Audio/input:** one sample exercising `ranger:core`
+```ts
+import { runtime, type Game, type FrameInfo } from "ranger:core"
+import * as TWO from "ranger:2d"       // or THREE / CANNON
+class MyGame implements Game {
+  async init(): Promise<void> { /* … */ }
+  update(frame: FrameInfo): void { /* … */ }
+  resize?(w: number, h: number): void { /* … */ }
+  shutdown?(): void { /* … */ }
+}
+runtime.start(new MyGame())
+```
 
-Exact order follows module readiness — do not skip 2D because Three landed
-first. Target imports: `ranger:2d` / `ranger_wasm::two_d` (D-2D).
+Comment markers:
 
-## Unit / contract tests that gate this folder
+| Marker | Meaning |
+|--------|---------|
+| `MISSING:` | API / asset / system not in the contract yet or not wired |
+| `TODO:` | Known follow-up for a fuller port |
+| `HACK:` | Temporary assumption (units, hybrid vectors, 2D Cannon plane) |
+| `NOT` | Explicitly rejected v1 pattern (`window`, RGSP1 slots, reconciler) |
 
-- Each game: headless smoke runner under `v2/tests/` or `games/<name>/tests/`
-- No import of `ThreeTsxBridge.reconcile` or v1 `three/tsx` wrappers
-- Shared geometry / shutdown paths obey D-LIFE (from CODE_CLEANUP examples)
+## Unit / contract tests (later)
 
-## Notes
-
-- Engine gates (create/free, adapter, WASM) come **before** game ports need
-  pixels
-- Assets may be copied from v1 game folders when useful; document the source
-  path in the game’s README
+- Headless smoke per game once façades exist
+- No `ThreeTsxBridge.reconcile` / v1 `three/tsx` imports
+- D-LIFE shutdown paths (remove ≠ release; shared atlas retains)
 
 ---
 
-*Scaffold only (Phase 0). Game subfolders are added when a title is selected.*
+*Sketches only — engine Phase 1–10b must land before these build.*

--- a/gallery/game_engine/v2/games/breakout/README.md
+++ b/gallery/game_engine/v2/games/breakout/README.md
@@ -1,0 +1,4 @@
+# breakout — v2 rewrite (`ranger:2d`)
+
+**v1 source:** [`../../../games/breakout/`](../../../games/breakout/).  
+Rewrite of playfield + bricks; multi-screen gameOver left as TODO comments.

--- a/gallery/game_engine/v2/games/breakout/game.tsx
+++ b/gallery/game_engine/v2/games/breakout/game.tsx
@@ -1,0 +1,236 @@
+/**
+ * Breakout — v2 rewrite (does not compile yet).
+ *
+ * v1: sprites() brick defs + screen model (play / gameOver) + HUD JSX.
+ * v2: retained Shape2D bricks, action map, playOneShot SFX.
+ */
+
+import {
+  runtime,
+  type Game,
+  type FrameInfo,
+  type ActionMap,
+  type AudioSource,
+  type AudioClip,
+} from "ranger:core"
+import * as TWO from "ranger:2d"
+
+const COLS = 10
+const ROWS = 5
+const BRICK_COUNT = COLS * ROWS
+const BRICK_W = 40
+const BRICK_H = 12
+const BRICK_GAP = 4
+const BRICK_TOP = 52
+const BRICK_LEFT = 40
+const PADDLE_W = 88
+const PADDLE_H = 10
+const PADDLE_HALF = 44
+const W = 480
+const H = 270
+
+const BRICK_COLORS = [0xdc505a, 0xff963c, 0xffdc50, 0x78dc8c, 0x5aaaff]
+
+class BreakoutGame implements Game {
+  private scene!: TWO.Scene2D
+  private camera!: TWO.Camera2D
+  private renderer!: TWO.Renderer2D
+  private paddle!: TWO.Shape2D
+  private ball!: TWO.Shape2D
+  private bricks: TWO.Shape2D[] = []
+  private alive: boolean[] = []
+
+  private controls!: ActionMap
+  private bounceSound!: AudioSource
+  private brickSound!: AudioSource
+  private bounceClip!: AudioClip
+  private brickClip!: AudioClip
+
+  private px = 240
+  private bx = 240
+  private by = 220
+  private vx = 180
+  private vy = 140
+  private score = 0
+  private lives = 3
+  // MISSING: screen stack (play / gameOver). v1 froze play state in screens{}.
+  private gameOver = false
+
+  async init(): Promise<void> {
+    this.scene = new TWO.Scene2D()
+    this.camera = new TWO.Camera2D()
+    this.camera.position.set(W / 2, H / 2)
+    this.renderer = new TWO.Renderer2D()
+    runtime.surface.attachRenderer(this.renderer)
+
+    this.paddle = new TWO.Shape2D({
+      kind: "rect",
+      width: PADDLE_W,
+      height: PADDLE_H,
+      color: 0x78dcff,
+    })
+    this.ball = new TWO.Shape2D({
+      kind: "circle",
+      radius: 5,
+      color: 0xf5f582,
+    })
+    this.scene.add(this.paddle)
+    this.scene.add(this.ball)
+
+    for (let i = 0; i < BRICK_COUNT; i++) {
+      const row = Math.floor(i / COLS)
+      const brick = new TWO.Shape2D({
+        kind: "rect",
+        width: BRICK_W,
+        height: BRICK_H,
+        color: BRICK_COLORS[row % BRICK_COLORS.length],
+      })
+      const col = i % COLS
+      brick.position.set(
+        BRICK_LEFT + col * (BRICK_W + BRICK_GAP) + BRICK_W / 2,
+        BRICK_TOP + row * (BRICK_H + BRICK_GAP) + BRICK_H / 2,
+      )
+      this.scene.add(brick)
+      this.bricks.push(brick)
+      this.alive.push(true)
+    }
+
+    this.controls = runtime.input.createActionMap({
+      move: {
+        type: "axis1d",
+        keyboard: { negative: "ArrowLeft", positive: "ArrowRight" },
+        // ALSO: KeyA / KeyD — ActionMap multi-binding not clearly specified
+        gamepad: { axis: "leftX" },
+      },
+      restart: {
+        type: "button",
+        keyboard: ["Space"],
+        gamepad: { button: "south" },
+      },
+    })
+
+    this.bounceClip = await runtime.assets.loadAudio("audio/breakout-bounce.ogg")
+    this.brickClip = await runtime.assets.loadAudio("audio/breakout-brick.ogg")
+    this.bounceSound = runtime.audio.createSource(this.bounceClip, { bus: "sfx" })
+    this.brickSound = runtime.audio.createSource(this.brickClip, { bus: "sfx" })
+
+    this.syncPaddleBall()
+  }
+
+  update(frame: FrameInfo): void {
+    if (this.gameOver) {
+      if (this.controls.wasPressed("restart")) {
+        this.resetPlay()
+      }
+      // MISSING: game-over overlay via Text2D / UI module
+      this.renderer.render(this.scene, this.camera)
+      return
+    }
+
+    const dt = frame.delta
+    this.px += this.controls.axis1D("move") * 340 * dt
+    this.px = clamp(this.px, PADDLE_HALF, W - PADDLE_HALF)
+
+    this.bx += this.vx * dt
+    this.by += this.vy * dt
+
+    if (this.by < 8) {
+      this.by = 8
+      this.vy = -this.vy
+      this.bounceSound.playOneShot()
+    }
+    if (this.bx < 6) {
+      this.bx = 6
+      this.vx = -this.vx
+      this.bounceSound.playOneShot()
+    }
+    if (this.bx > W - 6) {
+      this.bx = W - 6
+      this.vx = -this.vx
+      this.bounceSound.playOneShot()
+    }
+
+    const py = 248
+    if (this.by > py - 14 && this.bx > this.px - PADDLE_HALF && this.bx < this.px + PADDLE_HALF) {
+      this.by = py - 14
+      this.vy = -Math.abs(this.vy)
+      this.vx += ((this.bx - this.px) / PADDLE_HALF) * 60
+      this.bounceSound.playOneShot()
+    }
+
+    if (this.by > H) {
+      this.lives--
+      this.bx = this.px
+      this.by = py - 24
+      this.vx = 180
+      this.vy = 140
+      if (this.lives <= 0) {
+        this.gameOver = true
+        // TODO: freeze brick visibility; show "lose" UI
+      }
+    }
+
+    for (let i = 0; i < BRICK_COUNT; i++) {
+      if (!this.alive[i]) continue
+      const pos = this.bricks[i].position
+      // HACK: reading hybrid Vector2 — assume .x/.y after turn-start refresh (D-ADAPTER)
+      if (Math.abs(this.bx - pos.x) < BRICK_W / 2 + 5 && Math.abs(this.by - pos.y) < BRICK_H / 2 + 5) {
+        this.alive[i] = false
+        // D-LIFE: hide ≠ release — keep handle for possible level reset
+        this.bricks[i].visible = false
+        this.vy = -this.vy
+        this.score += 10
+        this.brickSound.playOneShot()
+      }
+    }
+
+    if (this.alive.every((a) => !a)) {
+      this.gameOver = true
+      // TODO: win screen
+    }
+
+    this.syncPaddleBall()
+    this.renderer.render(this.scene, this.camera)
+  }
+
+  shutdown(): void {
+    this.bounceSound.release()
+    this.brickSound.release()
+    this.bounceClip.release()
+    this.brickClip.release()
+    for (const b of this.bricks) {
+      this.scene.remove(b)
+      b.release()
+    }
+    this.scene.remove(this.paddle)
+    this.scene.remove(this.ball)
+    this.paddle.release()
+    this.ball.release()
+  }
+
+  private syncPaddleBall(): void {
+    this.paddle.position.set(this.px, 248)
+    this.ball.position.set(this.bx, this.by)
+  }
+
+  private resetPlay(): void {
+    this.gameOver = false
+    this.score = 0
+    this.lives = 3
+    this.px = 240
+    this.bx = 240
+    this.by = 220
+    this.vx = 180
+    this.vy = 140
+    for (let i = 0; i < BRICK_COUNT; i++) {
+      this.alive[i] = true
+      this.bricks[i].visible = true
+    }
+  }
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v
+}
+
+runtime.start(new BreakoutGame())

--- a/gallery/game_engine/v2/games/cannon_stack/README.md
+++ b/gallery/game_engine/v2/games/cannon_stack/README.md
@@ -1,0 +1,6 @@
+# cannon_stack — v2 rewrite (`ranger:2d` + `ranger:cannon`)
+
+**v1 source:** [`../../../games/cannon_stack/`](../../../games/cannon_stack/)  
+(2D circles + Cannon via GameRunner physics config).  
+
+Target: separate Body vs Shape2D handles; optional PoseBinding2D.

--- a/gallery/game_engine/v2/games/cannon_stack/game.tsx
+++ b/gallery/game_engine/v2/games/cannon_stack/game.tsx
@@ -1,0 +1,101 @@
+/**
+ * Cannon stack — v2 rewrite (does not compile yet).
+ *
+ * v1: sprites() circles + entities() physics blobs + game_cannon_physics bridge.
+ * v2: ranger:cannon bodies + ranger:2d shapes; sync guest-side or PoseBinding2D.
+ */
+
+import { runtime, type Game, type FrameInfo } from "ranger:core"
+import * as TWO from "ranger:2d"
+import * as CANNON from "ranger:cannon"
+
+const BALL_R = 14
+const W = 480
+const H = 270
+
+/** Guest-only: pairs a physics body with a drawable (D-MODULES guest class). */
+class BallVisual {
+  constructor(
+    readonly body: CANNON.Body,
+    readonly shape: TWO.Shape2D,
+  ) {}
+
+  syncFromPhysics(): void {
+    // bodyH ≠ shapeH — never treat them as the same handle (D-TYPE / D-2D)
+    const p = this.body.position
+    // Cannon 3D Vec3 — for 2D playfield we use x/y; z ignored.
+    // TODO: 2D physics helpers or Vec2 body API — using x/y plane by convention.
+    this.shape.position.set(p.x, p.y)
+  }
+}
+
+class CannonStackGame implements Game {
+  private scene!: TWO.Scene2D
+  private camera!: TWO.Camera2D
+  private renderer!: TWO.Renderer2D
+  private world!: CANNON.World
+  private balls: BallVisual[] = []
+  // MISSING: PoseBinding2D API — would replace syncFromPhysics in update:
+  //   runtime.bindings.bindPose2D({ source: body, target: shape, … })
+
+  async init(): Promise<void> {
+    this.scene = new TWO.Scene2D()
+    this.camera = new TWO.Camera2D()
+    this.camera.position.set(W / 2, H / 2)
+    this.renderer = new TWO.Renderer2D()
+    runtime.surface.attachRenderer(this.renderer)
+
+    this.world = new CANNON.World()
+    // TODO: gravity units — v1 used gravityY: 300 in pixel space.
+    this.world.gravity.set(0, 300, 0)
+
+    // Floor — static plane/box. MISSING: clean 2D ground helper.
+    const ground = new CANNON.Body({ mass: 0 })
+    ground.addShape(new CANNON.Plane())
+    // HACK: Plane orientation for "floor at y=H-20" is unclear in 2D mapping.
+    ground.position.set(0, H - 20, 0)
+    this.world.addBody(ground)
+
+    const colors = [0x78c8ff, 0xffc878, 0xc8ff8c]
+    const ys = [60, 110, 160]
+    for (let i = 0; i < 3; i++) {
+      const body = new CANNON.Body({ mass: 1 })
+      body.addShape(new CANNON.Sphere(BALL_R))
+      // TODO: Sphere vs Circle in 2D — Cannon is 3D; may want Cylinder or custom.
+      body.position.set(240, ys[i], 0)
+      // v1 restitution 0.05 — material API:
+      // body.material = new CANNON.Material({ restitution: 0.05 })
+      this.world.addBody(body)
+
+      const shape = new TWO.Shape2D({
+        kind: "circle",
+        radius: BALL_R,
+        color: colors[i],
+      })
+      this.scene.add(shape)
+      this.balls.push(new BallVisual(body, shape))
+    }
+  }
+
+  update(frame: FrameInfo): void {
+    this.world.fixedStep(frame.fixedDelta, frame.delta)
+    for (const b of this.balls) {
+      b.syncFromPhysics()
+    }
+    // Prefer later:
+    // for (const binding of this.bindings) { /* host already synced */ }
+
+    this.renderer.render(this.scene, this.camera)
+  }
+
+  shutdown(): void {
+    for (const b of this.balls) {
+      this.scene.remove(b.shape)
+      b.shape.release()
+      this.world.removeBody(b.body)
+      b.body.release()
+    }
+  }
+}
+
+runtime.start(new CannonStackGame())

--- a/gallery/game_engine/v2/games/cube/README.md
+++ b/gallery/game_engine/v2/games/cube/README.md
@@ -1,0 +1,4 @@
+# cube — v2 rewrite (`ranger:three`)
+
+**v1 source:** [`../../../games/cube/`](../../../games/cube/) (Three façade + `window`/`requestAnimationFrame`).  
+Target: `runtime.start` + `ranger:three` (no DOM, no reconciler).

--- a/gallery/game_engine/v2/games/cube/game.tsx
+++ b/gallery/game_engine/v2/games/cube/game.tsx
@@ -1,0 +1,74 @@
+/**
+ * Rotating cube — v2 rewrite (does not compile yet).
+ *
+ * v1: import * as THREE from 'three'; window.innerWidth; setAnimationLoop.
+ * v2: ranger:three + ranger:core surface; host-driven Game.update.
+ */
+
+import { runtime, type Game, type FrameInfo } from "ranger:core"
+import * as THREE from "ranger:three"
+
+class CubeGame implements Game {
+  private camera!: THREE.PerspectiveCamera
+  private scene!: THREE.Scene
+  private renderer!: THREE.WebGLRenderer
+  private mesh!: THREE.Mesh
+
+  async init(): Promise<void> {
+    const size = runtime.surface.size
+    // NOT window.innerWidth — surface is runtime-owned (D-MODULES)
+
+    this.camera = new THREE.PerspectiveCamera(
+      70,
+      size.width / size.height,
+      0.1,
+      100,
+    )
+    this.camera.position.z = 2
+
+    this.scene = new THREE.Scene()
+
+    // MISSING: TextureLoader path resolution vs runtime.assets.loadTexture.
+    // Prefer assets API for WASM/native parity (D-ASYNC):
+    //   const texture = await runtime.assets.loadTexture("textures/crate.gif")
+    // Until then, keep Three-compat loader as a thin wrapper over assets.
+    const texture = await runtime.assets.loadTexture("textures/crate.gif")
+    // TODO: colorSpace / SRGB — declare on Texture2D / Three Texture residency
+
+    const geometry = new THREE.BoxGeometry()
+    const material = new THREE.MeshBasicMaterial({ map: texture })
+    this.mesh = new THREE.Mesh(geometry, material)
+    this.scene.add(this.mesh)
+
+    this.renderer = new THREE.WebGLRenderer({ antialias: true })
+    runtime.surface.attachRenderer(this.renderer)
+    // NOT document.body.appendChild
+    this.renderer.setSize(size.width, size.height)
+    // NOT renderer.setAnimationLoop — host calls update (D-MODULES frame pipeline)
+  }
+
+  update(frame: FrameInfo): void {
+    // Scale rotation by delta so motion is frame-rate independent (v1 used fixed step).
+    this.mesh.rotation.x += 0.005 * (frame.delta * 60)
+    this.mesh.rotation.y += 0.01 * (frame.delta * 60)
+    this.renderer.render(this.scene, this.camera)
+  }
+
+  resize(width: number, height: number): void {
+    if (height === 0) return
+    this.camera.aspect = width / height
+    this.camera.updateProjectionMatrix()
+    this.renderer.setSize(width, height)
+  }
+
+  shutdown(): void {
+    this.scene.remove(this.mesh)
+    // D-LIFE: dispose_backend ≠ release
+    this.mesh.geometry.dispose()
+    this.mesh.material.dispose()
+    // TODO: texture.disposeBackend / release — ownership after material holds it (D-OWN)
+    this.mesh.release()
+  }
+}
+
+runtime.start(new CubeGame())

--- a/gallery/game_engine/v2/games/invaders/README.md
+++ b/gallery/game_engine/v2/games/invaders/README.md
@@ -1,0 +1,4 @@
+# invaders — v2 rewrite (`ranger:2d`)
+
+**v1 source:** [`../../../games/invaders/`](../../../games/invaders/).  
+Thin single-wave port; bitmap alien art and multi-level flow are TODOs.

--- a/gallery/game_engine/v2/games/invaders/game.tsx
+++ b/gallery/game_engine/v2/games/invaders/game.tsx
@@ -1,0 +1,186 @@
+/**
+ * Space Invaders — thin v2 rewrite (does not compile yet).
+ *
+ * v1: bitmap sprite frames in invaders_shared.tsx + multi-level screens.
+ * v2: Shape2D placeholders + ActionMap; atlas/bitmap path marked MISSING.
+ */
+
+import {
+  runtime,
+  type Game,
+  type FrameInfo,
+  type ActionMap,
+  type AudioSource,
+  type AudioClip,
+} from "ranger:core"
+import * as TWO from "ranger:2d"
+
+const COLS = 5
+const ROWS = 3
+const ALIEN_COUNT = COLS * ROWS
+const W = 480
+const H = 270
+
+class InvadersGame implements Game {
+  private scene!: TWO.Scene2D
+  private camera!: TWO.Camera2D
+  private renderer!: TWO.Renderer2D
+  private ship!: TWO.Shape2D
+  private aliens: TWO.Shape2D[] = []
+  private alienAlive: boolean[] = []
+  private shot: TWO.Shape2D | null = null
+
+  private controls!: ActionMap
+  private shootClip!: AudioClip
+  private shootSound!: AudioSource
+
+  private shipX = 240
+  private alienOriginX = 80
+  private alienOriginY = 40
+  private alienDir = 1
+  private shotX = 0
+  private shotY = -1
+  private cooldown = 0
+
+  async init(): Promise<void> {
+    this.scene = new TWO.Scene2D()
+    this.camera = new TWO.Camera2D()
+    this.camera.position.set(W / 2, H / 2)
+    this.renderer = new TWO.Renderer2D()
+    runtime.surface.attachRenderer(this.renderer)
+
+    // MISSING: Sprite2D + SpriteAtlas from pixel-art frames (v1 bitmap kinds).
+    // Using Shape2D rects as stand-ins until atlas bake lands (D-2D-2).
+    this.ship = new TWO.Shape2D({
+      kind: "rect",
+      width: 24,
+      height: 12,
+      color: 0x78ffc8,
+    })
+    this.scene.add(this.ship)
+
+    for (let i = 0; i < ALIEN_COUNT; i++) {
+      const alien = new TWO.Shape2D({
+        kind: "rect",
+        width: 20,
+        height: 14,
+        color: 0xffaa40,
+      })
+      this.scene.add(alien)
+      this.aliens.push(alien)
+      this.alienAlive.push(true)
+    }
+
+    this.controls = runtime.input.createActionMap({
+      move: {
+        type: "axis1d",
+        keyboard: { negative: "ArrowLeft", positive: "ArrowRight" },
+        gamepad: { axis: "leftX" },
+      },
+      fire: {
+        type: "button",
+        keyboard: ["Space", "KeyZ"],
+        gamepad: { button: "south" },
+      },
+    })
+
+    this.shootClip = await runtime.assets.loadAudio("audio/invaders-shot.ogg")
+    this.shootSound = runtime.audio.createSource(this.shootClip, { bus: "sfx" })
+
+    this.layoutAliens()
+    this.ship.position.set(this.shipX, H - 24)
+  }
+
+  update(frame: FrameInfo): void {
+    const dt = frame.delta
+    this.shipX += this.controls.axis1D("move") * 220 * dt
+    this.shipX = clamp(this.shipX, 20, W - 20)
+    this.ship.position.set(this.shipX, H - 24)
+
+    // March aliens
+    this.alienOriginX += this.alienDir * 40 * dt
+    if (this.alienOriginX < 40 || this.alienOriginX > 200) {
+      this.alienDir = -this.alienDir
+      this.alienOriginY += 12
+      // TODO: lose condition when aliens reach ship row
+    }
+    this.layoutAliens()
+
+    // MISSING: AnimationPlayer2D for 2-frame alien wiggle (v1 flipped bitmaps).
+
+    this.cooldown = Math.max(0, this.cooldown - dt)
+    if (this.controls.wasPressed("fire") && this.cooldown <= 0 && this.shot == null) {
+      this.shot = new TWO.Shape2D({
+        kind: "rect",
+        width: 3,
+        height: 10,
+        color: 0xffffff,
+      })
+      this.shotX = this.shipX
+      this.shotY = H - 40
+      this.scene.add(this.shot)
+      this.cooldown = 0.35
+      this.shootSound.playOneShot()
+    }
+
+    if (this.shot) {
+      this.shotY -= 320 * dt
+      this.shot.position.set(this.shotX, this.shotY)
+      if (this.shotY < 0) {
+        this.clearShot()
+      } else {
+        for (let i = 0; i < ALIEN_COUNT; i++) {
+          if (!this.alienAlive[i]) continue
+          const p = this.aliens[i].position
+          if (Math.abs(p.x - this.shotX) < 12 && Math.abs(p.y - this.shotY) < 10) {
+            this.alienAlive[i] = false
+            this.aliens[i].visible = false
+            this.clearShot()
+            break
+          }
+        }
+      }
+    }
+
+    // TODO: alien bombs, barriers, level-2 wave, win screen (v1 level2.tsx / win.tsx)
+
+    this.renderer.render(this.scene, this.camera)
+  }
+
+  shutdown(): void {
+    this.clearShot()
+    this.shootSound.release()
+    this.shootClip.release()
+    this.scene.remove(this.ship)
+    this.ship.release()
+    for (const a of this.aliens) {
+      this.scene.remove(a)
+      a.release()
+    }
+  }
+
+  private layoutAliens(): void {
+    for (let i = 0; i < ALIEN_COUNT; i++) {
+      if (!this.alienAlive[i]) continue
+      const col = i % COLS
+      const row = Math.floor(i / COLS)
+      this.aliens[i].position.set(
+        this.alienOriginX + col * 48,
+        this.alienOriginY + row * 28,
+      )
+    }
+  }
+
+  private clearShot(): void {
+    if (!this.shot) return
+    this.scene.remove(this.shot)
+    this.shot.release()
+    this.shot = null
+  }
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v
+}
+
+runtime.start(new InvadersGame())

--- a/gallery/game_engine/v2/games/pacman/README.md
+++ b/gallery/game_engine/v2/games/pacman/README.md
@@ -1,0 +1,7 @@
+# pacman — thin v2 rewrite (`ranger:2d`)
+
+**v1 source:** [`../../../games/pacman/`](../../../games/pacman/) (large shared
+module + many levels).  
+
+This port keeps **one maze + dots + one ghost** to exercise the API; full
+level pack stays in v1 until the 2D stack is solid.

--- a/gallery/game_engine/v2/games/pacman/game.tsx
+++ b/gallery/game_engine/v2/games/pacman/game.tsx
@@ -1,0 +1,215 @@
+/**
+ * Pac-Man — thin v2 rewrite (does not compile yet).
+ *
+ * v1: pacman_shared.tsx (~1450 lines), bitmap ghosts, multi-level progressive.
+ * v2: Shape2D stand-ins on a tiny hard-coded maze; marks missing atlas/AI.
+ */
+
+import {
+  runtime,
+  type Game,
+  type FrameInfo,
+  type ActionMap,
+  type AudioClip,
+  type AudioSource,
+} from "ranger:core"
+import * as TWO from "ranger:2d"
+
+// Tiny demo maze: 0 empty, 1 wall, 2 dot. Full v1 tile maps not ported.
+const MAZE: number[][] = [
+  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+  [1, 2, 2, 2, 2, 1, 2, 2, 2, 2, 1],
+  [1, 2, 1, 1, 2, 1, 2, 1, 1, 2, 1],
+  [1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1],
+  [1, 2, 1, 2, 1, 1, 1, 2, 1, 2, 1],
+  [1, 2, 2, 2, 2, 0, 2, 2, 2, 2, 1],
+  [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+]
+const TILE = 24
+
+class PacmanGame implements Game {
+  private scene!: TWO.Scene2D
+  private camera!: TWO.Camera2D
+  private renderer!: TWO.Renderer2D
+  private player!: TWO.Shape2D
+  private ghost!: TWO.Shape2D
+  private walls: TWO.Shape2D[] = []
+  private dots = new Map<string, TWO.Shape2D>()
+
+  private controls!: ActionMap
+  private chompClip!: AudioClip
+  private chompSound!: AudioSource
+
+  private col = 1
+  private row = 1
+  private ghostCol = 9
+  private ghostRow = 1
+  private moveCooldown = 0
+
+  async init(): Promise<void> {
+    this.scene = new TWO.Scene2D()
+    this.camera = new TWO.Camera2D()
+    this.renderer = new TWO.Renderer2D()
+    runtime.surface.attachRenderer(this.renderer)
+
+    // MISSING: TileMap2D (D-2D) — building walls as individual Shape2D is OK for
+    // a demo but will not scale to v1 mazes.
+    for (let r = 0; r < MAZE.length; r++) {
+      for (let c = 0; c < MAZE[r].length; c++) {
+        const cell = MAZE[r][c]
+        const x = c * TILE + TILE / 2
+        const y = r * TILE + TILE / 2
+        if (cell === 1) {
+          const wall = new TWO.Shape2D({
+            kind: "rect",
+            width: TILE - 2,
+            height: TILE - 2,
+            color: 0x2040c0,
+          })
+          wall.position.set(x, y)
+          this.scene.add(wall)
+          this.walls.push(wall)
+        } else if (cell === 2) {
+          const dot = new TWO.Shape2D({
+            kind: "circle",
+            radius: 3,
+            color: 0xffe0a0,
+          })
+          dot.position.set(x, y)
+          this.scene.add(dot)
+          this.dots.set(`${c},${r}`, dot)
+        }
+      }
+    }
+
+    // MISSING: Sprite2D wedge / mouth animation (v1 kind: "wedge")
+    this.player = new TWO.Shape2D({
+      kind: "circle",
+      radius: 10,
+      color: 0xffe040,
+    })
+    this.ghost = new TWO.Shape2D({
+      kind: "circle",
+      radius: 10,
+      color: 0xff4060,
+    })
+    this.scene.add(this.player)
+    this.scene.add(this.ghost)
+
+    this.controls = runtime.input.createActionMap({
+      // Discrete grid moves — axis thresholds in update
+      moveX: {
+        type: "axis1d",
+        keyboard: { negative: "ArrowLeft", positive: "ArrowRight" },
+        gamepad: { axis: "leftX" },
+      },
+      moveY: {
+        type: "axis1d",
+        keyboard: { negative: "ArrowUp", positive: "ArrowDown" },
+        gamepad: { axis: "leftY" },
+      },
+    })
+
+    this.chompClip = await runtime.assets.loadAudio("audio/pacman-chomp.ogg")
+    this.chompSound = runtime.audio.createSource(this.chompClip, { bus: "sfx" })
+
+    this.camera.position.set(
+      (MAZE[0].length * TILE) / 2,
+      (MAZE.length * TILE) / 2,
+    )
+    this.syncActors()
+  }
+
+  update(frame: FrameInfo): void {
+    this.moveCooldown -= frame.delta
+    if (this.moveCooldown <= 0) {
+      const dx = this.controls.axis1D("moveX")
+      const dy = this.controls.axis1D("moveY")
+      let stepC = 0
+      let stepR = 0
+      if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 0.4) {
+        stepC = dx > 0 ? 1 : -1
+      } else if (Math.abs(dy) > 0.4) {
+        stepR = dy > 0 ? 1 : -1
+      }
+      if (stepC !== 0 || stepR !== 0) {
+        const nc = this.col + stepC
+        const nr = this.row + stepR
+        if (walkable(nc, nr)) {
+          this.col = nc
+          this.row = nr
+          this.moveCooldown = 0.12
+          this.eatDot(nc, nr)
+        }
+      }
+
+      // MISSING: real ghost AI / frightened mode / tunnel wrap from v1
+      this.wanderGhost()
+    }
+
+    this.syncActors()
+    this.renderer.render(this.scene, this.camera)
+  }
+
+  shutdown(): void {
+    this.chompSound.release()
+    this.chompClip.release()
+    for (const w of this.walls) {
+      this.scene.remove(w)
+      w.release()
+    }
+    for (const d of this.dots.values()) {
+      this.scene.remove(d)
+      d.release()
+    }
+    this.scene.remove(this.player)
+    this.scene.remove(this.ghost)
+    this.player.release()
+    this.ghost.release()
+  }
+
+  private eatDot(c: number, r: number): void {
+    const key = `${c},${r}`
+    const dot = this.dots.get(key)
+    if (!dot) return
+    this.scene.remove(dot)
+    dot.release()
+    this.dots.delete(key)
+    this.chompSound.playOneShot()
+    // TODO: win when dots empty; power pellets; lives
+  }
+
+  private wanderGhost(): void {
+    const options = [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1],
+    ]
+    // HACK: deterministic pick — not v1 chase/scatter
+    for (const [dc, dr] of options) {
+      const nc = this.ghostCol + dc
+      const nr = this.ghostRow + dr
+      if (walkable(nc, nr)) {
+        this.ghostCol = nc
+        this.ghostRow = nr
+        break
+      }
+    }
+  }
+
+  private syncActors(): void {
+    this.player.position.set(this.col * TILE + TILE / 2, this.row * TILE + TILE / 2)
+    this.ghost.position.set(
+      this.ghostCol * TILE + TILE / 2,
+      this.ghostRow * TILE + TILE / 2,
+    )
+  }
+}
+
+function walkable(c: number, r: number): boolean {
+  if (r < 0 || r >= MAZE.length || c < 0 || c >= MAZE[0].length) return false
+  return MAZE[r][c] !== 1
+}
+
+runtime.start(new PacmanGame())

--- a/gallery/game_engine/v2/games/pong/README.md
+++ b/gallery/game_engine/v2/games/pong/README.md
@@ -1,0 +1,6 @@
+# pong — v2 rewrite (`ranger:2d`)
+
+**v1 source:** [`../../../games/pong/`](../../../games/pong/) (kept).  
+**Strategy:** rewrite on `ranger:core` + `ranger:2d` (not `sprites()` / GameRunner).
+
+Does **not** compile yet — documents the target API and gaps.

--- a/gallery/game_engine/v2/games/pong/game.tsx
+++ b/gallery/game_engine/v2/games/pong/game.tsx
@@ -1,0 +1,232 @@
+/**
+ * Pong — v2 rewrite (does not compile yet).
+ *
+ * v1: games/pong/index.tsx used GameRunner sprites() + initState/update +
+ *     game_helpers soundEvent. Pixel field 480×270.
+ *
+ * v2: runtime.start(Game), ranger:2d Shape2D, action maps, audio sources.
+ */
+
+import {
+  runtime,
+  type Game,
+  type FrameInfo,
+  type ActionMap,
+  type AudioClip,
+  type AudioSource,
+} from "ranger:core"
+import * as TWO from "ranger:2d"
+
+const W = 480
+const H = 270
+const PADDLE_HALF = 28
+const BALL_R = 6
+
+class PongGame implements Game {
+  private scene!: TWO.Scene2D
+  private camera!: TWO.Camera2D
+  private renderer!: TWO.Renderer2D
+
+  private ball!: TWO.Shape2D
+  private p1!: TWO.Shape2D
+  private p2!: TWO.Shape2D
+
+  private controlsP1!: ActionMap
+  private controlsP2!: ActionMap
+
+  // MISSING: Text2D / HUD layer for scores — v1 used host HUD/JSX.
+  private score1 = 0
+  private score2 = 0
+
+  private bx = W / 2
+  private by = H / 2
+  private p1y = H / 2
+  private p2y = H / 2
+  private vx = 160
+  private vy = 100
+
+  private wallClip!: AudioClip
+  private bounceClip!: AudioClip
+  private wallSound!: AudioSource
+  private bounceSound!: AudioSource
+
+  async init(): Promise<void> {
+    this.scene = new TWO.Scene2D()
+    this.camera = new TWO.Camera2D()
+    // TODO: Camera2D orthographic size / world units vs pixels is unspecified.
+    // Assuming 1 world unit = 1 pixel for the 480×270 playfield for now.
+    this.camera.position.set(W / 2, H / 2)
+    this.camera.zoom = 1
+
+    this.renderer = new TWO.Renderer2D()
+    runtime.surface.attachRenderer(this.renderer)
+    // MISSING: explicit setLogicalSize(480,270) — surface may be window-sized.
+
+    // guest: retained shapes (D-2D) — not frame-local DrawList2D
+    this.ball = new TWO.Shape2D({
+      kind: "circle",
+      radius: BALL_R,
+      color: 0xf5f582,
+    })
+    this.p1 = new TWO.Shape2D({
+      kind: "rect",
+      width: 10,
+      height: 56,
+      color: 0x78dca0,
+    })
+    this.p2 = new TWO.Shape2D({
+      kind: "rect",
+      width: 10,
+      height: 56,
+      color: 0xdc8c78,
+    })
+    this.scene.add(this.ball)
+    this.scene.add(this.p1)
+    this.scene.add(this.p2)
+
+    // Logical players — not gamepads[0]/1]
+    this.controlsP1 = runtime.input.createActionMap({
+      move: {
+        type: "axis1d",
+        keyboard: { negative: "KeyW", positive: "KeyS" },
+        gamepad: { axis: "leftY", player: 0 },
+      },
+    })
+    this.controlsP2 = runtime.input.createActionMap({
+      move: {
+        type: "axis1d",
+        keyboard: { negative: "ArrowUp", positive: "ArrowDown" },
+        gamepad: { axis: "leftY", player: 1 },
+      },
+    })
+    // TODO: confirm ActionMap can bind per logical player; v1 used playerSlots=2.
+
+    // MISSING: v1 used catalog sound names ("wall","bounce","lose") via soundEvent.
+    // Target: load clips; until assets exist, these paths are placeholders.
+    this.wallClip = await runtime.assets.loadAudio("audio/pong-wall.ogg")
+    this.bounceClip = await runtime.assets.loadAudio("audio/pong-bounce.ogg")
+    this.wallSound = runtime.audio.createSource(this.wallClip, {
+      bus: "sfx",
+      spatial: false,
+    })
+    this.bounceSound = runtime.audio.createSource(this.bounceClip, {
+      bus: "sfx",
+      spatial: false,
+    })
+
+    this.syncVisuals()
+  }
+
+  update(frame: FrameInfo): void {
+    const dt = frame.delta // seconds; v1 used ms-style dt — verify units!
+
+    const m1 = this.controlsP1.axis1D("move")
+    const m2 = this.controlsP2.axis1D("move")
+    this.p1y += m1 * 300 * dt
+    this.p2y += m2 * 300 * dt
+    this.p1y = clamp(this.p1y, 28, H - 28)
+    this.p2y = clamp(this.p2y, 28, H - 28)
+
+    const prevBx = this.bx
+    this.bx += this.vx * dt
+    this.by += this.vy * dt
+
+    if (this.by < BALL_R) {
+      this.by = BALL_R
+      this.vy = -this.vy
+      this.wallSound.playOneShot()
+    }
+    if (this.by > H - BALL_R) {
+      this.by = H - BALL_R
+      this.vy = -this.vy
+      this.wallSound.playOneShot()
+    }
+
+    // Paddle collision — ported from v1 discrete bounce tests
+    if (this.vx < 0 && this.hitPaddle(prevBx, this.bx, this.by, 18, 28, this.p1y)) {
+      this.bx = 28
+      this.vx = Math.abs(this.vx)
+      this.vy += ((this.by - this.p1y) / PADDLE_HALF) * 70
+      this.bounceSound.playOneShot()
+    }
+    if (this.vx > 0 && this.hitPaddle(prevBx, this.bx, this.by, 452, 462, this.p2y)) {
+      this.bx = 452
+      this.vx = -Math.abs(this.vx)
+      this.vy += ((this.by - this.p2y) / PADDLE_HALF) * 70
+      this.bounceSound.playOneShot()
+    }
+
+    if (this.bx < 0) {
+      this.score2++
+      this.resetBall(160)
+      // MISSING: "lose" cue — need another clip or mixer bus event
+    }
+    if (this.bx > W) {
+      this.score1++
+      this.resetBall(-160)
+    }
+
+    // TODO: draw net + scores. Options:
+    //   - DrawList2D each frame (immediate, no handle)
+    //   - Text2D when registered (D-2D mentions text)
+    // drawList.drawRect({ x: W/2-1, y: 0, width: 2, height: H, color: 0xffffff44 })
+
+    this.syncVisuals()
+    this.renderer.render(this.scene, this.camera)
+  }
+
+  resize(width: number, height: number): void {
+    // TODO: letterbox 480×270 into surface; Camera2D.viewport API from D-2D.
+    this.camera.viewport = { x: 0, y: 0, width, height }
+  }
+
+  shutdown(): void {
+    this.wallSound.release()
+    this.bounceSound.release()
+    this.wallClip.release()
+    this.bounceClip.release()
+    // D-LIFE: scene.remove ≠ release; release shapes when dropping the game
+    this.scene.remove(this.ball)
+    this.scene.remove(this.p1)
+    this.scene.remove(this.p2)
+    this.ball.release()
+    this.p1.release()
+    this.p2.release()
+  }
+
+  private syncVisuals(): void {
+    this.ball.position.set(this.bx, this.by)
+    this.p1.position.set(18, this.p1y)
+    this.p2.position.set(462, this.p2y)
+  }
+
+  private resetBall(vx: number): void {
+    this.bx = W / 2
+    this.by = H / 2
+    this.vx = vx
+    this.vy = 100
+  }
+
+  private hitPaddle(
+    prevBx: number,
+    bx: number,
+    by: number,
+    left: number,
+    right: number,
+    paddleY: number,
+  ): boolean {
+    if (by < paddleY - PADDLE_HALF || by > paddleY + PADDLE_HALF) return false
+    if (this.vx < 0) {
+      return prevBx > right && bx <= right
+    }
+    return prevBx < left && bx >= left
+  }
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  if (v < lo) return lo
+  if (v > hi) return hi
+  return v
+}
+
+runtime.start(new PongGame())

--- a/gallery/game_engine/v2/games/sprite_char/README.md
+++ b/gallery/game_engine/v2/games/sprite_char/README.md
@@ -1,0 +1,6 @@
+# sprite_char — v2 rewrite (`ranger:2d` + atlas)
+
+**v1 source:** [`../../../games/sprite_char/`](../../../games/sprite_char/) (RGSP1 WASM slots).  
+
+Target: `SpriteAtlas` / `AnimationPlayer2D` — **not** fixed RGSP1 slot indices
+(D-2D-8). Includes a Rust sketch using `ranger_wasm::two_d`.

--- a/gallery/game_engine/v2/games/sprite_char/game.rs
+++ b/gallery/game_engine/v2/games/sprite_char/game.rs
@@ -1,0 +1,96 @@
+//! Sprite character — Rust/WASM sketch (does not compile yet).
+//!
+//! Replaces RGSP1 `sprite_game!` slots with `ranger_wasm::two_d` handles (D-2D-8).
+
+use ranger_wasm::{
+    core::{
+        ActionMap, FrameInfo, Game, GameContext, GamepadAxis, InitContext, Key, Result,
+    },
+    two_d,
+};
+
+struct SpriteCharGame {
+    scene: two_d::Scene2D,
+    camera: two_d::Camera2D,
+    renderer: two_d::Renderer2D,
+    player: two_d::Sprite2D,
+    anim: two_d::AnimationPlayer2D,
+    controls: ActionMap,
+    // MISSING: store atlas handle for facing swaps
+}
+
+impl Game for SpriteCharGame {
+    async fn init(ctx: &mut InitContext) -> Result<Self> {
+        let scene = two_d::Scene2D::new()?;
+        let camera = two_d::Camera2D::new()?;
+        camera.position()?.set(240.0, 135.0)?;
+        // TODO: camera.set_zoom(2.0)
+        let renderer = two_d::Renderer2D::new()?;
+        ctx.surface().attach_renderer(&renderer)?;
+
+        // abi: load_sprite_atlas — not RGSP1 catalog ids
+        let atlas = ctx
+            .assets()
+            .load_sprite_atlas("lpc/characters/hero/atlas.json")
+            .await?;
+
+        let player = two_d::Sprite2D::new(&atlas.region("walk-down-0")?)?;
+        player.anchor()?.set(0.5, 1.0)?;
+        player.position()?.set(240.0, 180.0)?;
+        scene.add(&player)?;
+
+        let anim = two_d::AnimationPlayer2D::new(&player)?;
+        anim.play(
+            &atlas.animation("walk-down")?,
+            two_d::PlayOptions {
+                looping: true,
+                frames_per_second: 9.0,
+            },
+        )?;
+
+        let controls = ctx.input().create_action_map(
+            ActionMap::builder()
+                .axis_1d("move_x")
+                .keyboard(Key::ArrowLeft, Key::ArrowRight)
+                .gamepad_axis(GamepadAxis::LeftStickX)
+                .finish()
+                .axis_1d("move_y")
+                .keyboard(Key::ArrowUp, Key::ArrowDown)
+                .gamepad_axis(GamepadAxis::LeftStickY)
+                .finish()
+                .build(),
+        )?;
+
+        Ok(Self {
+            scene,
+            camera,
+            renderer,
+            player,
+            anim,
+            controls,
+        })
+    }
+
+    fn update(&mut self, _ctx: &mut GameContext, frame: FrameInfo) -> Result<()> {
+        let dx = self.controls.axis_1d("move_x")?;
+        let dy = self.controls.axis_1d("move_y")?;
+        let pos = self.player.position()?;
+        // HACK: Vector2Ref API — set from components after read
+        self.player.position()?.set(
+            pos.x + dx * 80.0 * frame.delta_seconds,
+            pos.y + dy * 80.0 * frame.delta_seconds,
+        )?;
+
+        // TODO: facing → anim.play(walk-*)
+        let _ = &self.anim;
+
+        self.camera
+            .position()?
+            .set(self.player.position()?.x, self.player.position()?.y)?;
+        self.renderer.render(&self.scene, &self.camera)?;
+        Ok(())
+    }
+}
+
+ranger_wasm::export_game!(SpriteCharGame);
+// NOT sprite_game! / RGSP1 exports — retired after D-2D-10

--- a/gallery/game_engine/v2/games/sprite_char/game.tsx
+++ b/gallery/game_engine/v2/games/sprite_char/game.tsx
@@ -1,0 +1,141 @@
+/**
+ * Sprite character demo — v2 rewrite (does not compile yet).
+ *
+ * v1: RGSP1 block with catalog character ids (hero/knight/mage/rogue) and
+ *     host-timed walk animation. Guest wrote slot array indices.
+ *
+ * v2: loadSpriteAtlas + Sprite2D + AnimationPlayer2D; identity is spriteH.
+ */
+
+import {
+  runtime,
+  type Game,
+  type FrameInfo,
+  type ActionMap,
+} from "ranger:core"
+import * as TWO from "ranger:2d"
+
+const CHARACTERS = ["hero", "knight", "mage", "rogue"] as const
+
+class SpriteCharGame implements Game {
+  private scene!: TWO.Scene2D
+  private camera!: TWO.Camera2D
+  private renderer!: TWO.Renderer2D
+  private player!: TWO.Sprite2D
+  private anim!: TWO.AnimationPlayer2D
+  private npcs: TWO.Sprite2D[] = []
+  private controls!: ActionMap
+  private facing: "down" | "left" | "right" | "up" = "down"
+
+  async init(): Promise<void> {
+    this.scene = new TWO.Scene2D()
+    this.camera = new TWO.Camera2D()
+    this.camera.position.set(240, 135)
+    this.camera.zoom = 2
+    this.renderer = new TWO.Renderer2D()
+    runtime.surface.attachRenderer(this.renderer)
+
+    // NOT RGSP1 catalog id — atlas JSON from LPC pack (v2/lpc/pack/characters)
+    // MISSING: exact atlas.json layout from LPC bake pipeline (D-2D-2).
+    const atlas = await runtime.assets.loadSpriteAtlas(
+      "lpc/characters/hero/atlas.json",
+    )
+
+    this.player = new TWO.Sprite2D(atlas.region("walk-down-0"))
+    this.player.anchor.set(0.5, 1.0)
+    this.player.position.set(240, 180)
+    this.scene.add(this.player)
+
+    this.anim = new TWO.AnimationPlayer2D(this.player)
+    this.anim.play(atlas.animation("walk-down"), {
+      loop: true,
+      framesPerSecond: 9,
+    })
+    // MISSING: v1 jumped via ACTION — need jump clip + one-shot play.
+
+    // Showcase other catalog characters as NPCs (separate atlas loads).
+    let x = 80
+    for (const name of CHARACTERS) {
+      if (name === "hero") continue
+      // TODO: batch atlas load / shared pack manifest via runtime.assets
+      const other = await runtime.assets.loadSpriteAtlas(
+        `lpc/characters/${name}/atlas.json`,
+      )
+      const npc = new TWO.Sprite2D(other.region("walk-down-0"))
+      npc.anchor.set(0.5, 1.0)
+      npc.position.set(x, 120)
+      this.scene.add(npc)
+      this.npcs.push(npc)
+      x += 80
+    }
+
+    this.controls = runtime.input.createActionMap({
+      moveX: {
+        type: "axis1d",
+        keyboard: { negative: "ArrowLeft", positive: "ArrowRight" },
+        gamepad: { axis: "leftX" },
+      },
+      moveY: {
+        type: "axis1d",
+        keyboard: { negative: "ArrowUp", positive: "ArrowDown" },
+        gamepad: { axis: "leftY" },
+      },
+      jump: {
+        type: "button",
+        keyboard: ["Space"],
+        gamepad: { button: "south" },
+      },
+    })
+  }
+
+  update(frame: FrameInfo): void {
+    const dx = this.controls.axis1D("moveX")
+    const dy = this.controls.axis1D("moveY")
+    const speed = 80
+    const p = this.player.position
+    // HACK: hybrid Vector2 mutation — prefer p.set(p.x + …) once API is firm
+    this.player.position.set(
+      p.x + dx * speed * frame.delta,
+      p.y + dy * speed * frame.delta,
+    )
+
+    const nextFacing = facingFromAxes(dx, dy, this.facing)
+    if (nextFacing !== this.facing) {
+      this.facing = nextFacing
+      // MISSING: atlas.animation(`walk-${facing}`) hot-swap without recreating player
+      // this.anim.play(atlas.animation(`walk-${this.facing}`), { loop: true })
+    }
+
+    if (this.controls.wasPressed("jump")) {
+      // TODO: AnimationPlayer2D one-shot "jump" then return to walk
+    }
+
+    // Animation advances on runtime.time inside the player — guest does not
+    // tick RGSP1 slot clocks (D-2D-5 / D-2D-8).
+
+    this.camera.position.set(this.player.position.x, this.player.position.y)
+    this.renderer.render(this.scene, this.camera)
+  }
+
+  shutdown(): void {
+    this.scene.remove(this.player)
+    this.player.release()
+    // TODO: animation player release / atlas release (D-OWN borrowed regions)
+    for (const npc of this.npcs) {
+      this.scene.remove(npc)
+      npc.release()
+    }
+  }
+}
+
+function facingFromAxes(
+  dx: number,
+  dy: number,
+  fallback: "down" | "left" | "right" | "up",
+): "down" | "left" | "right" | "up" {
+  if (Math.abs(dx) < 0.2 && Math.abs(dy) < 0.2) return fallback
+  if (Math.abs(dx) > Math.abs(dy)) return dx > 0 ? "right" : "left"
+  return dy > 0 ? "down" : "up"
+}
+
+runtime.start(new SpriteCharGame())

--- a/gallery/game_engine/v2/games/teapot/README.md
+++ b/gallery/game_engine/v2/games/teapot/README.md
@@ -1,0 +1,4 @@
+# teapot — v2 rewrite (`ranger:three`)
+
+**v1 source:** [`../../../games/teapot/`](../../../games/teapot/) (full Three example + GUI host).  
+Slimmed to lit teapot orbit; materials GUI / OrbitControls marked MISSING.

--- a/gallery/game_engine/v2/games/teapot/game.tsx
+++ b/gallery/game_engine/v2/games/teapot/game.tsx
@@ -1,0 +1,111 @@
+/**
+ * Teapot — slim v2 rewrite (does not compile yet).
+ *
+ * v1: full webgl_geometry_teapot with lil-gui + OrbitControls on the host.
+ * v2: one phong teapot + directional light; orbit via action map.
+ */
+
+import { runtime, type Game, type FrameInfo, type ActionMap } from "ranger:core"
+import * as THREE from "ranger:three"
+
+class TeapotGame implements Game {
+  private camera!: THREE.PerspectiveCamera
+  private scene!: THREE.Scene
+  private renderer!: THREE.WebGLRenderer
+  private teapot!: THREE.Mesh
+  private controls!: ActionMap
+  private yaw = 0
+  private pitch = 0.4
+  private distance = 1600
+
+  async init(): Promise<void> {
+    const size = runtime.surface.size
+
+    this.camera = new THREE.PerspectiveCamera(45, size.width / size.height, 1, 80000)
+    this.scene = new THREE.Scene()
+
+    const ambient = new THREE.AmbientLight(0x7c7c7c, 2.0)
+    const light = new THREE.DirectionalLight(0xffffff, 2.0)
+    light.position.set(0.32, 0.39, 0.7)
+    this.scene.add(ambient)
+    this.scene.add(light)
+
+    // MISSING: THREE.TeapotGeometry in ranger:three registry?
+    // v1 used custom TeapotGeometry — must be a registered class or guest mesh data.
+    const geometry = new THREE.TeapotGeometry(300, 15, true, true, true, true, true)
+    // TODO: if missing, load from BufferGeometry assets instead.
+
+    const material = new THREE.MeshPhongMaterial({
+      color: 0xc0c0c0,
+      specular: 0x404040,
+      shininess: 300,
+      side: THREE.DoubleSide,
+    })
+    // MISSING: multi-material switcher / envMap / uv grid from v1 example.
+
+    this.teapot = new THREE.Mesh(geometry, material)
+    this.scene.add(this.teapot)
+
+    this.renderer = new THREE.WebGLRenderer({ antialias: true })
+    runtime.surface.attachRenderer(this.renderer)
+    this.renderer.setSize(size.width, size.height)
+
+    // MISSING: OrbitControls as host helper — use action map orbit for now.
+    this.controls = runtime.input.createActionMap({
+      orbitX: {
+        type: "axis1d",
+        keyboard: { negative: "ArrowLeft", positive: "ArrowRight" },
+        gamepad: { axis: "rightX" },
+      },
+      orbitY: {
+        type: "axis1d",
+        keyboard: { negative: "ArrowDown", positive: "ArrowUp" },
+        gamepad: { axis: "rightY" },
+      },
+      zoom: {
+        type: "axis1d",
+        // TODO: mouse wheel binding not in ActionMap sketch yet
+        gamepad: { axis: "rightTrigger" },
+      },
+    })
+
+    this.applyCamera()
+  }
+
+  update(frame: FrameInfo): void {
+    this.yaw += this.controls.axis1D("orbitX") * 1.5 * frame.delta
+    this.pitch += this.controls.axis1D("orbitY") * 1.2 * frame.delta
+    this.pitch = Math.max(-1.2, Math.min(1.2, this.pitch))
+    this.distance *= 1 + this.controls.axis1D("zoom") * frame.delta
+    this.distance = Math.max(400, Math.min(4000, this.distance))
+
+    this.teapot.rotation.y += 0.15 * frame.delta
+    this.applyCamera()
+    this.renderer.render(this.scene, this.camera)
+  }
+
+  resize(width: number, height: number): void {
+    if (height === 0) return
+    this.camera.aspect = width / height
+    this.camera.updateProjectionMatrix()
+    this.renderer.setSize(width, height)
+  }
+
+  shutdown(): void {
+    this.scene.remove(this.teapot)
+    this.teapot.geometry.dispose()
+    this.teapot.material.dispose()
+    this.teapot.release()
+  }
+
+  private applyCamera(): void {
+    const x = Math.cos(this.pitch) * Math.sin(this.yaw) * this.distance
+    const y = Math.sin(this.pitch) * this.distance
+    const z = Math.cos(this.pitch) * Math.cos(this.yaw) * this.distance
+    this.camera.position.set(x, y, z)
+    this.camera.lookAt(0, 0, 0)
+    // TODO: lookAt residency / whether Camera has lookAt on host (D-ADAPTER)
+  }
+}
+
+runtime.start(new TeapotGame())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Non-compiling rewrites of selected v1 games under `gallery/game_engine/v2/games/`, targeting `runtime.start(Game)` and `ranger:core` / `ranger:2d` / `ranger:three` / `ranger:cannon` (plus a Rust `sprite_char` sketch on `ranger_wasm::two_d`).

v1 `games/` is left intact.

## Games

| Path | Modules | Notes |
|------|---------|-------|
| `pong`, `breakout`, `invaders`, `pacman` | `ranger:2d` + core | Shape2D stand-ins; HUD / full levels / bitmap art marked `MISSING` |
| `sprite_char` | `ranger:2d` (+ `game.rs`) | Atlas + AnimationPlayer — **not** RGSP1 slots |
| `cube`, `teapot` | `ranger:three` | No `window` / `setAnimationLoop`; OrbitControls/GUI TODO |
| `cannon_stack` | `ranger:2d` + `cannon` | Separate body vs shape handles; PoseBinding2D TODO |

## Comment convention

- `MISSING:` — API/asset gap
- `TODO:` — fuller port follow-up
- `HACK:` — temporary assumption
- `NOT` — rejected v1 pattern

These sketches are for API shaping; they intentionally do not build until façades land.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c00c897-4fd5-4b48-a5ef-504fb05fb889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c00c897-4fd5-4b48-a5ef-504fb05fb889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

