### PR TITLE
docs(v2): put unit-test gate first and drop progress log

### DIFF
--- a/gallery/game_engine/v2/README.md
+++ b/gallery/game_engine/v2/README.md
@@ -8,6 +8,25 @@ Headless interpreter + host arenas + WASM bridge first; rendering last.
 
 **Plan phase:** 0+ — see [`CODE_CLEANUP_PLAN.md`](../CODE_CLEANUP_PLAN.md).
 
+## Unit / contract tests
+
+Cross-cutting gates live under [`tests/`](./tests/) (harness
+`tests/harness/RgTest.rgr`). From the repo root:
+
+```bash
+bash gallery/game_engine/v2/tests/run.sh
+```
+
+Compiles every registered suite to ES6, runs it under Node, and prints
+`v2 ALL GREEN — N/N suites passed` (non-zero exit on any failure).
+
+- `tests/unit/*` and `tests/contract/*` are the cross-cutting gates
+- Folder-local `*_test.rgr` suites under interp/host/bridge/… are wired into
+  the same driver as phases land
+- A phase is done only when its folder README tests pass
+- Staged ports (`three/port/`, `physics/cannon/`, …) may still carry upstream
+  `*_test.rgr` files outside this driver — re-home runners as they go live
+
 ## Central model
 
 ```text
@@ -78,172 +97,12 @@ Phase 12 does **not** delete v1 runtime infrastructure. See plan Intent.
   `host/frame_commands/two_d/`
 - Staged copies are present; rewire imports before treating them as live
 
-## Unit / contract tests that gate this folder
-
-- `tests/unit/*` and `tests/contract/*` are the cross-cutting gates
-- A phase is done only when its folder README tests pass
-- Staged ports bring their upstream `*_test.rgr` files — re-home runners next
-
 ## Notes
 
 - Plan: [`../CODE_CLEANUP_PLAN.md`](../CODE_CLEANUP_PLAN.md) (rebuild policy +
   **Staged modular imports** + **2D sprites** + runnable→archival transition)
 - Contract: [`../CODE_CLEANUP.md`](../CODE_CLEANUP.md)
 - Testing debt / module coverage gaps: [`TODO.md`](./TODO.md)
-
----
-
-## Progress log
-
-- **Phase 1 — TSX evaluator core (D-IDENTITY): ✅ green.** A dependency-light,
-  v2-owned value slice proves reference identity without Three/rendering:
-  `interp/values/` (`RgValue`, `RgRealm`), `interp/semantics/`
-  (`RgMap`/`RgSet`/`RgArrayOps`), and the cross-cutting gate
-  `tests/contract/d_identity/`.
-- **Phase 2 — Host handles + typed arenas (D-HANDLE / D-TYPE / D-OWN): ✅ green.**
-  `host/handles/` (fat generation+realm+type handle, two-word transport),
-  `host/RgRegistry.rgr` (slot table with stale/cross-realm/wrong-type rejection),
-  `host/arenas/RgHost.rgr` (geometry/material/mesh arenas — create/release,
-  retain-on-create, borrowed getters, retain-new/release-old, weak attachments),
-  `host/ownership/OwnedHandle.rgr` (release-once), and the `tests/contract/d_own/`
-  gate.
-
-- **Phase 3 — Registry schema + codegen + golden ids (D-REGISTRY): ✅ green.**
-  `registry/schema/` (class/prop/method model with residency+ownership+sync),
-  `registry/codegen/` (host/wasm/adapter surfaces from one schema + golden-id
-  immutability checker), `registry/fixtures/` (Mesh/Geometry/Material sample +
-  golden table). Schema validation, codegen parity, and golden-id gates.
-
-- **Phase 4 — Native adapter (D-ADAPTER / D-PROP / hybrid invariants): ✅ green.**
-  `interp/adapter/RgAdapter.rgr` — one `construct`/`getProperty`/`setProperty`
-  interface over the arenas: one script object → one host handle, cached
-  wrapper per handle, hybrid `position` mirror (identity-stable, turn-snapshot,
-  guest-commit-wins), and the D-PROP overlay (unknown write → guest overlay, host
-  never sees it). Tests in `interp/adapter/tests/` + `tests/unit/interp/`.
-
-- **Phase 5 — WASM bridge (D-WASM / D-WASM-MEM / D-ASYNC): ✅ green.**
-  `bridge/wasm/imports/` (`rg_*` create/retain/release over the same host, two-word
-  handle transport), `bridge/wasm/async/` (poll-based D-ASYNC, exactly-once result
-  transfer), `bridge/wasm/memory/` (checked span bounds), and `bridge/parity/`
-  (adapter and WASM paths produce identical arena traces).
-
-- **Phase 6 — Lifetimes (D-LIFE): ✅ green.** Object ≠ scene membership ≠ backend
-  resource lifetime, each with its own commands + tests: `host/tests/membership`
-  (scene add/remove are pure edges — handles stay live), `host/tests/dispose_backend`
-  (`disposeBackend` bumps `resourceRevision`, keeps the handle + CPU data; separate
-  from `contentRevision` and from release), and `tests/contract/d_life` (a shared
-  geometry survives until its last owner releases).
-
-- **Phase 7 — Geometry upload / aliasing (D-GEO / D-WASM-MEM): ✅ green.**
-  `geometryCreateEmpty` → stable `geoH`; `geometrySetAttribute` / `updateRange` /
-  `readPositions` all mutate the same handle with bulk float spans, OOB rejected
-  without a trap. The Three-compat wrapper (`three/port/src/RgCompatAttribute.rgr`)
-  keeps a guest-aliased staging array; a write without `needsUpdate` never
-  renders, and a flush makes the host range byte-equal. Gate: `tests/contract/d_geo`.
-
-- **Phase 8a — Module isolation + runtime root (D-MODULES): ✅ green.**
-  `interp/module_isolation/RgModuleSystem.rgr` (per-import namespace objects, no
-  clobber, cached same-module import, per-realm instances, failed-init caching,
-  circular = hard error) and `modules/ranger_core/RgRuntime.rgr` (per-realm
-  capability root with `runtime.time` / `runtime.assets` / `runtime.log`,
-  cross-realm rejection, teardown). Gates: `interp/module_isolation/tests`,
-  `tests/contract/d_modules`.
-
-- **Phase 8b — Frame pipeline + runtime.time (D-MODULES): ✅ green.**
-  `runtime/frame/RgFramePipeline.rgr` — the host-owned 8-step tick: input
-  snapshot → drain async at the frame boundary → update → present (zero renders
-  re-present, never implicit) → advance input edges; no update before init;
-  update error → shutdown + teardown, no retry. `runtime.time` fixed-step clock.
-  Gates: `runtime/frame/tests`, `runtime/tests/clock_test`.
-
-- **Phase 9 — Physics (headless): ✅ green.** `physics/step/RgPhysicsWorld.rgr` —
-  a rigid-body world in its own arena (D-TYPE), fixed-step gravity integration,
-  generation-checked body handles. Pose sync copies a stepped body into a mesh
-  via host commands, bumping the mesh's hybrid host revision (Phase-4 invariants).
-  Gates: `physics/tests/physics_step_test`, `physics/tests/pose_sync_test`.
-
-- **Phase 10b — D-2D `ranger:2d` (P1): ✅ green.** `modules/ranger_2d/RgRanger2D.rgr`
-  — the first-class retained 2D system (Texture2D / SpriteAtlas / Sprite2D /
-  Layer2D / Camera2D / AnimationPlayer2D arenas + frame-local DrawList2D + weak
-  PoseBinding2D). Gate `tests/contract/d_2d` (44) covers all ten required parity
-  cases: stable sprite handles across reorder/reparent, shared atlas/texture,
-  layer-remove ≠ release, SW==GPU camera transforms, TS==WASM atlas region,
-  deterministic animation frame, leak-free draw lists, stale-binding rejection,
-  hot-reload count stability.
-
-- **Phase 11 — Render (software 2D present): ✅ green.**
-  `render/backends/software/RgSoftwareRenderer2D.rgr` rasterises retained
-  `ranger:2d` sprites into a CPU framebuffer through the shared `Camera2D` — the
-  backend reads host state only (rendering is not a sync boundary, D-SYNC: no
-  handles allocated, no scene mutation). Gate: `render/tests/software_present2d_test`.
-
-- **Phase 10 — Audio / input / surface devices (fakes): ✅ green.**
-  `modules/ranger_core/RgAudio.rgr` (clip ≠ source ≠ voice with D-OWN: source
-  retains clip; `play()` caller-owned voice; `playOneShot()` mixer-owned
-  auto-release; weak attach; disposeBackend ≠ release) and
-  `RgInputSurface.rgr` (generation-checked gamepad identity, player stable across
-  reconnect, action edge states + axis1D, split-screen panes). Gate:
-  `modules/ranger_core/tests/devices_test`.
-
-Shared harness `tests/harness/RgTest.rgr` + driver `tests/run.sh` (33 suites, 553
-checks). Run: `bash tests/run.sh` → `v2 ALL GREEN — 33/33 suites passed`.
-
-- **Real TSX guest end-to-end (BRIDGES.md steps 1–3): ✅ green.** The ylos2
-  must-pass runs as an ordinary TSX guest (`games/ylos2/index.tsx` — the v1
-  level tables + jump physics) evaluated by the staged `ComponentEngine`,
-  issuing commands through the table-driven `RgRegistryBridge` into the
-  ranger:2d / ranger:core arenas, presented split-screen by the software
-  backend. Both players climb the original tower and reach the goal;
-  celebration fires through the audio/vocal/music facades.
-- **D-MODULES (interpreter profile) — real `ranger:*` imports: ✅ green.**
-  Games are authored against virtual packages, not ambient globals:
-  `import { runtime } from "ranger:core"` + `import * as TWO from "ranger:2d"`
-  resolve to host-registered module sources (`modules/ranger_core/ranger_core.tsx`,
-  `modules/ranger_2d/ranger_2d.tsx`) evaluated once per realm — **no source
-  concatenation** (`games/ranger2d.tsx` prelude deleted); un-imported packages
-  are absent. The `runtime` capability root carries surface/input/audio(vocal,
-  music, clip≠source)/time/log/platform; a game is a class started with
-  `runtime.start(new Ylos2Game())`, driven through the `__rgGameInit/Update`
-  entry points (same two entry points a wasm guest exports). Engine work:
-  virtual-module registration + top-level statement execution + a caller-`this`
-  argument-binding fix in `callUserFunctionNode`. The example is COMPLETE:
-  assets from package data (`runtime.assets.loadSpriteAtlas("pkg://…")` over
-  the documented `.atlas` format, wasm profile lowers to D-ASYNC begin/poll),
-  the game owns its render calls (`renderer.render(scene, cam, pane)` — frame
-  pipeline step 6; `rg2d_render` binds pane views host-side), and test
-  observations moved to guest fixtures (`games/<name>/tests/probe.tsx` via the
-  host's fixture door — rule 5 satisfied, production exports none). KNOWN
-  LIMIT (tracked): module bindings still land in the shared scope —
-  per-namespace isolation is the remaining scope rework gated by
-  `interp/module_isolation`.
-  Gate: `tests/e2e/ylos2_e2e_test` (22 checks). Bridge design: `BRIDGES.md`
-  (rev 2 — semantic IDL + per-target ABI profiles, after design review).
-- **Launcher menu as a TSX guest + menu→game handoff: ✅ green.**
-  `menu/launcher.tsx` (categories → games tile pages, retained tile sprites,
-  D-pad navigation on wasPressed edges, select → `launch(path)`). Gate:
-  `tests/e2e/launcher_e2e_test` (19 checks): page turns release old tiles (no
-  arena leak), held keys don't repeat (edge ≠ level), the menu presents pixels,
-  selecting Pomppija reports `games/ylos2`, and the host's generic handoff
-  boots the ylos2 guest in a fresh realm.
-- **ONE generic game host — `runtime/game_host/RgGameHost.rgr`: ✅.** The
-  single generic host for interpreted v2 ranger2d TSX games (v1 GameRunner
-  analog): load(gameDir) → façade+TSX → init, host frame pipeline, and a
-  generic `launch(path)` handoff. Presentation moved to host-owned pane views
-  (`surfacePaneView` → `Rg2DPresenter` reads pane state; renderer choice lives
-  in the presenter, host is backend-agnostic); demo input moved to
-  `RgAttractDriver` (optional, out-of-band).
-  **A v2 game is a folder of `.tsx` files and nothing else** — per-game `.rgr`
-  runners are forbidden (the earlier `ylos2_v2_runner.rgr` /
-  `launcher_v2_runner.rgr` regression is deleted); e2e assertions live in thin
-  test drivers under `tests/e2e/`.
-
-Phases 1–11 of `../CODE_CLEANUP_PLAN.md` are validated headlessly (identity →
-handles/arenas → registry → adapter → WASM bridge → lifetimes → geometry →
-modules/frame → physics → 2D → software present → devices). Phase 12 (selected
-game ports) is the remaining integration milestone.
-
-- **Hybrid 2D+3D composition (design):** [`PLAN_2D_EMBED_3D.md`](./PLAN_2D_EMBED_3D.md)
-  — architecture approved; H0 not frozen pending review. Global `FramePass`
-  stream, `SurfaceTarget`/`PaneTarget`/`RenderTarget`, `TextureView2D` sprites,
-  ownership/residency/hazard rules; answers [`QUESTIONS.md`](./QUESTIONS.md)
-  Q2/Q3. Not implemented yet (H1–H7 after Phase 11).
+- Hybrid 2D+3D composition (design): [`PLAN_2D_EMBED_3D.md`](./PLAN_2D_EMBED_3D.md)
+  — answers [`QUESTIONS.md`](./QUESTIONS.md) Q2/Q3; not implemented yet
+  (H1–H7 after Phase 11).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restructure `gallery/game_engine/v2/README.md` so the unit/contract test gate is the first section after the intro, and remove the long Phase 1–11 progress log.

## Changes

- **Unit / contract tests** moved to the top, with the real driver command:
  `bash gallery/game_engine/v2/tests/run.sh`
- Removed the **Progress log** (stale suite counts / green claims that do not belong in the folder README)
- Kept a short pointer to `PLAN_2D_EMBED_3D.md` under Notes

## Why

The progress log mixed aspirational/history narrative with unverified checkmarks and outdated numbers (e.g. 33 suites). The README should point at how to run the gate, not narrate phase status.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-813e86e9-58c7-4f07-abea-4f313863a28e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-813e86e9-58c7-4f07-abea-4f313863a28e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

