### PR TITLE
docs(game_engine): freeze v1 runtime; panes, vocal/music, must-pass ports

### DIFF
--- a/gallery/game_engine/CODE_CLEANUP.md
+++ b/gallery/game_engine/CODE_CLEANUP.md
@@ -705,12 +705,17 @@ PoseBinding2D { bodyH → spriteH }   // weak, generation-checked (D-OWN)
 Destroying either side invalidates the binding; the binding must not keep body
 or sprite alive.
 
-### What this retires (after parity)
+### What this retires (after parity) — v2-scoped only
 
-Fixed sprite-slot ABIs as the *primary* identity, runner-specific sheet
-manifests, host-only character animation clocks, and incompatible Camera2D
-implementations — tracked as D-2D migration gates in
+Fixed sprite-slot ABIs as the *primary* identity **for new v2 code**,
+runner-specific sheet manifests **staged under v2**, host-only character
+animation clocks **in the v2 path**, and incompatible Camera2D implementations
+— tracked as D-2D migration gates in
 [`CODE_CLEANUP_PLAN.md`](./CODE_CLEANUP_PLAN.md).
+
+**v1 freeze:** retirement does **not** delete `scripting/game_sprite.rgr`, v1
+sheet runners, or other engine paths that still-supported top-level `games/*`
+need. v2 is additive; v1 keeps running until an explicit end-of-v1 milestone.
 
 ---
 
