### PR TITLE
game_engine: agent guidance encoding the TSX-only game-package rule

### DIFF
--- a/gallery/game_engine/AGENTS.md
+++ b/gallery/game_engine/AGENTS.md
@@ -17,7 +17,8 @@ Think of three layers. Code belongs to exactly one:
 |-------|----------|----------------|--------------------|
 | **Engine core** | `scripting/` runtime files, `framebuffer.rgr`, ABI helpers, generic runners | Framebuffers, the ABI *shape*, physics primitives, sprite/HUD *mechanisms* | Any specific game: its entities, world size, track, sprites, HUD gauges, sound names, player count |
 | **Reusable subsystems** | `physics/`, `lpc/`, `menu/`, `ui/`, `pose/` | Their own domain (physics bodies, spritesheets, UI trees) | Which game is using them |
-| **A game** | `games/<name>/` (loadable TSX/WASM/`.as`) **or** `ranger_games/` (static Ranger compiled to native), plus any `<Name>Setup`/`<Name>Render`/`<Name>Hud` modules | Everything about itself | Nothing needs to know about it in core |
+| **A game (guest source)** | `games/<name>/` (loadable TSX/WASM/`.as`) **or** `ranger_games/` (static Ranger compiled to native), plus any v1 `<Name>Setup`/`<Name>Render`/`<Name>Hud` modules | Everything about itself | Nothing needs to know about it in core |
+| **Host-side per-game test/demo drivers** | `tests/` (v1) · `v2/tests/e2e/` (v2) — **never inside `games/<name>/`** | The one generic runner + that game's expected outcomes | — |
 
 ### Hard rules
 
@@ -41,7 +42,16 @@ Think of three layers. Code belongs to exactly one:
    one game's numbers satisfy (world height `6000`, camera `5860`, id prefixes
    `t`/`c`/`b`, sound ids `wall`/`bounce`/`win`, `resolvePlayerCount → 2`, …).
 
-4. **The shared ABI stays game-neutral.** `wasm/wasm_game_abi.h` and
+4. **A game directory is guest content only (v2: strict).** Guest game source
+   and host-side per-game drivers are different layers even when both are
+   game-named. A runner/harness that sets up the interpreter, bridge, or
+   renderer for one game is a *host test driver* and lives under `tests/`
+   (v2: `v2/tests/e2e/`) — never inside `games/<name>/`. In `v2/`, **adding a
+   TSX game must not require adding or compiling a game-specific `.rgr`
+   file** (see `v2/games/AGENTS.md`; v1 `<Name>Setup`-style modules are
+   grandfathered).
+
+5. **The shared ABI stays game-neutral.** `wasm/wasm_game_abi.h` and
    `scripting/wasm_abi_io.rgr` define a *transport*. Body-index meaning, id-code
    ranges, and event sub-ids are **conventions the guest defines** — document
    them as such. Do not freeze one game's taxonomy into the ABI header as if it
@@ -50,6 +60,7 @@ Think of three layers. Code belongs to exactly one:
 ### Before you commit an engine-core change — checklist
 
 - [ ] No game name (`autopeli`, `pong`, …) appears in a generic `scripting/` file.
+- [ ] No `.rgr` runner / host setup / host assertions added inside a `games/<name>/` directory (host test drivers go under `tests/`; v2: `v2/tests/e2e/`).
 - [ ] No world constant that only one game satisfies is hardcoded in core.
 - [ ] Per-game behavior arrives via a parameter/field/provider, not a branch.
 - [ ] A hypothetical *second* physics game could use this file unchanged.

