### PR TITLE
game_engine/v2: BRIDGES.md — TSX call stack and layered genericity

### DIFF
--- a/gallery/game_engine/v2/BRIDGES.md
+++ b/gallery/game_engine/v2/BRIDGES.md
@@ -301,14 +301,26 @@ CODE_CLEANUP decisions that pin this stack:
 
 ### 6.3 Worked paths (ylos2 → display)
 
-All paths start in [`games/ylos2/index.tsx`](./games/ylos2/index.tsx). Guest
-wrappers live in `modules/ranger_{core,2d}/*.tsx`; transport in
-`RgRegistryBridge`; arenas in `RgRanger2D` / `RgInput` / `RgSurface`; pixels in
-`RgSoftwareRenderer2D`.
+All paths start in [`games/ylos2/index.tsx`](./games/ylos2/index.tsx). Each
+subsection shows: **guest TSX** → **façade** → **Ranger call sites** (with
+file paths) → **data structures touched**.
+
+| Role | Where in the tree |
+|------|-------------------|
+| Guest game | [`games/ylos2/index.tsx`](./games/ylos2/index.tsx) |
+| Guest façades | [`modules/ranger_2d/ranger_2d.tsx`](./modules/ranger_2d/ranger_2d.tsx), [`modules/ranger_core/ranger_core.tsx`](./modules/ranger_core/ranger_core.tsx) |
+| Schema rows | [`registry/schema/two_d/two_d_schema.rgr`](./registry/schema/two_d/two_d_schema.rgr), [`registry/schema/core/core_schema.rgr`](./registry/schema/core/core_schema.rgr) |
+| Interpreter seam | [`interp/migrate/src/ComponentEngine.rgr`](./interp/migrate/src/ComponentEngine.rgr) (`EvalNativeBridge`) |
+| Transport | [`interp/engine/RgRegistryBridge.rgr`](./interp/engine/RgRegistryBridge.rgr) |
+| 2D arenas | [`modules/ranger_2d/RgRanger2D.rgr`](./modules/ranger_2d/RgRanger2D.rgr) |
+| Input / surface | [`modules/ranger_core/RgInputSurface.rgr`](./modules/ranger_core/RgInputSurface.rgr) |
+| Handles | [`host/handles/RgHandle.rgr`](./host/handles/RgHandle.rgr), [`host/ownership/OwnedHandle.rgr`](./host/ownership/OwnedHandle.rgr), [`host/RgRegistry.rgr`](./host/RgRegistry.rgr) |
+| Present | [`runtime/game_host/Rg2DPresenter.rgr`](./runtime/game_host/Rg2DPresenter.rgr), [`render/backends/software/RgSoftwareRenderer2D.rgr`](./render/backends/software/RgSoftwareRenderer2D.rgr) |
+| Lifecycle host | [`runtime/game_host/RgGameHost.rgr`](./runtime/game_host/RgGameHost.rgr) |
 
 #### Path A — create a platform sprite and put it on a layer
 
-Guest (init):
+Guest (init) — [`games/ylos2/index.tsx`](./games/ylos2/index.tsx):
 
 ```ts
 const s = new TWO.Sprite2D(this.atlas, rPlat);
@@ -316,115 +328,363 @@ s.setPos(p.x + p.w / 2, p.y);
 this.layer.add(s);
 ```
 
-| Step | Actor | What happens |
-|------|-------|--------------|
-| 1 | guest | `new TWO.Sprite2D(atlas, rPlat)` |
-| 2 | façade `ranger_2d.tsx` | `this.id = rg2d_sprite_create(atlas.id, regionIndex)` |
-| 3 | interp | `ComponentEngine` → `EvalNativeBridge.invoke("rg2d_sprite_create", …)` |
-| 4 | bridge | table row → decode `h:i` → resolve guest atlas id → `RgHandle` |
-| 5 | host | `RgRanger2D.spriteCreate` — alloc typed slot, **retain** atlas (D-OWN), mint guest id |
-| 6 | guest | `s.setPos(…)` → `rg2d_sprite_set_pos` → `spriteSetPos` writes arena `x`/`y` |
-| 7 | guest | `layer.add(s)` → `rg2d_layer_add` → `layerAdd` sets `sprite.layerSlot`, bumps child count |
+Façade — [`modules/ranger_2d/ranger_2d.tsx`](./modules/ranger_2d/ranger_2d.tsx):
 
