### PR TITLE
v2: SDL run readiness gaps + engine:v2:test npm script

### DIFF
--- a/gallery/game_engine/v2/README.md
+++ b/gallery/game_engine/v2/README.md
@@ -8,10 +8,30 @@ Headless interpreter + host arenas + WASM bridge first; rendering last.
 
 **Plan phase:** 0+ — see [`CODE_CLEANUP_PLAN.md`](../CODE_CLEANUP_PLAN.md).
 
-## Unit / contract tests
+## How v2 runs today (headless Node + TSX interpreter)
 
-Cross-cutting gates live under [`tests/`](./tests/) (harness
-`tests/harness/RgTest.rgr`). From the repo root:
+There is **no SDL window** yet. Everything green below is the same stack:
+
+```text
+.rgr host/driver  ──(-es6)──►  Node.js process
+                                  │
+                                  ├─ RgGameHost / bridge / arenas / SW present
+                                  │     (Ranger compiled to ES6, executed by Node)
+                                  │
+                                  └─ ComponentEngine  ←── parses & evaluates guest .tsx
+                                        (TSX interpreter written in Ranger;
+                                         game source is NOT compiled to JS ahead of time)
+```
+
+| Layer | What runs it | Notes |
+|-------|--------------|-------|
+| Host (`RgGameHost`, e2e, screenshot tools) | **Node.js** after Ranger→ES6 | `tests/run.sh` and `engine:v2:shot:*` both use `-es6` |
+| Guest game (`games/*/index.tsx`) | **TSX interpreter** (`interp/migrate/src/ComponentEngine.rgr`) | Loaded at runtime via `host.load(dir, file)`; registry commands hit real host arenas |
+| Pixels | **Software / textured CPU present** → in-memory `RgFramebuffer` | No `gfx_sdl`, no GL window; shots dump RGB text → PNG |
+
+So: yes, the process is fully a Node backend today; yes, the game still runs through the **TSX interpreter** (not as native Node/TS modules). Node only hosts the compiled Ranger engine.
+
+### Unit / contract tests
 
 ```bash
 npm run engine:v2:test
@@ -21,16 +41,32 @@ npm run engine:v2:test
 Compiles every registered suite to ES6, runs it under Node, and prints
 `v2 ALL GREEN — N/N suites passed` (non-zero exit on any failure).
 
-**SDL / native window:** not ready. v1 still uses `npm run engine:game-sdl:run`;
-v2 has headless host + software present only. Gaps and the target
-`engine:v2:sdl` / `engine:v2:sdl:run` scripts are tracked in [`TODO.md`](./TODO.md).
-
 - `tests/unit/*` and `tests/contract/*` are the cross-cutting gates
 - Folder-local `*_test.rgr` suites under interp/host/bridge/… are wired into
   the same driver as phases land
 - A phase is done only when its folder README tests pass
 - Staged ports (`three/port/`, `physics/cannon/`, …) may still carry upstream
   `*_test.rgr` files outside this driver — re-home runners as they go live
+
+### Headless shots (diagnostic, not a gate)
+
+Same Node + interpreter path; after a few `host.frame` ticks the software
+presenter fills framebuffers and a tiny JS helper writes a PNG.
+
+```bash
+npm run engine:v2:shot:ylos2
+# → compile tests/tools/ylos2_screenshot.rgr → ES6
+# → Node: RgGameHost.load(v2/games/ylos2) → ComponentEngine evaluates index.tsx
+# → Rg2DPresenter.presentTextured → RGBSHOT dump → dump_rgb_to_png.js
+```
+
+Details: [`tests/tools/README.md`](./tests/tools/README.md).
+
+### SDL / native window
+
+**Not ready.** v1 still uses `npm run engine:game-sdl:run` (Ranger→C++ +
+`gfx_sdl`). v2 needs the same *host protocol* (`RgGameHost`) compiled to C++
+and bound to SDL for input/present — checklist in [`TODO.md`](./TODO.md).
 
 ## Central model
 

--- a/gallery/game_engine/v2/README.md
+++ b/gallery/game_engine/v2/README.md
@@ -14,11 +14,16 @@ Cross-cutting gates live under [`tests/`](./tests/) (harness
 `tests/harness/RgTest.rgr`). From the repo root:
 
 ```bash
-bash gallery/game_engine/v2/tests/run.sh
+npm run engine:v2:test
+# same as: bash gallery/game_engine/v2/tests/run.sh
 ```
 
 Compiles every registered suite to ES6, runs it under Node, and prints
 `v2 ALL GREEN — N/N suites passed` (non-zero exit on any failure).
+
+**SDL / native window:** not ready. v1 still uses `npm run engine:game-sdl:run`;
+v2 has headless host + software present only. Gaps and the target
+`engine:v2:sdl` / `engine:v2:sdl:run` scripts are tracked in [`TODO.md`](./TODO.md).
 
 - `tests/unit/*` and `tests/contract/*` are the cross-cutting gates
 - Folder-local `*_test.rgr` suites under interp/host/bridge/… are wired into

--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -14,51 +14,74 @@ Mark checklist items `[x]` when they land and stay green.
 
 ## P0 — SDL / native run readiness (not ready)
 
-v1 runs scripted games with SDL via:
+### How headless works today (for contrast)
+
+v2 games **do** run through the TSX interpreter already — just not in an SDL
+process:
+
+1. Compile a Ranger host/driver with `-es6` (e.g. `tests/e2e/ylos2_e2e_test.rgr`,
+   `tests/tools/ylos2_screenshot.rgr`).
+2. **Node.js** executes that ES6 host.
+3. Host constructs `RgGameHost` → `ComponentEngine.loadScript(…)` **parses and
+   evaluates** the guest `index.tsx` (interpreter, not tsc/esbuild).
+4. Frames + software/textured present write an in-memory `RgFramebuffer`;
+   shots dump RGB → PNG. No window, no `gfx_sdl`.
+
+See [`README.md`](./README.md) “How v2 runs today”.
+
+### What v1 SDL does (target shape)
 
 ```bash
 npm run engine:game-sdl:run -- gallery/game_engine/games/pong/index.tsx
-# → scripting/game_sdl_runner.rgr → C++ → tmp/game-sdl/game_sdl + gfx_sdl.rgr
+# → scripting/game_sdl_runner.rgr → C++ binary → gfx_sdl.rgr (window + input)
 ```
 
-v2 has **no equivalent path**. Headless ES6 e2e (`RgGameHost` + software present)
-works; there is no windowed host that binds SDL I/O into the v2 stack.
+v2 has **no equivalent**. Same guest protocol (`RgGameHost` + interpreter)
+must move from “ES6 under Node” to “C++ binary + SDL bindings”.
 
 ### What already exists (usable building blocks)
 
 | Piece | Status | Notes |
 |-------|--------|-------|
-| `RgGameHost` + `Rg2DPresenter` | live | load TSX → frame; software/textured present into `RgFramebuffer` |
-| Software / textured 2D present | live | Phase 11 SW path; used by e2e + `tests/tools/*_screenshot.rgr` |
-| `bridge.input.setAction(slot, action, down)` | live | e2e / `RgAttractDriver` feed this; guest sees logical actions only |
+| `RgGameHost` + `Rg2DPresenter` | live | load TSX via interpreter → frame; SW/textured present |
+| Software / textured 2D present | live | Phase 11; e2e + `tests/tools/*_screenshot.rgr` |
+| `bridge.input.setAction(slot, action, down)` | live | e2e / `RgAttractDriver`; guest sees logical actions only |
 | v1 `gallery/game_engine/gfx_sdl.rgr` | live (v1) | `gfx_open` / `gfx_present` / input poll — **not wired to v2** |
 | `render/backends/gl/` | scaffold only | README: “after software path works” |
 
-### Missing for “run like v1” (minimum bar)
+### Missing for SDL (checklist)
 
-- [ ] **`npm run engine:v2:sdl` / `engine:v2:sdl:run`** — root `package.json` scripts
-      mirroring `engine:game-sdl` / `engine:game-sdl:run` (build + optional `--run`
-      with a default game path, e.g. `v2/games/ylos2/index.tsx`)
-- [ ] **`gallery/game_engine/scripts/build-v2-sdl.sh`** — Ranger→C++→link SDL2
-      (same shape as `scripts/build-game-sdl.sh`, output under e.g. `tmp/v2-sdl/`)
+**Process / build**
+
+- [ ] **`npm run engine:v2:sdl` / `engine:v2:sdl:run`** — root scripts mirroring
+      `engine:game-sdl` / `:run` (default game e.g. `v2/games/ylos2/index.tsx`)
+- [ ] **`scripts/build-v2-sdl.sh`** — Ranger→C++→link SDL2 (like
+      `build-game-sdl.sh`, output under e.g. `tmp/v2-sdl/`)
+- [ ] **Prove `-l=cpp` on the v2 interpreter stack** — today every suite is
+      `-es6` only. SDL needs `ComponentEngine` + `RgRegistryBridge` + modules
+      to compile and link as a native binary (unproven)
+
+**Bindings (the actual SDL glue)**
+
 - [ ] **v2 SDL shell `.rgr`** (host-side, **not** inside a game folder) — generic
       loop over `RgGameHost`:
       1. `gfx_open` / `gfx_open_gpu`
-      2. poll SDL keys/pads → `bridge.input.setAction(…)` (same action names
-         guests already use: `left` / `right` / `jump` / …)
-      3. `host.frame(dtMs)`
+      2. poll SDL keys/pads → `bridge.input.setAction(…)` (`left` / `right` /
+         `jump` / … — same names guests already use)
+      3. `host.frame(dtMs)` — still the **TSX interpreter** inside the binary
       4. `Rg2DPresenter.presentTextured` (or SW) → blit to SDL
-      5. honour `launch()` via `host.loadLaunched()` like the e2e launcher path
-- [ ] **Framebuffer → `gfx_present` binding** — v2 `RgFramebuffer` is `[int]`
-      `0xRRGGBB`; v1 `gfx_present` expects an RGBA8888 `buffer` (`SoftCanvas.raw()`).
-      Need a pack/blit helper (or present into a SoftCanvas-compatible buffer)
-- [ ] **Prove C++ compile of the v2 interpreter stack** — today every v2 suite
-      is `-es6` only (`tests/run.sh`). The SDL binary needs
-      `ComponentEngine` + `RgRegistryBridge` + modules to compile with `-l=cpp`
-      and link; that path is **unproven**
-- [ ] **Wire default game + smoke** — at least
-      `engine:v2:sdl:run:ylos2` and a short-frame
-      `SDL_VIDEODRIVER=dummy` smoke (parity with `engine:game-sdl:smoke:*`)
+      5. honour `launch()` via `host.loadLaunched()`
+- [ ] **Framebuffer → `gfx_present`** — v2 `RgFramebuffer` is `[int]`
+      `0xRRGGBB`; `gfx_present` wants RGBA8888 `buffer` (`SoftCanvas.raw()`).
+      Need a pack/blit helper
+- [ ] **Smoke** — `engine:v2:sdl:run:ylos2` + short
+      `SDL_VIDEODRIVER=dummy` run (parity with `engine:game-sdl:smoke:*`)
+
+**Do not**
+
+- [ ] Reuse v1 `game_sdl_runner.rgr` as the v2 host — wrong protocol
+      (`GameRunner` vs `RgGameHost`). Staged `v2/web/` / `v2/sprites/` imports of
+      `../gfx_sdl.rgr` still point at **v1** layout.
 
 ### Follow-ons (after the first window opens)
 
@@ -66,9 +89,6 @@ works; there is no windowed host that binds SDL I/O into the v2 stack.
 - [ ] Audio: bridge `vocalCues` / `musicScore` / one-shots → SDL audio
       (v1: `game_audio_sdl.rgr`; v2 only records cues in the bridge today)
 - [ ] Real `render/backends/gl` path (GPU present) — optional once SW→SDL works
-- [ ] Do **not** reuse v1 `game_sdl_runner.rgr` as the v2 host — wrong protocol
-      (`GameRunner` vs `RgGameHost`); staged copies under `v2/web/`, `v2/sprites/`
-      that `Import "../gfx_sdl.rgr"` still point at **v1** layout
 
 ### Intentionally out of scope for “first SDL window”
 

--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -1,9 +1,80 @@
-# v2 — testing debt
+# v2 — debt & readiness
 
-Gaps found while reviewing unit/contract coverage under `gallery/game_engine/v2/`.
-The live headless gate is `bash gallery/game_engine/v2/tests/run.sh` (37 suites).
-Mark items `[x]` when they land in that driver (or a documented sibling runner
-that is kept green).
+Gaps found while reviewing coverage and **native/SDL run readiness** under
+`gallery/game_engine/v2/`.
+
+| Track | What is green today | What is not |
+|-------|---------------------|-------------|
+| Headless gate | `npm run engine:v2:test` → `bash gallery/game_engine/v2/tests/run.sh` (40 suites) | — |
+| SDL / native window | — | **not runnable** (see § SDL below) |
+
+Mark checklist items `[x]` when they land and stay green.
+
+---
+
+## P0 — SDL / native run readiness (not ready)
+
+v1 runs scripted games with SDL via:
+
+```bash
+npm run engine:game-sdl:run -- gallery/game_engine/games/pong/index.tsx
+# → scripting/game_sdl_runner.rgr → C++ → tmp/game-sdl/game_sdl + gfx_sdl.rgr
+```
+
+v2 has **no equivalent path**. Headless ES6 e2e (`RgGameHost` + software present)
+works; there is no windowed host that binds SDL I/O into the v2 stack.
+
+### What already exists (usable building blocks)
+
+| Piece | Status | Notes |
+|-------|--------|-------|
+| `RgGameHost` + `Rg2DPresenter` | live | load TSX → frame; software/textured present into `RgFramebuffer` |
+| Software / textured 2D present | live | Phase 11 SW path; used by e2e + `tests/tools/*_screenshot.rgr` |
+| `bridge.input.setAction(slot, action, down)` | live | e2e / `RgAttractDriver` feed this; guest sees logical actions only |
+| v1 `gallery/game_engine/gfx_sdl.rgr` | live (v1) | `gfx_open` / `gfx_present` / input poll — **not wired to v2** |
+| `render/backends/gl/` | scaffold only | README: “after software path works” |
+
+### Missing for “run like v1” (minimum bar)
+
+- [ ] **`npm run engine:v2:sdl` / `engine:v2:sdl:run`** — root `package.json` scripts
+      mirroring `engine:game-sdl` / `engine:game-sdl:run` (build + optional `--run`
+      with a default game path, e.g. `v2/games/ylos2/index.tsx`)
+- [ ] **`gallery/game_engine/scripts/build-v2-sdl.sh`** — Ranger→C++→link SDL2
+      (same shape as `scripts/build-game-sdl.sh`, output under e.g. `tmp/v2-sdl/`)
+- [ ] **v2 SDL shell `.rgr`** (host-side, **not** inside a game folder) — generic
+      loop over `RgGameHost`:
+      1. `gfx_open` / `gfx_open_gpu`
+      2. poll SDL keys/pads → `bridge.input.setAction(…)` (same action names
+         guests already use: `left` / `right` / `jump` / …)
+      3. `host.frame(dtMs)`
+      4. `Rg2DPresenter.presentTextured` (or SW) → blit to SDL
+      5. honour `launch()` via `host.loadLaunched()` like the e2e launcher path
+- [ ] **Framebuffer → `gfx_present` binding** — v2 `RgFramebuffer` is `[int]`
+      `0xRRGGBB`; v1 `gfx_present` expects an RGBA8888 `buffer` (`SoftCanvas.raw()`).
+      Need a pack/blit helper (or present into a SoftCanvas-compatible buffer)
+- [ ] **Prove C++ compile of the v2 interpreter stack** — today every v2 suite
+      is `-es6` only (`tests/run.sh`). The SDL binary needs
+      `ComponentEngine` + `RgRegistryBridge` + modules to compile with `-l=cpp`
+      and link; that path is **unproven**
+- [ ] **Wire default game + smoke** — at least
+      `engine:v2:sdl:run:ylos2` and a short-frame
+      `SDL_VIDEODRIVER=dummy` smoke (parity with `engine:game-sdl:smoke:*`)
+
+### Follow-ons (after the first window opens)
+
+- [ ] Split-screen present (`gfx_present_split` or compose panes) for ylos2
+- [ ] Audio: bridge `vocalCues` / `musicScore` / one-shots → SDL audio
+      (v1: `game_audio_sdl.rgr`; v2 only records cues in the bridge today)
+- [ ] Real `render/backends/gl` path (GPU present) — optional once SW→SDL works
+- [ ] Do **not** reuse v1 `game_sdl_runner.rgr` as the v2 host — wrong protocol
+      (`GameRunner` vs `RgGameHost`); staged copies under `v2/web/`, `v2/sprites/`
+      that `Import "../gfx_sdl.rgr"` still point at **v1** layout
+
+### Intentionally out of scope for “first SDL window”
+
+- Full launcher/catalog parity with v1 menu
+- WASM guest profiles on the SDL binary
+- Replacing v1 `engine:game-sdl:*` (v1 stays runnable)
 
 ---
 
@@ -85,8 +156,15 @@ Also correct the stale claim in [`lpc/TODO.md`](./lpc/TODO.md) §1b that marked
 ## How to re-check
 
 ```bash
-# Live v2 gate (must stay green)
-bash gallery/game_engine/v2/tests/run.sh
+# Live v2 headless gate (must stay green)
+npm run engine:v2:test
+# same as: bash gallery/game_engine/v2/tests/run.sh
+
+# Optional: offline PNG of ylos2 via textured software present (no SDL window)
+npm run engine:v2:shot:ylos2
+
+# SDL window (target — not implemented yet)
+# npm run engine:v2:sdl:run -- gallery/game_engine/v2/games/ylos2/index.tsx
 
 # Inventory: local tests vs central driver
 # (suites listed in tests/run.sh vs find v2 -name '*_test.rgr')

--- a/gallery/game_engine/v2/tests/tools/README.md
+++ b/gallery/game_engine/v2/tests/tools/README.md
@@ -6,24 +6,15 @@ these.
 
 ## ylos2_screenshot
 
-Renders a real frame of the v2 ylos2 guest (attract-driven, both panes) by
-rasterising host pane state — each sprite as a flat-colour rect of its atlas
-region's w×h. A diagnostic sibling of `RgSoftwareRenderer2D.present2D` (the
-contract-pinned marker rasteriser); it samples **no texels**, because the
-package carries only the `.atlas` manifest — region geometry exists host-side,
-pixel data does not (see `../../QUESTIONS.md` Q1).
+Renders a real frame of the v2 ylos2 guest through the **sampling** backend
+(`RgTexturedRenderer2D`) — LPC walk sheets + immediate environment — and
+emits an `RGBSHOT` dump. Not an SDL window; for the windowed path see
+[`../../TODO.md`](../../TODO.md) § SDL.
 
 ```sh
-node bin/output.js -es6 gallery/game_engine/v2/tests/tools/ylos2_screenshot.rgr \
-  -d=out -o=shot.js
-node out/shot.js > dump.txt
-node gallery/game_engine/v2/tests/tools/dump_to_png.js dump.txt shot.png 3
+npm run engine:v2:shot:ylos2
+# or: bash gallery/game_engine/v2/tests/tools/ylos2_screenshot.sh [out.png]
 ```
-
-Output legend: orange = player (idle region), yellow = player (walk region),
-green = platform region tick (32×8 — the guest maps each platform to ONE
-region sprite today, so platform WIDTH is not renderer state), thin line =
-pane divider.
 
 ## climber_shot
 

--- a/gallery/game_engine/v2/tests/tools/ylos2_screenshot.sh
+++ b/gallery/game_engine/v2/tests/tools/ylos2_screenshot.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Headless textured screenshot of v2/games/ylos2 (no SDL window).
+# Usage (from repo root): bash gallery/game_engine/v2/tests/tools/ylos2_screenshot.sh [out.png]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../../../.." && pwd)"
+cd "$ROOT"
+OUT_DIR="${TMPDIR:-/tmp}/v2-ylos2-shot"
+OUT_PNG="${1:-$OUT_DIR/ylos2.png}"
+mkdir -p "$OUT_DIR" "$(dirname "$OUT_PNG")"
+
+echo "==> compile ylos2_screenshot → ES6"
+node bin/output.js -es6 \
+  gallery/game_engine/v2/tests/tools/ylos2_screenshot.rgr \
+  -d="$OUT_DIR" -o=ylos2_screenshot.js
+
+echo "==> run → RGBSHOT dump"
+node "$OUT_DIR/ylos2_screenshot.js" >"$OUT_DIR/shot.txt"
+
+echo "==> dump → PNG"
+node gallery/game_engine/v2/tests/tools/dump_rgb_to_png.js \
+  "$OUT_DIR/shot.txt" "$OUT_PNG" 3
+
+echo "wrote $OUT_PNG"

--- a/package.json
+++ b/package.json
@@ -117,6 +117,8 @@
     "engine:compile:sdl": "cross-env RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -l=cpp ./gallery/game_engine/ranger_games/pong_sdl.rgr -d=./gallery/game_engine/ranger_games -o=pong_sdl.cpp -nodecli",
     "engine:sdl": "bash gallery/game_engine/scripts/build-sdl.sh",
     "engine:sdl:run": "bash gallery/game_engine/scripts/build-sdl.sh --run",
+    "engine:v2:test": "bash gallery/game_engine/v2/tests/run.sh",
+    "engine:v2:shot:ylos2": "bash gallery/game_engine/v2/tests/tools/ylos2_screenshot.sh",
     "engine:game-sdl": "bash gallery/game_engine/scripts/build-game-sdl.sh",
     "engine:game-sdl:run": "bash gallery/game_engine/scripts/build-game-sdl.sh --run",
     "engine:game-sdl:launcher": "bash gallery/game_engine/scripts/build-game-sdl.sh --run",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

v2 is **not** SDL-runnable yet. Headless host + software present work under **Node** after Ranger→ES6; guest games still run through the **TSX interpreter** (`ComponentEngine`), not as native Node/TS modules.

This PR documents that split clearly and lists the real SDL gaps.

## Changes

- **`README.md`**: “How v2 runs today” — Node hosts the compiled Ranger engine; `ComponentEngine` evaluates guest `.tsx`; headless shots via `npm run engine:v2:shot:ylos2`; SDL pointed at TODO
- **`TODO.md`**: SDL section contrasts headless Node+interpreter vs missing C++/SDL bindings (`engine:v2:sdl*`, build script, input/present glue, prove `-l=cpp`)
- **`package.json`**: `engine:v2:test`, `engine:v2:shot:ylos2`
- **`tests/tools/ylos2_screenshot.sh`**: wrapper for the shot npm script

## Answers (for reviewers)

| Question | Answer |
|----------|--------|
| Fully Node.js backend today? | **Yes** for the process — host/drivers compile to ES6 and run under Node |
| Uses the TSX interpreter? | **Yes** — `RgGameHost` → `ComponentEngine` parses/evaluates `index.tsx` at runtime |
| SDL? | **Missing** — need native binary + `gfx_sdl` bindings; see TODO checklist |

## Verify

```bash
npm run engine:v2:test   # 40/40 green
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34282659-0f3c-4d41-b747-ca7138a5a4fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34282659-0f3c-4d41-b747-ca7138a5a4fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