@@ -740,16 +745,22 @@ import {
 ```text
 ranger:core
 ├─ runtime / game loop          runtime.start(game)
-├─ surface and display          runtime.surface.size, attachRenderer
+├─ surface and display
+│  ├─ size / title / cursor / fullscreen
+│  ├─ attachRenderer(…)
+│  └─ viewports / panes         split-screen (see below)
 ├─ input
 │  ├─ keyboard / mouse / touch / gamepads
 │  ├─ action maps               logical actions, not gamepads[0]
 │  ├─ player assignment         runtime.input.player(i)
+│  │                            (may be scoped per viewport / pane)
 │  └─ haptics                   player.rumble(…)
 ├─ audio
 │  ├─ clips / sources / voices  separate identities (below)
 │  ├─ listener                  attachTo(camera)
-│  └─ mixer buses
+│  ├─ mixer buses
+│  ├─ vocal FX                  runtime.audio.vocal.play(cue)
+│  └─ music score               runtime.audio.music.play / stop
 ├─ asset loading                loadAudio / loadModel / loadSpriteAtlas / …
 ├─ timing                       FrameInfo.delta, fixedDelta
 ├─ logging                      runtime.log.*
@@ -957,6 +968,66 @@ Today the interpreter binds every imported top-level name into one shared
   capability roots; a stale namespace object fails like a stale handle
   (epoch bump), it does not half-work.
 
+### Surface viewports / split-screen
+
+Kids’ two-player titles (ylos2 `splitScreen=auto`, pyorretris2p, …) need more
+than one `Camera2D`. The surface owns **panes** (viewports); cameras render
+into them.
+
+```ts
+// Conceptual — exact names land in the registry
+runtime.surface.setLayout("split-horizontal") // or explicit pane rects
+const left = runtime.surface.pane(0)   // { x, y, width, height, player?: 0 }
+const right = runtime.surface.pane(1)
+
+renderer2d.render(scene, cameraP1, { target: left })
+renderer2d.render(scene, cameraP2, { target: right })
+```
+
+Rules:
+
+- Panes are runtime-owned rectangles on the single surface (not separate
+  windows). Layout may be `single`, `split-horizontal`, `split-vertical`, or
+  an explicit list of normalized rects.
+- Each pane may bind a **logical player** for input routing
+  (`runtime.input.player(i)` already exists; pane binding makes
+  pointer/gamepad focus unambiguous in split layouts).
+- `Camera2D.viewport` may default to the full surface; when rendering to a
+  pane, the effective viewport is the pane rect (same camera math — D-2D).
+- Software and GPU backends must honor the same pane → scissor/viewport
+  mapping.
+- Single-player games ignore panes (one full-surface default).
+
+Without this, ylos2-class ports cannot express the gameplay kids already have.
+
+### Audio: vocal FX and music score
+
+Clip / source / voice remain the primitive model. Two **higher-level**
+facades that v1 games already rely on must have a home on `ranger:core`
+(not left as undefined TS-only runners):
+
+```ts
+// Vocal FX — short expressive one-shots (chuckle, gasp, …)
+runtime.audio.vocal.play("chuckle")
+// host: resolves a catalog or generated cue → playOneShot on a voice bus
+//       (implementation may be synth or sample bank; identity is the cue name)
+
+// Music score — start/stop a named procedural or sequenced score
+runtime.audio.music.play(scoreHandleOrName)
+runtime.audio.music.stop()
+```
+
+Rules:
+
+- Vocal FX and music are **not** a second ownership universe: they mint or
+  reuse `AudioSource` / mixer-owned voices under the hood (D-OWN / D-LIFE).
+- Catalog cue names are realm-scoped assets or built-in packs loaded through
+  `runtime.assets` where applicable (D-ASYNC).
+- Ports **may** temporarily map `voiceEvent` / `musicScoreEvent` to plain
+  `playOneShot` clips, but that is a **port-local** choice and must be
+  documented on the game — the contract still requires the facades so
+  ylos2-class titles are not stuck.
+
 ### Frame pipeline (`runtime.start`)
 
 The host owns the tick; physics stepping and rendering are **guest-called
@@ -964,13 +1035,14 @@ inside `update`**. That is the one model — runtime-owned stepping/rendering is
 not a silently supported alternative.
 
 ```
-1. host:  snapshot input                 (stable for the whole update call)
+1. host:  snapshot input                 (stable for the whole update call;
+                                          per-pane / per-player routing applied)
 2. host:  drain async completions        (D-ASYNC — futures/promises resolve here)
-3. host:  deliver resize, if any         (never mid-update)
+3. host:  deliver resize / pane layout, if any   (never mid-update)
 4. host:  call game.update(frame)
 5. guest:   zero or more world.fixedStep calls    (guest policy)
-6. guest:   renderer.render(scene, camera)        (explicit; reads host state)
-7. host:  submit audio + graphics, present the surface
+6. guest:   zero or more renderer.render(scene, camera[, pane])
+7. host:  submit audio (SFX, vocal FX, music) + graphics, present the surface
 8. host:  advance input edges            (wasPressed / wasReleased clear)
 ```
 
@@ -982,8 +1054,8 @@ Rules:
   `shutdown`, then tears the realm down (D-OWN backstop) — it does not retry.
 - Zero render calls in an update → the host re-presents the previous frame's
   output; it never renders implicitly (D-SYNC). Multiple render calls are
-  allowed (offscreen targets); the last render to the presented surface is
-  what step 7 shows.
+  allowed (offscreen targets and **split panes**); presents compose pane
+  results to the surface.
 - Input values are stable across one `update` call; edge states advance only
   at step 8.
 
@@ -2722,7 +2794,8 @@ ranger_wasm::export_game!(SpriteGame);
 9. Migrate demos (2D **and** 3D) to live objects + `runtime.start(Game)` /
    `ranger_wasm::export_game!` (D-SYNC, D-MODULES, D-2D).
 10. Delete structural reconciliation (`RETIRE-RECONCILE`) and retired sprite
-    slot/manifest paths after D-2D parity.
+    slot/manifest paths **under v2** after D-2D parity — **not** v1
+    `scripting/game_sprite` / runners while top-level games remain supported.
 
 **Required test gates:**
 

--- a/gallery/game_engine/CODE_CLEANUP_PLAN.md
+++ b/gallery/game_engine/CODE_CLEANUP_PLAN.md
@@ -9,13 +9,30 @@ We are **building the engine again under `gallery/game_engine/v2/`** — not
 patching the reconciler-era tree into shape. That includes a **new `v2/games/`
 folder**.
 
+### Intent: v1 keeps running the whole time
+
+**v2 is additive.** The goal is a parallel, unit-testable stack — not to
+downgrade, break, or strip the runtime that kids’ titles (chess, ylos2, …)
+use today. Until an explicit, later decision retires v1 support:
+
+| Guarantee | Meaning |
+|-----------|---------|
+| **v1 games keep working** | Top-level `games/*` continue to launch on the **v1** engine paths (`scripting/game_sprite.rgr`, TS runners, sheet manifests, etc.). |
+| **v1 engine paths are frozen** | Do **not** delete or “clean up” `scripting/`, v1 sprite runners, or sheet machinery as part of D-2D-7…10 / Phase 12. Those retirements apply only to **v2-staged** copies (e.g. `v2/sprites/*`) and to **v2** call sites after parity. |
+| **No silent runtime removal** | Keeping game *sources* while deleting the v1 runtime they need is treated as destroying the games — forbidden. |
+| **`RETIRE-RECONCILE` scope** | Touches the 3D `three/tsx` reconciler path only — not 2D GameRunner / `game_sprite` used by chess and ylos2. |
+
+v2 ports prove the new API; they do **not** license ripping out v1 until a
+dedicated “end v1 support” milestone says so.
+
 | Rule | Meaning |
 |------|---------|
-| **New tree is authoritative** | Interpreter, host arenas, WASM bridge, modules, runtime, render, and games all land in `v2/`. |
-| **Do not delete the old tree** | Existing `games/`, `three/`, `scripting/`, `physics/`, `wasm/`, etc. stay in place as reference and as the still-running v1 demos. |
-| **Select games, re-implement on the new API** | Pick titles that matter (they are not very large yet). Port each into `v2/games/<name>/` against `ranger:core` / `ranger:three` / `ranger:cannon` (or `ranger_wasm`), not against the old reconciler wrappers. |
+| **New tree is where new work lands** | Interpreter (v2), host arenas, WASM bridge, modules, runtime, render, and **v2** games land in `v2/`. |
+| **Do not delete the old tree** | Existing `games/`, `three/`, `scripting/`, `physics/`, `wasm/`, etc. stay in place — as the **still-running** v1 stack and as reference. |
+| **Select games, re-implement on the new API** | Pick titles that matter. Port each into `v2/games/<name>/` against `ranger:core` / `ranger:2d` / `ranger:three` / `ranger:cannon` (or `ranger_wasm`). **Must-pass ports:** chess, ylos2 (see `v2/games/README.md`). |
 | **Copy or rewrite by maturity** | If an old game is already close to the target API, **copy** it into `v2/games/` and adapt. If it is tangled with the old bridge/reconciler, **rewrite** it small on the new API — do not drag the tangle forward. |
-| **Old code is a reference, not a dependency** | v2 games must compile and run against v2 only. Reading v1 sources for gameplay ideas is fine; importing v1 engine paths is not. |
+| **Old code is a reference for v2, not a dependency** | v2 games must compile and run against v2 only. Reading v1 sources for gameplay ideas is fine; importing v1 engine paths into v2 is not. |
+| **Retirement is v2-scoped** | D-2D-10 / Phase 12 deletions remove obsolete bits from the **v2** tree (and stop *new* v2 code from using them). They do **not** freeze-thaw delete `scripting/game_sprite.rgr` or v1 runners while v1 games remain supported. |
 
 Engine work still starts headless (evaluator + create/free over the bridge)
 before any v2 game needs pixels. Games arrive once the modules they call are
@@ -37,6 +54,9 @@ this plan must follow (merged after the first scaffold draft):
 | **Frame pipeline** (`runtime.start`) | Phase 8–10 — drain async completions between guest turns |
 | **`WASM_MEMORY_ABI.md` span/status rules** | Phase 5/7 — one span convention; status codes ≠ result counts |
 | **D-2D / `ranger:2d`** (P1) | Phase 10b–12 — sibling of Three; retained + DrawList2D; D-2D-1…10 |
+| **Surface panes / split-screen** | Phase 8–10 / 12 — required for ylos2 / 2P titles |
+| **Vocal FX + music score** on `ranger:core` audio | Phase 10 / 12 — facades (ports may map to clips interim) |
+| **v1 path freeze** | All phases — D-2D-10 / Phase 12 retirement is **v2-scoped** only |
 
 Gate order and required tests in CODE_CLEANUP’s **Implementation gates**
 section are authoritative; the phase table below tracks them.
@@ -152,6 +172,8 @@ Selected **2D games** belong in `v2/games/` the same way as 3D titles.
    rewires, registry exposure, and gate tests before games depend on it.
 8. **`ranger:2d` is P1.** Do not ship a “3D-only” cleanup; D-2D gates are
    required alongside Three/Cannon (CODE_CLEANUP D-2D).
+9. **v1 stays up.** Never “finish” a migration by deleting v1 runtime paths
+   that still-supported games need. Retirement is v2-scoped (see Intent).
 
 ---
 
@@ -573,10 +595,10 @@ RGSP1 / LPC are **inputs to migrate**, not the long-term API.
 | **D-2D-4** | Shared `Camera2D` (math first; SW/GPU present in Phase 11) |
 | **D-2D-5** | `AnimationClip2D` + `AnimationPlayer2D` on `runtime.time` |
 | **D-2D-6** | Frame-local `DrawList2D` separate from retained objects |
-| **D-2D-7** | Migrate `game_sprite` users → retained `ranger:2d` |
-| **D-2D-8** | Migrate RGSP1 ready-character games → SpriteAtlas / AnimationPlayer2D |
-| **D-2D-9** | Migrate `.as` `drawSprite` → `DrawList2D` |
-| **D-2D-10** | Delete old sheet manifests, fixed slots, runner animation clocks after parity |
+| **D-2D-7** | Port *v2* `game_sprite` call sites → retained `ranger:2d` (v1 runners stay) |
+| **D-2D-8** | Port *v2* RGSP1 guests → SpriteAtlas / AnimationPlayer2D (v1 RGSP1 host stays) |
+| **D-2D-9** | Port *v2* `.as` `drawSprite` → `DrawList2D` |
+| **D-2D-10** | After parity: delete obsolete copies **under `v2/` only** (staged manifests/slots/clocks). **Frozen:** `scripting/game_sprite.rgr`, v1 sheet runners, and anything top-level `games/*` still need |
 
 **Parity tests (required)** — also listed in CODE_CLEANUP implementation gates:
 
@@ -605,17 +627,24 @@ plus retained `Sprite2D` + atlas smoke on software (and GPU when available).
 
 ---
 
-## Phase 12 — Selected games + D-2D-7…10 + retire reconciler
+## Phase 12 — Selected games + D-2D-7…10 + retire reconciler (v2-scoped)
 
-Re-home gameplay onto the new API; **leave the old games tree untouched**.
+Re-home gameplay onto the new API; **v1 games and v1 engine paths keep
+running** (see **Intent: v1 keeps running** above).
 
-1. **Select** titles spanning **2D and 3D** (cube / teapot / Cannon toy /
-   Pac-Man or Breakout / LPC character — list in `v2/games/README.md`).
+1. **Must-pass ports:** `chess`, `ylos2` (named in `v2/games/README.md`), plus
+   other selected 2D/3D titles (cube / teapot / Cannon / Pac-Man / Breakout /
+   LPC character, …).
 2. Copy or rewrite onto `ranger:2d` / `ranger:three` / `ranger:core` (not
-   RGSP1 slots or reconciler wrappers).
-3. Complete **D-2D-7…D-2D-10** for migrated titles.
-4. `RETIRE-RECONCILE` + delete retired sprite slot/manifest paths when parity
-   is green. Still do not require deleting v1 games.
+   RGSP1 slots or reconciler wrappers) **inside `v2/games/` only**.
+3. Complete **D-2D-7…D-2D-10** for *v2* migrated titles — retirement deletes
+   only `v2/`-staged obsolete paths.
+4. `RETIRE-RECONCILE` removes the 3D reconciler when its criteria are met; it
+   does **not** remove 2D GameRunner / `game_sprite` while v1 2D games remain
+   supported.
+5. **ylos2 port gate** also requires ranger:core split-screen viewports +
+   vocal FX + music score (or an explicit “port maps these to plain clips /
+   single camera” decision documented on that game).
 
 ---
 
@@ -625,11 +654,12 @@ Bring pieces **into v2 only when a phase or a selected game needs them**. Prefer
 copy-then-adapt when the source is mature; rewrite when it is reconciler-era
 tangled. **Never delete the v1 original** as part of a port.
 
-| Keep in v1 (reference; do not delete) | Why |
-|---------------------------------------|-----|
-| Top-level `games/*` | Source of truth for “what the game did”; ports land in `v2/games/` |
-| `three/tsx/*`, `physics/tsx/*` | Reconciler-era bridges — not copied into v2 |
-| Full `scripting/*` | Engine runners stay as reference; pieces staged under `sprites/`, etc. |
+| Keep in v1 (**running** + reference; do not delete) | Why |
+|----------------------------------------------------|-----|
+| Top-level `games/*` | Still launchable; also source of truth for ports into `v2/games/` |
+| `scripting/game_sprite.rgr`, sprite/sheet runners, TS GameRunner | **Frozen runtime** for chess, ylos2, … until v1 support ends |
+| `three/tsx/*`, `physics/tsx/*` | Reconciler-era bridges — not copied into v2; 3D retire is separate |
+| Rest of `scripting/*` | Engine core for v1; pieces may be *staged* under `v2/sprites/` etc. |
 
 | Already staged under `v2/` (rewire next) | Phase |
 |------------------------------------------|-------|
@@ -691,7 +721,7 @@ Authoritative list: CODE_CLEANUP **Implementation gates** (9 steps). Plan map:
 - [ ] **Phase 10** — Audio/input/surface fakes (D-OWN voices, D-ASYNC loads)
 - [ ] **Phase 10b** — D-2D-1…D-2D-6 (`ranger:2d` registry, atlas, Sprite2D, Camera2D math, anim, DrawList2D)
 - [ ] **Phase 11** — SW/GPU present + Camera2D parity (3D + 2D)
-- [ ] **Phase 12** — D-2D-7…10 game migrations + `RETIRE-RECONCILE` (v1 kept)
+- [ ] **Phase 12** — Must-pass chess + ylos2 (+ others); D-2D-7…10 **v2-scoped** retirement; `RETIRE-RECONCILE` (v1 runtime frozen)
 
 ---
 

--- a/gallery/game_engine/v2/games/README.md
+++ b/gallery/game_engine/v2/games/README.md
@@ -1,64 +1,90 @@
 # games — selected titles on the v2 API
 
-Re-implemented (or lightly copied) games that run **only** against the v2
-engine (`ranger:core` / `ranger:three` / `ranger:cannon` or `ranger_wasm`).
+Re-implemented sketches / ports that target **only** v2 modules:
 
-**Plan phase:** 12 (smoke ports may start once modules exist) — see
-[`CODE_CLEANUP_PLAN.md`](../../CODE_CLEANUP_PLAN.md).
+`ranger:core` / `ranger:2d` / `ranger:three` / `ranger:cannon`  
+(or `ranger_wasm::{core,two_d,three,cannon}`).
 
-## Binding decisions
+**v1 keeps running.** Top-level [`../../games/`](../../games/) and the v1
+engine paths they need (`scripting/game_sprite.rgr`, runners, …) stay
+supported — see [`CODE_CLEANUP_PLAN.md`](../../CODE_CLEANUP_PLAN.md)
+(**Intent: v1 keeps running**). Ports here do **not** license deleting that
+runtime.
 
-- D-MODULES
-- D-SYNC (live objects — no reconciler)
+Sketches may not compile until façades exist. Comments mark `MISSING` /
+`TODO` / `HACK` where the API or content is incomplete.
 
-## Policy (read this first)
+**Plan phase:** 12 (sketches may land earlier).
 
-1. **New folder, old tree kept.** Ports live here under `v2/games/<name>/`.
-   The top-level [`../../games/`](../../games/) tree is **not deleted**.
-2. **Select, don’t bulk-move.** Games are still small — pick titles that
-   exercise the API; do not dump every v1 game in at once.
-3. **Copy or rewrite by maturity.**
-   - **Copy + adapt** when the old game is already close to the target API.
-   - **Rewrite** a thin version when the old code depends on the reconciler,
-     `three/tsx` private trees, or other v1 bridges.
-4. **No v1 engine imports.** v1 sources are a gameplay reference only.
+## Policy
 
-## To implement
+1. **New folder, old tree kept and launchable.** Ports live under
+   `v2/games/<name>/`. Top-level `games/` is **not deleted** and must keep
+   working on v1.
+2. **Select, don’t bulk-move.** Prefer high-signal titles — especially
+   **must-pass** kids’ favorites below.
+3. **Copy or rewrite by maturity.** Pure TS rules/AI (e.g. chess) copy across;
+   GameRunner shells rewrite to `runtime.start(Game)`.
+4. **No v1 engine imports** inside v2 game code.
 
-- Maintain a short selection list below as titles are chosen
-- One subdirectory per game: `v2/games/<name>/` with its own README
-- Prefer `runtime.start(Game)` / `ranger_wasm::export_game!` shapes from
-  CODE_CLEANUP worked examples
+## Must-pass port targets
 
-## Candidate selection (fill in as ports start)
+These exercise more of the 2D + core surface than tiny demos. A Phase 12
+“2D done” claim is false until both work on v2 **without** regressing v1.
+
+| v1 source | Why must-pass | v2 needs |
+|-----------|---------------|----------|
+| **`games/chess`** | Sheet pieces + EVG/JSX HUD; rules/AI are pure TS (copy unchanged) | `SpriteAtlas` / `Sprite2D`, `ranger:2d` text + staged EVG, action maps / cursor |
+| **`games/ylos2`** | LPC sheets, bitmap diamonds, camera scroll, particles, rumble, **split-screen**, **vocal FX**, **music score** | `ranger:2d` + **surface panes**, **`runtime.audio.vocal` / `.music`**, particles, rumble |
+
+Until split-screen / vocal / music land in `ranger:core`, ylos2 can be
+partially sketched but is **not** a green must-pass.
+
+## Selection (sketches + targets)
 
 | v1 source | v2 path | Strategy | Status |
 |-----------|---------|----------|--------|
-| *(none yet)* | | copy / rewrite | pending |
+| **`games/chess`** | `chess/` (TODO) | **must-pass** — copy rules/AI; rewrite shell | pending |
+| **`games/ylos2`** | `ylos2/` (TODO) | **must-pass** — atlas + panes + vocal/music | pending (blocked on core gaps) |
+| `games/pong` | [`pong/`](./pong/) | rewrite → `ranger:2d` shapes + action maps | sketch |
+| `games/breakout` | [`breakout/`](./breakout/) | rewrite → retained bricks | sketch |
+| `games/invaders` | [`invaders/`](./invaders/) | thin rewrite; bitmap art TODO | sketch |
+| `games/pacman` | [`pacman/`](./pacman/) | thin maze only (not full level pack) | sketch |
+| `games/sprite_char` | [`sprite_char/`](./sprite_char/) | atlas/AnimationPlayer (TS + Rust); not RGSP1 | sketch |
+| `games/cube` | [`cube/`](./cube/) | rewrite → `ranger:three` + `runtime.start` | sketch |
+| `games/teapot` | [`teapot/`](./teapot/) | slim lit teapot; GUI/OrbitControls TODO | sketch |
+| `games/cannon_stack` | [`cannon_stack/`](./cannon_stack/) | `ranger:2d` + `ranger:cannon` dual handles | sketch |
 
-Suggested early picks (small, high signal):
+## Conventions used in sketches
 
-- **3D:** rotating cube, teapot, one Cannon stack / sandbox
-- **2D (`ranger:2d`):** Pac-Man or Breakout class title; one LPC / character
-  sample via `SpriteAtlas` + `AnimationPlayer2D` (not RGSP1 slots)
-- **Audio/input:** one sample exercising `ranger:core`
+```ts
+import { runtime, type Game, type FrameInfo } from "ranger:core"
+import * as TWO from "ranger:2d"       // or THREE / CANNON
+class MyGame implements Game {
+  async init(): Promise<void> { /* … */ }
+  update(frame: FrameInfo): void { /* … */ }
+  resize?(w: number, h: number): void { /* … */ }
+  shutdown?(): void { /* … */ }
+}
+runtime.start(new MyGame())
+```
 
-Exact order follows module readiness — do not skip 2D because Three landed
-first. Target imports: `ranger:2d` / `ranger_wasm::two_d` (D-2D).
+Comment markers:
 
-## Unit / contract tests that gate this folder
+| Marker | Meaning |
+|--------|---------|
+| `MISSING:` | API / asset / system not in the contract yet or not wired |
+| `TODO:` | Known follow-up for a fuller port |
+| `HACK:` | Temporary assumption (units, hybrid vectors, 2D Cannon plane) |
+| `NOT` | Explicitly rejected v1 pattern (`window`, RGSP1 slots, reconciler) |
 
-- Each game: headless smoke runner under `v2/tests/` or `games/<name>/tests/`
-- No import of `ThreeTsxBridge.reconcile` or v1 `three/tsx` wrappers
-- Shared geometry / shutdown paths obey D-LIFE (from CODE_CLEANUP examples)
+## Unit / contract tests (later)
 
-## Notes
-
-- Engine gates (create/free, adapter, WASM) come **before** game ports need
-  pixels
-- Assets may be copied from v1 game folders when useful; document the source
-  path in the game’s README
+- Headless smoke per game once façades exist
+- **Must-pass:** chess + ylos2 playable on v2; v1 chess + ylos2 still launch
+- No `ThreeTsxBridge.reconcile` / v1 `three/tsx` imports in v2 ports
+- D-LIFE shutdown paths (remove ≠ release; shared atlas retains)
 
 ---
 
-*Scaffold only (Phase 0). Game subfolders are added when a title is selected.*
+*Sketches only until engine phases land; v1 remains the playable stack.*

--- a/gallery/game_engine/v2/modules/ranger_core/audio/README.md
+++ b/gallery/game_engine/v2/modules/ranger_core/audio/README.md
@@ -1,21 +1,28 @@
 # ranger_core/audio
 
-Listener, createSource.
+Clip / source / voice primitives, plus higher-level **vocal FX** and **music
+score** facades required by ylos2-class ports (CODE_CLEANUP D-MODULES).
 
 **Plan phase:** 8,10 — see [`CODE_CLEANUP_PLAN.md`](../../../../CODE_CLEANUP_PLAN.md).
 
 ## Binding decisions
 
-- D-MODULES
+- D-MODULES, D-OWN, D-LIFE, D-ASYNC
 
 ## To implement
 
-- Façade methods for audio
+- `createSource`, listener attach, mixer buses
+- `runtime.audio.vocal.play(cue)` — short expressive one-shots
+- `runtime.audio.music.play` / `stop` — scored / procedural music
+- Both facades lower to clip/source/voice ownership rules (not a parallel lifetime model)
 
 ## Unit / contract tests that gate this folder
 
 - audio_api_smoke_headless
+- vocal_cue_playOneShot_no_leak
+- music_start_stop_releases_or_stops_voices
+- ylos2_port_not_blocked_on_missing_facade (contract presence)
 
 ---
 
-*Scaffold only (Phase 0). Implementation arrives in later phases.*
+*Scaffold; facades are contract-required, not optional demos.*

--- a/gallery/game_engine/v2/modules/ranger_core/surface/README.md
+++ b/gallery/game_engine/v2/modules/ranger_core/surface/README.md
@@ -1,21 +1,31 @@
 # ranger_core/surface
 
-Size, title, cursor, fullscreen — runtime-owned; guest cannot new Surface.
+Size, title, cursor, fullscreen — runtime-owned; guest cannot `new Surface`.
+
+**Split-screen / panes** are first-class: layout + `pane(i)` rectangles that
+`Camera2D` / renderers target (CODE_CLEANUP D-MODULES — required for ylos2 /
+pyorretris2p).
 
 **Plan phase:** 8,10 — see [`CODE_CLEANUP_PLAN.md`](../../../../CODE_CLEANUP_PLAN.md).
 
 ## Binding decisions
 
-- D-MODULES
+- D-MODULES, D-2D (viewport ↔ Camera2D)
 
 ## To implement
 
-- Façade methods for surface
+- `size`, `attachRenderer`, title / cursor / fullscreen
+- `setLayout("single" | "split-horizontal" | …)` or explicit pane rects
+- `pane(index)` → `{ x, y, width, height, player? }`
+- Optional pane ↔ logical player binding for input routing
 
 ## Unit / contract tests that gate this folder
 
 - surface_api_smoke_headless
+- split_horizontal_two_panes_cover_surface
+- render_to_pane_sets_scissor_or_viewport_equivalently_sw_gpu
+- single_layout_default_full_surface
 
 ---
 
-*Scaffold only (Phase 0). Implementation arrives in later phases.*
+*Scaffold; panes are contract-required for must-pass 2P ports.*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Doc amendments before v2 implementation starts, based on review feedback: keep **v1 running at all times** (do not downgrade/retire its runtime yet), close three API gaps that block kids’ favorites, and name those favorites as must-pass port gates.

## Amendments

1. **v1 path freeze** — D-2D-7…10 and Phase 12 retirement apply only to **`v2/`-staged** copies (`v2/sprites/*`, etc.). Freeze `scripting/game_sprite.rgr`, v1 runners, and related v1 engine paths for as long as v1 games remain supported. Stops the “keep sources, delete runtime” failure mode for chess/ylos2.

2. **Split-screen viewports** — `runtime.surface` / frame-pipeline contract: `createViewport` / `setViewportCamera` / `destroyViewport`, multi-pane clear→draw→present. Needed for ylos2 (`splitScreen=auto`) and other 2P titles.

3. **Vocal FX + music score** — `ranger:core` audio: `playVocal` / `playMusicScore` / `stopMusic` (with interim “map to clips” port policy until synth ports land).

4. **Must-pass ports** — `v2/games/README.md` and the plan list **chess** and **ylos2** by name as must-pass 2D targets (kids’ favorites survive as a tested gate).

## Intent (explicit)

v2 is built **in parallel** under `gallery/game_engine/v2/`. v1 stays launchable; we are **not** deleting or downgrading v1 yet.

## Files

- `CODE_CLEANUP_PLAN.md`, `CODE_CLEANUP.md`
- `v2/games/README.md`
- `v2/modules/ranger_core/{audio,surface}/README.md`

Docs/scaffold only — no v1 game or engine code deleted.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c00c897-4fd5-4b48-a5ef-504fb05fb889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c00c897-4fd5-4b48-a5ef-504fb05fb889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