-The guest `Sprite2D` is a thin id holder. Authoritative pixels/pose live in the
-host arena. Reordering/reparenting never changes the guest id (D-IDENTITY /
-D-2D).
+```ts
+class Sprite2D {
+  id = 0;
+  constructor(atlas, regionIndex) { this.id = rg2d_sprite_create(atlas.id, regionIndex); }
+  setPos(x, y) { rg2d_sprite_set_pos(this.id, x, y); }
+}
+class Layer2D {
+  add(sprite) { rg2d_layer_add(sprite.id, this.id); }
+}
+```
+
+Schema seed (command names + `argSpec`) —
+[`registry/schema/two_d/two_d_schema.rgr`](./registry/schema/two_d/two_d_schema.rgr):
+
+```rgr
+sprite.addMethod((RgMethodDef.cmd(2020 "rg2d_sprite_create" "rg2d_sprite_create" "h:i" "h" "create")))
+sprite.addMethod((RgMethodDef.cmd(2021 "rg2d_sprite_set_pos" "rg2d_sprite_set_pos" "h:d:d" "v" "none")))
+layer.addMethod((RgMethodDef.cmd(2031 "rg2d_layer_add" "rg2d_layer_add" "h:h" "v" "none")))
+```
+
+Interpreter → bridge — [`ComponentEngine.rgr`](./interp/migrate/src/ComponentEngine.rgr)
+sees an unknown name and forwards to the native bridge:
+
+```rgr
+if (nativeBridge) {
+    def bridge:EvalNativeBridge (unwrap nativeBridge)
+    if (bridge.has(fnName)) {
+        def nativeArgs:[EvalValue] (this.collectCallArgs(node))
+        return (bridge.invoke(fnName nativeArgs))
+    }
+}
+```
+
+Transport — [`RgRegistryBridge.rgr`](./interp/engine/RgRegistryBridge.rgr).
+`invoke` is table-driven; `h` args resolve guest surrogate ids → fat handles:
+
+```rgr
+fn invoke:EvalValue (name:string args:[EvalValue]) {
+    def row:RgCommand (RgCodegen.findByName(this.table name))
+    def dec:RgDecodedArgs (this.decode(row args))
+    return (this.dispatchRow(row dec))
+}
+; decode of argSpec token "h":
+def gid:int (to_int v.numberValue)
+def h:RgHandle (this.resolveGuestId(gid))   ; owned[] surrogate → RgHandle
+```
+
+Dispatch call sites (same file):
+
+```rgr
+if (row.name == "rg2d_sprite_create") {
+    def o:OwnedHandle (this.d2.spriteCreate((a.handleAt(0)) (a.intAt(1))))
+    def gid:int (this.mintId(o))            ; push OwnedHandle → guest id
+    return (RgRegistryBridge.retI(gid))
+}
+if (row.name == "rg2d_sprite_set_pos") {
+    this.d2.spriteSetPos((a.handleAt(0)) (a.dblAt(1)) (a.dblAt(2)))
+    return (EvalValue.null())
+}
+if (row.name == "rg2d_layer_add") {
+    this.d2.layerAdd((a.handleAt(0)) (a.handleAt(1)))
+    return (EvalValue.null())
+}
+```
+
+Host arena — [`RgRanger2D.rgr`](./modules/ranger_2d/RgRanger2D.rgr).
+**Structures accessed:**
+
+| Structure | Fields touched | Role |
+|-----------|----------------|------|
+| `RgRanger2D.sprites:[RgSprite2D]` | `atlasH`, `regionIndex`, `x`, `y`, `layerSlot` | authoritative sprite payload |
+| `RgRanger2D.layers:[RgLayer2D]` | `childCount` | membership counter (not ownership) |
+| `RgRanger2D.registry:RgRegistry` | slot / gen / type / payload | typed handle table |
+| `OwnedHandle` | `handle`, `released` | ownership wrapper; mint → `bridge.owned[]` |
+| `RgHandle` | `slot`, `generation`, `realmId`, `typeId` | fat handle (`typeId` = `Rg2DType.sprite()` = 32) |
+
+```rgr
+class RgSprite2D {
+    def atlasH:RgHandle (new RgHandle)
+    def regionIndex:int 0
+    def x:double 0.0
+    def y:double 0.0
+    def layerSlot:int 0    ; membership (0 = none)
+}
+
+fn spriteCreate:OwnedHandle (atlasH:RgHandle regionIndex:int) {
+    def idx:int (this.allocSprite())
+    def sp:RgSprite2D (itemAt this.sprites idx)
+    sp.atlasH = atlasH
+    sp.regionIndex = regionIndex
+    this.registry.retain(atlasH)                          ; D-OWN shared retain
+    def h:RgHandle (this.registry.alloc(this.realmId (Rg2DType.sprite()) idx))
+    return (OwnedHandle.own(h))
+}
+
+fn spriteSetPos:void (spriteH:RgHandle x:double y:double) {
+    def sp:RgSprite2D (this.spriteResolve(spriteH))       ; resolveTyped(sprite)
+    sp.x = x
+    sp.y = y
+}
+
+fn layerAdd:RgResolve (spriteH:RgHandle layerH:RgHandle) {
+    ; … resolveTyped sprite + layer …
+    sp.layerSlot = layerH.slot
+    ly.childCount = (ly.childCount + 1)
+}
+```
+
+The guest `Sprite2D` is a thin id holder. Authoritative pose/membership live in
+`RgSprite2D`. Reordering never changes the guest id (D-IDENTITY / D-2D).
 
 #### Path B — read input each frame
 
-Guest (`updatePlayer`):
+Guest — [`games/ylos2/index.tsx`](./games/ylos2/index.tsx):
 
 ```ts
 const pad = runtime.input.player(pl.slot);
 const left = pad.isDown("left");
 ```
 
-| Step | Actor | What happens |
-|------|-------|--------------|
-| 1 | façade | `player(index)` returns a **guest-only** helper (no host handle) |
-| 2 | façade | `isDown("left")` → `rgcore_input_is_down(index, "left")` |
-| 3 | bridge | decode `i:s` → `RgInput.isDown` → logical action state → `1`/`0` |
+Façade — [`modules/ranger_core/ranger_core.tsx`](./modules/ranger_core/ranger_core.tsx)
+(`__RgPlayerInput` is guest-only — no host handle):
 
-Who *feeds* the pad is outside the game: e2e uses `RgAttractDriver` + guest
-`autopilotBits`; a real device writes the same `RgInput` actions. The game
-never sees the source — only logical actions. That is genericity of **input
-policy** at the host edge, not inside the guest.
+```ts
+class __RgPlayerInput {
+  isDown(action) { return rgcore_input_is_down(this.index, action) > 0; }
+}
+```
+
+Schema — [`core_schema.rgr`](./registry/schema/core/core_schema.rgr):
+`rgcore_input_is_down` · `argSpec "i:s"` · ret `"i"`.
+
+Ranger call sites — bridge dispatch →
+[`RgInputSurface.rgr`](./modules/ranger_core/RgInputSurface.rgr):
+
+```rgr
+; RgRegistryBridge.dispatchRow
+if (row.name == "rgcore_input_is_down") {
+    if (this.input.isDown((a.intAt(0)) (a.strAt(1)))) {
+        return (RgRegistryBridge.retI(1))
+    }
+    return (RgRegistryBridge.retI(0))
+}
+
+; RgInput — modules/ranger_core/RgInputSurface.rgr
+fn isDown:boolean (playerIndex:int action:string) {
+    def p:RgPlayerInput (itemAt this.players playerIndex)
+    def idx:int (p.findAction(action))
+    if (idx < 0) { return false }
+    return (itemAt p.isDown idx)
+}
+```
+
+**Structures accessed:**
+
+| Structure | Fields | File |
+|-----------|--------|------|
+| `RgRegistryBridge.input:RgInput` | `players:[RgPlayerInput]` | `RgRegistryBridge.rgr` owns the instance |
+| `RgPlayerInput` | `actions:[string]`, `isDown:[boolean]`, `wasPressed:[boolean]` | `RgInputSurface.rgr` |
+
+Who *feeds* the pad is outside the game: e2e uses
+[`RgAttractDriver.rgr`](./runtime/game_host/RgAttractDriver.rgr) →
+`bridge.input.setAction(…)`; a real device writes the same arrays. The guest
+sees only logical action names.
 
 #### Path C — load the atlas from package data
 
-Guest (init):
+Guest — [`games/ylos2/index.tsx`](./games/ylos2/index.tsx):
 
 ```ts
 this.atlas = runtime.assets.loadSpriteAtlas("pkg://player.atlas");
 this.rIdle = this.atlas.regionIndex("idle");
 ```
 
-| Step | Actor | What happens |
-|------|-------|--------------|
-| 1 | façade | `rgcore_assets_load_atlas("pkg://player.atlas")` |
-| 2 | bridge | strip `pkg://`, read `{packageDir}/player.atlas` |
-| 3 | host | `textureCreate` → `atlasCreate` → `atlasAddRegion` / `atlasAddClip` |
-| 4 | bridge | mint atlas guest id; façade wraps `__RgLoadedAtlas` |
-| 5 | guest | `regionIndex("idle")` → `rg2d_atlas_region_index` (same atlas handle sprites use) |
+Façade — [`ranger_core.tsx`](./modules/ranger_core/ranger_core.tsx):
 