--- a/gallery/game_engine/v2/AGENTS.md
+++ b/gallery/game_engine/v2/AGENTS.md
@@ -1,0 +1,93 @@
+# v2 agent instructions
+
+Read this before writing or changing anything under `v2/`. It encodes the
+architecture boundaries **and the mistakes already made once** in this tree
+(each documented in detail in [`WHYWRONG.md`](./WHYWRONG.md) and
+[`games/WHYWRONG.md`](./games/WHYWRONG.md)) so they are not made twice.
+
+## What v2 is
+
+```text
+ordinary TSX game content (guest)
+    → TSX evaluator (interp/, staged ComponentEngine)
+    → ONE table-driven transport (interp/engine/RgRegistryBridge — generated
+      from the registry, never hand-authored per domain)
+    → typed host arenas (host/, modules/ranger_2d, modules/ranger_core, …)
+    → host-owned frame pipeline (runtime/)
+    → renderer READS host state (render/ — not a sync boundary)
+```
+
+The product is that **ordinary TSX runs with exact JS identity semantics over
+host-native objects** (D-IDENTITY and the other D-* decisions in
+[`../CODE_CLEANUP.md`](../CODE_CLEANUP.md)). Every layer exists to serve that.
+
+## Boundary map (who may know what)
+
+| Layer | Lives in | May know | Must NOT know |
+|---|---|---|---|
+| Guest games / menus | `games/<name>/`, `menu/` — **TSX only** | its own world; the `ranger:*` capabilities; the game protocol | anything about the host's internals |
+| Guest façades | `games/ranger2d.tsx` (interim → generated) | the generated command names | host state layout |
+| Generic host | `runtime/game_host/` | the game protocol; the frame pipeline | **any specific game** |
+| Transport | `interp/engine/` | the generated command table | per-command semantics (rows are data) |
+| Registry | `registry/` | the semantic interface + ABI profiles ([`BRIDGES.md`](./BRIDGES.md) rev 2) | any single transport as "the" identity |
+| Arenas / modules | `host/`, `modules/` | their own domain | which guest is calling |
+| Render backends | `render/` | how to read host state | how to mutate anything |
+
+## Rules distilled from this tree's own failures
+
+1. **Games are TSX guests — never Ranger.** A game/menu is a folder of `.tsx`
+   (+ assets/metadata). *Adding a TSX game must not require adding or
+   compiling a game-specific `.rgr` file.* Per-game host shells are forbidden;
+   the one generic host is `runtime/game_host/RgGameHost.rgr`. Strict package
+   rules: [`games/AGENTS.md`](./games/AGENTS.md).
+   *(Failure prevented: `ylos2_v2_runner.rgr` placed inside the game folder.)*
+
+2. **Mocks are not validation.** A component is done when its **real caller**
+   invokes it with data that originated in guest source — not when a
+   self-written test passes against a hand-driven slice. Fakes are allowed
+   only at true device edges (GPU present, audio DAC, gamepad HID), never for
+   the evaluator, adapter, bridge, or arenas.
+   *(Failure prevented: 33 green suites while no TSX had ever run.)*
+
+3. **Bridges are generated, never authored per domain.** No if-chain command
+   bridges, no game- or domain-named command surfaces, no second command
+   table. The authored source is the semantic interface; transports are
+   generated per ABI profile — see [`BRIDGES.md`](./BRIDGES.md) rev 2.
+   *(Failures prevented: a hand `rg2d_*` if-chain bridge; then a single
+   transport-shaped table conflating semantics with wasm32 lowering.)*
+
+4. **Follow the plan's named sources.** When a phase says "port/adapt file X",
+   writing a fresh parallel file instead is a decision that needs explicit
+   sign-off, not a silent substitution.
+   *(Failure prevented: fresh `RgValue` slices while `interp/migrate/src/`
+   held the real staged evaluator.)*
+
+5. **Run before writing.** Before designing a piece of this system, execute
+   the existing end-to-end path (`tests/run.sh`, the e2e suites, a v1 demo)
+   and be able to trace one real guest statement (`new Sprite2D(...)`) through
+   parser → evaluator → bridge → arena. If you cannot write that trace, you
+   are not ready to modify the layer.
+
+## Working rules
+
+- **Gate:** `bash tests/run.sh` must end `v2 ALL GREEN` before any commit.
+  New capabilities need a suite registered there; e2e drivers live under
+  `tests/e2e/` (host-side, may be game-aware — game folders may not be
+  host-aware).
+- **Scope:** edit only inside `v2/` unless unavoidable; v1
+  (`../scripting/`, `../games/`, runners) stays untouched and runnable.
+- **Registry ids are immutable** once published (golden tests enforce:
+  meaning-change / renumber / tombstone-reuse / lowering-change all fail).
+- Ranger-language pitfalls (parenthesized nested calls, `idiv`, reserved
+  names like `make`/`wrap`, one-statement-per-line): root `/AGENTS.md` and
+  `/ai/*.md`.
+
+## Key documents
+
+| Doc | What it governs |
+|---|---|
+| [`../CODE_CLEANUP.md`](../CODE_CLEANUP.md) | the binding contract (all D-*) |
+| [`../CODE_CLEANUP_PLAN.md`](../CODE_CLEANUP_PLAN.md) | phase plan + v1 policy |
+| [`BRIDGES.md`](./BRIDGES.md) | bridge/IDL/ABI-profile design (rev 2) |
+| [`games/AGENTS.md`](./games/AGENTS.md) | the TSX-only game-package rules |
+| [`WHYWRONG.md`](./WHYWRONG.md), [`games/WHYWRONG.md`](./games/WHYWRONG.md) | the full post-mortems behind rules 1–5 |

