### PR TITLE
fix(ylos2-v2): restore summit music + jump/mover fidelity

### DIFF
--- a/gallery/game_engine/v2/QUESTIONS.md
+++ b/gallery/game_engine/v2/QUESTIONS.md
@@ -212,3 +212,134 @@ is a profile detail (§2), not what games should author.
 | 1 | Freeze guest signature as `render(scene, cam, pane\|options)` and keep `i` only in the interpreter/wasm lowering? |
 | 2 | Prefer declare-once `pane.setView` + implicit present, or keep explicit per-frame `render(…, pane)` (current frame-pipeline step 6)? |
 | 3 | Offscreen targets: same `target:` slot, or a different object type (`RenderTarget2D`) beside panes? |
+
+---
+
+## Q4 — How much of v1 Pomppija must the v2 ylos2 guest reproduce?
+
+v2 [`games/ylos2/index.tsx`](./games/ylos2/index.tsx) states a split:
+
+```text
+Faithful: platforms, jump constants, land-on-top, per-player camera,
+          goal → celebration, split-screen, summit music score
+Out of scope: enemies, bullets, fruits/diamonds, super mode, LPC art
+```
+
+A functional diff against v1 [`games/ylos2/index.tsx`](../games/ylos2/index.tsx)
+showed the “faithful” slice itself was incomplete (stub summit score, mover
+bounds, jump edge-trigger, platform carry, goal proximity). Some of that is
+now restored; several celebration / SFX / visual pieces are still missing.
+
+### Answer (current)
+
+| Area | Status |
+|------|--------|
+| Level tables + jump numbers | Present |
+| Summit `SUMMIT_MUSIC` text | Restored to v1 verbatim (duration:pitch + four phrases); start-once |
+| Mover clamp / carry / landing slack / jump edge | Aligned with v1 |
+| Finish timeline (bounce → walk → particles, 7.5 s) | **Missing** — goal only sets `reachedGoal` + cheer + music |
+| SFX vocabulary (`bounce` / `wall` / `celebrate`) | **Missing** — `celebrateSfx` is `createClip()` with no samples |
+| Sprite facing / LPC sheets / HUD / flag / sky | **Missing** (facing: no `Sprite2D` flip API yet) |
+| Enemies / pickups / super / bullets | Explicitly out of scope |
+| Victory banner + restart + `stopMusic` | **Missing** |
+
+E2E (`tests/e2e/ylos2_e2e_test`) gates climb + cheer + music **score text**,
+not celebration choreography or SFX content.
+
+### Open
+
+| # | Question |
+|---|----------|
+| 1 | Is “must-pass ylos2” **climb + split + vocal/music façades**, or **play-feel parity** on the faithful slice (finish phase, landing/jump SFX, ride movers under real input)? |
+| 2 | Should remaining faithful gaps become e2e assertions (finishMs phases, `music.stop` on restart), or stay manual / follow-up PRs? |
+| 3 | When (if ever) do out-of-scope systems (enemies, diamonds/super) re-enter the v2 guest — after `ranger:2d` bitmap/sheet APIs, or never (v1 stays the full game)? |
+
+---
+
+## Q5 — What is the guest contract for `runtime.audio.music.play(score)`?
+
+v1 emits scored music via helpers:
+
+```ts
+musicScoreEvent(SUMMIT_MUSIC, false)  // loop === false → amount 0
+stopMusicEvent()                      // only on post-victory restart
+```
+
+v2 ylos2:
+
+```ts
+runtime.audio.music.play(SUMMIT_MUSIC);  // no loop flag
+// no music.stop() on any path yet
+```
+
+The façade today ([`ranger_core.tsx`](./modules/ranger_core/ranger_core.tsx)):
+
+```ts
+play(score) { rgcore_music_play(score); }
+stop() { rgcore_music_stop(); }
+```
+
+Headless bridge only stores `musicPlaying` + `musicScore` string — it does
+**not** parse or schedule notes. Real playback (when wired) must use the same
+`game_soundscore` grammar as v1 (`tempo` / `beats` / `@melody` lines,
+`beats:pitch` tokens). A one-line stub without durations is silent / wrong
+under that parser — which is why the port’s score was restored verbatim.
+
+### Open
+
+| # | Question |
+|---|----------|
+| 1 | Does `music.play` take `(score, opts?: { loop?: boolean })` (or a second `loop` arg), matching v1’s non-looping summit line? |
+| 2 | Is **start-once / replace / layer** policy host-owned (second `play` no-ops or restarts), or must every guest keep a `summitMusicStarted` flag? |
+| 3 | Who owns score identity for tests — exact string equality, or “parser accepts and schedules N beats”? |
+| 4 | When the real synth path lands, does the headless bridge grow a tiny scheduler (so e2e can assert audible structure), or stay a record-only stub? |
+
+---
+
+## Q6 — Celebration: one-shot clip vs vocal cue vs particles?
+
+On goal, v2 today:
+
+```ts
+this.celebrateSfx.playOneShot();       // empty clip from createClip()
+runtime.audio.vocal.play("cheer");
+this.tryStartSummitMusic();            // once per run
+```
+
+v1 fires `soundEvent("celebrate")`, rumble, a burst of particle events, then
+a timed finish phase (celebrate hop → goal walk → victory ready).
+
+### Answer (current)
+
+- E2E asserts `oneShotCount` and vocal `"cheer"` — so the **façade calls**
+  matter more than clip bytes today.
+- `createClip()` with no upload means the one-shot is a **lifecycle probe**,
+  not an audible celebrate sample.
+- Particles / rumble are not on the ylos2 guest path yet (no
+  `runtime.particles` / `runtime.input.rumble` usage in this port).
+
+### Open
+
+| # | Question |
+|---|----------|
+| 1 | Is `vocal.play("cheer")` the canonical celebrate cue on v2, with `playOneShot` only proving D-LIFE — or should a real celebrate buffer be packaged (`pkg://…`)? |
+| 2 | Do finish particles/rumble wait on new `ranger:core` capabilities, or can the guest approximate with `ranger:2d` sprites until then? |
+| 3 | Should reaching the goal **lock** the player into a finish state machine (v1), or keep free physics after `reachedGoal` (current v2)? |
+
+---
+
+## Q7 — Attract / autopilot vs v1 jump edge-trigger?
+
+Grounded jumps are edge-triggered (v1 `jumpHold`). Attract feeds actions every
+frame via `autopilotBits` → `RgAttractDriver` → `setAction(…, "jump", …)`.
+
+A constant jump bit (always `+4`) never re-jumps after the first takeoff.
+The guest now pulses jump: set while grounded or rising, clear while falling.
+
+### Open
+
+| # | Question |
+|---|----------|
+| 1 | Is pulse-on-fall the permanent attract contract, or should the driver synthesize edges (press/release) so games can keep level-triggered bits? |
+| 2 | Should `autopilotBits` stay a game export, or move to a shared attract helper that understands edge-triggered jump? |
+| 3 | Does human input need the same documentation (hold ≠ auto-rejump) in the must-pass writeup / games README? |

