### PR TITLE
fix(compiler): linear-time normalizeLineEndings (faster compiles)

### DIFF
--- a/bin/output.js
+++ b/bin/output.js
@@ -6851,18 +6851,11 @@ class RangerLispParser  {
   };
 }
 RangerLispParser.normalizeLineEndings = function(src) {
-  let s = src;
-  let pos = s.indexOf("\r\n");
-  while (pos >= 0) {
-    s = ((s.substring(0, pos )) + "\n") + (s.substring((pos + 2), (s.length) ));
-    pos = s.indexOf("\r\n");
-  };
-  pos = s.indexOf("\r");
-  while (pos >= 0) {
-    s = ((s.substring(0, pos )) + "\n") + (s.substring((pos + 1), (s.length) ));
-    pos = s.indexOf("\r");
-  };
-  return s;
+  if ( (src.indexOf("\r")) < 0 ) {
+    return src;
+  }
+  const s = (src.split("\r\n")).join("\n");
+  return (s.split("\r")).join("\n");
 };
 class TTypes  {
   constructor() {

--- a/compiler/ng_parser_v2.rgr
+++ b/compiler/ng_parser_v2.rgr
@@ -31,19 +31,14 @@ class RangerLispParser {
   def disableOperators false
 
   ; Accept LF, CRLF, and lone CR — normalize to LF before tokenization.
+  ; Use split/join (linear) instead of repeated substring rebuilds (quadratic on
+  ; large CRLF sources such as Lang.rgr / lib/*.rgr).
   static fn normalizeLineEndings:string (src:string) {
-    def s:string src
-    def pos (indexOf s "\r\n")
-    while (pos >= 0) {
-      s = (substring s 0 pos) + "\n" + (substring s (pos + 2) (strlen s))
-      pos = (indexOf s "\r\n")
+    if ((indexOf src "\r") < 0) {
+      return src
     }
-    pos = (indexOf s "\r")
-    while (pos >= 0) {
-      s = (substring s 0 pos) + "\n" + (substring s (pos + 1) (strlen s))
-      pos = (indexOf s "\r")
-    }
-    return s
+    def s:string (join (strsplit src "\r\n") "\n")
+    return (join (strsplit s "\r") "\n")
   }
   
   Constructor ( code_module:SourceCode ) {

--- a/dist/rgrc.js
+++ b/dist/rgrc.js
@@ -6788,18 +6788,11 @@ class RangerLispParser  {
   };
 }
 RangerLispParser.normalizeLineEndings = function(src) {
-  let s = src;
-  let pos = s.indexOf("\r\n");
-  while (pos >= 0) {
-    s = ((s.substring(0, pos )) + "\n") + (s.substring((pos + 2), (s.length) ));
-    pos = s.indexOf("\r\n");
-  };
-  pos = s.indexOf("\r");
-  while (pos >= 0) {
-    s = ((s.substring(0, pos )) + "\n") + (s.substring((pos + 1), (s.length) ));
-    pos = s.indexOf("\r");
-  };
-  return s;
+  if ( (src.indexOf("\r")) < 0 ) {
+    return src;
+  }
+  const s = (src.split("\r\n")).join("\n");
+  return (s.split("\r")).join("\n");
 };
 class TTypes  {
   constructor() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Node CPU profiling showed `RangerLispParser.normalizeLineEndings` taking ~74% of a light compile (~900ms of ~1.2s). The old loop rebuilt the whole string once per `\r`/`\r\n`, which is quadratic on CRLF sources like `Lang.rgr` (~5852 CRLFs).

Replace it with an LF-only fast path plus `strsplit`/`join` (linear). Same behavior: CRLF, lone CR, and LF all normalize to LF before tokenization.

## Results

| Workload | Before | After |
|---|---|---|
| Light suite compile (`rg_value_test`) | ~1.2s | ~0.2s |
| Heavy suite compile (`ylos2_e2e`) | ~4.0s | ~2.0s |
| Full v2 unit suite (`tests/run.sh`) | ~55s | **~17s** (37/37 green) |

## Test plan

- [x] `npx vitest run --config tests/vitest.config.ts tests/compiler-imports.test.ts` (LF Issue #12)
- [x] `bash gallery/game_engine/v2/tests/run.sh` → ALL GREEN 37/37
- [x] Semantic check: new helper matches `replace(/\r\n/g,"\n").replace(/\r/g,"\n")` on `Lang.rgr`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8df408c0-a356-428e-8110-3e728b12dde2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8df408c0-a356-428e-8110-3e728b12dde2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

