### PR TITLE
cpp: read-only buffer params as const& (fix CubeCamera copyInto)

### DIFF
--- a/bin/output.js
+++ b/bin/output.js
@@ -19123,6 +19123,15 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       if ( ((v_type != 16) && (v_type != 17)) && (v_type != 18) ) {
         return false;
       }
+      if ( (typeof(variant.container_class) !== "undefined" && variant.container_class != null )  ) {
+        const cc = variant.container_class;
+        if ( cc.is_inherited ) {
+          return false;
+        }
+        if ( (cc.extends_classes.length) > 0 ) {
+          return false;
+        }
+      }
       if ( typeof(variant.fnBody) === "undefined" ) {
         return false;
       }
@@ -19553,6 +19562,15 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       }
       const tn = typeNode.type_name;
       if ( tn == "string" ) {
+        return true;
+      }
+      if ( tn == "buffer" ) {
+        return true;
+      }
+      if ( tn == "int_buffer" ) {
+        return true;
+      }
+      if ( tn == "double_buffer" ) {
         return true;
       }
       if ( (tn.length) > 0 ) {
@@ -39701,8 +39719,12 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       this.mutatingOps["buffer_set"] = true;
       this.mutatingOps["int_buffer_set"] = true;
       this.mutatingOps["double_buffer_set"] = true;
+      this.mutatingOps["buffer_fill"] = true;
       this.mutatingOps["int_buffer_fill"] = true;
       this.mutatingOps["double_buffer_fill"] = true;
+      this.mutatingOps["buffer_copy"] = true;
+      this.mutatingOps["int_buffer_copy"] = true;
+      this.mutatingOps["double_buffer_copy"] = true;
       this.mutatingOps["push"] = true;
       this.mutatingOps["set"] = true;
       this.mutatingOps["clear"] = true;
@@ -40388,6 +40410,10 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         var m = cl.methods[i];
         this.analyzeFunction(m);
       };
+      for ( let i_1 = 0; i_1 < cl.static_methods.length; i_1++) {
+        var sm = cl.static_methods[i_1];
+        this.analyzeFunction(sm);
+      };
       if ( (typeof(cl.constructor_fn) !== "undefined" && cl.constructor_fn != null )  ) {
         this.analyzeFunction(cl.constructor_fn);
       }
@@ -40500,6 +40526,10 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         var m = cl.methods[i];
         this.analyzeTransitiveMutBorrow(m, changedParams);
       };
+      for ( let i_1 = 0; i_1 < cl.static_methods.length; i_1++) {
+        var sm = cl.static_methods[i_1];
+        this.analyzeTransitiveMutBorrow(sm, changedParams);
+      };
       if ( (typeof(cl.constructor_fn) !== "undefined" && cl.constructor_fn != null )  ) {
         this.analyzeTransitiveMutBorrow(cl.constructor_fn, changedParams);
       }
@@ -40601,6 +40631,10 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         var m = cl.methods[i];
         this.analyzeMethodMutation(m);
       };
+      for ( let i_1 = 0; i_1 < cl.static_methods.length; i_1++) {
+        var sm = cl.static_methods[i_1];
+        this.analyzeMethodMutation(sm);
+      };
       if ( (typeof(cl.constructor_fn) !== "undefined" && cl.constructor_fn != null )  ) {
         this.analyzeMethodMutation(cl.constructor_fn);
       }