--- a/gallery/game_engine/v2/games/ylos2/index.tsx
+++ b/gallery/game_engine/v2/games/ylos2/index.tsx
@@ -30,7 +30,18 @@ const MOVING_PLAT_SPEED = 0.06;
 const PLAYER_W = 26;
 const PLAYER_H = 44;
 
-const SUMMIT_MUSIC = "tempo 152 beats 4/4 @melody piano E4 G4 A4 G4 E4";
+// v1 score verbatim (game_soundscore: duration:pitch tokens, newline headers).
+// The previous one-liner stub dropped durations and three of four phrases, so
+// the real parser heard nothing useful / a different tune.
+const SUMMIT_MUSIC =
+  "tempo 152\n" +
+  "beats 4/4\n" +
+  "\n" +
+  "@melody piano\n" +
+  "0.5:E4 0.5:G4 1:A4 1:G4 1:E4\n" +
+  "0.5:D4 0.5:E4 1:G4 2:E4\n" +
+  "0.5:E4 0.5:G4 1:A4 1:C5 1:B4\n" +
+  "1:A4 1:G4 2:E4\n";
 
 // v1 level tables, verbatim.
 const BASE_PLATFORMS = [
@@ -84,6 +95,7 @@ class Ylos2Game {
   players = [];
   nowMs = 0;
   goalIndex = 16;
+  summitMusicStarted = 0;
 
   makePlayer(slot, startX) {
     return {
@@ -91,8 +103,10 @@ class Ylos2Game {
       x: startX, y: 1830 - PLAYER_H, vx: 0, vy: 0,
       grounded: 1, facing: 1,
       jumpHoldMs: -1,
+      jumpHeld: 0,
       lastGroundFeet: 1830,
       reachedGoal: 0,
+      onMover: -1,
       sprite: null, anim: null
     };
   }
@@ -134,7 +148,10 @@ class Ylos2Game {
       const s = new TWO.Sprite2D(this.atlas, rPlat);
       s.setPos(m.x + m.w / 2, m.y);
       this.layer.add(s);
-      this.movingPlats.push({ x: m.x, y: m.y, w: m.w, h: m.h, min: m.min, max: m.max, dir: m.dir, sprite: s });
+      this.movingPlats.push({
+        x: m.x, y: m.y, w: m.w, h: m.h, min: m.min, max: m.max, dir: m.dir,
+        vx: MOVING_PLAT_SPEED * m.dir, sprite: s
+      });
       i = i + 1;
     }
 
@@ -152,13 +169,29 @@ class Ylos2Game {
     return 1;
   }
 
+  tryStartSummitMusic() {
+    if (this.summitMusicStarted == 1) { return; }
+    this.summitMusicStarted = 1;
+    runtime.audio.music.play(SUMMIT_MUSIC);
+  }
+
+  markGoal(pl) {
+    if (pl.reachedGoal == 1) { return; }
+    pl.reachedGoal = 1;
+    this.celebrateSfx.playOneShot();
+    runtime.audio.vocal.play("cheer");
+    this.tryStartSummitMusic();
+  }
+
   updateMovers(dt) {
     let i = 0;
     while (i < this.movingPlats.length) {
       const m = this.movingPlats[i];
+      // v1 clamps the *right edge* to max (x + w <= max), not the left edge.
       m.x = m.x + MOVING_PLAT_SPEED * m.dir * dt;
       if (m.x < m.min) { m.x = m.min; m.dir = 1; }
-      if (m.x > m.max) { m.x = m.max; m.dir = -1; }
+      if (m.x + m.w > m.max) { m.x = m.max - m.w; m.dir = -1; }
+      m.vx = MOVING_PLAT_SPEED * m.dir;
       m.sprite.setPos(m.x + m.w / 2, m.y);
       i = i + 1;
     }
@@ -179,41 +212,43 @@ class Ylos2Game {
 
     pl.vy = pl.vy + GRAV * dt;
 
+    // v1 edge-triggers grounded jumps (hold does not auto-rejump on land).
     if (jump) {
       if (pl.grounded == 1) {
-        pl.vy = 0 - JUMP_MIN_V;
-        pl.grounded = 0;
-        pl.jumpHoldMs = 0;
+        if (pl.jumpHeld == 0) {
+          pl.vy = 0 - JUMP_MIN_V;
+          pl.grounded = 0;
+          pl.onMover = -1;
+          pl.jumpHoldMs = 0;
+        }
       } else if (pl.jumpHoldMs >= 0 && pl.jumpHoldMs < JUMP_HOLD_MAX_MS && pl.vy < 0) {
         pl.vy = pl.vy - JUMP_HOLD_LIFT * dt;
         if (pl.vy < 0 - JUMP_MAX_V) { pl.vy = 0 - JUMP_MAX_V; }
         pl.jumpHoldMs = pl.jumpHoldMs + dt;
       }
     } else {
-      if (pl.jumpHoldMs >= 0 && pl.vy < 0) { pl.vy = pl.vy * JUMP_CUT; }
+      if (pl.jumpHoldMs > 0 && pl.vy < 0) { pl.vy = pl.vy * JUMP_CUT; }
       pl.jumpHoldMs = -1;
     }
+    pl.jumpHeld = jump ? 1 : 0;
 
     const prevFeet = pl.y + PLAYER_H;
     let newY = pl.y + pl.vy * dt;
     const newFeet = newY + PLAYER_H;
     pl.grounded = 0;
+    pl.onMover = -1;
+    // Landing slack matches v1 (prevFeet <= plat.y + 4).
     if (pl.vy >= 0) {
       let i = 0;
       while (i < BASE_PLATFORMS.length) {
         const p = BASE_PLATFORMS[i];
         if (overlapsX(pl.x, PLAYER_W, p)) {
-          if (prevFeet <= p.y + 1 && newFeet >= p.y) {
+          if (prevFeet <= p.y + 4 && newFeet >= p.y) {
             newY = p.y - PLAYER_H;
             pl.vy = 0;
             pl.grounded = 1;
             pl.lastGroundFeet = p.y;
-            if (i == this.goalIndex && pl.reachedGoal == 0) {
-              pl.reachedGoal = 1;
-              this.celebrateSfx.playOneShot();
-              runtime.audio.vocal.play("cheer");
-              runtime.audio.music.play(SUMMIT_MUSIC);
-            }
+            if (i == this.goalIndex) { this.markGoal(pl); }
           }
         }
         i = i + 1;
@@ -222,10 +257,11 @@ class Ylos2Game {
       while (k < this.movingPlats.length) {
         const m = this.movingPlats[k];
         if (overlapsX(pl.x, PLAYER_W, m)) {
-          if (prevFeet <= m.y + 1 && newFeet >= m.y) {
+          if (prevFeet <= m.y + 4 && newFeet >= m.y) {
             newY = m.y - PLAYER_H;
             pl.vy = 0;
             pl.grounded = 1;
+            pl.onMover = k;
             pl.lastGroundFeet = m.y;
           }
         }
@@ -233,6 +269,26 @@ class Ylos2Game {
       }
     }
     pl.y = newY;
+
+    // Ride moving platforms (v1 carryVx).
+    if (pl.grounded == 1 && pl.onMover >= 0) {
+      const m = this.movingPlats[pl.onMover];
+      pl.x = pl.x + m.vx * dt;
+      if (pl.x < 0) { pl.x = 0; }
+      if (pl.x > BASE_W - PLAYER_W) { pl.x = BASE_W - PLAYER_W; }
+      if (!overlapsX(pl.x, PLAYER_W, m)) {
+        pl.grounded = 0;
+        pl.onMover = -1;
+      }
+    }
+
+    // v1 also finishes by proximity (feet near goal), not only by landing.
+    if (pl.reachedGoal == 0) {
+      if (pl.y + PLAYER_H <= BASE_PLATFORMS[this.goalIndex].y + 22) {
+        this.markGoal(pl);
+      }
+    }
+
     if (pl.y > WORLD_H) { pl.y = 1830 - PLAYER_H; pl.vy = 0; }
 
     pl.sprite.setPos(pl.x + PLAYER_W / 2, pl.y + PLAYER_H / 2);

--- a/gallery/game_engine/v2/games/ylos2/index.tsx
+++ b/gallery/game_engine/v2/games/ylos2/index.tsx
@@ -345,11 +345,18 @@ const __game = new Ylos2Game();
 runtime.start(__game);
 
 // ---- attract mode (game feature): suggest input as bits left=1 right=2 jump=4
+// Jump must be pulsed: grounded jumps are edge-triggered (v1 jumpHold), so a
+// held jump bit across landing would never leave the ground again.
 function autopilotBits(slot) {
   const pl = __game.players[slot];
   const target = __game.nextTargetAbove(pl);
   if (target == null) { return 0; }
-  let bits = 4;
+  let bits = 0;
+  if (pl.grounded == 1) {
+    bits = 4;
+  } else if (pl.vy < 0) {
+    bits = 4;
+  }
   const cx = pl.x + PLAYER_W / 2;
   const inSpan = cx > target.x + 6 && cx < target.x + target.w - 6;
   if (!inSpan) {

--- a/gallery/game_engine/v2/tests/e2e/ylos2_e2e_test.rgr
+++ b/gallery/game_engine/v2/tests/e2e/ylos2_e2e_test.rgr
@@ -66,6 +66,11 @@ class Ylos2E2ETest {
         t.eqInt("vocal cues (both players)" (array_length host.bridge.vocalCues) 2)
         t.eqStr("vocal cue is the cheer" (itemAt host.bridge.vocalCues 0) "cheer")
         t.ok("summit music playing" host.bridge.musicPlaying)
+        ; v1 score uses duration:pitch tokens — bare "E4 G4 …" stubs parse as silence
+        t.ok("summit score has timed melody tokens"
+            (contains host.bridge.musicScore "0.5:E4"))
+        t.ok("summit score keeps the full four-phrase tune"
+            (contains host.bridge.musicScore "1:C5"))
 
         ; ---- identity across the whole game ---------------------------------
         def sprite1IdB:int (to_int (host.callSlot("playerSpriteId" 0)))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Functional review of `gallery/game_engine/v2/games/ylos2/index.tsx` against v1 `gallery/game_engine/games/ylos2/index.tsx` found the summit tune (and a few in-scope physics mismatches) diverging from the original climber. This PR fixes the clear regressions inside the port’s stated “faithful v1 pieces” scope, and records the remaining design questions in `QUESTIONS.md`.

### Summit music (reported)

v2 had replaced the full score with a one-line stub without `beats:pitch` durations. Restored the verbatim v1 score and start-once guard.

### Other in-scope fixes

- Moving platform right-edge clamp, landing slack `+4`, jump edge-trigger, mover carry, goal proximity
- Attract autopilot pulses jump so edge-trigger still climbs

### QUESTIONS.md (Q4–Q7)

Open follow-ups from this review:

- **Q4** — must-pass scope vs play-feel parity on the faithful slice
- **Q5** — `music.play` loop / replace / test identity contract
- **Q6** — celebration: vocal vs clip vs finish state machine
- **Q7** — attract pulse vs driver-synthesized jump edges

## Test plan

- [x] `bash gallery/game_engine/v2/tests/run.sh` → **37/37 suites passed**
- [x] `ylos2_e2e_test` asserts timed summit score tokens
- [ ] Play to summit and hear the full four-phrase piano line once
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b06aa19b-eaeb-41c7-8fb2-d9be9432723c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b06aa19b-eaeb-41c7-8fb2-d9be9432723c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