-**Profile split:** interpreter profile resolves synchronously; wasm profile
-lowers the *same* semantic op to D-ASYNC begin/poll. URI form is
-package-relative (`pkg://…`) — host filesystem paths never enter the game API
-(§2.7).
+```ts
+loadSpriteAtlas(uri) { return new __RgLoadedAtlas(rgcore_assets_load_atlas(uri)); }
+```
+
+Package file — [`games/ylos2/player.atlas`](./games/ylos2/player.atlas)
+(`texture` / `region` / `clip` lines).
+
+Ranger — bridge loads into the **same** 2D arenas sprites use
+([`RgRegistryBridge.loadAtlasAsset`](./interp/engine/RgRegistryBridge.rgr)):
+
+```rgr
+fn loadAtlasAsset:int (uri:string) {
+    ; strip pkg:// → read packageDir/rel
+    def raw:buffer (buffer_read_file pdir rel)
+    ; for each line:
+    ;   texture → d2.textureCreate + d2.atlasCreate + mintId
+    ;   region  → d2.atlasAddRegion(atlasH, name, x, y, w, h)
+    ;   clip    → d2.atlasAddClip(…)
+    return atlasGuestId
+}
+
+; dispatchRow:
+if (row.name == "rgcore_assets_load_atlas") {
+    def atlasId:int (this.loadAtlasAsset((a.strAt(0))))
+    return (RgRegistryBridge.retI(atlasId))
+}
+```
+
+**Structures accessed:**
+
+| Structure | Fields | File |
+|-----------|--------|------|
+| `RgRegistryBridge.packageDir` | game folder path | set by `RgGameHost.load` |
+| `RgRanger2D.textures:[RgTexture2D]` | `width`, `height` | `RgRanger2D.rgr` |
+| `RgRanger2D.atlases:[RgSpriteAtlas]` | `textureH`, `regions:[RgSpriteRegion]`, `clips:[RgAnimClip2D]` | same |
+| `RgSpriteRegion` | `name`, `x`, `y`, `w`, `h` | same |
+| `bridge.owned:[OwnedHandle]` | atlas (+ texture) guest ids | `RgRegistryBridge.rgr` |
+
+`regionIndex("idle")` then hits `rg2d_atlas_region_index` →
+`RgRanger2D.atlasRegionIndex` scanning `at.regions` by name — the same
+`RgSpriteAtlas` Path A’s sprites retain.
+
+**Profile split:** interpreter resolves synchronously here; wasm profile lowers
+the same semantic op to D-ASYNC begin/poll. URIs stay `pkg://…` (§2.7).
 
 #### Path D — render call → pane bind → pixels on the “display card”
 
-This is the full path to the framebuffer (the software stand-in for a display
-card / window surface).
-
-Guest (`update`):
+Guest — [`games/ylos2/index.tsx`](./games/ylos2/index.tsx):
 
 ```ts
 this.renderer.render(this.layer, this.cam1, 0);
 this.renderer.render(this.layer, this.cam2, 1);
 ```
 
-| Step | Actor | What happens |
-|------|-------|--------------|
-| 1 | façade | `rg2d_render(scene.id, cam.id, pane)` |
-| 2 | bridge | decode `h:h:i` → **`surface.paneSetView(pane, layerH, camH)`** |
-| 3 | — | **no pixels yet** — only host pane state is updated |
-| 4 | host (after update) | test/runtime: `Rg2DPresenter.present(bridge, pane, fb)` |
-| 5 | presenter | `paneLayer` / `paneCam` → real `RgHandle`s |
-| 6 | backend | `RgSoftwareRenderer2D.present2D(d2, fb, layerH, camH)` |
-| 7 | backend | for each live sprite on that layer: `worldToScreenSw*` → `fb.plot` |
+Façade — [`ranger_2d.tsx`](./modules/ranger_2d/ranger_2d.tsx):
 
-Split-screen is two pane binds of the **same** layer with two cameras — not
-two scene graphs. A GPU presenter is a sibling adapter over the same pane
-state; games and `RgGameHost` do not change.
+```ts
+class Renderer2D {
+  render(scene, cam, pane) { rg2d_render(scene.id, cam.id, pane); }
+}
+```
 
-e2e checks the end of this path: left/right framebuffers get non-zero centre
-pixels for P1/P2 (`tests/e2e/ylos2_e2e_test`).
+Schema: `rg2d_render` · `argSpec "h:h:i"` (layer, camera, pane index).
+
+**Step 6 — bind only (no pixels).** Bridge dispatch →
+[`RgSurface.paneSetView`](./modules/ranger_core/RgInputSurface.rgr):
+
+```rgr
+; RgRegistryBridge.dispatchRow
+if (row.name == "rg2d_render") {
+    this.surface.paneSetView((a.intAt(2)) (a.handleAt(0)) (a.handleAt(1)))
+    return (EvalValue.null())
+}
+
+; RgSurface — modules/ranger_core/RgInputSurface.rgr
+class RgPane {
+    def layerH:RgHandle (new RgHandle)   ; REAL handles, host-owned
+    def camH:RgHandle (new RgHandle)
+}
+fn paneSetView:void (i:int layerH:RgHandle camH:RgHandle) {
+    def p:RgPane (itemAt this.panes i)
+    p.layerH = layerH
+    p.camH = camH
+}
+```
+
+**Step 7 — present to the framebuffer** (“display card” stand-in).
+Caller (e2e / runtime) —
+[`Rg2DPresenter.rgr`](./runtime/game_host/Rg2DPresenter.rgr) +
+[`RgSoftwareRenderer2D.rgr`](./render/backends/software/RgSoftwareRenderer2D.rgr):
+
+```rgr
+; Rg2DPresenter.present
+sfn present:int (bridge:RgRegistryBridge paneIndex:int fb:RgFramebuffer) {
+    def layerH:RgHandle (bridge.surface.paneLayer(paneIndex))
+    def camH:RgHandle (bridge.surface.paneCam(paneIndex))
+    return (RgSoftwareRenderer2D.present2D(bridge.d2 fb layerH camH))
+}
+
+; RgSoftwareRenderer2D.present2D — READS host state only (D-SYNC)
+sfn present2D:int (d:RgRanger2D fb:RgFramebuffer layerH:RgHandle camH:RgHandle) {
+    def handles:[RgHandle] (d.liveSpriteHandles())
+    ; for each live sprite whose layerSlot == layerH.slot:
+    def sx:double (d.worldToScreenSwX(camH (d.spriteX(sh)) (d.spriteY(sh))))
+    def sy:double (d.worldToScreenSwY(camH (d.spriteX(sh)) (d.spriteY(sh))))
+    fb.plot(px py color)   ; RgFramebuffer.pixels:[int]
+}
+```
+
+**Structures accessed end-to-end:**
+
+| Structure | Access | File |
+|-----------|--------|------|
+| `RgSurface.panes:[RgPane]` | write `layerH`/`camH` at render; read at present | `RgInputSurface.rgr` |
+| `RgRanger2D.sprites` + `cameras` | read pose + camera math | `RgRanger2D.rgr` |
+| `RgRegistry` (via `liveSpriteHandles`) | enumerate live `typeId == sprite` slots | `RgRanger2D.rgr` / `host/RgRegistry.rgr` |
+| `RgFramebuffer.pixels:[int]` | `plot` / `at` | `RgSoftwareRenderer2D.rgr` |
+
+Split-screen = two pane binds of the **same** layer, two cameras — not two
+scene graphs. e2e asserts centre pixels on left/right fbs
+([`tests/e2e/ylos2_e2e_test.rgr`](./tests/e2e/ylos2_e2e_test.rgr)).
 
 #### Path E — lifecycle: `runtime.start` → init → update → present
 