@@ -40673,6 +40707,10 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       for ( let i = 0; i < cl.methods.length; i++) {
         var m = cl.methods[i];
         this.analyzeMethodParamMutations(m);
+      };
+      for ( let i_1 = 0; i_1 < cl.static_methods.length; i_1++) {
+        var sm = cl.static_methods[i_1];
+        this.analyzeMethodParamMutations(sm);
       };
       if ( (typeof(cl.constructor_fn) !== "undefined" && cl.constructor_fn != null )  ) {
         this.analyzeMethodParamMutations(cl.constructor_fn);

--- a/compiler/ng_RangerCppClassWriter.rgr
+++ b/compiler/ng_RangerCppClassWriter.rgr
@@ -460,6 +460,21 @@ class RangerCppClassWriter {
     if (((v_type != RangerNodeType.Buffer) && (v_type != RangerNodeType.IntBuffer)) && (v_type != RangerNodeType.DoubleBuffer)) {
       return false
     }
+    ; Methods that take part in virtual dispatch must keep one signature across
+    ; the whole override set. A sibling override may legitimately return a fresh
+    ; buffer (by value), so we cannot unilaterally switch one variant to a
+    ; reference return without risking a signature mismatch that silently breaks
+    ; overriding. Keep value semantics for any method whose class participates
+    ; in inheritance (either as a base with subclasses or as a derived class).
+    if (!null? variant.container_class) {
+      def cc:RangerAppClassDesc (unwrap variant.container_class)
+      if cc.is_inherited {
+        return false
+      }
+      if ((array_length cc.extends_classes) > 0) {
+        return false
+      }
+    }
     if (null? variant.fnBody) {
       return false
     }
@@ -970,6 +985,14 @@ class RangerCppClassWriter {
     ; Params often carry their type in type_name with value_type still NoType.
     def tn:string typeNode.type_name
     if (tn == "string") { return true }
+    ; A buffer parameter that is never written is read-only. Passing it as
+    ; `const std::vector<T>&` (rather than a non-const `&`) both avoids the copy
+    ; and — crucially — lets it bind to a temporary, e.g. a buffer returned
+    ; by value from an accessor: copyInto(renderer.raw(), ...). Mutated buffers
+    ; are caught above (set_cnt / needs_cpp_reference) and stay non-const.
+    if (tn == "buffer") { return true }
+    if (tn == "int_buffer") { return true }
+    if (tn == "double_buffer") { return true }
     if ((strlen tn) > 0) {
       ; Collection literal types "[T]" / "[K:T]" map to std::vector / std::map.
       def firstCh:string (substring tn 0 1)

--- a/compiler/ng_StaticAnalysis.rgr
+++ b/compiler/ng_StaticAnalysis.rgr
@@ -23,12 +23,21 @@ class StaticAnalyzer {
   }
   
   fn initMutatingOps:void () {
-    ; Buffer/array mutation operators - these modify data IN-PLACE
+    ; Buffer/array mutation operators - these modify their target IN-PLACE.
+    ; The mutated argument is the operator's first operand (e.g. the buffer in
+    ; `buffer_set`, the destination in `buffer_copy`). Every op that writes its
+    ; target must be listed here so the target parameter is passed by non-const
+    ; reference (a read-only buffer is now passed as const&, which would break
+    ; an in-place write that this list fails to flag).
     set mutatingOps "buffer_set" true
     set mutatingOps "int_buffer_set" true
     set mutatingOps "double_buffer_set" true
+    set mutatingOps "buffer_fill" true
     set mutatingOps "int_buffer_fill" true
     set mutatingOps "double_buffer_fill" true
+    set mutatingOps "buffer_copy" true
+    set mutatingOps "int_buffer_copy" true
+    set mutatingOps "double_buffer_copy" true
     
     ; Array mutation operators - these modify the array IN-PLACE
     set mutatingOps "push" true
@@ -956,11 +965,18 @@ class StaticAnalyzer {
   ; Analyze all methods in a class
   fn analyzeClass:void (cl:RangerAppClassDesc) {
     currentClass = cl
-    
+
     for cl.methods m:RangerAppFunctionDesc i {
       this.analyzeFunction(m)
     }
-    
+    ; Static methods need the same param-mutation analysis as instance methods,
+    ; otherwise a mutated buffer/array/map parameter of an `sfn` is emitted by
+    ; value and its in-place writes are silently lost (and, with read-only
+    ; buffers now passed as const&, a mutated one would wrongly become const).
+    for cl.static_methods sm:RangerAppFunctionDesc i {
+      this.analyzeFunction(sm)
+    }
+
     ; Also analyze the constructor
     if (!null? cl.constructor_fn) {
       this.analyzeFunction((unwrap cl.constructor_fn))
@@ -1116,11 +1132,14 @@ class StaticAnalyzer {
   ; Analyze transitive mutable borrow for all methods in a class
   fn analyzeClassTransitiveMutBorrow:void (cl:RangerAppClassDesc changedParams:[string]) {
     currentClass = cl
-    
+
     for cl.methods m:RangerAppFunctionDesc i {
       this.analyzeTransitiveMutBorrow(m changedParams)
     }
-    
+    for cl.static_methods sm:RangerAppFunctionDesc i {
+      this.analyzeTransitiveMutBorrow(sm changedParams)
+    }
+
     if (!null? cl.constructor_fn) {
       this.analyzeTransitiveMutBorrow((unwrap cl.constructor_fn) changedParams)
     }
@@ -1257,11 +1276,14 @@ class StaticAnalyzer {
   ; Analyze mutation behavior for all methods in a class
   fn analyzeClassMutation:void (cl:RangerAppClassDesc) {
     currentClass = cl
-    
+
     for cl.methods m:RangerAppFunctionDesc i {
       this.analyzeMethodMutation(m)
     }
-    
+    for cl.static_methods sm:RangerAppFunctionDesc i {
+      this.analyzeMethodMutation(sm)
+    }
+
     if (!null? cl.constructor_fn) {
       this.analyzeMethodMutation((unwrap cl.constructor_fn))
     }
@@ -1362,11 +1384,14 @@ class StaticAnalyzer {
   ; Analyze parameter mutations for all methods in a class
   fn analyzeClassParamMutations:void (cl:RangerAppClassDesc) {
     currentClass = cl
-    
+
     for cl.methods m:RangerAppFunctionDesc i {
       this.analyzeMethodParamMutations(m)
     }
-    
+    for cl.static_methods sm:RangerAppFunctionDesc i {
+      this.analyzeMethodParamMutations(sm)
+    }
+
     if (!null? cl.constructor_fn) {
       this.analyzeMethodParamMutations((unwrap cl.constructor_fn))
     }

--- a/gallery/game_engine/three/src/three_gl.rgr
+++ b/gallery/game_engine/three/src/three_gl.rgr
@@ -103,7 +103,9 @@ function __rglEnd(){ }
                   (imp "<vector>") (imp "<string>") (imp "<cstdint>") (imp "<cmath>")
 (create_polyfill "
 #if defined(__APPLE__)
+#ifndef GL_SILENCE_DEPRECATION
 #define GL_SILENCE_DEPRECATION
+#endif
 #include <OpenGL/gl3.h>
 #elif defined(__arm__) || defined(__aarch64__)
 #include <GLES2/gl2.h>

--- a/gallery/game_engine/v2/three/port/src/three_gl.rgr
+++ b/gallery/game_engine/v2/three/port/src/three_gl.rgr
@@ -103,7 +103,9 @@ function __rglEnd(){ }
                   (imp "<vector>") (imp "<string>") (imp "<cstdint>") (imp "<cmath>")
 (create_polyfill "
 #if defined(__APPLE__)
+#ifndef GL_SILENCE_DEPRECATION
 #define GL_SILENCE_DEPRECATION
+#endif
 #include <OpenGL/gl3.h>
 #elif defined(__arm__) || defined(__aarch64__)
 #include <GLES2/gl2.h>

--- a/tests/codegen-cpp.test.ts
+++ b/tests/codegen-cpp.test.ts
@@ -245,6 +245,41 @@ describe("C++ Code Generation", () => {
       expect(result.code).toContain(
         "std::vector<uint8_t>& faceBuffer( int face );"
       );
+      // The static copyInto's read-only `src` is a const reference (so it can
+      // bind to a by-value buffer temporary such as renderer.raw()), while its
+      // written `dst` stays a non-const reference (writes reach the caller).
+      // This also exercises mutation analysis of a static (sfn) method.
+      expect(result.code).toContain(
+        "Worker::copyInto( const std::vector<uint8_t>& src , std::vector<uint8_t>& dst , int n )"
+      );
+    });
+  });
+
+  describe("Static method parameter mutation", () => {
+    // Static (sfn) methods must get the same parameter-mutation analysis as
+    // instance methods: a mutated buffer/array/map parameter is a non-const
+    // reference (its in-place writes must reach the caller), and a read-only
+    // one is a const reference. Regression for static methods previously being
+    // skipped by the analysis (mutations were silently lost / could not compile).
+    it("should pass mutated static-method collection params by non-const reference", () => {
+      const result = getGeneratedCppCode(
+        `${FIXTURES_DIR}/static_param_mutation.rgr`
+      );
+      expect(result.success, `Failed: ${result.error}`).toBe(true);
+      // buffer written via buffer_set -> non-const reference
+      expect(result.code).toContain(
+        "M::sWriteBuf( std::vector<uint8_t>& dst"
+      );
+      // array mutated via push -> non-const reference
+      expect(result.code).toContain("M::sPush( std::vector<int>& arr");
+      // buffer only read -> const reference (binds to temporaries)
+      expect(result.code).toContain(
+        "M::sReadBuf( const std::vector<uint8_t>& src"
+      );
+      // destination of buffer_copy is written -> non-const reference
+      expect(result.code).toContain(
+        "M::sCopy( std::vector<uint8_t>& dst , const std::vector<uint8_t>& src"
+      );
     });
   });
 });

--- a/tests/fixtures/buffer_return_ref.rgr
+++ b/tests/fixtures/buffer_return_ref.rgr
@@ -42,9 +42,9 @@ class Worker {
 
     sfn run:void () {
         def cube:CubeMap (CubeMap.create(2))
-        def src:buffer (buffer_alloc 12)
-        ; Passing the accessor result directly to a non-const buffer& parameter
-        ; only compiles if faceBuffer returns a reference.
-        Worker.copyInto(src (cube.faceBuffer(0)) 12)
+        ; Pass a by-value buffer temporary as src (like renderer.raw()) and a
+        ; reference-returning accessor as dst (like faceBuffer). Compiles only
+        ; when src is const& (binds to the temporary) and faceBuffer returns &.
+        Worker.copyInto((cube.makeScratch(12)) (cube.faceBuffer(0)) 12)
     }
 }

--- a/tests/fixtures/static_param_mutation.rgr
+++ b/tests/fixtures/static_param_mutation.rgr
@@ -1,0 +1,33 @@
+; Regression fixture: static (sfn) methods must receive the same parameter
+; mutation analysis as instance methods. A mutated buffer/array parameter must
+; be a non-const C++ reference (its in-place writes must be visible to the
+; caller); a read-only buffer parameter is a const reference (so it also binds
+; to by-value temporaries). Static methods were previously skipped entirely by
+; the analysis, so their mutated collection params were emitted by value and
+; the writes were silently dropped.
+class M {
+    ; buffer written in place -> non-const reference
+    sfn sWriteBuf:void (dst:buffer n:int) {
+        def i:int 0
+        while (i < n) {
+            buffer_set dst i 7
+            i = (i + 1)
+        }
+    }
+
+    ; array mutated in place -> non-const reference
+    sfn sPush:void (arr:[int] x:int) {
+        push arr x
+    }
+
+    ; buffer only read -> const reference
+    sfn sReadBuf:int (src:buffer i:int) {
+        return (buffer_get src i)
+    }
+
+    ; destination of buffer_copy is written -> non-const reference;
+    ; source is read -> const reference
+    sfn sCopy:void (dst:buffer src:buffer n:int) {
+        buffer_copy dst 0 src 0 n
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Re-lands the orphaned C++ backend fix for the `game_sdl` / `ThreeCubeCamera::copyInto` clang++ failure:

```text
non-const lvalue reference to type 'vector<...>' cannot bind to a temporary
ThreeCubeCamera::copyInto(renderer->raw(), cube->faceBuffer(face), bytes);
```

`renderer.raw()` legitimately returns a buffer **by value** (it forwards through a virtual backend chain). That temporary cannot bind to a non-const `std::vector<uint8_t>&`. `copyInto` only *reads* `src`, so the parameter should be `const std::vector<uint8_t>&`, which binds to temporaries.

This change was previously committed as `2d5c720f` on `claude/ranger-compiler-sdl-errors-ba405c-d4rafp` but never merged to `master`, so the build break came back.

### Compiler changes

- Treat read-only `buffer` / `int_buffer` / `double_buffer` params as `const T&` via the `type_name` fallback in `cppReadonlyValueParam` (value_type is often still `NoType` on params).
- Walk `static_methods` in all mutation-analysis passes so `sfn` methods like `copyInto` get correct const vs non-const refs (and mutated static params are not silently dropped).
- Register `buffer_fill` / `buffer_copy` (and int_/double_ variants) as mutating ops.
- Suppress buffer return-by-reference for methods on classes that participate in inheritance (override signature consistency).
- Guard `#define GL_SILENCE_DEPRECATION` with `#ifndef` to silence the macOS command-line redefine warning.

### Tests

- Extends `buffer_return_ref` expectations: `copyInto(const& src, & dst, …)`.
- Fixture call site now uses `copyInto((cube.makeScratch(12)) (cube.faceBuffer(0)) 12)` — the same temporary-as-src shape as `renderer.raw()`.
- Adds `static_param_mutation` fixture covering static buffer/array mutation and `buffer_copy`.

## Test plan

- [x] `codegen-cpp.test.ts` — 27/27 passed (includes buffer return-by-ref + static param mutation)
- [x] `compiler-cpp.test.ts` — 14/14 passed
- [x] Generated C++ shows `Worker::copyInto(cube->makeScratch(12), cube->faceBuffer(0), 12)` with `const std::vector<uint8_t>& src`
- [ ] Re-run local `game_sdl` clang++ build (macOS / SDL2 + OpenGL) and confirm `copyInto` compiles without the temporary-binding error
- [ ] Confirm `GL_SILENCE_DEPRECATION` redefine warning is gone
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bbc40fc-fec4-4941-84c4-f58589111eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bbc40fc-fec4-4941-84c4-f58589111eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