--- a/gallery/game_engine/v2/games/AGENTS.md
+++ b/gallery/game_engine/v2/games/AGENTS.md
@@ -1,0 +1,67 @@
+# v2 game-package rules
+
+A loadable TSX game is **guest content, not a host program**.
+
+This file exists because the rule was violated in practice: a game-specific
+host shell (`ylos2/ylos2_v2_runner.rgr` — interpreter setup, bridge
+construction, renderer calls, host assertions) was placed inside a game
+directory. The broader "engine core must stay generic" rule
+(`../../AGENTS.md`) did not prevent it, because that file governed *engine
+core*, not the *game package boundary*. These rules close that gap.
+
+## The enforcement sentence
+
+> **Adding a TSX game must not require adding or compiling a game-specific
+> `.rgr` file.**
+
+If your change to `games/<name>/` makes that sentence false, the change is
+wrong — regardless of how reasonable it looks as "just a runner" or "just a
+test harness".
+
+## Hard rules
+
+1. TSX game directories **may** contain:
+   - `.tsx` guest source
+   - game metadata
+   - assets and data files
+   - game-facing documentation
+
+2. TSX game directories **must not** contain:
+   - `.rgr` runners
+   - interpreter setup
+   - bridge construction
+   - renderer construction
+   - arena or registry inspection
+   - host lifecycle loops
+   - host-side assertion code
+
+3. All TSX games run through the **same generic runtime entrypoint**
+   (`../runtime/game_host/RgGameHost.rgr` — the v1 `GameRunner` analog). The
+   host knows the *game protocol* (`init()` / `update(props)` / `getLayerId()`
+   / `getCameraId(pane)` / optional `autopilotBits(slot)` attract mode), never
+   a game.
+
+4. Game-specific **host** tests belong under `v2/tests/` (e.g.
+   `v2/tests/e2e/ylos2_e2e_test.rgr`), not under `v2/games/<name>/`. A test
+   driver may be game-aware; a game directory may not be host-aware.
+
+5. Production game source must not export test-only accessors for host
+   inspection. Use guest-visible diagnostics or test fixtures where needed.
+   *(Known deviation: `ylos2/index.tsx` currently exports `playerY` /
+   `playerX` / `reachedGoal` / `playerSpriteId` for the e2e driver — these
+   should migrate to a guest-side test fixture under `games/<name>/tests/`
+   that runs through the generic host.)*
+
+6. Adding a new TSX game must not require compiling a new `.rgr` program.
+
+7. A game package is valid only when **copying its directory to another
+   compatible host is sufficient to run it**.
+
+## Why this matters (the v1 lesson, one level up)
+
+v1 rotted through per-game engine growth: RGSP1 slots, runner-specific sheet
+manifests, `Standard body indices (autopeli)` in the shared ABI. The v2 form
+of the same disease is subtler — a "helpful" per-game `.rgr` host shell. The
+package boundary is the firewall: games stay data + guest code, hosts stay
+generic, and the two meet only at the game protocol and the `ranger:*`
+capabilities.