-```text
-RgGameHost.load(dir, "index.tsx")
-  ├─ registerVirtualModule("ranger:core", …)
-  ├─ registerVirtualModule("ranger:2d", …)
-  ├─ loadScript(index.tsx)
-  │    ├─ materialize imports
-  │    └─ run top-level:  const __game = new Ylos2Game();
-  │                       runtime.start(__game);   // stores __rgGame
-  └─ callFunction("__rgGameInit")
-       └─ ranger_core: __rgGame.init()             // Path A + C + layout
+Guest top-level — [`games/ylos2/index.tsx`](./games/ylos2/index.tsx):
 
-each tick — RgGameHost.frame(dtMs)
-  ├─ callFunction("__rgGameUpdate", { dtMs })
-  │    └─ __rgGame.update(props)                   // Path B + D binds
-  ├─ bridge.frameBoundary(dt)                      // clock / audio / input edges
-  └─ (outside host) Rg2DPresenter.present(…)       // Path D pixels
+```ts
+const __game = new Ylos2Game();
+runtime.start(__game);
 ```
 
-Wasm guests export the same two entry points (`init` / `update`); only the
-transport of the host-owned tick differs. Attract-mode input
-(`RgAttractDriver` + optional `autopilotBits`) is out-of-band — the generic
-host stays input-agnostic.
+Façade lifecycle shims — [`ranger_core.tsx`](./modules/ranger_core/ranger_core.tsx):
+
+```ts
+start(game) { __rgGame = game; }
+function __rgGameInit() { return __rgGame.init(); }
+function __rgGameUpdate(props) { return __rgGame.update(props); }
+```
+
+Ranger host — [`RgGameHost.rgr`](./runtime/game_host/RgGameHost.rgr):
+
+```rgr
+fn load:boolean (dir:string file:string) {
+    this.bridge = (RgRegistryBridge.create())
+    this.engine.setNativeBridge(this.bridge)
+    this.engine.registerVirtualModule("ranger:core" (buffer_to_string coreSrc))
+    this.engine.registerVirtualModule("ranger:2d" (buffer_to_string twoSrc))
+    this.bridge.packageDir = dir
+    this.engine.loadScript((buffer_to_string game))   ; top-level runtime.start
+    def initR:EvalValue (this.engine.callFunction("__rgGameInit" (EvalValue.null())))
+    …
+}
+
+fn frame:void (dtMs:double) {
+    this.engine.callFunction("__rgGameUpdate" (EvalValue.object(keys vals)))
+    this.bridge.frameBoundary((dtMs / 1000.0))
+    ; present is NOT here — caller/presenter reads pane state (Path D step 7)
+}
+```
+
+```text
+RgGameHost.load
+  ├─ registerVirtualModule ranger:core / ranger:2d
+  ├─ loadScript → runtime.start(__game)          ; stores __rgGame in guest
+  └─ callFunction("__rgGameInit")                ; Paths A + C + surface layout
+
+RgGameHost.frame(dtMs)
+  ├─ callFunction("__rgGameUpdate", { dtMs })    ; Paths B + D binds
+  ├─ bridge.frameBoundary                        ; clock / audio / input edges
+  └─ (outside) Rg2DPresenter.present             ; Path D pixels
+```
+
+**Structures accessed at the host edge:**
+`RgGameHost.engine:ComponentEngine`, `RgGameHost.bridge:RgRegistryBridge`
+(owns `d2`, `input`, `surface`, `audio`, `clock`, `owned[]`). No ylos2 types
+appear in this file — only the lifecycle protocol.
+
+Wasm guests export the same two entry points; only the transport differs.
+Attract input (`RgAttractDriver` + optional `autopilotBits`) stays out-of-band.
 
 ### 6.4 One semantic op, two lowerings (preview)
 

--- a/gallery/game_engine/v2/BRIDGES.md
+++ b/gallery/game_engine/v2/BRIDGES.md
@@ -14,6 +14,11 @@ Transport details move one layer down. Rev 1's rule "no second command table
 anywhere" is replaced by: **no second *semantic* definition anywhere; every
 profile's table is a generated, separately versioned artifact.**
 
+**Also in this doc:** §6 walks the *live* TSX call stack — how a guest call
+in [`games/ylos2`](./games/ylos2/index.tsx) crosses façades → interpreter
+bridge → host arenas → presenter → framebuffer, and how genericity is layered
+(game-specific only at the top; host/bridge/presenter stay game-blind).
+
 ---
 
 ## 1. Why v1 died at the bridges (unchanged from rev 1)
@@ -205,3 +210,249 @@ returns a dead sentinel → `INVALID` from poll, no-op from cancel/release.
 | capability profiles | headless / no-audio / 2D-only hosts instantiate correctly; missing-required fails typed |
 | conformance guests | TSX + Rust wasm32 against one host; old-guest/new-host |
 | regen determinism | same IDL × profile ⇒ byte-identical artifacts |
+
+---
+
+## 6. Live call stack — how a TSX call reaches the display
+
+Rev 2 above is the *contract*. This section is the *path*: what happens when
+[`games/ylos2/index.tsx`](./games/ylos2/index.tsx) runs under the interpreter
+profile today. Genericity is not one abstraction — it is a stack of layers,
+each generic for a different reason.
+
+### 6.1 The layer stack
+
+```text
+┌─────────────────────────────────────────────────────────────────────┐
+│  GAME  games/ylos2/index.tsx                                        │
+│  level tables · jump physics · who climbs · when to cheer           │
+│  knows: ranger:core + ranger:2d APIs only                           │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │ import { runtime } from "ranger:core"
+                             │ import * as TWO from "ranger:2d"
+                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  VIRTUAL MODULES  (guest façades — interim, hand-written)           │
+│  modules/ranger_core/ranger_core.tsx   → runtime.* capabilities     │
+│  modules/ranger_2d/ranger_2d.tsx       → TWO.Sprite2D / Layer2D /…  │
+│  thin classes: hold a guest id, call flat rg2d_* / rgcore_* names   │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │ ComponentEngine evaluates TSX
+                             │ unknown name → EvalNativeBridge
+                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  INTERPRETER TRANSPORT  interp/engine/RgRegistryBridge.rgr          │
+│  table lookup → argSpec decode → guest-id → RgHandle → dispatchRow  │
+│  interpreter-profile prototype (§2.8) — not a published ABI         │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │ same semantic ops the wasm profile will
+                             │ call as generated imports
+                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  HOST ARENAS  (authoritative state)                                 │
+│  RgRanger2D · RgInput · RgSurface · RgAudio · RgClock · RgRegistry  │
+│  typed, realm/generation-checked handles (D-HANDLE / D-TYPE / D-OWN)│
+└────────────────────────────┬────────────────────────────────────────┘
+                             │ guest: renderer.render(layer, cam, pane)
+                             │   → binds pane view (no pixels yet)
+                             │ host:  Rg2DPresenter.present(pane, fb)
+                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  PRESENT / DISPLAY                                                  │
+│  Rg2DPresenter → RgSoftwareRenderer2D.present2D → RgFramebuffer     │
+│  reads host state only (D-SYNC); backend choice lives here          │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Cross-cutting host that owns the tick (not the game):
+[`runtime/game_host/RgGameHost.rgr`](./runtime/game_host/RgGameHost.rgr) —
+load a folder of `.tsx`, register virtual packages, call `__rgGameInit` /
+`__rgGameUpdate`, honour generic `launch(path)`. A v2 game is **only** TSX;
+no per-game `.rgr` runner.
+
+### 6.2 Genericity at each layer
+
+| Layer | What is generic | What must stay game-specific | How genericity is enforced |
+|-------|-----------------|------------------------------|----------------------------|
+| **Game TSX** | Uses only `runtime` + `TWO` | Level data, physics constants, win conditions, attract policy | Imports virtual packages; no host/arena types |
+| **`ranger:core` / `ranger:2d` façades** | Capability + domain wrappers over command names | Nothing about ylos2 | Shared module sources; D-MODULES — un-imported packages are absent |
+| **`ComponentEngine`** | Parse / eval / imports / `new` / method call / native bridge seam | Nothing about games | One interpreter for every guest |
+| **`RgRegistryBridge`** | Table lookup, `argSpec` decode, surrogate guest ids, typed errors | Nothing about games; interim `dispatchRow` is schema-shaped | Schema rows (`core` ∪ `two_d`); coverage gate runs every row |
+| **Host arenas** | Sprite/layer/camera/input/audio/surface mechanics | Nothing about games | Typed arenas; wrong-type / stale handle rejected |
+| **`RgGameHost`** | Lifecycle protocol: load → init → frame → launch handoff | Only the path the *caller* passes | Forbidden: game names, world constants, sprite maps |
+| **`Rg2DPresenter` + backend** | Pane index → layerH/camH → pixels | Nothing about games | Presenter chooses software/GPU; host stays backend-agnostic |
+
+**Rule of thumb:** if a hypothetical second 2D climber could reuse a file
+unchanged, that file is generic. If it names Pomppija platforms, jump heights,
+or `cheer`, it belongs under `games/ylos2/`.
+
+CODE_CLEANUP decisions that pin this stack:
+
+- **D-MODULES** — `ranger:core` (capabilities) vs `ranger:2d` (domain objects);
+  virtual imports, not ambient globals.
+- **D-ADAPTER / D-SYNC** — live host-backed objects; each `new` / method hits
+  the host now; render is **not** a sync/reconcile boundary.
+- **D-2D** — retained sprites with stable identity; layer membership ≠ release;
+  shared `Camera2D` math for SW and GPU.
+- **D-REGISTRY** — one schema seeds interpreter table *and* (later) wasm
+  imports; integers are link artifacts (§2.2), not public identity.
+- **Frame pipeline** — host owns the tick; guest may call `render` in
+  `update` (step 6); host presents afterward (step 7).
+
+### 6.3 Worked paths (ylos2 → display)
+
+All paths start in [`games/ylos2/index.tsx`](./games/ylos2/index.tsx). Guest
+wrappers live in `modules/ranger_{core,2d}/*.tsx`; transport in
+`RgRegistryBridge`; arenas in `RgRanger2D` / `RgInput` / `RgSurface`; pixels in
+`RgSoftwareRenderer2D`.
+
+#### Path A — create a platform sprite and put it on a layer
+
+Guest (init):
+
+```ts
+const s = new TWO.Sprite2D(this.atlas, rPlat);
+s.setPos(p.x + p.w / 2, p.y);
+this.layer.add(s);
+```
+
+| Step | Actor | What happens |
+|------|-------|--------------|
+| 1 | guest | `new TWO.Sprite2D(atlas, rPlat)` |
+| 2 | façade `ranger_2d.tsx` | `this.id = rg2d_sprite_create(atlas.id, regionIndex)` |
+| 3 | interp | `ComponentEngine` → `EvalNativeBridge.invoke("rg2d_sprite_create", …)` |
+| 4 | bridge | table row → decode `h:i` → resolve guest atlas id → `RgHandle` |
+| 5 | host | `RgRanger2D.spriteCreate` — alloc typed slot, **retain** atlas (D-OWN), mint guest id |
+| 6 | guest | `s.setPos(…)` → `rg2d_sprite_set_pos` → `spriteSetPos` writes arena `x`/`y` |
+| 7 | guest | `layer.add(s)` → `rg2d_layer_add` → `layerAdd` sets `sprite.layerSlot`, bumps child count |
+
+The guest `Sprite2D` is a thin id holder. Authoritative pixels/pose live in the
+host arena. Reordering/reparenting never changes the guest id (D-IDENTITY /
+D-2D).
+
+#### Path B — read input each frame
+
+Guest (`updatePlayer`):
+
+```ts
+const pad = runtime.input.player(pl.slot);
+const left = pad.isDown("left");
+```
+
+| Step | Actor | What happens |
+|------|-------|--------------|
+| 1 | façade | `player(index)` returns a **guest-only** helper (no host handle) |
+| 2 | façade | `isDown("left")` → `rgcore_input_is_down(index, "left")` |
+| 3 | bridge | decode `i:s` → `RgInput.isDown` → logical action state → `1`/`0` |
+
+Who *feeds* the pad is outside the game: e2e uses `RgAttractDriver` + guest
+`autopilotBits`; a real device writes the same `RgInput` actions. The game
+never sees the source — only logical actions. That is genericity of **input
+policy** at the host edge, not inside the guest.
+
+#### Path C — load the atlas from package data
+
+Guest (init):
+
+```ts
+this.atlas = runtime.assets.loadSpriteAtlas("pkg://player.atlas");
+this.rIdle = this.atlas.regionIndex("idle");
+```
+
+| Step | Actor | What happens |
+|------|-------|--------------|
+| 1 | façade | `rgcore_assets_load_atlas("pkg://player.atlas")` |
+| 2 | bridge | strip `pkg://`, read `{packageDir}/player.atlas` |
+| 3 | host | `textureCreate` → `atlasCreate` → `atlasAddRegion` / `atlasAddClip` |
+| 4 | bridge | mint atlas guest id; façade wraps `__RgLoadedAtlas` |
+| 5 | guest | `regionIndex("idle")` → `rg2d_atlas_region_index` (same atlas handle sprites use) |
+
+**Profile split:** interpreter profile resolves synchronously; wasm profile
+lowers the *same* semantic op to D-ASYNC begin/poll. URI form is
+package-relative (`pkg://…`) — host filesystem paths never enter the game API
+(§2.7).
+
+#### Path D — render call → pane bind → pixels on the “display card”
+
+This is the full path to the framebuffer (the software stand-in for a display
+card / window surface).
+
+Guest (`update`):
+
+```ts
+this.renderer.render(this.layer, this.cam1, 0);
+this.renderer.render(this.layer, this.cam2, 1);
+```
+
+| Step | Actor | What happens |
+|------|-------|--------------|
+| 1 | façade | `rg2d_render(scene.id, cam.id, pane)` |
+| 2 | bridge | decode `h:h:i` → **`surface.paneSetView(pane, layerH, camH)`** |
+| 3 | — | **no pixels yet** — only host pane state is updated |
+| 4 | host (after update) | test/runtime: `Rg2DPresenter.present(bridge, pane, fb)` |
+| 5 | presenter | `paneLayer` / `paneCam` → real `RgHandle`s |
+| 6 | backend | `RgSoftwareRenderer2D.present2D(d2, fb, layerH, camH)` |
+| 7 | backend | for each live sprite on that layer: `worldToScreenSw*` → `fb.plot` |
+
+Split-screen is two pane binds of the **same** layer with two cameras — not
+two scene graphs. A GPU presenter is a sibling adapter over the same pane
+state; games and `RgGameHost` do not change.
+
+e2e checks the end of this path: left/right framebuffers get non-zero centre
+pixels for P1/P2 (`tests/e2e/ylos2_e2e_test`).
+
+#### Path E — lifecycle: `runtime.start` → init → update → present
+
+```text
+RgGameHost.load(dir, "index.tsx")
+  ├─ registerVirtualModule("ranger:core", …)
+  ├─ registerVirtualModule("ranger:2d", …)
+  ├─ loadScript(index.tsx)
+  │    ├─ materialize imports
+  │    └─ run top-level:  const __game = new Ylos2Game();
+  │                       runtime.start(__game);   // stores __rgGame
+  └─ callFunction("__rgGameInit")
+       └─ ranger_core: __rgGame.init()             // Path A + C + layout
+
+each tick — RgGameHost.frame(dtMs)
+  ├─ callFunction("__rgGameUpdate", { dtMs })
+  │    └─ __rgGame.update(props)                   // Path B + D binds
+  ├─ bridge.frameBoundary(dt)                      // clock / audio / input edges
+  └─ (outside host) Rg2DPresenter.present(…)       // Path D pixels
+```
+
+Wasm guests export the same two entry points (`init` / `update`); only the
+transport of the host-owned tick differs. Attract-mode input
+(`RgAttractDriver` + optional `autopilotBits`) is out-of-band — the generic
+host stays input-agnostic.
+
+### 6.4 One semantic op, two lowerings (preview)
+
+```text
+                    semantic:  sprite.set-position(sprite, x, y)
+                              /                              \
+           interpreter profile                                 wasm32 profile
+  TWO.Sprite2D.setPos → rg2d_sprite_set_pos          generated import / ranger_wasm
+  EvalValue args · guest surrogate id                i32 handle words · spans
+  RgRegistryBridge.decode(argSpec)                   profile wire format
+                              \                              /
+                               ▼                            ▼
+                         RgRanger2D.spriteSetPos(spriteH, x, y)   ← one host
+```
+
+Today only the left column runs end-to-end for ylos2. The right column is why
+the table must stay a *generated profile artifact* (§2), not the semantic
+source of truth.
+
+### 6.5 What is still interim on this path
+
+| Piece | Status |
+|-------|--------|
+| `ranger_*.tsx` façades | hand wrappers → generated (§2.8) |
+| `dispatchRow` in `RgRegistryBridge` | interim hand glue; coverage-gated → codegen emitter |
+| Command ids 1000/2000 ranges | interpreter link artifact, not public identity (§2.2) |
+| Soft-2D `fb.plot` colours | headless present proof; GPU presenter is a sibling |
+| Module binding namespaces | packages resolve; per-namespace isolation still tracked |
+
+The example is otherwise complete: real `ranger:*` imports, package assets,
+game-owned render calls, host-owned pane presentation, generic load/launch.

--- a/gallery/game_engine/v2/BRIDGES.md
+++ b/gallery/game_engine/v2/BRIDGES.md
@@ -19,6 +19,9 @@ in [`games/ylos2`](./games/ylos2/index.tsx) crosses façades → interpreter
 bridge → host arenas → presenter → framebuffer, and how genericity is layered
 (game-specific only at the top; host/bridge/presenter stay game-blind).
 
+Open follow-ups (atlas pixels, 2D+3D on one surface, …):
+[`QUESTIONS.md`](./QUESTIONS.md).
+
 ---
 
 ## 1. Why v1 died at the bridges (unchanged from rev 1)

--- a/gallery/game_engine/v2/BRIDGES.md
+++ b/gallery/game_engine/v2/BRIDGES.md
@@ -510,8 +510,39 @@ Façade — [`ranger_core.tsx`](./modules/ranger_core/ranger_core.tsx):
 loadSpriteAtlas(uri) { return new __RgLoadedAtlas(rgcore_assets_load_atlas(uri)); }
 ```
 
-Package file — [`games/ylos2/player.atlas`](./games/ylos2/player.atlas)
-(`texture` / `region` / `clip` lines).
+##### Where is the asset?
+
+**On disk there is only one file** in the game package:
+
+[`games/ylos2/player.atlas`](./games/ylos2/player.atlas) — a **text manifesto**,
+not a PNG sheet:
+
+```text
+texture 256 256
+region idle 0 0 32 48
+region walk 32 0 32 48
+region plat 64 0 32 8
+clip walk idle,walk 120,120
+```
+
+| Line | Meaning | What the host creates |
+|------|---------|------------------------|
+| `texture 256 256` | logical sheet size | `RgTexture2D` with `width`/`height` only — **no pixel buffer** |
+| `region idle 0 0 32 48` | named rect in that sheet | `RgSpriteRegion{name,x,y,w,h}` pushed on the atlas |
+| `region walk …` / `region plat …` | more named rects | same; indices 0, 1, 2 |
+| `clip walk idle,walk 120,120` | animation: region names + ms/frame | `RgAnimClip2D{frames,durations}` |
+
+Resolution: `pkg://player.atlas` → strip `pkg://` → read
+`{bridge.packageDir}/player.atlas` (set by `RgGameHost.load` to
+`gallery/game_engine/v2/games/ylos2`). Host filesystem paths never appear in
+guest code (§2.7).
+
+There is **no** `player.png` (or any image) under `games/ylos2/` today. The
+software presenter does not sample texels — it plots a colour keyed on
+`regionIndex` (`100 + region`, see Path D). So the regions are enough for the
+headless e2e to tell idle vs walk vs plat apart. v1 ylos used real PNGs
+(`games/ylos2/assets/p1_walk.png`, …); that art path is out of scope for this
+v2 port until a backend reads texture pixels.
 
 Ranger — bridge loads into the **same** 2D arenas sprites use
 ([`RgRegistryBridge.loadAtlasAsset`](./interp/engine/RgRegistryBridge.rgr)):