--- a/gallery/game_engine/v2/games/README.md
+++ b/gallery/game_engine/v2/games/README.md
@@ -78,9 +78,15 @@ Comment markers:
 | `HACK:` | Temporary assumption (units, hybrid vectors, 2D Cannon plane) |
 | `NOT` | Explicitly rejected v1 pattern (`window`, RGSP1 slots, reconciler) |
 
-## Unit / contract tests (later)
+## Unit / contract tests
 
-- Headless smoke per game once façades exist
+- Host-side headless and contract runners live under `v2/tests/` (e2e drivers
+  in `v2/tests/e2e/`). Optional guest-side TSX test fixtures may live under
+  `games/<name>/tests/`, but they must run through the generic host.
+- **A game directory contains guest content only** — `.tsx` source, metadata,
+  assets, docs. Never `.rgr` runners, interpreter/bridge/renderer setup, or
+  host-side assertions. Adding a TSX game must not require adding or compiling
+  a game-specific `.rgr` file. Full rules: [`AGENTS.md`](./AGENTS.md).
 - **Must-pass:** chess + ylos2 playable on v2; v1 chess + ylos2 still launch
 - No `ThreeTsxBridge.reconcile` / v1 `three/tsx` imports in v2 ports
 - D-LIFE shutdown paths (remove ≠ release; shared atlas retains)


### PR DESCRIPTION
## Summary

Follow-up to #409 (the generic game host). That PR fixed the *code* regression — a per-game `.rgr` runner inside `games/ylos2/`; this one fixes the *guidance* that allowed it. The existing docs had two gaps: `gallery/game_engine/AGENTS.md`'s layer table let a game-named **host** module pass as game code, and `v2/games/README.md` explicitly permitted "headless smoke runner under … `games/<name>/tests/`". These changes close both, with the mechanical enforcement sentence that would have caught the mistake:

> **Adding a TSX game must not require adding or compiling a game-specific `.rgr` file.**

## Changes

### New: `v2/games/AGENTS.md` — the strict package rule
A loadable TSX game is **guest content, not a host program**:
- may contain: `.tsx` source, metadata, assets, game-facing docs
- must not contain: `.rgr` runners, interpreter/bridge/renderer setup, arena/registry inspection, host lifecycle loops, host-side assertions
- all games run through the one generic entrypoint (`runtime/game_host/RgGameHost.rgr`); game-specific host tests live under `v2/tests/`, never under `games/<name>/`
- portability criterion: a package is valid only when copying its directory to another compatible host suffices to run it
- honest known-deviation note: `ylos2/index.tsx` still exports test-only accessors (rule 5), flagged for migration to guest-side fixtures

### New: `v2/AGENTS.md` — v2-wide agent instructions
Per-layer boundary map (who may know what) plus five rules distilled from this tree's own documented failures (`WHYWRONG.md` post-mortems), each citing the mistake it prevents: TSX-only games · mocks are not validation ("done" = invoked by the real caller with guest-originated data) · bridges are generated, never hand-authored per domain · plan-named sources are binding · run before writing. Includes the `tests/run.sh` ALL-GREEN commit gate and doc pointers (CODE_CLEANUP, BRIDGES rev 2).

### Fixed: `v2/games/README.md`
The loophole line is replaced with: host-side headless/contract runners live under `v2/tests/` only; optional guest-side TSX fixtures under `games/<name>/tests/` must run through the generic host; game directories are guest content only.

### Fixed: `gallery/game_engine/AGENTS.md`
- Layer table now separates **"a game (guest source)"** from **"host-side per-game test/demo drivers"** (home: `tests/` / `v2/tests/e2e/` — never inside `games/<name>/`)
- New hard rule 4 carrying the enforcement sentence (v2 strict; v1 `<Name>Setup`-style modules grandfathered)
- Commit checklist gains a matching item

## Test plan

- Docs-only change; `bash gallery/game_engine/v2/tests/run.sh` verified unaffected → `v2 ALL GREEN — 37/37 suites passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wi8xneHxDrhrUpUpem17Kc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wi8xneHxDrhrUpUpem17Kc)_