@@ -521,9 +552,9 @@ fn loadAtlasAsset:int (uri:string) {
     ; strip pkg:// → read packageDir/rel
     def raw:buffer (buffer_read_file pdir rel)
     ; for each line:
-    ;   texture → d2.textureCreate + d2.atlasCreate + mintId
+    ;   texture → d2.textureCreate(w, h) + d2.atlasCreate + mintId
     ;   region  → d2.atlasAddRegion(atlasH, name, x, y, w, h)
-    ;   clip    → d2.atlasAddClip(…)
+    ;   clip    → resolve region names → d2.atlasAddClip(…)
     return atlasGuestId
 }
 
@@ -534,10 +565,29 @@ if (row.name == "rgcore_assets_load_atlas") {
 }
 ```
 
+Host create (no pixels) — [`RgRanger2D.rgr`](./modules/ranger_2d/RgRanger2D.rgr):
+
+```rgr
+fn textureCreate:OwnedHandle (w:int h:int) {
+    ; … alloc RgTexture2D …
+    tx.width = w
+    tx.height = h          ; dimensions only — no RGBA store yet
+    …
+}
+fn atlasAddRegion:int (atlasH:RgHandle name:string x:int y:int w:int h:int) {
+    def reg:RgSpriteRegion (new RgSpriteRegion)
+    reg.name = name
+    reg.x = x   reg.y = y   reg.w = w   reg.h = h
+    push at.regions reg
+    return ((array_length at.regions) - 1)
+}
+```
+
 **Structures accessed:**
 
 | Structure | Fields | File |
 |-----------|--------|------|
+| `games/ylos2/player.atlas` | text lines on disk | game package (only asset file) |
 | `RgRegistryBridge.packageDir` | game folder path | set by `RgGameHost.load` |
 | `RgRanger2D.textures:[RgTexture2D]` | `width`, `height` | `RgRanger2D.rgr` |
 | `RgRanger2D.atlases:[RgSpriteAtlas]` | `textureH`, `regions:[RgSpriteRegion]`, `clips:[RgAnimClip2D]` | same |

--- a/gallery/game_engine/v2/QUESTIONS.md
+++ b/gallery/game_engine/v2/QUESTIONS.md
@@ -130,3 +130,85 @@ model stays**; games should not grow a second ad-hoc window.
 Until those land, keep 2D games on `TWO.Renderer2D` + `rg2d_render`; treat 3D
 demos as separate hosts. See also [`BRIDGES.md`](./BRIDGES.md) §6.3 Path D
 (render bind vs present).
+
+---
+
+## Q3 — Are pane indices `0` / `1` the most portable render target?
+
+ylos2 today:
+
+```ts
+runtime.surface.setLayout("split-vertical");
+runtime.surface.pane(0).assignPlayer(0);
+runtime.surface.pane(1).assignPlayer(1);
+// …
+this.renderer.render(this.layer, this.cam1, 0);
+this.renderer.render(this.layer, this.cam2, 1);
+```
+
+Is the third argument as a bare integer the right long-term / portable shape?
+
+### Answer (short)
+
+**The idea is portable; the bare `0`/`1` literals are the least portable
+expression of it.**
+
+What *is* portable (and matches CODE_CLEANUP):
+
+- One surface owns **panes** (viewports), not separate windows.
+- The game calls `render(scene, camera, …)` once per pane it cares about.
+- SW and GPU honour the same pane → scissor/viewport mapping.
+- Single-player omits the target (full-surface default).
+
+What is *less* portable about today’s ylos2 form:
+
+| Issue | Why |
+|-------|-----|
+| Magic indices | `0`/`1` encode layout order; easy to desync from `setLayout` / player binding |
+| Wire shape leaked to guest | Schema is `rg2d_render(h,h,i)` — interpreter-friendly, but guest API need not look like that |
+| No pane identity object | CODE_CLEANUP’s conceptual API passes a **pane / target**, not a raw int |
+| Re-bind every frame | Correct today (bind view each `render`), but games that only need a stable bind could declare once via `pane.setView(layer, cam)` (façade already has it; unused by ylos2) |
+
+CODE_CLEANUP sketch ([`CODE_CLEANUP.md`](../CODE_CLEANUP.md) — Surface viewports):
+
+```ts
+runtime.surface.setLayout("split-horizontal")
+const left = runtime.surface.pane(0)
+const right = runtime.surface.pane(1)
+
+renderer2d.render(scene, cameraP1, { target: left })
+renderer2d.render(scene, cameraP2, { target: right })
+```
+
+That is the more portable *guest* shape: hold the pane you got from the
+surface after layout, pass it as the render target. Under the hood the
+interpreter/wasm profile may still lower to a pane index or a handle — that
+is a profile detail (§2), not what games should author.
+
+### Ranking (guest API)
+
+| Form | Portability | Status |
+|------|-------------|--------|
+| `render(scene, cam)` — single full surface | Best for 1P | Intended; ylos2 is 2P so N/A |
+| `render(scene, cam, { target: pane })` or `render(scene, cam, pane)` | Best for split-screen | **Contract intent**; not what ylos2 calls today |
+| `pane.setView(layer, cam)` once + present | Good when view is stable | Façade method exists; host stores real handles |
+| `render(scene, cam, 0)` / `…, 1)` | Works; brittle authorship | **What ylos2 does now** (`argSpec "h:h:i"`) |
+
+### What stays true either way
+
+- Targeting a **surface-owned pane** (not a platform window, not a GPU
+  texture name invented by the game) is the portable model across Mac/SDL,
+  Pi, wasm, software present.
+- Indices are a fine *lowering* (and fine in headless tests). They should
+  not be the only guest-facing vocabulary once pane objects exist.
+- Player binding (`pane(i).assignPlayer(j)`) is separate from the render
+  target — input routing vs where pixels go. Don’t collapse “player 0” with
+  “pane 0” in the render API even when ylos2 happens to use the same numbers.
+
+### Open
+
+| # | Question |
+|---|----------|
+| 1 | Freeze guest signature as `render(scene, cam, pane\|options)` and keep `i` only in the interpreter/wasm lowering? |
+| 2 | Prefer declare-once `pane.setView` + implicit present, or keep explicit per-frame `render(…, pane)` (current frame-pipeline step 6)? |
+| 3 | Offscreen targets: same `target:` slot, or a different object type (`RenderTarget2D`) beside panes? |

--- a/gallery/game_engine/v2/QUESTIONS.md
+++ b/gallery/game_engine/v2/QUESTIONS.md
@@ -1,0 +1,132 @@
+# QUESTIONS.md — open design questions on the v2 stack
+
+Working notes. Answers below reflect **what the code does today**; items
+marked *open* need a design decision before implementation.
+
+Related: [`BRIDGES.md`](./BRIDGES.md) §6 (live call stack),
+[`CODE_CLEANUP.md`](../CODE_CLEANUP.md) (D-2D / D-MODULES / frame pipeline).
+
+---
+
+## Q1 — Where are the ylos2 player atlas assets?
+
+Guest loads:
+
+```ts
+this.atlas = runtime.assets.loadSpriteAtlas("pkg://player.atlas");
+```
+
+The file on disk is only:
+
+[`games/ylos2/player.atlas`](./games/ylos2/player.atlas)
+
+```text
+texture 256 256
+region idle 0 0 32 48
+region walk 32 0 32 48
+region plat 64 0 32 8
+clip walk idle,walk 120,120
+```
+
+### Answer (current)
+
+| Fact | Detail |
+|------|--------|
+| Package location | `gallery/game_engine/v2/games/ylos2/` — resolved via `pkg://` → `bridge.packageDir` |
+| What exists | **One text manifesto** (`.atlas`). No `player.png` / sheet image in the folder |
+| What `texture 256 256` creates | Host `RgTexture2D` with `width`/`height` only — **no RGBA pixel store** |
+| What regions/clips create | Metadata on `RgSpriteAtlas` (`RgSpriteRegion`, `RgAnimClip2D`) |
+| How the e2e “sees” art | `RgSoftwareRenderer2D` plots `color = 100 + regionIndex` — does not sample texels |
+| v1 contrast | Playable v1 used real PNGs (`games/ylos2/assets/p1_walk.png`, …); out of scope for this v2 port |
+
+Full call path: [`BRIDGES.md`](./BRIDGES.md) §6.3 Path C.
+
+**Open follow-up:** when a GPU/SW backend starts sampling textures, does the
+manifest gain a `image <uri>` line (or separate `pkg://player.png`), and does
+`textureCreate` grow a pixel/upload path?
+
+---
+
+## Q2 — Can the same game add a 3D renderer for effects on top of the 2D surface?
+
+ylos2 today:
+
+```ts
+this.renderer = new TWO.Renderer2D();
+runtime.surface.attachRenderer(this.renderer);
+// …
+this.renderer.render(this.layer, this.cam1, 0);
+this.renderer.render(this.layer, this.cam2, 1);
+```
+
+Desired shape (sketch): keep the 2D climber, and also draw some 3D (particles,
+backdrop mesh, celebration burst, …) composited onto the same surface / panes.
+
+### Answer (current — would it work *now*?)
+
+**No — not on the live ylos2 path.**
+
+1. **`attachRenderer` is a guest-only stub.**  
+   In [`modules/ranger_core/ranger_core.tsx`](./modules/ranger_core/ranger_core.tsx):
+
+   ```ts
+   class __RgSurface {
+     renderer = null;
+     attachRenderer(r) { this.renderer = r; }  // no rgcore_* call, no host state
+   }
+   ```
+
+   It does not register a backend with `RgSurface` / `RgGameHost` /
+   `Rg2DPresenter`. Presentation is driven by **`renderer.render(…)` →
+   `rg2d_render` → pane bind**, then a host-side presenter that only knows 2D.
+
+2. **Present is 2D-only today.**  
+   [`Rg2DPresenter`](./runtime/game_host/Rg2DPresenter.rgr) →
+   [`RgSoftwareRenderer2D.present2D`](./render/backends/software/RgSoftwareRenderer2D.rgr).
+   There is no compose step that blends a 3D pass over the 2D framebuffer.
+
+3. **`ranger:three` is not a live guest module yet.**  
+   [`modules/ranger_three/`](./modules/ranger_three/) is scaffold; ylos2’s host
+   registers only `ranger:core` + `ranger:2d`
+   ([`RgGameHost.load`](./runtime/game_host/RgGameHost.rgr)). Soft 3D demos
+   exist under `web/` / `model3d/` as separate hosts, not as a second pass
+   inside the generic game host.
+
+### What the architecture *intends* (so a later “yes” is plausible)
+
+From CODE_CLEANUP frame pipeline:
+
+- Guest may issue **multiple** `renderer.render(scene, camera[, pane])` calls
+  per update (split panes, offscreen targets).
+- Host **presents** afterward and **composes pane results** to the surface.
+- `ranger:2d` and `ranger:three` are **sibling** domain packages under one
+  `runtime` / `runtime.surface` — not mutually exclusive worlds.
+
+A workable future shape (not implemented):
+
+```text
+update:
+  twoD.render(layer, cam2d, pane)     → bind / fill 2D view for pane
+  three.render(scene, cam3d, pane)    → bind / fill 3D view for same pane
+present (host):
+  compose 2D + 3D into pane rect      → single surface (depth/overlay policy TBD)
+```
+
+`attachRenderer` would need to become real (capability: which backends the
+surface will present) — or be dropped in favour of “render calls declare the
+passes; the presenter selects backends.” Either way, **one surface / pane
+model stays**; games should not grow a second ad-hoc window.
+
+### Open design choices
+
+| # | Question |
+|---|----------|
+| 1 | Overlay policy: 3D always on top of 2D, or shared depth / offscreen layers? |
+| 2 | Same `pane` index for both passes, or explicit render targets? |
+| 3 | Does `attachRenderer` become multi-attach (`attachRenderer(twoD)`, `attachRenderer(three)`), or does the host infer backends from which `render` commands ran? |
+| 4 | Split-screen: does each pane get its own 3D camera, or is 3D full-bleed under/over the split? |
+| 5 | Does the generic `RgGameHost` gain a compose presenter, or a sibling `RgHybridPresenter`, without taking game knowledge? |
+
+Until those land, keep 2D games on `TWO.Renderer2D` + `rg2d_render`; treat 3D
+demos as separate hosts. See also [`BRIDGES.md`](./BRIDGES.md) §6.3 Path D
+(render bind vs present).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the v2 bridge docs around the live ylos2 TSX path:

- [`BRIDGES.md`](gallery/game_engine/v2/BRIDGES.md) §6 — call stack, layered genericity, worked paths with Ranger call sites + data structures (including where `player.atlas` lives)
- [`QUESTIONS.md`](gallery/game_engine/v2/QUESTIONS.md) — open questions:
  1. Atlas assets (text manifesto only; no PNG yet)
  2. Can a game attach a 3D renderer over the 2D surface? (not today)
  3. Are pane indices `0`/`1` the most portable render target? (idea yes; bare ints are the least portable guest form — prefer pane/`target` objects)

Documentation only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-672c4cba-3d63-477c-baa6-a3021ab59462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-672c4cba-3d63-477c-baa6-a3021ab59462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

