### PR TITLE
v2 SDL: runnable macOS launcher — rich EVG/menu UI, input nav, game handoff, sound

### DIFF
--- a/gallery/game_engine/scripts/build-sdl-v2.sh
+++ b/gallery/game_engine/scripts/build-sdl-v2.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Ranger Game Engine v2: RgSdlMain.rgr -> C++ -> native SDL2 launcher binary.
+#
+# Boots the v2 rich launcher screen (title / subtitle / category cards / footer)
+# in a native SDL2 window via the GENERIC RgSdlGameHost + registry bridge. The
+# launcher navigates categories -> games and hands off to a chosen game folder
+# through the same RgGameHost the headless tests use — no game logic, and no
+# additions to ranger:core. See gallery/game_engine/v2/runtime/sdl/README.md.
+#
+# The v2 host imports only gfx_sdl.rgr (SDL2 + GL); unlike the v1 game runner it
+# needs NO wasm3 and NO libcurl.
+#
+# Requirements:
+#   * a C++17 compiler (clang++ or g++)
+#   * SDL2 development libraries (brew install sdl2 / apt-get install libsdl2-dev)
+#   * OpenGL (macOS: system framework; Linux: libGL; Pi: libgles2-mesa-dev)
+#
+# Usage:
+#   ./gallery/game_engine/scripts/build-sdl-v2.sh          # build only
+#   ./gallery/game_engine/scripts/build-sdl-v2.sh --run    # build + launch
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SOURCE="$ROOT/gallery/game_engine/v2/runtime/sdl/RgSdlMain.rgr"
+OUT_DIR="$ROOT/tmp/sdl-v2"
+CPP_FILE="$OUT_DIR/RgSdlMain.cpp"
+BIN_FILE="$OUT_DIR/ranger-v2"
+
+mkdir -p "$OUT_DIR"
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  PREFERRED=(clang++ g++)
+else
+  PREFERRED=(g++ clang++)
+fi
+CXX=""
+for cc in "${PREFERRED[@]}"; do
+  if command -v "$cc" >/dev/null 2>&1; then
+    CXX="$cc"
+    break
+  fi
+done
+if [[ -z "$CXX" ]]; then
+  echo "error: no C++ compiler (clang++ / g++) found" >&2
+  exit 1
+fi
+
+if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists sdl2; then
+  SDL_FLAGS="$(pkg-config --cflags --libs sdl2)"
+elif command -v sdl2-config >/dev/null 2>&1; then
+  SDL_FLAGS="$(sdl2-config --cflags --libs)"
+else
+  echo "error: SDL2 not found. Install libsdl2-dev (or brew install sdl2 on macOS)" >&2
+  exit 1
+fi
+
+echo "==> 1/2 Ranger -> C++"
+cd "$ROOT"
+RANGER_OUT="$(RANGER_LIB="$ROOT/compiler/Lang.rgr:$ROOT/lib/stdops.rgr" node "$ROOT/bin/output.js" \
+  -l=cpp "$SOURCE" \
+  -nodecli \
+  -d="tmp/sdl-v2" \
+  -o="RgSdlMain.cpp" 2>&1)" || true
+echo "$RANGER_OUT" | tail -20
+if echo "$RANGER_OUT" | grep -q '\[FAIL\]'; then
+  echo "error: Ranger compilation failed (see output above)" >&2
+  exit 1
+fi
+
+echo "==> 2/2 $CXX -> native binary (SDL2 + OpenGL)"
+# gfx_sdl.rgr's shared C++ prelude includes the (unused-by-the-launcher) 3D GL
+# path, so the link still needs a GL library even though the launcher only 2D-
+# blits. Same detection as build-game-sdl.sh.
+GL_FLAGS=""
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  GL_FLAGS="-framework OpenGL -DGL_SILENCE_DEPRECATION -Wno-deprecated-declarations"
+else
+  ARCH="$(uname -m)"
+  if [[ "$ARCH" == "aarch64" || "$ARCH" == arm* ]]; then
+    if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists glesv2; then
+      GL_FLAGS="$(pkg-config --libs glesv2)"
+    else
+      GL_FLAGS="-lGLESv2"
+    fi
+  elif ldconfig -p 2>/dev/null | grep -q 'libGL\.so'; then
+    GL_FLAGS="-lGL"
+  fi
+fi
+if [[ -z "$GL_FLAGS" ]]; then
+  echo "error: OpenGL not found. On Raspberry Pi: sudo apt-get install libgles2-mesa-dev" >&2
+  exit 1
+fi
+CXX_OPT="${CXX_OPT:--O3}"
+# shellcheck disable=SC2086
+"$CXX" $CXX_OPT -std=c++17 "$CPP_FILE" -o "$BIN_FILE" $SDL_FLAGS $GL_FLAGS -lm
+
+echo "==> Ready: $BIN_FILE"
+
+if [[ "${1:-}" == "--run" ]]; then
+  echo "==> Launching v2 launcher (arrows move, Space/A select, S back, Q/Esc quit)"
+  "$BIN_FILE"
+else
+  echo "Launch: npm run engine:game-sdl:launcher:v2"
+fi

--- a/gallery/game_engine/v2/audio/game_audio.rgr
+++ b/gallery/game_engine/v2/audio/game_audio.rgr
@@ -1,0 +1,1111 @@
+; ==============================================================================
+; game_audio - built-in synthetic sounds + host callback sink.
+; ==============================================================================
+;
+; No file-based resource management yet. Games emit { kind: "playSound", id }
+; events (or call GameAudio.play directly from the host). Built-in ids are
+; synthesised on demand as mono PCM and delivered to an optional sink callback
+; (SDL runner queues them; headless tests count plays).
+;
+; Built-in sound ids:
+;   blip, brick, bounce, wall, lose, win
+;
+; Score instruments (game_soundscore.rgr):
+;   piano   — warm plucked keys (v2 additive synth, saved voice)
+;   violin  — bowed string with vibrato
+;   harp    — bright plucked arpeggios
+;   flute   — soft breathy tone
+;   guitar  — nylon pluck
+;   brass   — mellow horn (odd harmonics)
+;   organ   — sustained drawbar tone
+;   pad     — soft synth pad
+;   bell    — short shimmer
+;   square  — retro bass (band-limited)
+;   triangle, sine — simple waves
+;   drums   — K/S/H hits
+; ==============================================================================
+
+class ScoreVoiceHit {
+    def instrument:string "piano"
+    def pitch:string ""
+}
+
+class ScoreVoiceRender {
+    def pcm:buffer (buffer_alloc 0)
+    def frames:int 0
+}
+
+class NoteNames {
+    def midiByPitch:[string:int]
+
+    fn init:void () {
+        this.fillMap()
+    }
+
+    fn addPitch:void (pitch:string midi:int) {
+        set midiByPitch pitch midi
+    }
+
+    fn fillMap:void () {
+        def names:[string]
+        push names "C"
+        push names "C#"
+        push names "D"
+        push names "D#"
+        push names "E"
+        push names "F"
+        push names "F#"
+        push names "G"
+        push names "G#"
+        push names "A"
+        push names "A#"
+        push names "B"
+        def oct 0
+        while (oct < 9) {
+            def suf:string (to_string oct)
+            def base:int 0
+            base = (oct + 1)
+            base = (base * 12)
+            def i 0
+            while (i < 12) {
+                def nm:string (itemAt names i)
+                def key:string (nm + suf)
+                this.addPitch(key (base + i))
+                i = (i + 1)
+            }
+            oct = (oct + 1)
+        }
+    }
+
+    fn pitchToMidi:int (pitch:string) {
+        def v@(optional):int (get midiByPitch pitch)
+        if (!null? v) {
+            return (unwrap v)
+        }
+        return 60
+    }
+
+    fn letterAt:string (index:int) {
+        if (index == 0) {
+            return "C"
+        }
+        if (index == 1) {
+            return "C#"
+        }
+        if (index == 2) {
+            return "D"
+        }
+        if (index == 3) {
+            return "D#"
+        }
+        if (index == 4) {
+            return "E"
+        }
+        if (index == 5) {
+            return "F"
+        }
+        if (index == 6) {
+            return "F#"
+        }
+        if (index == 7) {
+            return "G"
+        }
+        if (index == 8) {
+            return "G#"
+        }
+        if (index == 9) {
+            return "A"
+        }
+        if (index == 10) {
+            return "A#"
+        }
+        return "B"
+    }
+
+    fn midiToPitch:string (midi:int) {
+        if (midi < 0) {
+            midi = 0
+        }
+        if (midi > 127) {
+            midi = 127
+        }
+        def oct:int (to_int (midi / 12))
+        oct = (oct - 1)
+        def rem:int (midi - ((oct + 1) * 12))
+        if (rem < 0) {
+            rem = (rem + 12)
+            oct = (oct - 1)
+        }
+        if (rem >= 12) {
+            rem = (rem - 12)
+            oct = (oct + 1)
+        }
+        def nm:string (this.letterAt(rem))
+        return (nm + (to_string oct))
+    }
+
+    fn transposePitch:string (pitch:string semitones:int) {
+        if (semitones == 0) {
+            return pitch
+        }
+        if (pitch == "_") {
+            return pitch
+        }
+        if (pitch == "K") {
+            return pitch
+        }
+        if (pitch == "S") {
+            return pitch
+        }
+        if (pitch == "H") {
+            return pitch
+        }
+        def midi:int (this.pitchToMidi(pitch))
+        midi = (midi + semitones)
+        return (this.midiToPitch(midi))
+    }
+}
+
+; Waveform selector for the tone generator.
+class SynthWave {
+    sfn sine:int () { return 0 }
+    sfn square:int () { return 1 }
+    sfn triangle:int () { return 2 }
+    sfn noise:int () { return 3 }
+}
+
+; Parameters for a single synthetic tone burst.
+class SynthToneSpec {
+    def freqHz:double 440.0
+    def durationMs:int 80
+    def volume:double 0.35
+    def wave:int 0
+    def slideHz:double 0.0        ; linear freq slide to this value over duration
+}
+
+; Host callback interface. Override onSynthPlay in a subclass (e.g. SDL sink).
+class GameAudioSink {
+    fn onSynthPlay:void (soundId:string sampleRate:int sampleCount:int pcm:buffer) {
+    }
+
+    fn onClearQueue:void () {
+    }
+}
+
+; ---------------------------------------------------------------------------
+; GameSoundPalette — the sound vocabulary as DATA, not branches (IDEAL.md §4).
+;
+; The engine core owns the synth (SynthToneSpec + the wave sampler in GameAudio);
+; a sound's NAME and tone are game data registered into this table. This replaces
+; the fixed `if (id == "wall") {...}` ladder — core dispatches a sound by table
+; lookup and ships only the synth, so a game adds `registerSound("brick", spec)`
+; with no new branch in game_audio.rgr (IDEAL_API §4 / §6 registries).
+;
+; registerDefaults() installs the engine's built-in palette (identical tones to
+; the former hardcoded set) as a starting point; a game may override a name or
+; register new ones before playing.
+; ---------------------------------------------------------------------------
+class GameSoundPalette {
+    def specs:[string:SynthToneSpec]
+
+    sfn tone:SynthToneSpec (f:double dur:int vol:double wave:int slide:double) {
+        def s:SynthToneSpec (new SynthToneSpec)
+        s.freqHz = f
+        s.durationMs = dur
+        s.volume = vol
+        s.wave = wave
+        s.slideHz = slide
+        return s
+    }
+
+    ; Register or override a sound by name. The game owns the vocabulary.
+    fn register:void (name:string spec:SynthToneSpec) {
+        set specs name spec
+    }
+
+    fn has:boolean (name:string) {
+        return (has specs name)
+    }
+
+    ; The registered spec for a name, or a neutral default tone if unregistered.
+    fn spec:SynthToneSpec (name:string) {
+        def v@(optional):SynthToneSpec (get specs name)
+        if (!null? v) {
+            return (unwrap v)
+        }
+        return (GameSoundPalette.tone(440.0 60 0.25 (SynthWave.sine()) 0.0))
+    }
+
+    fn count:int () {
+        return (array_length (keys specs))
+    }
+
+    ; The engine's default palette — data, not branches. Tones match the former
+    ; hardcoded GameAudio.lookupSpec set exactly, so behaviour is preserved.
+    fn registerDefaults:void () {
+        this.register("blip"      (GameSoundPalette.tone(660.0 40  0.30 (SynthWave.square())   0.0)))
+        this.register("brick"     (GameSoundPalette.tone(880.0 55  0.32 (SynthWave.square())   0.0)))
+        this.register("bounce"    (GameSoundPalette.tone(330.0 45  0.28 (SynthWave.triangle()) 0.0)))
+        this.register("wall"      (GameSoundPalette.tone(220.0 25  0.18 (SynthWave.triangle()) 0.0)))
+        this.register("lose"      (GameSoundPalette.tone(420.0 280 0.30 (SynthWave.sine())     160.0)))
+        this.register("win"       (GameSoundPalette.tone(523.0 120 0.30 (SynthWave.sine())     0.0)))
+        this.register("celebrate" (GameSoundPalette.tone(392.0 160 0.32 (SynthWave.sine())     0.0)))
+    }
+}
+
+class GameAudio {
+    def sampleRate:int 44100
+    def sink:GameAudioSink (new GameAudioSink)
+    def playCount:int 0
+    def lastId:string ""
+    ; The registered sound vocabulary (IDEAL.md §4). Defaults installed lazily;
+    ; a game may register/override names via registerSound() before playing.
+    def palette:GameSoundPalette (new GameSoundPalette)
+    def paletteReady:boolean false
+    def verbose:boolean false
+    def sineSteps:int 256
+    def sineTable:[double]
+    def midiFreq:[double]
+    def noteNames:NoteNames (new NoteNames)
+
+    fn init:void () {
+        sineTable = (this.buildSineTable())
+        midiFreq = (this.buildMidiFreqTable())
+        noteNames.init()
+    }
+
+    fn semitoneRatio:double (semitones:int) {
+        def ratios:[double]
+        push ratios 1.0
+        push ratios 1.059463094359
+        push ratios 1.12246204831
+        push ratios 1.189207115
+        push ratios 1.25992105
+        push ratios 1.33483985
+        push ratios 1.41421356
+        push ratios 1.49830708
+        push ratios 1.58740105
+        push ratios 1.68179283
+        push ratios 1.78179744
+        push ratios 1.88774863
+        def octaves:int (to_int (semitones / 12))
+        def rem:int (semitones - (octaves * 12))
+        if (rem < 0) {
+            rem = (rem + 12)
+            octaves = (octaves - 1)
+        }
+        def r:double (itemAt ratios rem)
+        if (octaves > 0) {
+            def i 0
+            while (i < octaves) {
+                r = (r * 2.0)
+                i = (i + 1)
+            }
+        }
+        if (octaves < 0) {
+            def i 0
+            while (i > octaves) {
+                r = (r * 0.5)
+                i = (i - 1)
+            }
+        }
+        return r
+    }
+
+    fn buildMidiFreqTable:[double] () {
+        def table:[double]
+        def m 0
+        while (m < 128) {
+            def ratio:double (this.semitoneRatio((m - 69)))
+            push table (440.0 * ratio)
+            m = (m + 1)
+        }
+        return table
+    }
+
+    fn pitchToFreq:double (pitch:string) {
+        if (pitch == "_") {
+            return 0.0
+        }
+        def midi:int (noteNames.pitchToMidi(pitch))
+        return (itemAt midiFreq midi)
+    }
+
+    fn instrumentWave:int (instrument:string) {
+        if (instrument == "square") {
+            return 1
+        }
+        if (instrument == "triangle") {
+            return 2
+        }
+        if (instrument == "violin") {
+            return 0
+        }
+        if (instrument == "drums") {
+            return 3
+        }
+        return 0
+    }
+
+    fn instrumentVolume:double (instrument:string) {
+        if (instrument == "square") {
+            return 0.30
+        }
+        if (instrument == "violin") {
+            return 0.32
+        }
+        if (instrument == "piano") {
+            return 0.30
+        }
+        if (instrument == "harp") {
+            return 0.30
+        }
+        if (instrument == "flute") {
+            return 0.34
+        }
+        if (instrument == "guitar") {
+            return 0.30
+        }
+        if (instrument == "brass") {
+            return 0.34
+        }
+        if (instrument == "organ") {
+            return 0.32
+        }
+        if (instrument == "pad") {
+            return 0.36
+        }
+        if (instrument == "bell") {
+            return 0.32
+        }
+        if (instrument == "drums") {
+            return 0.38
+        }
+        if (instrument == "sine") {
+            return 0.30
+        }
+        if (instrument == "triangle") {
+            return 0.26
+        }
+        return 0.30
+    }
+
+    fn buildSineTable:[double] () {
+        def table:[double]
+        def steps:int sineSteps
+        def i 0
+        while (i < steps) {
+            def angle:double ((to_double i) / (to_double steps))
+            angle = (angle * 6.283185307)
+            def x:double angle
+            def x3:double (x * x * x)
+            def x5:double (x3 * x * x)
+            def x7:double (x5 * x * x)
+            def s:double (x - (x3 / 6.0) + (x5 / 120.0) - (x7 / 5040.0))
+            push table s
+            i = (i + 1)
+        }
+        return table
+    }
+
+    fn wrapPhase:double (phase:double) {
+        def p:double phase
+        while (p >= 1.0) {
+            p = (p - 1.0)
+        }
+        while (p < 0.0) {
+            p = (p + 1.0)
+        }
+        return p
+    }
+
+    fn harmPhase:double (phase:double harmonic:int) {
+        return (this.wrapPhase(phase * (to_double harmonic)))
+    }
+
+    fn sampleSine:double (phase:double) {
+        def p:double (this.wrapPhase(phase))
+        def idx:int (bit_and (to_int (p * (to_double sineSteps))) (sineSteps - 1))
+        return (itemAt sineTable idx)
+    }
+
+    fn samplePiano:double (phase:double) {
+        ; Warm pluck — few harmonics (5th/6th cause hiss on additive sine).
+        def s:double (this.sampleSine(phase))
+        def p2:double (this.harmPhase(phase 2))
+        def p3:double (this.harmPhase(phase 3))
+        def p4:double (this.harmPhase(phase 4))
+        s = (s + (0.36 * (this.sampleSine(p2))))
+        s = (s + (0.16 * (this.sampleSine(p3))))
+        s = (s + (0.07 * (this.sampleSine(p4))))
+        return (s * 0.50)
+    }
+
+    fn sampleViolin:double (phase:double) {
+        def s:double (this.sampleSine(phase))
+        def p2:double (this.harmPhase(phase 2))
+        def p3:double (this.harmPhase(phase 3))
+        s = (s + (0.48 * (this.sampleSine(p2))))
+        s = (s + (0.22 * (this.sampleSine(p3))))
+        return (s * 0.42)
+    }
+
+    fn sampleSquareBass:double (phase:double) {
+        def s:double (this.sampleSine(phase))
+        def p3:double (this.harmPhase(phase 3))
+        def p5:double (this.harmPhase(phase 5))
+        def p7:double (this.harmPhase(phase 7))
+        def p9:double (this.harmPhase(phase 9))
+        s = (s + (0.55 * (this.sampleSine(p3))))
+        s = (s + (0.38 * (this.sampleSine(p5))))
+        s = (s + (0.24 * (this.sampleSine(p7))))
+        s = (s + (0.14 * (this.sampleSine(p9))))
+        return (s * 0.40)
+    }
+
+    fn sampleHarp:double (phase:double) {
+        def s:double (this.sampleSine(phase))
+        def p2:double (this.harmPhase(phase 2))
+        def p3:double (this.harmPhase(phase 3))
+        def p4:double (this.harmPhase(phase 4))
+        def p5:double (this.harmPhase(phase 5))
+        s = (s + (0.55 * (this.sampleSine(p2))))
+        s = (s + (0.30 * (this.sampleSine(p3))))
+        s = (s + (0.15 * (this.sampleSine(p4))))
+        s = (s + (0.06 * (this.sampleSine(p5))))
+        return (s * 0.38)
+    }
+
+    fn sampleFlute:double (phase:double) {
+        def s:double (this.sampleSine(phase))
+        def p2:double (this.harmPhase(phase 2))
+        s = (s + (0.04 * (this.sampleSine(p2))))
+        return (s * 0.62)
+    }
+
+    fn sampleGuitar:double (phase:double) {
+        def s:double (this.sampleSine(phase))
+        def p2:double (this.harmPhase(phase 2))
+        def p3:double (this.harmPhase(phase 3))
+        def p4:double (this.harmPhase(phase 4))
+        s = (s + (0.45 * (this.sampleSine(p2))))
+        s = (s + (0.22 * (this.sampleSine(p3))))
+        s = (s + (0.10 * (this.sampleSine(p4))))
+        return (s * 0.40)
+    }
+
+    fn sampleBrass:double (phase:double) {
+        def s:double (this.sampleSine(phase))
+        def p3:double (this.harmPhase(phase 3))
+        def p5:double (this.harmPhase(phase 5))
+        def p7:double (this.harmPhase(phase 7))
+        s = (s + (0.55 * (this.sampleSine(p3))))
+        s = (s + (0.28 * (this.sampleSine(p5))))
+        s = (s + (0.14 * (this.sampleSine(p7))))
+        return (s * 0.36)
+    }
+
+    fn sampleOrgan:double (phase:double) {
+        def s:double (this.sampleSine(phase))
+        def p2:double (this.harmPhase(phase 2))
+        def p3:double (this.harmPhase(phase 3))
+        def p4:double (this.harmPhase(phase 4))
+        s = (s + (0.48 * (this.sampleSine(p2))))
+        s = (s + (0.24 * (this.sampleSine(p3))))
+        s = (s + (0.12 * (this.sampleSine(p4))))
+        return (s * 0.40)
+    }
+
+    fn samplePad:double (phase:double) {
+        def s:double (this.sampleSine(phase))
+        return (s * 0.65)
+    }
+
+    fn sampleBell:double (phase:double) {
+        def s:double (this.sampleSine(phase))
+        def p2:double (this.harmPhase(phase 2))
+        def p3:double (this.harmPhase(phase 3))
+        def p5:double (this.harmPhase(phase 5))
+        def p7:double (this.harmPhase(phase 7))
+        s = (s + (0.40 * (this.sampleSine(p2))))
+        s = (s + (0.28 * (this.sampleSine(p3))))
+        s = (s + (0.16 * (this.sampleSine(p5))))
+        s = (s + (0.10 * (this.sampleSine(p7))))
+        return (s * 0.34)
+    }
+
+    fn instrumentVibrato:boolean (instrument:string) {
+        if (instrument == "violin") {
+            return true
+        }
+        if (instrument == "flute") {
+            return true
+        }
+        return false
+    }
+
+    fn vibratoDepth:double (instrument:string) {
+        if (instrument == "flute") {
+            return 0.0035
+        }
+        if (instrument == "violin") {
+            return 0.0075
+        }
+        return 0.0
+    }
+
+    fn sampleInstrument:double (instrument:string phase:double noiseSeed:int) {
+        if (instrument == "piano") {
+            return (this.samplePiano(phase))
+        }
+        if (instrument == "violin") {
+            return (this.sampleViolin(phase))
+        }
+        if (instrument == "harp") {
+            return (this.sampleHarp(phase))
+        }
+        if (instrument == "flute") {
+            return (this.sampleFlute(phase))
+        }
+        if (instrument == "guitar") {
+            return (this.sampleGuitar(phase))
+        }
+        if (instrument == "brass") {
+            return (this.sampleBrass(phase))
+        }
+        if (instrument == "organ") {
+            return (this.sampleOrgan(phase))
+        }
+        if (instrument == "pad") {
+            return (this.samplePad(phase))
+        }
+        if (instrument == "bell") {
+            return (this.sampleBell(phase))
+        }
+        if (instrument == "square") {
+            return (this.sampleSquareBass(phase))
+        }
+        if (instrument == "sine") {
+            return (this.sampleSine(phase))
+        }
+        if (instrument == "triangle") {
+            if (phase < 0.25) {
+                return (phase * 4.0)
+            }
+            if (phase < 0.75) {
+                return (1.0 - ((phase - 0.25) * 4.0))
+            }
+            return (-1.0 + ((phase - 0.75) * 4.0))
+        }
+        if (instrument == "drums") {
+            def n:int (bit_and ((noiseSeed * 1103515245) + 12345) 255)
+            return ((to_double n) / 127.5) - 1.0
+        }
+        return (this.sampleSine(phase))
+    }
+
+    fn melodyEnvelope:double (instrument:string t:double) {
+        if (instrument == "piano") {
+            def atk:double 0.004
+            if (t < atk) {
+                return (t / atk)
+            }
+            ; Pluck decays quickly; beat duration is spacing, not sustain.
+            def decayEnd:double 0.30
+            if (t > decayEnd) {
+                return 0.0
+            }
+            def d:double ((t - atk) / (decayEnd - atk))
+            def env:double (1.0 - d)
+            env = (env * env)
+            return env
+        }
+        if (instrument == "harp") {
+            def atk:double 0.003
+            if (t < atk) {
+                return (t / atk)
+            }
+            def d:double ((t - atk) / (1.0 - atk))
+            def env:double (1.0 - d)
+            env = (env * env * env * env)
+            return env
+        }
+        if (instrument == "guitar") {
+            def atk:double 0.004
+            if (t < atk) {
+                return (t / atk)
+            }
+            def d:double ((t - atk) / (1.0 - atk))
+            def env:double (1.0 - d)
+            env = (env * env * env)
+            return (env * 0.92)
+        }
+        if (instrument == "violin") {
+            def atk:double 0.04
+            if (t < atk) {
+                return (t / atk)
+            }
+            def d:double ((t - atk) / (1.0 - atk))
+            return (0.22 + (0.78 * (1.0 - (d * d))))
+        }
+        if (instrument == "flute") {
+            def atk:double 0.05
+            if (t < atk) {
+                return (t / atk)
+            }
+            def d:double ((t - atk) / (1.0 - atk))
+            return (0.35 + (0.65 * (1.0 - (d * d))))
+        }
+        if (instrument == "brass") {
+            def atk:double 0.03
+            if (t < atk) {
+                return (t / atk)
+            }
+            def d:double ((t - atk) / (1.0 - atk))
+            return (0.40 + (0.60 * (1.0 - d)))
+        }
+        if (instrument == "organ") {
+            def atk:double 0.02
+            if (t < atk) {
+                return (t / atk)
+            }
+            return 0.95
+        }
+        if (instrument == "pad") {
+            def atk:double 0.12
+            if (t < atk) {
+                return (t / atk)
+            }
+            def rel:double 0.18
+            if (t > (1.0 - rel)) {
+                def u:double ((t - (1.0 - rel)) / rel)
+                return (1.0 - u)
+            }
+            return 0.88
+        }
+        if (instrument == "bell") {
+            def env:double (1.0 - t)
+            env = (env * env)
+            return env
+        }
+        if (instrument == "square") {
+            def env:double (1.0 - (t * 0.08))
+            return env
+        }
+        def env2:double (1.0 - t)
+        env2 = (env2 * env2)
+        return env2
+    }
+
+    fn setSink:void (s:GameAudioSink) {
+        sink = s
+    }
+
+    ; Ensure the default palette is installed before the first lookup. Lazy so an
+    ; existing GameAudio (constructed without an explicit init) still works.
+    fn ensurePalette:void () {
+        if (paletteReady) {
+            return
+        }
+        palette.registerDefaults()
+        paletteReady = true
+    }
+
+    ; Register (or override) a game sound by name — the §4 registry entry point.
+    ; A game calls this at setup; core never grows an `id == "brick"` branch.
+    fn registerSound:void (name:string spec:SynthToneSpec) {
+        this.ensurePalette()
+        palette.register(name spec)
+    }
+
+    fn hasBuiltin:boolean (id:string) {
+        this.ensurePalette()
+        return (palette.has(id))
+    }
+
+    ; Resolve a sound name to its tone through the palette (data-driven, §4).
+    fn lookupSpec:SynthToneSpec (id:string) {
+        this.ensurePalette()
+        return (palette.spec(id))
+    }
+
+    fn sampleWave:double (wave:int phase:double noiseSeed:int) {
+        if (wave == (SynthWave.square())) {
+            return (this.sampleSquareBass(phase))
+        }
+        if (wave == (SynthWave.triangle())) {
+            return (this.sampleInstrument("triangle" phase noiseSeed))
+        }
+        if (wave == (SynthWave.noise())) {
+            return (this.sampleInstrument("drums" phase noiseSeed))
+        }
+        return (this.sampleSine(phase))
+    }
+
+    fn synthMelody:buffer (instrument:string freq:double durationMs:int volume:double) {
+        def frames:int (to_int (((to_double durationMs) * (to_double sampleRate)) / 1000.0))
+        if (frames < 1) {
+            frames = 1
+        }
+        def pcm:buffer (buffer_alloc (frames * 2))
+        def phase:double 0.0
+        def vibrato:boolean (this.instrumentVibrato(instrument))
+        def vibDepth:double (this.vibratoDepth(instrument))
+        def i 0
+        while (i < frames) {
+            def t:double ((to_double i) / (to_double frames))
+            def env:double (this.melodyEnvelope(instrument t))
+            def freqNow:double freq
+            if (vibrato) {
+                def vib:double (1.0 + (vibDepth * (this.sampleSine((to_double i) / 165.0))))
+                freqNow = (freq * vib)
+            }
+            def sample:double (this.sampleInstrument(instrument phase i))
+            def amp:double (sample * volume * env * 32767.0)
+            if (i >= (frames - 8)) {
+                def tail:int (frames - i)
+                amp = (amp * ((to_double tail) / 8.0))
+            }
+            def iv:int (to_int amp)
+            if (iv > 32767) { iv = 32767 }
+            if (iv < -32768) { iv = -32768 }
+            def v:int iv
+            if (v < 0) {
+                v = (65536 + v)
+            }
+            def lo:int (bit_and v 255)
+            def hi:int (bit_and (to_int (v / 256)) 255)
+            def off:int (i * 2)
+            buffer_set pcm off lo
+            buffer_set pcm (off + 1) hi
+            phase = (phase + (freqNow / (to_double sampleRate)))
+            phase = (this.wrapPhase(phase))
+            i = (i + 1)
+        }
+        return pcm
+    }
+
+    fn synthDrum:buffer (hit:string durationMs:int) {
+        def spec:SynthToneSpec (new SynthToneSpec)
+        spec.durationMs = durationMs
+        spec.volume = 0.38
+        if (hit == "K") {
+            spec.durationMs = 110
+            spec.volume = 0.46
+        }
+        if (hit == "S") {
+            spec.durationMs = 85
+            spec.volume = 0.34
+        }
+        if (hit == "H") {
+            spec.durationMs = 45
+            spec.volume = 0.18
+        }
+        def frames:int (to_int (((to_double spec.durationMs) * (to_double sampleRate)) / 1000.0))
+        if (frames < 1) {
+            frames = 1
+        }
+        def pcm:buffer (buffer_alloc (frames * 2))
+        def phase:double 0.0
+        def i 0
+        while (i < frames) {
+            def t:double ((to_double i) / (to_double frames))
+            def env:double (1.0 - t)
+            env = (env * env)
+            def sample:double 0.0
+            if (hit == "K") {
+                def kickHz:double (120.0 - (75.0 * t))
+                sample = (this.sampleSine(phase))
+                phase = (phase + (kickHz / (to_double sampleRate)))
+                phase = (this.wrapPhase(phase))
+                env = (env * env)
+            } {
+                if (hit == "S") {
+                    def tonePhase:double (this.harmPhase(phase 4))
+                    def tone:double (this.sampleSine(tonePhase))
+                    def noise:double (this.sampleInstrument("drums" phase i))
+                    sample = ((tone * 0.35) + (noise * 0.65))
+                    phase = (phase + (180.0 / (to_double sampleRate)))
+                    phase = (this.wrapPhase(phase))
+                } {
+                    if (hit == "H") {
+                        sample = (this.sampleInstrument("drums" (phase + ((to_double i) * 0.013)) i))
+                        env = (env * env * env)
+                    } {
+                        sample = (this.sampleInstrument("drums" phase i))
+                    }
+                }
+            }
+            def amp:double (sample * spec.volume * env * 32767.0)
+            def iv:int (to_int amp)
+            if (iv > 32767) { iv = 32767 }
+            if (iv < -32768) { iv = -32768 }
+            def v:int iv
+            if (v < 0) {
+                v = (65536 + v)
+            }
+            def lo:int (bit_and v 255)
+            def hi:int (bit_and (to_int (v / 256)) 255)
+            def off:int (i * 2)
+            buffer_set pcm off lo
+            buffer_set pcm (off + 1) hi
+            i = (i + 1)
+        }
+        return pcm
+    }
+
+    fn mixBuffers:buffer (a:buffer b:buffer frames:int) {
+        def bytesA:int (buffer_length a)
+        def bytesB:int (buffer_length b)
+        def framesA:int (to_int (bytesA / 2))
+        def framesB:int (to_int (bytesB / 2))
+        def useFrames:int frames
+        if (useFrames > framesA) {
+            useFrames = framesA
+        }
+        if (useFrames > framesB) {
+            useFrames = framesB
+        }
+        def pcm:buffer (buffer_alloc (frames * 2))
+        def i 0
+        while (i < frames) {
+            def off:int (i * 2)
+            def sa:int 0
+            def sb:int 0
+            if (i < useFrames) {
+                def loA:int (buffer_get a off)
+                def hiA:int (buffer_get a (off + 1))
+                sa = (loA + (hiA * 256))
+                if (sa >= 32768) { sa = (sa - 65536) }
+                def loB:int (buffer_get b off)
+                def hiB:int (buffer_get b (off + 1))
+                sb = (loB + (hiB * 256))
+                if (sb >= 32768) { sb = (sb - 65536) }
+            }
+            def mix:int (sa + sb)
+            if (mix > 32767) { mix = 32767 }
+            if (mix < -32768) { mix = -32768 }
+            def v:int mix
+            if (v < 0) {
+                v = (65536 + v)
+            }
+            def lo:int (bit_and v 255)
+            def hi:int (bit_and (to_int (v / 256)) 255)
+            buffer_set pcm off lo
+            buffer_set pcm (off + 1) hi
+            i = (i + 1)
+        }
+        return pcm
+    }
+
+    fn playScoreNote:void (instrument:string pitch:string durationMs:int) {
+        def rendered:ScoreVoiceRender (this.renderScoreNote(instrument pitch durationMs))
+        if (rendered.frames <= 0) {
+            return
+        }
+        playCount = (playCount + 1)
+        lastId = ("score:" + pitch)
+        sink.onSynthPlay(lastId sampleRate rendered.frames rendered.pcm)
+    }
+
+    fn melodySynthMs:int (instrument:string beatMs:int) {
+        if (beatMs < 40) {
+            return 40
+        }
+        if (instrument == "piano") {
+            if (beatMs > 170) {
+                return 170
+            }
+            return beatMs
+        }
+        if (instrument == "guitar") {
+            if (beatMs > 190) {
+                return 190
+            }
+            return beatMs
+        }
+        if (instrument == "harp") {
+            if (beatMs > 150) {
+                return 150
+            }
+            return beatMs
+        }
+        if (instrument == "bell") {
+            if (beatMs > 280) {
+                return 280
+            }
+            return beatMs
+        }
+        return beatMs
+    }
+
+    fn renderScoreNote:ScoreVoiceRender (instrument:string pitch:string durationMs:int) {
+        def out:ScoreVoiceRender (new ScoreVoiceRender)
+        if (durationMs < 40) {
+            durationMs = 40
+        }
+        if (instrument == "drums") {
+            out.pcm = (this.synthDrum(pitch durationMs))
+            out.frames = (to_int (((to_double durationMs) * (to_double sampleRate)) / 1000.0))
+            return out
+        }
+        def freq:double (this.pitchToFreq(pitch))
+        if (freq <= 0.0) {
+            return out
+        }
+        def synthMs:int (this.melodySynthMs(instrument durationMs))
+        def vol:double (this.instrumentVolume(instrument))
+        out.pcm = (this.synthMelody(instrument freq synthMs vol))
+        out.frames = (to_int (((to_double synthMs) * (to_double sampleRate)) / 1000.0))
+        return out
+    }
+
+    fn playScoreChord:void (notes:[ScoreVoiceHit] durationMs:int) {
+        if ((array_length notes) == 0) {
+            return
+        }
+        playCount = (playCount + 1)
+        lastId = "score:chord"
+        def frames:int (to_int (((to_double durationMs) * (to_double sampleRate)) / 1000.0))
+        if (frames < 1) {
+            frames = 1
+        }
+        def mixed:buffer (buffer_alloc (frames * 2))
+        def i 0
+        while (i < frames) {
+            buffer_set mixed (i * 2) 0
+            buffer_set mixed ((i * 2) + 1) 0
+            i = (i + 1)
+        }
+        def ni 0
+        while (ni < (array_length notes)) {
+            def ev:ScoreVoiceHit (itemAt notes ni)
+            def hasPart:boolean false
+            def part:buffer (buffer_alloc (frames * 2))
+            def synthMs:int (this.melodySynthMs(ev.instrument durationMs))
+            if (ev.instrument == "drums") {
+                part = (this.synthDrum(ev.pitch synthMs))
+                hasPart = true
+            } {
+                def freq:double (this.pitchToFreq(ev.pitch))
+                if (freq > 0.0) {
+                    def vol:double (this.instrumentVolume(ev.instrument))
+                    part = (this.synthMelody(ev.instrument freq synthMs vol))
+                    hasPart = true
+                }
+            }
+            if (hasPart) {
+                mixed = (this.mixBuffers(mixed part frames))
+            }
+            ni = (ni + 1)
+        }
+        sink.onSynthPlay(lastId sampleRate frames mixed)
+    }
+
+    fn synthTone:buffer (spec:SynthToneSpec) {
+        def frames:int (to_int (((to_double spec.durationMs) * (to_double sampleRate)) / 1000.0))
+        if (frames < 1) {
+            frames = 1
+        }
+        def pcm:buffer (buffer_alloc (frames * 2))
+        def phase:double 0.0
+        def freq:double spec.freqHz
+        def slidePerFrame:double 0.0
+        if (spec.slideHz != 0.0) {
+            slidePerFrame = ((spec.slideHz - spec.freqHz) / (to_double frames))
+        }
+        def i 0
+        while (i < frames) {
+            def t:double ((to_double i) / (to_double frames))
+            def env:double (1.0 - t)
+            env = (env * env)
+            def sample:double (this.sampleWave(spec.wave phase i))
+            def amp:double (sample * spec.volume * env * 32767.0)
+            def iv:int (to_int amp)
+            if (iv > 32767) { iv = 32767 }
+            if (iv < -32768) { iv = -32768 }
+            ; Inline LE int16 write: C++ passes buffer method args by value, so keep
+            ; buffer_set in the same method that owns the local pcm buffer.
+            def v:int iv
+            if (v < 0) {
+                v = (65536 + v)
+            }
+            def lo:int (bit_and v 255)
+            def hi:int (bit_and (to_int (v / 256)) 255)
+            def off:int (i * 2)
+            buffer_set pcm off lo
+            buffer_set pcm (off + 1) hi
+            freq = (freq + slidePerFrame)
+            if (freq < 40.0) { freq = 40.0 }
+            phase = (phase + (freq / (to_double sampleRate)))
+            phase = (this.wrapPhase(phase))
+            i = (i + 1)
+        }
+        return pcm
+    }
+
+    fn queueSpec:void (id:string spec:SynthToneSpec) {
+        def pcm:buffer (this.synthTone(spec))
+        def frames:int (to_int (((to_double spec.durationMs) * (to_double sampleRate)) / 1000.0))
+        if (frames < 1) {
+            frames = 1
+        }
+        sink.onSynthPlay(id sampleRate frames pcm)
+    }
+
+    fn play:void (id:string) {
+        playCount = (playCount + 1)
+        lastId = id
+        if verbose {
+            print ("[audio] play " + id)
+        }
+        if (id == "win") {
+            this.playWinArpeggio()
+            return
+        }
+        if (id == "celebrate") {
+            this.playCelebrateFanfare()
+            return
+        }
+        def spec:SynthToneSpec (this.lookupSpec(id))
+        this.queueSpec(id spec)
+    }
+
+    fn playWinArpeggio:void () {
+        def notes:[double]
+        push notes 523.0
+        push notes 659.0
+        push notes 784.0
+        push notes 1046.0
+        def i 0
+        while (i < (array_length notes)) {
+            def spec:SynthToneSpec (new SynthToneSpec)
+            spec.freqHz = (itemAt notes i)
+            spec.durationMs = 90
+            spec.volume = 0.28
+            spec.wave = (SynthWave.sine())
+            this.queueSpec("win" spec)
+            i = (i + 1)
+        }
+    }
+
+    fn playCelebrateFanfare:void () {
+        def notes:[double]
+        push notes 523.0
+        push notes 659.0
+        push notes 784.0
+        push notes 988.0
+        push notes 1174.0
+        push notes 1318.0
+        def i 0
+        while (i < (array_length notes)) {
+            def spec:SynthToneSpec (new SynthToneSpec)
+            spec.freqHz = (itemAt notes i)
+            spec.durationMs = 140
+            spec.volume = 0.30
+            spec.wave = (SynthWave.sine())
+            this.queueSpec("celebrate" spec)
+            i = (i + 1)
+        }
+    }
+}

--- a/gallery/game_engine/v2/audio/game_soundscore.rgr
+++ b/gallery/game_engine/v2/audio/game_soundscore.rgr
@@ -1,0 +1,594 @@
+; ==============================================================================
+; game_soundscore - text-based multi-voice music scores for GameAudio.
+; ==============================================================================
+;
+; Score format (whitespace-separated tokens per line):
+;
+;   tempo 100
+;   beats 4/4
+;   transpose -2          ; global semitones (negative = down)
+;
+;   @melody piano -2      ; optional per-track semitones (adds to global)
+;   1:C4 1:E4 1:G4 1:C5
+;
+;   @harmony violin
+;   4:C3 4:G3
+;
+;   @arp harp
+;   1:C3 1:E3 1:G3 1:C4
+;
+; Instruments: piano, violin, harp, flute, guitar, brass, organ, pad, bell,
+;              square, triangle, sine, drums (K/S/H)
+; Note duration: beats:note — beats may be fractional (e.g. 0.5:G4).
+; ==============================================================================
+
+Import "./game_audio.rgr"
+
+class ScoreNote {
+    def beats:double 1.0
+    def pitch:string ""
+}
+
+class ScoreTrack {
+    def name:string ""
+    def instrument:string "piano"
+    def transpose:int 0
+    def notes:[ScoreNote]
+}
+
+class SoundScore {
+    def tempo:int 120
+    def beatsNum:int 4
+    def beatsDen:int 4
+    def transpose:int 0
+    def tracks:[ScoreTrack]
+    def totalBeats:double 0.0
+}
+
+class ScheduledNote {
+    def beat:double 0.0
+    def beats:double 1.0
+    def instrument:string "piano"
+    def pitch:string ""
+    def played:boolean false
+}
+
+class SoundScoreParser {
+    def pitchNames:NoteNames (new NoteNames)
+    def pitchNamesReady:boolean false
+
+    fn ensurePitchNames:void () {
+        if (false == pitchNamesReady) {
+            pitchNames.init()
+            pitchNamesReady = true
+        }
+    }
+
+    fn parseSignedIntStr:int (s:string) {
+        if ((strlen s) == 0) {
+            return 0
+        }
+        def neg:boolean false
+        def start:int 0
+        def ch0:string (substring s 0 1)
+        if (ch0 == "-") {
+            neg = true
+            start = 1
+        } {
+            if (ch0 == "+") {
+                start = 1
+            }
+        }
+        if (start >= (strlen s)) {
+            return 0
+        }
+        def val:int (this.parseIntStr((substring s start (strlen s))))
+        if (neg) {
+            val = (0 - val)
+        }
+        return val
+    }
+
+    fn looksLikeSignedInt:boolean (s:string) {
+        if ((strlen s) == 0) {
+            return false
+        }
+        def start:int 0
+        def ch0:string (substring s 0 1)
+        if (ch0 == "-") {
+            start = 1
+        } {
+            if (ch0 == "+") {
+                start = 1
+            }
+        }
+        if (start >= (strlen s)) {
+            return false
+        }
+        def i:int start
+        while (i < (strlen s)) {
+            def ch:int (charAt s i)
+            if (ch < 48) {
+                return false
+            }
+            if (ch > 57) {
+                return false
+            }
+            i = (i + 1)
+        }
+        return true
+    }
+
+    fn parseIntStr:int (s:string) {
+        def out:int 0
+        def i:int 0
+        while (i < (strlen s)) {
+            def ch:int (charAt s i)
+            if (ch >= 48) {
+                if (ch <= 57) {
+                    out = ((out * 10) + (ch - 48))
+                }
+            }
+            i = (i + 1)
+        }
+        return out
+    }
+
+    fn parseDoubleStr:double (s:string) {
+        def whole:double 0.0
+        def frac:double 0.0
+        def fracDiv:double 0.1
+        def seenDot:boolean false
+        def i:int 0
+        while (i < (strlen s)) {
+            def ch:int (charAt s i)
+            if (ch == 46) {
+                seenDot = true
+            } {
+                if (ch >= 48) {
+                    if (ch <= 57) {
+                        if (seenDot) {
+                            frac = (frac + ((to_double (ch - 48)) * fracDiv))
+                            fracDiv = (fracDiv * 0.1)
+                        } {
+                            whole = ((whole * 10.0) + (to_double (ch - 48)))
+                        }
+                    }
+                }
+            }
+            i = (i + 1)
+        }
+        return (whole + frac)
+    }
+
+    fn trim:string (s:string) {
+        def start:int 0
+        def end:int (strlen s)
+        while (start < end) {
+            def ch:string (substring s start (start + 1))
+            if (ch == " ") {
+                start = (start + 1)
+            } {
+                if (ch == "\t") {
+                    start = (start + 1)
+                } {
+                    break
+                }
+            }
+        }
+        while (end > start) {
+            def ch2:string (substring s (end - 1) end)
+            if (ch2 == " ") {
+                end = (end - 1)
+            } {
+                if (ch2 == "\t") {
+                    end = (end - 1)
+                } {
+                    break
+                }
+            }
+        }
+        if (end <= start) {
+            return ""
+        }
+        return (substring s start end)
+    }
+
+    fn splitLines:[string] (s:string) {
+        def out:[string]
+        def cur:string ""
+        def i 0
+        while (i < (strlen s)) {
+            def ch:string (substring s i (i + 1))
+            if (ch == "\n") {
+                push out cur
+                cur = ""
+            } {
+                if (ch == "\r") {
+                } {
+                    cur = (cur + ch)
+                }
+            }
+            i = (i + 1)
+        }
+        push out cur
+        return out
+    }
+
+    fn splitTokens:[string] (s:string) {
+        def out:[string]
+        def cur:string ""
+        def i 0
+        while (i < (strlen s)) {
+            def ch:string (substring s i (i + 1))
+            if (ch == " ") {
+                if ((strlen cur) > 0) {
+                    push out cur
+                    cur = ""
+                }
+            } {
+                if (ch == "\t") {
+                    if ((strlen cur) > 0) {
+                        push out cur
+                        cur = ""
+                    }
+                } {
+                    cur = (cur + ch)
+                }
+            }
+            i = (i + 1)
+        }
+        if ((strlen cur) > 0) {
+            push out cur
+        }
+        return out
+    }
+
+    fn parseNoteToken:boolean (tok:string noteOut:ScoreNote) {
+        def colon:int -1
+        def i 0
+        while (i < (strlen tok)) {
+            def ch:string (substring tok i (i + 1))
+            if (ch == ":") {
+                colon = i
+                break
+            }
+            i = (i + 1)
+        }
+        if (colon < 1) {
+            return false
+        }
+        def beatsStr:string (substring tok 0 colon)
+        def pitch:string (substring tok (colon + 1) (strlen tok))
+        noteOut.beats = (this.parseDoubleStr(beatsStr))
+        if (noteOut.beats <= 0.0) {
+            noteOut.beats = 1.0
+        }
+        noteOut.pitch = pitch
+        return true
+    }
+
+    fn parseTempo:boolean (line:string score:SoundScore) {
+        if ((strlen line) < 7) {
+            return false
+        }
+        def head:string (substring line 0 6)
+        if (head != "tempo ") {
+            return false
+        }
+        def valStr:string (this.trim((substring line 6 (strlen line))))
+        def val:int (this.parseIntStr(valStr))
+        if (val < 20) {
+            val = 20
+        }
+        if (val > 400) {
+            val = 400
+        }
+        score.tempo = val
+        return true
+    }
+
+    fn parseBeats:boolean (line:string score:SoundScore) {
+        if ((strlen line) < 7) {
+            return false
+        }
+        def head:string (substring line 0 6)
+        if (head != "beats ") {
+            return false
+        }
+        def sig:string (this.trim((substring line 6 (strlen line))))
+        def slash:int -1
+        def i 0
+        while (i < (strlen sig)) {
+            def ch:string (substring sig i (i + 1))
+            if (ch == "/") {
+                slash = i
+                break
+            }
+            i = (i + 1)
+        }
+        if (slash < 1) {
+            return false
+        }
+        score.beatsNum = (this.parseIntStr((substring sig 0 slash)))
+        score.beatsDen = (this.parseIntStr((substring sig (slash + 1) (strlen sig))))
+        if (score.beatsNum < 1) {
+            score.beatsNum = 4
+        }
+        if (score.beatsDen < 1) {
+            score.beatsDen = 4
+        }
+        return true
+    }
+
+    fn parseTranspose:boolean (line:string score:SoundScore) {
+        if ((strlen line) < 11) {
+            return false
+        }
+        def head:string (substring line 0 10)
+        if (head != "transpose ") {
+            return false
+        }
+        def valStr:string (this.trim((substring line 10 (strlen line))))
+        score.transpose = (this.parseSignedIntStr(valStr))
+        return true
+    }
+
+    fn parseTrackHeader:boolean (line:string trackOut:ScoreTrack) {
+        if ((strlen line) < 2) {
+            return false
+        }
+        def ch0:string (substring line 0 1)
+        if (ch0 != "@") {
+            return false
+        }
+        def rest:string (this.trim((substring line 1 (strlen line))))
+        def toks:[string] (this.splitTokens(rest))
+        if ((array_length toks) < 2) {
+            return false
+        }
+        trackOut.name = (itemAt toks 0)
+        trackOut.transpose = 0
+        trackOut.instrument = "piano"
+        def lastIdx:int ((array_length toks) - 1)
+        def lastTok:string (itemAt toks lastIdx)
+        if (this.looksLikeSignedInt(lastTok)) {
+            trackOut.transpose = (this.parseSignedIntStr(lastTok))
+            if (lastIdx > 1) {
+                trackOut.instrument = (itemAt toks 1)
+            }
+        } {
+            trackOut.instrument = (itemAt toks 1)
+        }
+        if ((strlen trackOut.instrument) == 0) {
+            trackOut.instrument = "piano"
+        }
+        return true
+    }
+
+    fn computeTotalBeats:double (score:SoundScore) {
+        def maxBeats:double 0.0
+        def ti 0
+        while (ti < (array_length score.tracks)) {
+            def tr:ScoreTrack (itemAt score.tracks ti)
+            def pos:double 0.0
+            def ni 0
+            while (ni < (array_length tr.notes)) {
+                def n:ScoreNote (itemAt tr.notes ni)
+                pos = (pos + n.beats)
+                ni = (ni + 1)
+            }
+            if (pos > maxBeats) {
+                maxBeats = pos
+            }
+            ti = (ti + 1)
+        }
+        return maxBeats
+    }
+
+    fn parse:SoundScore (text:string) {
+        def score:SoundScore (new SoundScore)
+        def curTrackIdx:int -1
+        def lines:[string] (this.splitLines(text))
+        def li 0
+        while (li < (array_length lines)) {
+            def line:string (this.trim((itemAt lines li)))
+            if ((strlen line) > 0) {
+                if ((substring line 0 1) != "#") {
+                    if (this.parseTempo(line score)) {
+                    } {
+                        if (this.parseBeats(line score)) {
+                        } {
+                            if (this.parseTranspose(line score)) {
+                            } {
+                            def hdr:ScoreTrack (new ScoreTrack)
+                            if (this.parseTrackHeader(line hdr)) {
+                                push score.tracks hdr
+                                curTrackIdx = ((array_length score.tracks) - 1)
+                            } {
+                                if (curTrackIdx >= 0) {
+                                    def tr:ScoreTrack (itemAt score.tracks curTrackIdx)
+                                    def toks:[string] (this.splitTokens(line))
+                                    def ti 0
+                                    while (ti < (array_length toks)) {
+                                        def note:ScoreNote (new ScoreNote)
+                                        if (this.parseNoteToken((itemAt toks ti) note)) {
+                                            push tr.notes note
+                                        }
+                                        ti = (ti + 1)
+                                    }
+                                }
+                            }
+                            }
+                        }
+                    }
+                }
+            }
+            li = (li + 1)
+        }
+        score.totalBeats = (this.computeTotalBeats(score))
+        return score
+    }
+
+    fn buildSchedule:[ScheduledNote] (score:SoundScore) {
+        this.ensurePitchNames()
+        def out:[ScheduledNote]
+        def ti 0
+        while (ti < (array_length score.tracks)) {
+            def tr:ScoreTrack (itemAt score.tracks ti)
+            def semi:int (score.transpose + tr.transpose)
+            def beat:double 0.0
+            def ni 0
+            while (ni < (array_length tr.notes)) {
+                def n:ScoreNote (itemAt tr.notes ni)
+                if (n.pitch != "_") {
+                    def ev:ScheduledNote (new ScheduledNote)
+                    ev.beat = beat
+                    ev.beats = n.beats
+                    ev.instrument = tr.instrument
+                    ev.pitch = (pitchNames.transposePitch(n.pitch semi))
+                    push out ev
+                }
+                beat = (beat + n.beats)
+                ni = (ni + 1)
+            }
+            ti = (ti + 1)
+        }
+        this.sortScheduleByBeat(out)
+        return out
+    }
+
+    fn sortScheduleByBeat:void (schedule:[ScheduledNote]) {
+        def n:int (array_length schedule)
+        def i 0
+        while (i < n) {
+            def j (i + 1)
+            while (j < n) {
+                def a:ScheduledNote (itemAt schedule i)
+                def b:ScheduledNote (itemAt schedule j)
+                if (b.beat < a.beat) {
+                    set schedule i b
+                    set schedule j a
+                }
+                j = (j + 1)
+            }
+            i = (i + 1)
+        }
+    }
+}
+
+class SoundScorePlayer {
+    def audio:GameAudio
+    def parser:SoundScoreParser (new SoundScoreParser)
+    def score:SoundScore (new SoundScore)
+    def schedule:[ScheduledNote]
+    def nextIdx:int 0
+    def beatPos:double 0.0
+    def msPerBeat:double 500.0
+    def playing:boolean false
+    def loop:boolean true
+    def noteStarts:int 0
+
+    fn startPendingVoices:void (pending:[ScheduledNote]) {
+        def n:int (array_length pending)
+        if (n <= 0) {
+            return
+        }
+        if (n == 1) {
+            def src:ScheduledNote (itemAt pending 0)
+            def durMs:int (to_int (src.beats * msPerBeat))
+            if (durMs < 40) {
+                durMs = 40
+            }
+            audio.playScoreNote(src.instrument src.pitch durMs)
+            noteStarts = (noteStarts + 1)
+            return
+        }
+        def hits:[ScoreVoiceHit]
+        def head:ScheduledNote (itemAt pending 0)
+        def durMs:int (to_int (head.beats * msPerBeat))
+        if (durMs < 40) {
+            durMs = 40
+        }
+        def i 0
+        while (i < n) {
+            def src:ScheduledNote (itemAt pending i)
+            def hit:ScoreVoiceHit (new ScoreVoiceHit)
+            hit.instrument = src.instrument
+            hit.pitch = src.pitch
+            push hits hit
+            i = (i + 1)
+        }
+        audio.playScoreChord(hits durMs)
+        noteStarts = (noteStarts + n)
+    }
+
+    fn load:void (text:string) {
+        score = (parser.parse(text))
+        schedule = (parser.buildSchedule(score))
+        msPerBeat = (60000.0 / (to_double score.tempo))
+        nextIdx = 0
+        beatPos = 0.0
+        noteStarts = 0
+    }
+
+    fn play:void (loopScore:boolean) {
+        loop = loopScore
+        playing = true
+        nextIdx = 0
+        beatPos = 0.0
+    }
+
+    fn stop:void () {
+        playing = false
+        nextIdx = 0
+        beatPos = 0.0
+    }
+
+    fn isPlaying:boolean () {
+        return playing
+    }
+
+    fn flushPending:void (pending:[ScheduledNote]) {
+        this.startPendingVoices(pending)
+    }
+
+    fn tick:void (dtMs:int) {
+        if (false == playing) {
+            return
+        }
+        if ((array_length schedule) == 0) {
+            playing = false
+            return
+        }
+        beatPos = (beatPos + ((to_double dtMs) / msPerBeat))
+        while (nextIdx < (array_length schedule)) {
+            def ev:ScheduledNote (itemAt schedule nextIdx)
+            if (ev.beat > beatPos) {
+                break
+            }
+            def targetBeat:double ev.beat
+            def pending:[ScheduledNote]
+            while (nextIdx < (array_length schedule)) {
+                def cand:ScheduledNote (itemAt schedule nextIdx)
+                if (cand.beat > beatPos) {
+                    break
+                }
+                if (cand.beat != targetBeat) {
+                    break
+                }
+                push pending cand
+                nextIdx = (nextIdx + 1)
+            }
+            this.startPendingVoices(pending)
+        }
+        if (beatPos >= score.totalBeats) {
+            if (loop) {
+                beatPos = 0.0
+                nextIdx = 0
+            } {
+                playing = false
+            }
+        }
+    }
+}

--- a/gallery/game_engine/v2/audio/tests/audio_score_test.rgr
+++ b/gallery/game_engine/v2/audio/tests/audio_score_test.rgr
@@ -1,0 +1,80 @@
+; ==============================================================================
+; audio_score_test — the headless score engine (parse -> schedule -> synth).
+; ==============================================================================
+; The v2 sound path is self-contained under v2/audio (game_soundscore +
+; game_audio, copied in, no imports outside v2). This drives the WHOLE headless
+; pipeline on ylos2's actual summit score:
+;   * the parser reads tempo / time signature / a @melody track of dur:pitch
+;     tokens into notes and a beat-sorted schedule,
+;   * the synth maps pitches to equal-tempered frequencies and renders PCM,
+;   * the player ticks the schedule in real time and starts every note once.
+; No native audio device is involved — this is the deterministic core the SDL
+; gfx_audio_* sink consumes on a real machine.
+; ==============================================================================
+
+Import "../game_soundscore.rgr"
+Import "../../tests/harness/RgTest.rgr"
+
+class AudioScoreTest {
+    ; ylos2's SUMMIT_MUSIC, verbatim (tempo 152, one piano melody, 16 beats).
+    sfn score:string () {
+        return ("tempo 152\nbeats 4/4\n\n@melody piano\n0.5:E4 0.5:G4 1:A4 1:G4 1:E4\n0.5:D4 0.5:E4 1:G4 2:E4\n0.5:E4 0.5:G4 1:A4 1:C5 1:B4\n1:A4 1:G4 2:E4\n")
+    }
+
+    sfn m@(main):void () {
+        def t:RgTest (RgTest.forSuite("audio/score (parse + schedule + synth)"))
+
+        ; ---- parse ----------------------------------------------------------
+        def txt:string (AudioScoreTest.score())
+        def parser:SoundScoreParser (new SoundScoreParser)
+        def sc:SoundScore (parser.parse(txt))
+        t.eqInt("tempo parsed" sc.tempo 152)
+        t.eqInt("time signature numerator" sc.beatsNum 4)
+        t.eqInt("one track" (array_length sc.tracks) 1)
+        def tr:ScoreTrack (itemAt sc.tracks 0)
+        t.eqStr("melody track name" tr.name "melody")
+        t.eqStr("piano instrument" tr.instrument "piano")
+        t.eqInt("17 notes across the phrases" (array_length tr.notes) 17)
+        def tb:int (to_int sc.totalBeats)
+        t.eqInt("16 total beats (4 bars of 4/4)" tb 16)
+
+        ; ---- schedule (beat-sorted) -----------------------------------------
+        def sched:[ScheduledNote] (parser.buildSchedule(sc))
+        t.eqInt("17 scheduled notes" (array_length sched) 17)
+        def first:ScheduledNote (itemAt sched 0)
+        t.ok("first note starts at beat 0" (first.beat == 0.0))
+        def last:ScheduledNote (itemAt sched 16)
+        t.ok("notes are ordered (last starts after first)" (last.beat > first.beat))
+
+        ; ---- synth (pitch -> frequency -> PCM) ------------------------------
+        def ga:GameAudio (new GameAudio)
+        ga.init()
+        def fA:double (ga.pitchToFreq("A4"))
+        t.ok("A4 resolves to ~440 Hz" ((fA > 439.0) && (fA < 441.0)))
+        def fA5:double (ga.pitchToFreq("A5"))
+        t.ok("A5 is one octave up (~880 Hz)" ((fA5 > 878.0) && (fA5 < 882.0)))
+        def rest:double (ga.pitchToFreq("_"))
+        t.ok("a rest ('_') has no pitch" (rest == 0.0))
+        def pcm:buffer (ga.synthMelody("piano" fA 100 0.5))
+        ; 100ms @ 44100Hz, 16-bit mono = 4410 frames * 2 bytes
+        t.eqInt("PCM length matches 100ms @ 44.1kHz 16-bit" (buffer_length pcm) 8820)
+
+        ; ---- player: tick the whole score, every note fires once ------------
+        def player:SoundScorePlayer (new SoundScorePlayer)
+        player.audio = ga
+        player.load(txt)
+        t.ok("player is silent before play()" ((player.isPlaying()) == false))
+        player.play(false)
+        t.ok("player is playing after play()" (player.isPlaying()))
+        ; 16 beats @152bpm ~= 6.3s; step past the end in 50ms ticks.
+        def elapsed 0
+        while (elapsed < 8000) {
+            player.tick(50)
+            elapsed = (elapsed + 50)
+        }
+        t.eqInt("all 17 notes were started exactly once" player.noteStarts 17)
+        t.ok("non-looping playback finished at the end" ((player.isPlaying()) == false))
+
+        t.summary()
+    }
+}

--- a/gallery/game_engine/v2/framebuffer.rgr
+++ b/gallery/game_engine/v2/framebuffer.rgr
@@ -1,0 +1,1058 @@
+; ==============================================================================
+; SoftCanvas - a tiny, portable RGBA8888 software framebuffer.
+; ==============================================================================
+;
+; This is the "render to a native buffer" layer of the PoC. It owns a raw byte
+; buffer laid out as tightly-packed RGBA (4 bytes per pixel, row-major) - i.e.
+; exactly the format an SDL2 streaming texture (SDL_PIXELFORMAT_RGBA32) or a
+; browser canvas ImageData expects. The platform layer just uploads `raw()`.
+;
+; It is pure Ranger built only on the `buffer` primitive (buffer_alloc /
+; buffer_set), so it compiles cleanly to every target (JS, C++, Go, Rust, LLVM)
+; and produces bit-identical pixels everywhere - the foundation for
+; golden-frame tests across Mac and Raspberry Pi.
+;
+; It deliberately mirrors a subset of the EVG raster API (clear / fillRect /
+; fillCircle) so game code can later swap in the full EVG vector renderer
+; without changing call sites, once the EVG stack builds natively (see
+; RENDERING_EVG.md).
+;
+; blitImage() composes RGBA ImageBuffer sprites via RgbaFastBlit (alpha-aware).
+; ==============================================================================
+
+Import "./rgba_fast_blit.rgr"
+Import "imaging/jpeg/ImageBuffer.rgr"
+Import "imaging/raster/RasterBuffer.rgr"
+
+class SoftCanvas {
+    def w:int 0
+    def h:int 0
+    ; initialised so the field is a concrete (non-optional) buffer; init()
+    ; reallocates it to the real frame size.
+    def px:buffer (buffer_alloc 4)
+    def blitter:RgbaFastBlit (new RgbaFastBlit)
+
+    fn init:void (width:int height:int) {
+        w = width
+        h = height
+        ; size kept in a local: the es6 buffer_alloc template inlines its
+        ; argument into an IIFE, so a bare `this.w * this.h` would lose `this`.
+        def total:int (w * h * 4)
+        px = (buffer_alloc total)
+    }
+
+    fn getWidth:int () {
+        return w
+    }
+
+    fn getHeight:int () {
+        return h
+    }
+
+    ; The tightly-packed RGBA bytes to hand straight to the display backend.
+    fn raw:buffer () {
+        return px
+    }
+
+    ; Copy px into dst.pixels (w*h*4 bytes). Use this instead of buffer_copy on
+    ; raw(): the C++ backend returns raw() by value, so buffer ops on raw() touch
+    ; temporaries and can crash (iterator pair from different vectors).
+    fn copyPixelsToImage:void (dst:ImageBuffer) {
+        def len:int (w * h * 4)
+        buffer_copy dst.pixels 0 px 0 len
+    }
+
+    ; Fill `count` consecutive opaque RGBA pixels starting at byte offset `off`.
+    ;
+    ; Small spans are written directly byte-by-byte: at low optimization levels
+    ; (the game build compiles with no -O flag) buffer_copy lowers to a real
+    ; std::copy call whose per-call overhead dominates a short run, so direct
+    ; writes are strictly faster there and never slower elsewhere.
+    ;
+    ; Large spans use exponential doubling: write the first pixel, then keep
+    ; doubling the filled run with buffer_copy (a native memmove-class span copy),
+    ; so a big run costs 4 writes + ~log2(W) copies instead of 4*W writes.
+    ; This is the high-level colour-fill primitive the fill/blit paths build on.
+    fn fillSpanRGB:void (off:int count:int r:int g:int b:int) {
+        if (count <= 0) {
+            return
+        }
+        ; Direct byte writes for short runs (no buffer_copy call overhead).
+        if (count <= 32) {
+            def o off
+            def i 0
+            while (i < count) {
+                buffer_set px o r
+                buffer_set px (o + 1) g
+                buffer_set px (o + 2) b
+                buffer_set px (o + 3) 255
+                o = (o + 4)
+                i = (i + 1)
+            }
+            return
+        }
+        buffer_set px off r
+        buffer_set px (off + 1) g
+        buffer_set px (off + 2) b
+        buffer_set px (off + 3) 255
+        def filled 1
+        while (filled < count) {
+            def copyCount filled
+            def remaining (count - filled)
+            if (copyCount > remaining) {
+                copyCount = remaining
+            }
+            buffer_copy px (off + (filled * 4)) px off (copyCount * 4)
+            filled = (filled + copyCount)
+        }
+    }
+
+    ; Fill the whole frame with an opaque colour. The frame is one contiguous
+    ; RGBA span, so this is a single exponential-doubling fill.
+    fn clear:void (r:int g:int b:int) {
+        this.fillSpanRGB(0 (w * h) r g b)
+    }
+
+    ; Set one pixel (opaque). Out-of-bounds writes are ignored so callers can
+    ; draw shapes that run off the edge without special-casing.
+    fn setPixel:void (x:int y:int r:int g:int b:int) {
+        if (x < 0) {
+            return
+        }
+        if (x >= w) {
+            return
+        }
+        if (y < 0) {
+            return
+        }
+        if (y >= h) {
+            return
+        }
+        def o (((y * w) + x) * 4)
+        buffer_set px o r
+        buffer_set px (o + 1) g
+        buffer_set px (o + 2) b
+        buffer_set px (o + 3) 255
+    }
+
+    fn fillRect:void (x:int y:int rw:int rh:int r:int g:int b:int) {
+        if (rw <= 0) {
+            return
+        }
+        if (rh <= 0) {
+            return
+        }
+        def x0 x
+        def y0 y
+        def x1 (x + rw)
+        def y1 (y + rh)
+        if (x0 < 0) {
+            x0 = 0
+        }
+        if (y0 < 0) {
+            y0 = 0
+        }
+        if (x1 > w) {
+            x1 = w
+        }
+        if (y1 > h) {
+            y1 = h
+        }
+        if (x0 >= x1) {
+            return
+        }
+        if (y0 >= y1) {
+            return
+        }
+        def spanPixels (x1 - x0)
+
+        ; Full-width rectangles are one contiguous RGBA region — fill in a single
+        ; span (this is the dominant createStaticBg ground-slice case).
+        if (x0 == 0) {
+            if (x1 == w) {
+                def base (((y0 * w)) * 4)
+                this.fillSpanRGB(base (spanPixels * (y1 - y0)) r g b)
+                return
+            }
+        }
+
+        ; Narrow rectangles (small sprites, bitmap pixels, thin lines) are filled
+        ; with direct byte writes: the per-row buffer_copy call overhead would
+        ; dominate a short row at low optimization levels (the game build uses no
+        ; -O flag), so a plain nested write loop is strictly faster and never
+        ; slower. Wide rectangles fill the first scanline then replicate it down
+        ; with contiguous row copies.
+        if (spanPixels < 32) {
+            def yy y0
+            while (yy < y1) {
+                def o (((yy * w) + x0) * 4)
+                def xx x0
+                while (xx < x1) {
+                    buffer_set px o r
+                    buffer_set px (o + 1) g
+                    buffer_set px (o + 2) b
+                    buffer_set px (o + 3) 255
+                    o = (o + 4)
+                    xx = (xx + 1)
+                }
+                yy = (yy + 1)
+            }
+            return
+        }
+
+        def firstRowOff (((y0 * w) + x0) * 4)
+        this.fillSpanRGB(firstRowOff spanPixels r g b)
+        def spanBytes (spanPixels * 4)
+        def yy2 (y0 + 1)
+        while (yy2 < y1) {
+            def rowOff (((yy2 * w) + x0) * 4)
+            buffer_copy px rowOff px firstRowOff spanBytes
+            yy2 = (yy2 + 1)
+        }
+    }
+
+    ; Filled horizontal trapezoid (parallel top/bottom edges). Scanline-lerps
+    ; left/right X from (y0,x0L..x0R) to (y1,x1L..x1R). Used for pseudo-3D
+    ; road bands so edges stay diagonal instead of staircased rect strips.
+    fn fillTrapezoid:void (y0:int x0L:int x0R:int y1:int x1L:int x1R:int r:int g:int b:int) {
+        def ty0:int y0
+        def ty1:int y1
+        def aL:int x0L
+        def aR:int x0R
+        def bL:int x1L
+        def bR:int x1R
+        if (ty0 > ty1) {
+            ty0 = y1
+            ty1 = y0
+            aL = x1L
+            aR = x1R
+            bL = x0L
+            bR = x0R
+        }
+        if (aL > aR) {
+            def tmp:int aL
+            aL = aR
+            aR = tmp
+        }
+        if (bL > bR) {
+            def tmp2:int bL
+            bL = bR
+            bR = tmp2
+        }
+        def dy:int (ty1 - ty0)
+        if (dy < 0) {
+            return
+        }
+        if (dy == 0) {
+            def xL0:int aL
+            def xR0:int aR
+            if (xL0 < 0) {
+                xL0 = 0
+            }
+            if (xR0 > w) {
+                xR0 = w
+            }
+            if (xL0 < xR0) {
+                if (ty0 >= 0) {
+                    if (ty0 < h) {
+                        this.fillSpanRGB((((ty0 * w) + xL0) * 4) (xR0 - xL0) r g b)
+                    }
+                }
+            }
+            return
+        }
+        def yy:int ty0
+        while (yy <= ty1) {
+            if (yy >= 0) {
+                if (yy < h) {
+                    def num:int (yy - ty0)
+                    def xL:int (aL + (idiv ((bL - aL) * num) dy))
+                    def xR:int (aR + (idiv ((bR - aR) * num) dy))
+                    if (xL > xR) {
+                        def sw:int xL
+                        xL = xR
+                        xR = sw
+                    }
+                    if (xL < 0) {
+                        xL = 0
+                    }
+                    if (xR > w) {
+                        xR = w
+                    }
+                    if (xL < xR) {
+                        this.fillSpanRGB((((yy * w) + xL) * 4) (xR - xL) r g b)
+                    }
+                }
+            }
+            yy = (yy + 1)
+        }
+    }
+
+    ; Alpha-composite an RGBA ImageBuffer onto this canvas (top-left at dx,dy).
+    ; Clips to the framebuffer here because RgbaFastBlit.blitRect does not bounds
+    ; check the destination — an off-screen sprite would otherwise wrap rows or
+    ; write past the buffer.
+    fn blitImage:void (src:ImageBuffer dx:int dy:int) {
+        if (src.width <= 0) {
+            return
+        }
+        if (src.height <= 0) {
+            return
+        }
+        def sx:int 0
+        def sy:int 0
+        def ddx:int dx
+        def ddy:int dy
+        if (ddx < 0) {
+            sx = (0 - ddx)
+            ddx = 0
+        }
+        if (ddy < 0) {
+            sy = (0 - ddy)
+            ddy = 0
+        }
+        def sw:int (src.width - sx)
+        def sh:int (src.height - sy)
+        if ((ddx + sw) > w) {
+            sw = (w - ddx)
+        }
+        if ((ddy + sh) > h) {
+            sh = (h - ddy)
+        }
+        if (sw <= 0) {
+            return
+        }
+        if (sh <= 0) {
+            return
+        }
+        ; Blit straight into our pixel buffer (passed by reference). Wrapping px
+        ; in a temporary RasterBuffer copies the std::vector under C++ value
+        ; semantics and silently drops the writes (text/sprites invisible on the
+        ; native build) — see rgba_fast_blit.blitRectBuf.
+        blitter.blitRectBuf(px w src sx sy sw sh ddx ddy)
+    }
+
+    ; Alpha-composite a source sub-rectangle onto this canvas (centered draw uses
+    ; dx/dy as the top-left of the blitted region after caller offset).
+    fn blitImageRect:void (src:ImageBuffer sx:int sy:int sw:int sh:int dx:int dy:int) {
+        if (src.width <= 0) {
+            return
+        }
+        if (src.height <= 0) {
+            return
+        }
+        if (sw <= 0) {
+            return
+        }
+        if (sh <= 0) {
+            return
+        }
+        def ddx:int dx
+        def ddy:int dy
+        def ssx:int sx
+        def ssy:int sy
+        def ssw:int sw
+        def ssh:int sh
+        if (ddx < 0) {
+            ssx = (ssx + (0 - ddx))
+            ssw = (ssw - (0 - ddx))
+            ddx = 0
+        }
+        if (ddy < 0) {
+            ssy = (ssy + (0 - ddy))
+            ssh = (ssh - (0 - ddy))
+            ddy = 0
+        }
+        if ((ddx + ssw) > w) {
+            ssw = (w - ddx)
+        }
+        if ((ddy + ssh) > h) {
+            ssh = (h - ddy)
+        }
+        if (ssw <= 0) {
+            return
+        }
+        if (ssh <= 0) {
+            return
+        }
+        def view:RasterBuffer (new RasterBuffer)
+        view.width = w
+        view.height = h
+        view.pixels = px
+        blitter.blitRect(view src ssx ssy ssw ssh ddx ddy)
+        px = view.pixels
+    }
+
+    ; Nearest-neighbour scale-blit of a source sub-rectangle (sw×sh → dw×dh).
+    fn blitImageRectScaled:void (src:ImageBuffer sx:int sy:int sw:int sh:int dx:int dy:int dw:int dh:int) {
+        if (sw <= 0) {
+            return
+        }
+        if (sh <= 0) {
+            return
+        }
+        if (dw <= 0) {
+            return
+        }
+        if (dh <= 0) {
+            return
+        }
+        def srcW:int src.width
+        def y 0
+        while (y < dh) {
+            def dstY:int (dy + y)
+            if (dstY < 0) {
+                y = (y + 1)
+            } {
+                if (dstY >= h) {
+                    y = (y + 1)
+                } {
+                    def syOff:int (sy + (to_int ((to_double (y * sh)) / (to_double dh))))
+                    if (syOff >= src.height) {
+                        syOff = (src.height - 1)
+                    }
+                    def x 0
+                    while (x < dw) {
+                        def dstX:int (dx + x)
+                        if (dstX < 0) {
+                            x = (x + 1)
+                        } {
+                            if (dstX >= w) {
+                                x = (x + 1)
+                            } {
+                                def sxOff:int (sx + (to_int ((to_double (x * sw)) / (to_double dw))))
+                                if (sxOff >= srcW) {
+                                    sxOff = (srcW - 1)
+                                }
+                                def sOff:int (((syOff * srcW) + sxOff) * 4)
+                                def srcA:int (buffer_get src.pixels (sOff + 3))
+                                if (srcA > 0) {
+                                    def dOff:int (((dstY * w) + dstX) * 4)
+                                    if (srcA >= 255) {
+                                        buffer_set px dOff (buffer_get src.pixels sOff)
+                                        buffer_set px (dOff + 1) (buffer_get src.pixels (sOff + 1))
+                                        buffer_set px (dOff + 2) (buffer_get src.pixels (sOff + 2))
+                                        buffer_set px (dOff + 3) 255
+                                    } {
+                                        blitter.blendOverBytes(px dOff
+                                            (buffer_get src.pixels sOff)
+                                            (buffer_get src.pixels (sOff + 1))
+                                            (buffer_get src.pixels (sOff + 2))
+                                            srcA)
+                                    }
+                                }
+                                x = (x + 1)
+                            }
+                        }
+                    }
+                    y = (y + 1)
+                }
+            }
+        }
+    }
+
+    fn degToRad:double (deg:double) {
+        return (deg * 0.017453292519943295)
+    }
+
+    ; Solid rectangle from pivot along +X (length rw), thickness rh, rotated angleDeg (Y-down).
+    fn fillRectRotated:void (pivotX:int pivotY:int rw:int rh:int angleDeg:double r:int g:int b:int) {
+        if (rw <= 0) {
+            return
+        }
+        if (rh <= 0) {
+            return
+        }
+        if (angleDeg == 0.0) {
+            def halfH:int (to_int ((to_double rh) * 0.5))
+            this.fillRect(pivotX (pivotY - halfH) rw rh r g b)
+            return
+        }
+        def rad:double (this.degToRad(angleDeg))
+        def cosA:double (cos(rad))
+        def sinA:double (sin(rad))
+        def halfTh:double ((to_double rh) * 0.5)
+        def y 0
+        while (y < rh) {
+            def ly:double ((to_double y) - halfTh)
+            def x 0
+            while (x < rw) {
+                def lx:double (to_double x)
+                def wx:double ((lx * cosA) - (ly * sinA))
+                def wy:double ((lx * sinA) + (ly * cosA))
+                def dstX:int (pivotX + (to_int wx))
+                def dstY:int (pivotY + (to_int wy))
+                if (dstX >= 0) {
+                    if (dstX < w) {
+                        if (dstY >= 0) {
+                            if (dstY < h) {
+                                this.setPixel(dstX dstY r g b)
+                            }
+                        }
+                    }
+                }
+                x = (x + 1)
+            }
+            y = (y + 1)
+        }
+    }
+
+    ; Centre-pivoted rotated rect fill: the rect of size rw x rh is centred on
+    ; (cx, cy) and rotated clockwise (Y-down). Unlike fillRectRotated (whose local
+    ; origin sits at the left edge / vertical centre), this rotates about the true
+    ; centre — what a guest-authored sprite needs so it spins in place.
+    fn fillRectRotatedC:void (cx:int cy:int rw:int rh:int angleDeg:double r:int g:int b:int) {
+        if (rw <= 0) {
+            return
+        }
+        if (rh <= 0) {
+            return
+        }
+        if (angleDeg == 0.0) {
+            def hx:int (to_int ((to_double rw) * 0.5))
+            def hy:int (to_int ((to_double rh) * 0.5))
+            this.fillRect((cx - hx) (cy - hy) rw rh r g b)
+            return
+        }
+        def rad:double (this.degToRad(angleDeg))
+        def cosA:double (cos(rad))
+        def sinA:double (sin(rad))
+        def hw:double ((to_double rw) * 0.5)
+        def hh:double ((to_double rh) * 0.5)
+        def y 0
+        while (y < rh) {
+            def ly:double ((to_double y) - hh)
+            def x 0
+            while (x < rw) {
+                def lx:double ((to_double x) - hw)
+                def wx:double ((lx * cosA) - (ly * sinA))
+                def wy:double ((lx * sinA) + (ly * cosA))
+                def dstX:int (cx + (to_int wx))
+                def dstY:int (cy + (to_int wy))
+                if (dstX >= 0) {
+                    if (dstX < w) {
+                        if (dstY >= 0) {
+                            if (dstY < h) {
+                                this.setPixel(dstX dstY r g b)
+                            }
+                        }
+                    }
+                }
+                x = (x + 1)
+            }
+            y = (y + 1)
+        }
+    }
+
+    ; A guest-authored rotatable sprite drawn as a bevelled block: a dark base, a
+    ; bright face, and one corner "stud" — all sharing the same centre + rotation.
+    ; The stud makes the rotation legible even though a bare square is 4-fold
+    ; symmetric, so a spinning piece reads clearly. rot is clockwise degrees.
+    fn drawBlockRotated:void (cx:int cy:int size:int angleDeg:double r:int g:int b:int) {
+        if (size <= 0) {
+            return
+        }
+        def dr:int (idiv (r * 42) 100)
+        def dg:int (idiv (g * 42) 100)
+        def db:int (idiv (b * 42) 100)
+        this.fillRectRotatedC(cx cy size size angleDeg dr dg db)
+        def face:int (size - 3)
+        if (face < 1) {
+            face = 1
+        }
+        this.fillRectRotatedC(cx cy face face angleDeg r g b)
+        ; corner stud: offset toward the block's local top-left, rotated with it
+        def studSize:int (idiv size 3)
+        if (studSize < 2) {
+            studSize = 2
+        }
+        def off:double ((to_double size) * 0.26)
+        def rad:double (this.degToRad(angleDeg))
+        def cosA:double (cos(rad))
+        def sinA:double (sin(rad))
+        def lx:double (0.0 - off)
+        def ly:double (0.0 - off)
+        def wx:double ((lx * cosA) - (ly * sinA))
+        def wy:double ((lx * sinA) + (ly * cosA))
+        def sx:int (cx + (to_int wx))
+        def sy:int (cy + (to_int wy))
+        def hr:int (r + 60)
+        def hg:int (g + 60)
+        def hb:int (b + 60)
+        if (hr > 255) { hr = 255 }
+        if (hg > 255) { hg = 255 }
+        if (hb > 255) { hb = 255 }
+        this.fillRectRotatedC(sx sy studSize studSize angleDeg hr hg hb)
+    }
+
+    ; Rotate + scale blit around pivot (screen pixels). angleDeg: clockwise, Y-down.
+    fn blitImageRectScaledRotated:void (src:ImageBuffer sx:int sy:int sw:int sh:int pivotX:int pivotY:int dw:int dh:int angleDeg:double) {
+        if (sw <= 0) {
+            return
+        }
+        if (sh <= 0) {
+            return
+        }
+        if (dw <= 0) {
+            return
+        }
+        if (dh <= 0) {
+            return
+        }
+        if (angleDeg == 0.0) {
+            def halfDw:int (to_int ((to_double dw) * 0.5))
+            def halfDh:int (to_int ((to_double dh) * 0.5))
+            def dx:int (pivotX - halfDw)
+            def dy:int (pivotY - halfDh)
+            this.blitImageRectScaled(src sx sy sw sh dx dy dw dh)
+            return
+        }
+        def srcW:int src.width
+        def rad:double (this.degToRad(angleDeg))
+        def cosA:double (cos(rad))
+        def sinA:double (sin(rad))
+        def hw:double ((to_double dw) * 0.5)
+        def hh:double ((to_double dh) * 0.5)
+        def y 0
+        while (y < dh) {
+            def ly:double ((to_double y) - hh)
+            def x 0
+            while (x < dw) {
+                def lx:double ((to_double x) - hw)
+                def wx:double ((lx * cosA) - (ly * sinA))
+                def wy:double ((lx * sinA) + (ly * cosA))
+                def dstX:int (pivotX + (to_int wx))
+                def dstY:int (pivotY + (to_int wy))
+                if (dstX >= 0) {
+                    if (dstX < w) {
+                        if (dstY >= 0) {
+                            if (dstY < h) {
+                                def sxOff:int (sx + (to_int ((to_double (x * sw)) / (to_double dw))))
+                                if (sxOff >= srcW) {
+                                    sxOff = (srcW - 1)
+                                }
+                                def syOff:int (sy + (to_int ((to_double (y * sh)) / (to_double dh))))
+                                if (syOff >= src.height) {
+                                    syOff = (src.height - 1)
+                                }
+                                def sOff:int (((syOff * srcW) + sxOff) * 4)
+                                def srcA:int (buffer_get src.pixels (sOff + 3))
+                                if (srcA > 0) {
+                                    def dOff:int (((dstY * w) + dstX) * 4)
+                                    if (srcA >= 255) {
+                                        buffer_set px dOff (buffer_get src.pixels sOff)
+                                        buffer_set px (dOff + 1) (buffer_get src.pixels (sOff + 1))
+                                        buffer_set px (dOff + 2) (buffer_get src.pixels (sOff + 2))
+                                        buffer_set px (dOff + 3) 255
+                                    } {
+                                        blitter.blendOverBytes(px dOff
+                                            (buffer_get src.pixels sOff)
+                                            (buffer_get src.pixels (sOff + 1))
+                                            (buffer_get src.pixels (sOff + 2))
+                                            srcA)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                x = (x + 1)
+            }
+            y = (y + 1)
+        }
+    }
+
+    fn fillCircle:void (cx:int cy:int rad:int r:int g:int b:int) {
+        def r2 (rad * rad)
+        def yy (cy - rad)
+        def yEnd (cy + rad)
+        while (yy <= yEnd) {
+            ; Clip the scanline to the buffer (matches setPixel's y bounds check).
+            if (yy >= 0) {
+                if (yy < h) {
+                    def dy (yy - cy)
+                    def rem (r2 - (dy * dy))
+                    if (rem >= 0) {
+                        ; Half-width of the circle at this row: largest hw with
+                        ; hw*hw <= rem (identical to the per-pixel dx*dx+dy*dy<=r2
+                        ; test, but computed once per row).
+                        def hw 0
+                        while (((hw + 1) * (hw + 1)) <= rem) {
+                            hw = (hw + 1)
+                        }
+                        def x0 (cx - hw)
+                        def x1 (cx + hw + 1)
+                        if (x0 < 0) {
+                            x0 = 0
+                        }
+                        if (x1 > w) {
+                            x1 = w
+                        }
+                        if (x0 < x1) {
+                            def rowOff (((yy * w) + x0) * 4)
+                            this.fillSpanRGB(rowOff (x1 - x0) r g b)
+                        }
+                    }
+                }
+            }
+            yy = (yy + 1)
+        }
+    }
+
+    ; Directional wedge cut from a filled circle (mouth, pie slice, radar sweep).
+    ; wedgeDir: 0=up 1=right 2=down 3=left. wedgeOpen: 0=closed .. 3=wide.
+    fn wedgeSkipPixel:boolean (cx:int cy:int px:int py:int wedgeDir:int wedgeOpen:int) {
+        if (wedgeOpen <= 0) {
+            return false
+        }
+        def dx (px - cx)
+        def dy (py - cy)
+        def adx dx
+        def ady dy
+        if (adx < 0) { adx = 0 - adx }
+        if (ady < 0) { ady = 0 - ady }
+        def gap (wedgeOpen + 1)
+        if (wedgeDir == 1) {
+            if (dx <= 0) { return false }
+            if (ady * gap < dx) { return true }
+            return false
+        }
+        if (wedgeDir == 3) {
+            if (dx >= 0) { return false }
+            if (ady * gap < (0 - dx)) { return true }
+            return false
+        }
+        if (wedgeDir == 0) {
+            if (dy >= 0) { return false }
+            if (adx * gap < (0 - dy)) { return true }
+            return false
+        }
+        if (dy <= 0) { return false }
+        if (adx * gap < dy) { return true }
+        return false
+    }
+
+    fn fillWedgeCircle:void (cx:int cy:int rad:int wedgeDir:int wedgeOpen:int r:int g:int b:int) {
+        def r2 (rad * rad)
+        def yy (cy - rad)
+        def yEnd (cy + rad)
+        while (yy <= yEnd) {
+            def xx (cx - rad)
+            def xEnd (cx + rad)
+            while (xx <= xEnd) {
+                def dx (xx - cx)
+                def dy (yy - cy)
+                if (((dx * dx) + (dy * dy)) <= r2) {
+                    if (false == (this.wedgeSkipPixel(cx cy xx yy wedgeDir wedgeOpen))) {
+                        this.setPixel(xx yy r g b)
+                    }
+                }
+                xx = (xx + 1)
+            }
+            yy = (yy + 1)
+        }
+    }
+
+    fn clampChan:int (n:int) {
+        if (n < 0) {
+            return 0
+        }
+        if (n > 255) {
+            return 255
+        }
+        return n
+    }
+
+    ; Pac-style ghost: domed head, straight sides, scalloped hem, plus-shaped eyes.
+    ; faceDir: 0=up 1=right 2=down 3=left. eyesOnly: 0=full body, 1=small fleeing eyes.
+    fn ghostBodyAt:boolean (cx:int cy:int px:int py:int rad:int) {
+        def dx (px - cx)
+        def adx dx
+        if (adx < 0) {
+            adx = 0 - adx
+        }
+        if (py > (cy + rad)) {
+            return false
+        }
+        if (py < (cy - rad)) {
+            return false
+        }
+        if (px < (cx - rad)) {
+            return false
+        }
+        if (px > (cx + rad)) {
+            return false
+        }
+        def domeY (cy - 1)
+        def ddx (px - cx)
+        def ddy (py - domeY)
+        def r2 (rad * rad)
+        if (py <= (cy + 1)) {
+            if (((ddx * ddx) + (ddy * ddy)) <= r2) {
+                return true
+            }
+        }
+        if (py <= (cy + rad - 1)) {
+            if (adx <= rad) {
+                return true
+            }
+        }
+        if (py == (cy + rad - 1)) {
+            def wave ((px - cx + rad) % 4)
+            if (wave == 0) {
+                return false
+            }
+            if (wave == 3) {
+                return false
+            }
+            if (adx <= rad) {
+                return true
+            }
+        }
+        if (py == (cy + rad)) {
+            def wave2 ((px - cx + rad + 1) % 4)
+            if (wave2 == 1) {
+                return true
+            }
+            if (wave2 == 2) {
+                return true
+            }
+        }
+        return false
+    }
+
+    fn ghostEyePlus:boolean (ex:int ey:int px:int py:int) {
+        if (px == ex) {
+            if (py >= (ey - 1)) {
+                if (py <= (ey + 1)) {
+                    return true
+                }
+            }
+        }
+        if (py == ey) {
+            if (px >= (ex - 1)) {
+                if (px <= (ex + 1)) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    fn fillGhost:void (cx:int cy:int rad:int faceDir:int eyesOnly:int r:int g:int b:int) {
+        if (eyesOnly != 0) {
+            this.fillCircle(cx cy rad 255 255 255)
+        } {
+            def yy (cy - rad)
+            def yEnd (cy + rad)
+            while (yy <= yEnd) {
+                def xx (cx - rad)
+                def xEnd (cx + rad)
+                while (xx <= xEnd) {
+                    if (this.ghostBodyAt(cx cy xx yy rad)) {
+                        def br:int r
+                        def bg:int g
+                        def bb:int b
+                        if (yy <= (cy - 2)) {
+                            if (xx <= (cx - 1)) {
+                                br = (this.clampChan(r + 40))
+                                bg = (this.clampChan(g + 40))
+                                bb = (this.clampChan(b + 40))
+                            }
+                        }
+                        if (yy <= cy) {
+                            if (br == r) {
+                                br = (this.clampChan(r + 18))
+                                bg = (this.clampChan(g + 18))
+                                bb = (this.clampChan(b + 18))
+                            }
+                        }
+                        this.setPixel(xx yy br bg bb)
+                    }
+                    xx = (xx + 1)
+                }
+                yy = (yy + 1)
+            }
+        }
+        def le (cx - 3)
+        def re (cx + 3)
+        def ey (cy - 1)
+        if (eyesOnly != 0) {
+            le = (cx - 2)
+            re = (cx + 2)
+            ey = cy
+        }
+        def pOffX 0
+        def pOffY 0
+        if (faceDir == 0) {
+            pOffY = 0 - 1
+        }
+        if (faceDir == 1) {
+            pOffX = 1
+        }
+        if (faceDir == 2) {
+            pOffY = 1
+        }
+        if (faceDir == 3) {
+            pOffX = 0 - 1
+        }
+        def pr (this.clampChan(r - 90))
+        def pg (this.clampChan(g - 90))
+        def pb (this.clampChan(b - 90))
+        if (pr < 16) {
+            pr = 16
+        }
+        if (pg < 16) {
+            pg = 16
+        }
+        if (pb < 16) {
+            pb = 16
+        }
+        def py (ey - 2)
+        def pyEnd (ey + 2)
+        while (py <= pyEnd) {
+            def px (cx - rad)
+            def pxEnd (cx + rad)
+            while (px <= pxEnd) {
+                if (this.ghostEyePlus(le ey px py)) {
+                    this.setPixel(px py 235 245 255)
+                }
+                if (this.ghostEyePlus(re ey px py)) {
+                    this.setPixel(px py 235 245 255)
+                }
+                px = (px + 1)
+            }
+            py = (py + 1)
+        }
+        this.setPixel((le + pOffX) (ey + pOffY) pr pg pb)
+        this.setPixel((re + pOffX) (ey + pOffY) pr pg pb)
+    }
+
+    ; Copy a rectangle from another canvas (opaque). Used for static level layers.
+    ; One contiguous row copy (native memcpy) per scanline instead of per-pixel
+    ; channel writes — the source is tightly-packed RGBA so a whole row is one span.
+    fn copyRectFrom:void (src:SoftCanvas sx:int sy:int sw:int sh:int dx:int dy:int) {
+        def srcW (src.w)
+        def srcH (src.h)
+        def row 0
+        while (row < sh) {
+            def pxY (sy + row)
+            def dstY (dy + row)
+            if (pxY >= 0) {
+                if (pxY < srcH) {
+                    if (dstY >= 0) {
+                        if (dstY < h) {
+                            ; clip the horizontal span to both buffers once per row
+                            def cStart 0
+                            def cEnd sw
+                            if ((sx + cStart) < 0) {
+                                cStart = (0 - sx)
+                            }
+                            if ((dx + cStart) < 0) {
+                                cStart = (0 - dx)
+                            }
+                            if ((sx + cEnd) > srcW) {
+                                cEnd = (srcW - sx)
+                            }
+                            if ((dx + cEnd) > w) {
+                                cEnd = (w - dx)
+                            }
+                            if (cEnd > cStart) {
+                                def sOff (((pxY * srcW) + (sx + cStart)) * 4)
+                                def dOff (((dstY * w) + (dx + cStart)) * 4)
+                                def len ((cEnd - cStart) * 4)
+                                buffer_copy px dOff (src.px) sOff len
+                            }
+                        }
+                    }
+                }
+            }
+            row = (row + 1)
+        }
+    }
+
+    ; Nearest-neighbour scale-blit (split-screen autoscale: 480x270 → 240x270).
+    ; The per-pixel source-column mapping is constant across rows, so it is
+    ; precomputed once into a LUT — this removes both integer divisions from the
+    ; inner loop (the hot path that was dropping split-screen to ~30fps).
+    fn copyRectScaledFrom:void (src:SoftCanvas sx:int sy:int sw:int sh:int dx:int dy:int dw:int dh:int) {
+        if (dw <= 0) {
+            return
+        }
+        if (dh <= 0) {
+            return
+        }
+        def srcW (src.w)
+        def srcH (src.h)
+        ; LUT: source byte offset (within a row) for each destination column.
+        def colOff:int_buffer (int_buffer_alloc dw)
+        def c 0
+        while (c < dw) {
+            def srcCol:int (idiv (c * sw) dw)
+            int_buffer_set colOff c ((sx + srcCol) * 4)
+            c = (c + 1)
+        }
+        def row 0
+        while (row < dh) {
+            def srcRow:int (idiv (row * sh) dh)
+            def pxY (sy + srcRow)
+            def dstY (dy + row)
+            if (pxY >= 0) {
+                if (pxY < srcH) {
+                    if (dstY >= 0) {
+                        if (dstY < h) {
+                            def srcRowBase ((pxY * srcW) * 4)
+                            def dstRowBase (((dstY * w) + dx) * 4)
+                            def col 0
+                            while (col < dw) {
+                                def dstX (dx + col)
+                                if (dstX >= 0) {
+                                    if (dstX < w) {
+                                        def sOff (srcRowBase + (int_buffer_get colOff col))
+                                        def dOff (dstRowBase + (col * 4))
+                                        buffer_copy px dOff (src.px) sOff 4
+                                    }
+                                }
+                                col = (col + 1)
+                            }
+                        }
+                    }
+                }
+            }
+            row = (row + 1)
+        }
+    }
+
+    ; Read one pixel's red channel - used by golden-frame / rendering tests.
+    fn pixelR:int (x:int y:int) {
+        def o (((y * w) + x) * 4)
+        return (buffer_get px o)
+    }
+    fn pixelG:int (x:int y:int) {
+        def o (((y * w) + x) * 4)
+        return (buffer_get px (o + 1))
+    }
+    fn pixelB:int (x:int y:int) {
+        def o (((y * w) + x) * 4)
+        return (buffer_get px (o + 2))
+    }
+
+    ; Count pixels whose channel sum (r+g+b) exceeds minSum - a cheap,
+    ; deterministic "did we actually draw foreground" signal for tests.
+    fn litPixels:int (minSum:int) {
+        def n (w * h)
+        def i 0
+        def count 0
+        while (i < n) {
+            def o (i * 4)
+            def r (buffer_get px o)
+            def g (buffer_get px (o + 1))
+            def b (buffer_get px (o + 2))
+            if (((r + g) + b) > minSum) {
+                count = (count + 1)
+            }
+            i = (i + 1)
+        }
+        return count
+    }
+}

--- a/gallery/game_engine/v2/imaging/fonts/FontManager.rgr
+++ b/gallery/game_engine/v2/imaging/fonts/FontManager.rgr
@@ -1,0 +1,310 @@
+; FontManager.rgr - Manage loaded fonts and provide text measurement
+;
+; Usage:
+;   def fm (new FontManager())
+;   fm.setFontsDirectory("./Fonts")
+;   fm.loadFont("Open_Sans/OpenSans-Regular.ttf")
+;   def width:double (fm.measureText("Hello" "Open Sans" 14.0))
+
+Import "TrueTypeFont.rgr"
+Import "../../evg/EVGTextMeasurer.rgr"
+
+class FontManager {
+    def fonts:[TrueTypeFont]
+    def fontNames:[string]
+    def fontsDirectory:string "./Fonts"
+    def fontsDirectories:[string]  ; Multiple search directories
+    def defaultFont:TrueTypeFont (new TrueTypeFont())
+    def hasDefaultFont:boolean false
+    
+    Constructor () {
+        def f:[TrueTypeFont]
+        fonts = f
+        def n:[string]
+        fontNames = n
+        def fd:[string]
+        fontsDirectories = fd
+    }
+    
+    fn setFontsDirectory:void (path:string) {
+        fontsDirectory = path
+    }
+    
+    ; Returns the number of fonts that have been successfully loaded
+    fn getFontCount:int () {
+        return (array_length fonts)
+    }
+    
+    ; Add a directory to search for fonts
+    fn addFontsDirectory:void (path:string) {
+        push fontsDirectories path
+    }
+    
+    ; Set multiple directories from semicolon-separated string
+    ; Example: "./Fonts;./assets/fonts;/usr/share/fonts"
+    fn setFontsDirectories:void (paths:string) {
+        ; Split by semicolon
+        def start:int 0
+        def i:int 0
+        def len:int (strlen paths)
+        while (i <= len) {
+            def ch:string ""
+            if (i < len) {
+                ch = (substring paths i (i + 1))
+            }
+            if ((ch == ";") || (i == len)) {
+                if (i > start) {
+                    def part:string (substring paths start i)
+                    push fontsDirectories part
+                    print ("FontManager: Added fonts directory: " + part)
+                }
+                start = i + 1
+            }
+            i = i + 1
+        }
+        ; Set first as primary
+        if ((array_length fontsDirectories) > 0) {
+            fontsDirectory = (itemAt fontsDirectories 0)
+        }
+    }
+    
+    fn loadFont:boolean (relativePath:string) {
+        ; Try each directory in order
+        def i:int 0
+        while (i < (array_length fontsDirectories)) {
+            def dir:string (itemAt fontsDirectories i)
+            def fullPath:string (dir + "/" + relativePath)
+            def font (new TrueTypeFont())
+            if ((font.loadFromFile(fullPath)) == true) {
+                push fonts font
+                push fontNames font.fontFamily
+                if (hasDefaultFont == false) {
+                    defaultFont = font
+                    hasDefaultFont = true
+                }
+                print ("FontManager: Loaded font '" + font.fontFamily + "' (" + font.fontStyle + ") from " + fullPath)
+                return true
+            }
+            i = i + 1
+        }
+        ; Fallback to single fontsDirectory for backward compatibility
+        ; Check if fontsDirectory ends with "/" to avoid double slash
+        def separator:string "/"
+        def dirLen:int (strlen fontsDirectory)
+        if (dirLen > 0) {
+            def lastChar:string (substring fontsDirectory (dirLen - 1) dirLen)
+            if (lastChar == "/") {
+                separator = ""
+            }
+        }
+        def fullPath:string (fontsDirectory + separator + relativePath)
+        print ("FontManager: Trying to load font from: " + fullPath)
+        def font (new TrueTypeFont())
+        
+        if ((font.loadFromFile(fullPath)) == false) {
+            print ("FontManager: Failed to load font: " + relativePath + " (full path: " + fullPath + ")")
+            return false
+        }
+        
+        push fonts font
+        push fontNames font.fontFamily
+        
+        ; First loaded font becomes default
+        if (hasDefaultFont == false) {
+            defaultFont = font
+            hasDefaultFont = true
+        }
+        
+        print ("FontManager: Loaded font '" + font.fontFamily + "' (" + font.fontStyle + ")")
+        return true
+    }
+    
+    fn loadFontFamily:void (familyDir:string) {
+        ; Load common variants from a font family directory
+        ; e.g., loadFontFamily("Open_Sans") loads Regular, Bold, Italic, BoldItalic
+        this.loadFont(familyDir + "/" + familyDir + "-Regular.ttf")
+        ; Try common naming patterns
+        ; OpenSans-Regular.ttf, Roboto-Regular.ttf, etc.
+    }
+    
+    fn getFont:TrueTypeFont (fontFamily:string) {
+        ; Find font by family name
+        ; Support formats: "Cinzel", "Cinzel/Cinzel-Bold", "Cinzel-Bold"
+        
+        ; First, check if fontFamily contains "/" - this indicates path format like "Cinzel/Cinzel-Bold"
+        def slashIdx:int (indexOf fontFamily "/")
+        def searchFamily:string fontFamily
+        def searchStyle:string ""
+        
+        if (slashIdx >= 0) {
+            ; Extract family and style from path format "Family/Family-Style"
+            searchFamily = (substring fontFamily 0 slashIdx)
+            def afterSlash:string (substring fontFamily (slashIdx + 1) (strlen fontFamily))
+            ; Find the dash in "Cinzel-Bold" to get "Bold"
+            def dashIdx:int (indexOf afterSlash "-")
+            if (dashIdx >= 0) {
+                searchStyle = (substring afterSlash (dashIdx + 1) (strlen afterSlash))
+            }
+        } {
+            ; Check for dash format like "Cinzel-Bold"
+            def dashIdx:int (indexOf fontFamily "-")
+            if (dashIdx >= 0) {
+                searchFamily = (substring fontFamily 0 dashIdx)
+                searchStyle = (substring fontFamily (dashIdx + 1) (strlen fontFamily))
+            }
+        }
+        
+        ; Exact match on both family and style
+        def i:int 0
+        while (i < (array_length fonts)) {
+            def f:TrueTypeFont (itemAt fonts i)
+            if (f.fontFamily == searchFamily) {
+                if ((strlen searchStyle) > 0) {
+                    ; Check if style matches
+                    if (f.fontStyle == searchStyle) {
+                        return f
+                    }
+                } {
+                    ; No style specified, return first match
+                    return f
+                }
+            }
+            i = i + 1
+        }
+        
+        ; Try case-insensitive style match
+        i = 0
+        while (i < (array_length fonts)) {
+            def f:TrueTypeFont (itemAt fonts i)
+            if (f.fontFamily == searchFamily) {
+                if ((strlen searchStyle) > 0) {
+                    ; Check if style contains the search term (case-insensitive would be better but use contains)
+                    if ((indexOf f.fontStyle searchStyle) >= 0) {
+                        return f
+                    }
+                }
+            }
+            i = i + 1
+        }
+        
+        ; Fallback: try original exact match
+        i = 0
+        while (i < (array_length fonts)) {
+            def f:TrueTypeFont (itemAt fonts i)
+            if (f.fontFamily == fontFamily) {
+                return f
+            }
+            i = i + 1
+        }
+        
+        ; Try partial match on original fontFamily
+        i = 0
+        while (i < (array_length fonts)) {
+            def f:TrueTypeFont (itemAt fonts i)
+            ; Check if fontFamily contains the search term
+            if ((indexOf f.fontFamily fontFamily) >= 0) {
+                return f
+            }
+            i = i + 1
+        }
+        
+        ; Return default font (may be empty if no fonts loaded)
+        return defaultFont
+    }
+    
+    fn measureText:double (text:string fontFamily:string fontSize:double) {
+        def font:TrueTypeFont (this.getFont(fontFamily))
+        if (font.unitsPerEm > 0) {
+            return (font.measureText(text fontSize))
+        }
+        ; Fallback to estimate
+        return ((to_double (strlen text)) * fontSize * 0.5)
+    }
+    
+    fn getLineHeight:double (fontFamily:string fontSize:double) {
+        def font:TrueTypeFont (this.getFont(fontFamily))
+        if (font.unitsPerEm > 0) {
+            return (font.getLineHeight(fontSize))
+        }
+        return (fontSize * 1.2)
+    }
+    
+    fn getAscender:double (fontFamily:string fontSize:double) {
+        def font:TrueTypeFont (this.getFont(fontFamily))
+        if (font.unitsPerEm > 0) {
+            return (font.getAscender(fontSize))
+        }
+        return (fontSize * 0.8)
+    }
+    
+    fn getDescender:double (fontFamily:string fontSize:double) {
+        def font:TrueTypeFont (this.getFont(fontFamily))
+        if (font.unitsPerEm > 0) {
+            return (font.getDescender(fontSize))
+        }
+        return (fontSize * -0.2)
+    }
+    
+    fn getFontData:buffer (fontFamily:string) {
+        def font:TrueTypeFont (this.getFont(fontFamily))
+        return (font.getFontData())
+    }
+    
+    fn getPostScriptName:string (fontFamily:string) {
+        def font:TrueTypeFont (this.getFont(fontFamily))
+        return (font.getPostScriptName())
+    }
+    
+    fn printLoadedFonts:void () {
+        print ("FontManager: " + (to_string (array_length fonts)) + " fonts loaded:")
+        def i:int 0
+        while (i < (array_length fonts)) {
+            def f:TrueTypeFont (itemAt fonts i)
+            print ("  - " + f.fontFamily + " (" + f.fontStyle + ")")
+            i = i + 1
+        }
+    }
+}
+
+; Text measurer that uses FontManager for accurate measurements
+class TTFTextMeasurer {
+    Extends(EVGTextMeasurer)
+    
+    def fontManager:FontManager
+    
+    Constructor (fm:FontManager) {
+        fontManager = fm
+    }
+    
+    fn measureText:EVGTextMetrics (text:string fontFamily:string fontSize:double) {
+        def width:double (fontManager.measureText(text fontFamily fontSize))
+        def lineHeight:double (fontManager.getLineHeight(fontFamily fontSize))
+        def ascent:double (fontManager.getAscender(fontFamily fontSize))
+        def descent:double (fontManager.getDescender(fontFamily fontSize))
+        
+        def metrics (new EVGTextMetrics())
+        metrics.width = width
+        metrics.height = lineHeight
+        metrics.ascent = ascent
+        metrics.descent = descent
+        metrics.lineHeight = lineHeight
+        return metrics
+    }
+    
+    fn measureTextWidth:double (text:string fontFamily:string fontSize:double) {
+        return (fontManager.measureText(text fontFamily fontSize))
+    }
+    
+    fn getLineHeight:double (fontFamily:string fontSize:double) {
+        return (fontManager.getLineHeight(fontFamily fontSize))
+    }
+    
+    fn measureChar:double (ch:int fontFamily:string fontSize:double) {
+        def font:TrueTypeFont (fontManager.getFont(fontFamily))
+        if (font.unitsPerEm > 0) {
+            return (font.getCharWidthPoints(ch fontSize))
+        }
+        ; Fallback
+        return (fontSize * 0.5)
+    }
+}

--- a/gallery/game_engine/v2/imaging/fonts/TrueTypeFont.rgr
+++ b/gallery/game_engine/v2/imaging/fonts/TrueTypeFont.rgr
@@ -1,0 +1,578 @@
+; TrueTypeFont.rgr - Parse TrueType font files for metrics and embedding
+;
+; TrueType file structure:
+; - Offset Table (header)
+; - Table Directory (list of tables)
+; - Tables: head, hhea, hmtx, cmap, maxp, name, OS/2, post, glyf, loca, etc.
+;
+; For text measurement we need:
+; - cmap: character to glyph mapping
+; - hmtx: horizontal metrics (advance widths)
+; - hhea: horizontal header (ascender, descender)
+; - head: font header (units per em)
+
+Import "../core/Buffer.rgr"
+
+class TTFTableRecord {
+    def tag:string ""
+    def checksum:int 0
+    def offset:int 0
+    def length:int 0
+}
+
+class TTFGlyphMetrics {
+    def advanceWidth:int 0
+    def leftSideBearing:int 0
+}
+
+class TrueTypeFont {
+    def fontData:buffer (buffer_alloc 0)
+    def fontPath:string ""
+    def fontFamily:string ""
+    def fontStyle:string "Regular"
+    
+    ; Offset table
+    def sfntVersion:int 0
+    def numTables:int 0
+    def searchRange:int 0
+    def entrySelector:int 0
+    def rangeShift:int 0
+    
+    ; Table directory
+    def tables:[TTFTableRecord]
+    
+    ; head table
+    def unitsPerEm:int 1000
+    def xMin:int 0
+    def yMin:int 0
+    def xMax:int 0
+    def yMax:int 0
+    def indexToLocFormat:int 0
+    
+    ; hhea table
+    def ascender:int 0
+    def descender:int 0
+    def lineGap:int 0
+    def numberOfHMetrics:int 0
+    
+    ; maxp table
+    def numGlyphs:int 0
+    
+    ; cmap table - character to glyph mapping
+    def cmapFormat:int 0
+    def cmapOffset:int 0
+    
+    ; hmtx table - glyph widths
+    def glyphWidths:[int]
+    def defaultWidth:int 500
+    
+    ; Character to width cache (ASCII 0-255)
+    def charWidths:[int]
+    def charWidthsLoaded:boolean false
+    
+    Constructor () {
+        def t:[TTFTableRecord]
+        tables = t
+        def gw:[int]
+        glyphWidths = gw
+        def cw:[int]
+        charWidths = cw
+    }
+    
+    fn loadFromFile:boolean (path:string) {
+        fontPath = path
+        ; Split path into directory and filename for buffer_read_file
+        def lastSlash:int -1
+        def i:int 0
+        while (i < (strlen path)) {
+            def ch:int (charAt path i)
+            if ((ch == 47) || (ch == 92)) {
+                lastSlash = i
+            }
+            i = i + 1
+        }
+        
+        def dirPath:string "."
+        def fileName:string path
+        if (lastSlash >= 0) {
+            dirPath = (substring path 0 lastSlash)
+            fileName = (substring path (lastSlash + 1) (strlen path))
+        }
+        
+        ; Check if file exists before trying to load
+        if ((file_exists dirPath fileName) == false) {
+            return false
+        }
+        
+        fontData = (buffer_read_file dirPath fileName)
+        if ((buffer_length fontData) == 0) {
+            print ("TrueTypeFont: Failed to load " + path)
+            return false
+        }
+        
+        ; Parse the font
+        if ((this.parseOffsetTable()) == false) {
+            return false
+        }
+        if ((this.parseTableDirectory()) == false) {
+            return false
+        }
+        
+        ; Parse required tables
+        this.parseHeadTable()
+        this.parseHheaTable()
+        this.parseMaxpTable()
+        this.parseCmapTable()
+        this.parseHmtxTable()
+        this.parseNameTable()
+        
+        ; Build character width cache
+        this.buildCharWidthCache()
+        
+        return true
+    }
+    
+    fn parseOffsetTable:boolean () {
+        if ((buffer_length fontData) < 12) {
+            return false
+        }
+        
+        sfntVersion = (this.readUInt32(0))
+        numTables = (this.readUInt16(4))
+        searchRange = (this.readUInt16(6))
+        entrySelector = (this.readUInt16(8))
+        rangeShift = (this.readUInt16(10))
+        
+        return true
+    }
+    
+    fn parseTableDirectory:boolean () {
+        def offset:int 12
+        def i:int 0
+        
+        while (i < numTables) {
+            def record (new TTFTableRecord())
+            record.tag = (this.readTag(offset))
+            record.checksum = (this.readUInt32(offset + 4))
+            record.offset = (this.readUInt32(offset + 8))
+            record.length = (this.readUInt32(offset + 12))
+            push tables record
+            offset = offset + 16
+            i = i + 1
+        }
+        
+        return true
+    }
+    
+    fn findTable:TTFTableRecord (tag:string) {
+        def i:int 0
+        while (i < (array_length tables)) {
+            def t:TTFTableRecord (itemAt tables i)
+            if (t.tag == tag) {
+                return t
+            }
+            i = i + 1
+        }
+        ; Return empty record if not found
+        def empty (new TTFTableRecord())
+        return empty
+    }
+    
+    fn parseHeadTable:void () {
+        def table:TTFTableRecord (this.findTable("head"))
+        if (table.offset == 0) {
+            return
+        }
+        
+        def off:int table.offset
+        ; Skip version, fontRevision, checksumAdjustment, magicNumber, flags
+        unitsPerEm = (this.readUInt16(off + 18))
+        ; Skip created, modified dates (16 bytes)
+        xMin = (this.readInt16(off + 36))
+        yMin = (this.readInt16(off + 38))
+        xMax = (this.readInt16(off + 40))
+        yMax = (this.readInt16(off + 42))
+        ; Skip macStyle, lowestRecPPEM, fontDirectionHint
+        indexToLocFormat = (this.readInt16(off + 50))
+    }
+    
+    fn parseHheaTable:void () {
+        def table:TTFTableRecord (this.findTable("hhea"))
+        if (table.offset == 0) {
+            return
+        }
+        
+        def off:int table.offset
+        ; Skip version (4 bytes)
+        ascender = (this.readInt16(off + 4))
+        descender = (this.readInt16(off + 6))
+        lineGap = (this.readInt16(off + 8))
+        ; Skip advanceWidthMax, minLeftSideBearing, minRightSideBearing, xMaxExtent
+        ; Skip caretSlopeRise, caretSlopeRun, caretOffset, reserved (8 bytes)
+        ; Skip metricDataFormat
+        numberOfHMetrics = (this.readUInt16(off + 34))
+    }
+    
+    fn parseMaxpTable:void () {
+        def table:TTFTableRecord (this.findTable("maxp"))
+        if (table.offset == 0) {
+            return
+        }
+        
+        def off:int table.offset
+        ; Skip version (4 bytes)
+        numGlyphs = (this.readUInt16(off + 4))
+    }
+    
+    fn parseCmapTable:void () {
+        def table:TTFTableRecord (this.findTable("cmap"))
+        if (table.offset == 0) {
+            return
+        }
+        
+        def off:int table.offset
+        ; Skip version (2 bytes)
+        def numSubtables:int (this.readUInt16(off + 2))
+        
+        ; Look for Unicode BMP table (platformID=3, encodingID=1 for Windows Unicode BMP)
+        ; or platformID=0 for Unicode
+        def i:int 0
+        def subtableOffset:int 0
+        
+        while (i < numSubtables) {
+            def recordOff:int (off + 4 + (i * 8))
+            def platformID:int (this.readUInt16(recordOff))
+            def encodingID:int (this.readUInt16(recordOff + 2))
+            def subOff:int (this.readUInt32(recordOff + 4))
+            
+            ; Prefer Windows Unicode BMP (3,1) or Unicode (0,3)
+            if ((platformID == 3) && (encodingID == 1)) {
+                subtableOffset = subOff
+            }
+            if ((platformID == 0) && (subtableOffset == 0)) {
+                subtableOffset = subOff
+            }
+            
+            i = i + 1
+        }
+        
+        if (subtableOffset > 0) {
+            cmapOffset = off + subtableOffset
+            cmapFormat = (this.readUInt16(cmapOffset))
+        }
+    }
+    
+    fn parseHmtxTable:void () {
+        def table:TTFTableRecord (this.findTable("hmtx"))
+        if (table.offset == 0) {
+            return
+        }
+        
+        def off:int table.offset
+        
+        ; Read all advance widths
+        def i:int 0
+        while (i < numberOfHMetrics) {
+            def advanceWidth:int (this.readUInt16(off + (i * 4)))
+            push glyphWidths advanceWidth
+            i = i + 1
+        }
+        
+        ; Remaining glyphs use the last advance width
+        if (numberOfHMetrics > 0) {
+            defaultWidth = (itemAt glyphWidths (numberOfHMetrics - 1))
+        }
+    }
+    
+    fn parseNameTable:void () {
+        def table:TTFTableRecord (this.findTable("name"))
+        if (table.offset == 0) {
+            return
+        }
+        
+        def off:int table.offset
+        ; Skip format (2 bytes)
+        def count:int (this.readUInt16(off + 2))
+        def stringOffset:int (this.readUInt16(off + 4))
+        
+        ; Look for font family name (nameID = 1) and subfamily (nameID = 2)
+        def i:int 0
+        while (i < count) {
+            def recordOff:int (off + 6 + (i * 12))
+            def platformID:int (this.readUInt16(recordOff))
+            def encodingID:int (this.readUInt16(recordOff + 2))
+            def languageID:int (this.readUInt16(recordOff + 4))
+            def nameID:int (this.readUInt16(recordOff + 6))
+            def length:int (this.readUInt16(recordOff + 8))
+            def strOffset:int (this.readUInt16(recordOff + 10))
+            
+            ; Get font family (nameID = 1) - prefer Windows platform (3)
+            if ((nameID == 1) && (platformID == 3)) {
+                def strOff:int (off + stringOffset + strOffset)
+                fontFamily = (this.readUnicodeString(strOff length))
+            }
+            if ((nameID == 1) && (platformID == 1) && ((strlen fontFamily) == 0)) {
+                def strOff:int (off + stringOffset + strOffset)
+                fontFamily = (this.readAsciiString(strOff length))
+            }
+            
+            ; Get font style (nameID = 2)
+            if ((nameID == 2) && (platformID == 3)) {
+                def strOff:int (off + stringOffset + strOffset)
+                fontStyle = (this.readUnicodeString(strOff length))
+            }
+            if ((nameID == 2) && (platformID == 1) && ((strlen fontStyle) == 0)) {
+                def strOff:int (off + stringOffset + strOffset)
+                fontStyle = (this.readAsciiString(strOff length))
+            }
+            
+            i = i + 1
+        }
+    }
+    
+    fn getGlyphIndex:int (charCode:int) {
+        ; Get glyph index for a character code using cmap
+        if (cmapOffset == 0) {
+            return 0
+        }
+        
+        ; Format 4: Segment mapping to delta values (most common for Unicode BMP)
+        if (cmapFormat == 4) {
+            return (this.getGlyphIndexFormat4(charCode))
+        }
+        
+        ; Format 0: Byte encoding table (simple, limited to 256 chars)
+        if (cmapFormat == 0) {
+            if ((charCode >= 0) && (charCode < 256)) {
+                return (this.readUInt8(cmapOffset + 6 + charCode))
+            }
+        }
+        
+        ; Format 6: Trimmed table mapping
+        if (cmapFormat == 6) {
+            def firstCode:int (this.readUInt16(cmapOffset + 6))
+            def entryCount:int (this.readUInt16(cmapOffset + 8))
+            if ((charCode >= firstCode) && (charCode < (firstCode + entryCount))) {
+                return (this.readUInt16(cmapOffset + 10 + ((charCode - firstCode) * 2)))
+            }
+        }
+        
+        return 0  ; .notdef glyph
+    }
+    
+    fn getGlyphIndexFormat4:int (charCode:int) {
+        ; Format 4 is segment-based mapping
+        def off:int cmapOffset
+        ; Skip format, length (4 bytes)
+        def segCountX2:int (this.readUInt16(off + 6))
+        def segCountD:double ((to_double segCountX2) / 2.0)
+        def segCount:int (to_int segCountD)
+        
+        ; Arrays start after header (14 bytes)
+        def endCodesOff:int (off + 14)
+        def startCodesOff:int (endCodesOff + segCountX2 + 2)  ; +2 for reservedPad
+        def idDeltaOff:int (startCodesOff + segCountX2)
+        def idRangeOffsetOff:int (idDeltaOff + segCountX2)
+        
+        ; Binary search for segment (or linear for simplicity)
+        def i:int 0
+        while (i < segCount) {
+            def endCode:int (this.readUInt16(endCodesOff + (i * 2)))
+            def startCode:int (this.readUInt16(startCodesOff + (i * 2)))
+            
+            if ((charCode >= startCode) && (charCode <= endCode)) {
+                def idDelta:int (this.readInt16(idDeltaOff + (i * 2)))
+                def idRangeOffset:int (this.readUInt16(idRangeOffsetOff + (i * 2)))
+                
+                if (idRangeOffset == 0) {
+                    ; Simple delta
+                    return ((charCode + idDelta) % 65536)
+                } {
+                    ; Use glyph ID array
+                    def glyphIdOff:int (idRangeOffsetOff + (i * 2) + idRangeOffset + ((charCode - startCode) * 2))
+                    def glyphId:int (this.readUInt16(glyphIdOff))
+                    if (glyphId != 0) {
+                        return ((glyphId + idDelta) % 65536)
+                    }
+                }
+            }
+            i = i + 1
+        }
+        
+        return 0
+    }
+    
+    fn getGlyphWidth:int (glyphIndex:int) {
+        if (glyphIndex < (array_length glyphWidths)) {
+            return (itemAt glyphWidths glyphIndex)
+        }
+        return defaultWidth
+    }
+    
+    fn buildCharWidthCache:void () {
+        ; Pre-compute widths for ASCII characters (0-255)
+        def i:int 0
+        while (i < 256) {
+            def glyphIdx:int (this.getGlyphIndex(i))
+            def width:int (this.getGlyphWidth(glyphIdx))
+            push charWidths width
+            i = i + 1
+        }
+        charWidthsLoaded = true
+    }
+    
+    fn getCharWidth:int (charCode:int) {
+        ; Get width for a character in font units. The (charCode >= 0) guard is
+        ; essential: charAt can yield a NEGATIVE value for bytes >= 0x80 (a signed
+        ; char, e.g. UTF-8 lead byte 0xC3 -> -61), which passes "< 256" and would
+        ; index the 256-entry cache out of range (std::out_of_range on the native
+        ; build). Negative / >=256 codes fall through to the cmap glyph lookup.
+        if (charWidthsLoaded && (charCode >= 0) && (charCode < 256)) {
+            return (itemAt charWidths charCode)
+        }
+        def glyphIdx:int (this.getGlyphIndex(charCode))
+        return (this.getGlyphWidth(glyphIdx))
+    }
+    
+    fn getCharWidthPoints:double (charCode:int fontSize:double) {
+        ; Get character width in points
+        def fontUnits:int (this.getCharWidth(charCode))
+        return ((to_double fontUnits) * fontSize / (to_double unitsPerEm))
+    }
+    
+    fn measureText:double (text:string fontSize:double) {
+        ; Measure text width in points
+        def width:double 0.0
+        def len:int (strlen text)
+        def i:int 0
+        
+        while (i < len) {
+            def ch:int (charAt text i)
+            width = width + (this.getCharWidthPoints(ch fontSize))
+            i = i + 1
+        }
+        
+        return width
+    }
+    
+    fn getAscender:double (fontSize:double) {
+        return ((to_double ascender) * fontSize / (to_double unitsPerEm))
+    }
+    
+    fn getDescender:double (fontSize:double) {
+        return ((to_double descender) * fontSize / (to_double unitsPerEm))
+    }
+    
+    fn getLineHeight:double (fontSize:double) {
+        def asc:double (this.getAscender(fontSize))
+        def desc:double (this.getDescender(fontSize))
+        def gap:double ((to_double lineGap) * fontSize / (to_double unitsPerEm))
+        return (asc - desc + gap)
+    }
+    
+    ; Get font data for PDF embedding (subset or full)
+    fn getFontData:buffer () {
+        return fontData
+    }
+    
+    ; Get PostScript name for PDF
+    fn getPostScriptName:string () {
+        ; Usually fontFamily with spaces removed
+        def name:string fontFamily
+        ; Simple space removal
+        def result:string ""
+        def i:int 0
+        while (i < (strlen name)) {
+            def ch:int (charAt name i)
+            if (ch != 32) {
+                result = result + (strfromcode ch)
+            }
+            i = i + 1
+        }
+        if ((strlen result) == 0) {
+            return "CustomFont"
+        }
+        return result
+    }
+    
+    ; ============ Binary reading helpers ============
+    
+    fn readUInt8:int (offset:int) {
+        return (buffer_get fontData offset)
+    }
+    
+    fn readUInt16:int (offset:int) {
+        ; Big-endian
+        def b1:int (buffer_get fontData offset)
+        def b2:int (buffer_get fontData (offset + 1))
+        return ((b1 * 256) + b2)
+    }
+    
+    fn readInt16:int (offset:int) {
+        def val:int (this.readUInt16(offset))
+        if (val >= 32768) {
+            return (val - 65536)
+        }
+        return val
+    }
+    
+    fn readUInt32:int (offset:int) {
+        ; Big-endian
+        def b1:int (buffer_get fontData offset)
+        def b2:int (buffer_get fontData (offset + 1))
+        def b3:int (buffer_get fontData (offset + 2))
+        def b4:int (buffer_get fontData (offset + 3))
+        def result:int (((((b1 * 256) + b2) * 256) + b3) * 256 + b4)
+        return result
+    }
+    
+    fn readTag:string (offset:int) {
+        def result:string ""
+        def i:int 0
+        while (i < 4) {
+            def ch:int (buffer_get fontData (offset + i))
+            result = result + (strfromcode ch)
+            i = i + 1
+        }
+        return result
+    }
+    
+    fn readAsciiString:string (offset:int length:int) {
+        def result:string ""
+        def i:int 0
+        while (i < length) {
+            def ch:int (buffer_get fontData (offset + i))
+            if (ch > 0) {
+                result = result + (strfromcode ch)
+            }
+            i = i + 1
+        }
+        return result
+    }
+    
+    fn readUnicodeString:string (offset:int length:int) {
+        ; UTF-16BE string
+        def result:string ""
+        def i:int 0
+        while (i < length) {
+            def ch:int (this.readUInt16(offset + i))
+            if ((ch > 0) && (ch < 128)) {
+                result = result + (strfromcode ch)
+            }
+            i = i + 2
+        }
+        return result
+    }
+    
+    ; Debug: print font info
+    fn printInfo:void () {
+        print ("Font: " + fontFamily + " " + fontStyle)
+        print ("  Units per EM: " + (to_string unitsPerEm))
+        print ("  Ascender: " + (to_string ascender))
+        print ("  Descender: " + (to_string descender))
+        print ("  Line gap: " + (to_string lineGap))
+        print ("  Num glyphs: " + (to_string numGlyphs))
+        print ("  Num hMetrics: " + (to_string numberOfHMetrics))
+        print ("  Tables: " + (to_string (array_length tables)))
+    }
+}

--- a/gallery/game_engine/v2/imaging/raster/RasterBlur.rgr
+++ b/gallery/game_engine/v2/imaging/raster/RasterBlur.rgr
@@ -1,0 +1,388 @@
+; RasterBlur - Blur algorithms for shadow and effect rendering
+; Implements box blur (fast) for shadow effects
+
+Import "RasterBuffer.rgr"
+Import "RasterCompositing.rgr"
+
+; Box blur implementation - fast O(n) blur using sliding window
+class RasterBlur {
+    
+    ; Horizontal pass of box blur
+    ; Uses accumulator for O(1) per pixel
+    fn blurHorizontal:RasterBuffer (src:RasterBuffer radius:int) {
+        def dst:RasterBuffer (new RasterBuffer())
+        dst.create(src.width src.height)
+        
+        if (radius < 1) {
+            ; No blur, just copy
+            def i:int 0
+            def size:int (src.width * src.height * 4)
+            while (i < size) {
+                buffer_set dst.pixels i (buffer_get src.pixels i)
+                i = i + 1
+            }
+            return dst
+        }
+        
+        def diameter:int ((radius * 2) + 1)
+        def divisor:double (to_double diameter)
+        
+        def y:int 0
+        while (y < src.height) {
+            ; Initialize accumulators for first pixel
+            def sumR:int 0
+            def sumG:int 0
+            def sumB:int 0
+            def sumA:int 0
+            
+            ; Pre-fill accumulator with left edge pixels (clamped)
+            def i:int (0 - radius)
+            while (i <= radius) {
+                def sampleX:int i
+                if (sampleX < 0) {
+                    sampleX = 0
+                }
+                if (sampleX >= src.width) {
+                    sampleX = src.width - 1
+                }
+                def p:RasterPixel (src.getPixel(sampleX y))
+                sumR = sumR + p.r
+                sumG = sumG + p.g
+                sumB = sumB + p.b
+                sumA = sumA + p.a
+                i = i + 1
+            }
+            
+            ; Process each pixel in the row
+            def x:int 0
+            while (x < src.width) {
+                ; Write current pixel
+                def outR:int (to_int ((to_double sumR) / divisor))
+                def outG:int (to_int ((to_double sumG) / divisor))
+                def outB:int (to_int ((to_double sumB) / divisor))
+                def outA:int (to_int ((to_double sumA) / divisor))
+                dst.setPixel(x y outR outG outB outA)
+                
+                ; Slide the window: remove left pixel, add right pixel
+                def leftX:int (x - radius)
+                def rightX:int (x + radius + 1)
+                
+                ; Clamp indices
+                if (leftX < 0) {
+                    leftX = 0
+                }
+                if (rightX >= src.width) {
+                    rightX = src.width - 1
+                }
+                
+                ; Subtract left pixel
+                def leftP:RasterPixel (src.getPixel(leftX y))
+                sumR = sumR - leftP.r
+                sumG = sumG - leftP.g
+                sumB = sumB - leftP.b
+                sumA = sumA - leftP.a
+                
+                ; Add right pixel
+                def rightP:RasterPixel (src.getPixel(rightX y))
+                sumR = sumR + rightP.r
+                sumG = sumG + rightP.g
+                sumB = sumB + rightP.b
+                sumA = sumA + rightP.a
+                
+                x = x + 1
+            }
+            
+            y = y + 1
+        }
+        
+        return dst
+    }
+    
+    ; Vertical pass of box blur
+    fn blurVertical:RasterBuffer (src:RasterBuffer radius:int) {
+        def dst:RasterBuffer (new RasterBuffer())
+        dst.create(src.width src.height)
+        
+        if (radius < 1) {
+            def i:int 0
+            def size:int (src.width * src.height * 4)
+            while (i < size) {
+                buffer_set dst.pixels i (buffer_get src.pixels i)
+                i = i + 1
+            }
+            return dst
+        }
+        
+        def diameter:int ((radius * 2) + 1)
+        def divisor:double (to_double diameter)
+        
+        def x:int 0
+        while (x < src.width) {
+            ; Initialize accumulators for first pixel
+            def sumR:int 0
+            def sumG:int 0
+            def sumB:int 0
+            def sumA:int 0
+            
+            ; Pre-fill accumulator with top edge pixels (clamped)
+            def i:int (0 - radius)
+            while (i <= radius) {
+                def sampleY:int i
+                if (sampleY < 0) {
+                    sampleY = 0
+                }
+                if (sampleY >= src.height) {
+                    sampleY = src.height - 1
+                }
+                def p:RasterPixel (src.getPixel(x sampleY))
+                sumR = sumR + p.r
+                sumG = sumG + p.g
+                sumB = sumB + p.b
+                sumA = sumA + p.a
+                i = i + 1
+            }
+            
+            ; Process each pixel in the column
+            def y:int 0
+            while (y < src.height) {
+                ; Write current pixel
+                def outR:int (to_int ((to_double sumR) / divisor))
+                def outG:int (to_int ((to_double sumG) / divisor))
+                def outB:int (to_int ((to_double sumB) / divisor))
+                def outA:int (to_int ((to_double sumA) / divisor))
+                dst.setPixel(x y outR outG outB outA)
+                
+                ; Slide the window
+                def topY:int (y - radius)
+                def bottomY:int (y + radius + 1)
+                
+                if (topY < 0) {
+                    topY = 0
+                }
+                if (bottomY >= src.height) {
+                    bottomY = src.height - 1
+                }
+                
+                def topP:RasterPixel (src.getPixel(x topY))
+                sumR = sumR - topP.r
+                sumG = sumG - topP.g
+                sumB = sumB - topP.b
+                sumA = sumA - topP.a
+                
+                def bottomP:RasterPixel (src.getPixel(x bottomY))
+                sumR = sumR + bottomP.r
+                sumG = sumG + bottomP.g
+                sumB = sumB + bottomP.b
+                sumA = sumA + bottomP.a
+                
+                y = y + 1
+            }
+            
+            x = x + 1
+        }
+        
+        return dst
+    }
+    
+    ; Full box blur (separable: horizontal then vertical)
+    ; Multiple passes approximate Gaussian blur
+    fn boxBlur:RasterBuffer (src:RasterBuffer radius:int) {
+        def temp:RasterBuffer (this.blurHorizontal(src radius))
+        return (this.blurVertical(temp radius))
+    }
+    
+    ; Box blur with multiple passes for smoother result
+    ; 3 passes of box blur approximates Gaussian blur
+    fn boxBlurMultiPass:RasterBuffer (src:RasterBuffer radius:int passes:int) {
+        def result:RasterBuffer src
+        def i:int 0
+        while (i < passes) {
+            result = (this.boxBlur(result radius))
+            i = i + 1
+        }
+        return result
+    }
+    
+    ; Gaussian-approximating blur using 3 box blur passes
+    ; Provides smooth shadow effect
+    fn gaussianApproxBlur:RasterBuffer (src:RasterBuffer radius:int) {
+        ; Use 3 passes with adjusted radius for Gaussian-like result
+        ; Each pass uses radius/3 (approximately)
+        def passRadius:int (to_int ((to_double radius) / 3.0))
+        if (passRadius < 1) {
+            passRadius = 1
+        }
+        return (this.boxBlurMultiPass(src passRadius 3))
+    }
+}
+
+; Shadow rendering using blur
+class RasterShadow {
+    def blur:RasterBlur (new RasterBlur())
+    
+    ; Create a shadow buffer from a shape
+    ; The shape is represented as alpha values in the source buffer
+    ; shadowColor: the color of the shadow (with alpha)
+    ; blurRadius: how much to blur the shadow
+    fn createShadow:RasterBuffer (src:RasterBuffer blurRadius:int shadowR:int shadowG:int shadowB:int shadowA:int) {
+        ; Create a buffer with just the shadow shape
+        def shadowShape:RasterBuffer (new RasterBuffer())
+        shadowShape.create(src.width src.height)
+        
+        ; Copy source alpha to shadow buffer with shadow color
+        def y:int 0
+        while (y < src.height) {
+            def x:int 0
+            while (x < src.width) {
+                def srcAlpha:int (src.getA(x y))
+                if (srcAlpha > 0) {
+                    ; Scale shadow alpha by source alpha
+                    def outAlpha:int (to_int ((to_double (srcAlpha * shadowA)) / 255.0))
+                    shadowShape.setPixel(x y shadowR shadowG shadowB outAlpha)
+                }
+                x = x + 1
+            }
+            y = y + 1
+        }
+        
+        ; Blur the shadow
+        if (blurRadius > 0) {
+            return (blur.gaussianApproxBlur(shadowShape blurRadius))
+        }
+        
+        return shadowShape
+    }
+    
+    ; Create a drop shadow with offset
+    ; Returns a buffer larger than the original to accommodate blur spread
+    fn createDropShadow:RasterBuffer (src:RasterBuffer offsetX:int offsetY:int blurRadius:int shadowR:int shadowG:int shadowB:int shadowA:int) {
+        ; Calculate expanded buffer size to accommodate shadow spread
+        def spread:int (blurRadius * 2)
+        
+        ; Calculate absolute offset values
+        def absOffsetX:int offsetX
+        if (absOffsetX < 0) {
+            absOffsetX = 0 - absOffsetX
+        }
+        def absOffsetY:int offsetY
+        if (absOffsetY < 0) {
+            absOffsetY = 0 - absOffsetY
+        }
+        
+        def newWidth:int (src.width + spread + absOffsetX)
+        def newHeight:int (src.height + spread + absOffsetY)
+        
+        ; Calculate position of source in expanded buffer
+        def srcX:int spread
+        def srcY:int spread
+        if (offsetX < 0) {
+            srcX = srcX - offsetX
+        }
+        if (offsetY < 0) {
+            srcY = srcY - offsetY
+        }
+        
+        ; Create expanded shadow shape
+        def shadowShape:RasterBuffer (new RasterBuffer())
+        shadowShape.create(newWidth newHeight)
+        
+        ; Copy source alpha to shadow position (with offset)
+        def shadowPosX:int (srcX + offsetX)
+        def shadowPosY:int (srcY + offsetY)
+        
+        def y:int 0
+        while (y < src.height) {
+            def x:int 0
+            while (x < src.width) {
+                def srcAlpha:int (src.getA(x y))
+                if (srcAlpha > 0) {
+                    def outAlpha:int (to_int ((to_double (srcAlpha * shadowA)) / 255.0))
+                    shadowShape.setPixel((shadowPosX + x) (shadowPosY + y) shadowR shadowG shadowB outAlpha)
+                }
+                x = x + 1
+            }
+            y = y + 1
+        }
+        
+        ; Blur the shadow
+        if (blurRadius > 0) {
+            return (blur.gaussianApproxBlur(shadowShape blurRadius))
+        }
+        
+        return shadowShape
+    }
+    
+    ; Render a rectangular shadow (common case - optimized)
+    fn renderRectShadow:RasterBuffer (width:int height:int blurRadius:int shadowR:int shadowG:int shadowB:int shadowA:int) {
+        ; Create a solid rectangle buffer
+        def rect:RasterBuffer (new RasterBuffer())
+        def spreadW:int (width + (blurRadius * 4))
+        def spreadH:int (height + (blurRadius * 4))
+        rect.create(spreadW spreadH)
+        
+        ; Fill the center rectangle with opaque pixels
+        def offsetX:int (blurRadius * 2)
+        def offsetY:int (blurRadius * 2)
+        rect.fillRect(offsetX offsetY width height 255 255 255 255)
+        
+        ; Create shadow from the rectangle
+        return (this.createShadow(rect blurRadius shadowR shadowG shadowB shadowA))
+    }
+    
+    ; Render a rounded rectangle shadow
+    fn renderRoundedRectShadow:RasterBuffer (width:int height:int radius:int blurRadius:int shadowR:int shadowG:int shadowB:int shadowA:int) {
+        ; Create a rounded rectangle buffer
+        def spreadW:int (width + (blurRadius * 4))
+        def spreadH:int (height + (blurRadius * 4))
+        def rect:RasterBuffer (new RasterBuffer())
+        rect.create(spreadW spreadH)
+        
+        def offsetX:int (blurRadius * 2)
+        def offsetY:int (blurRadius * 2)
+        
+        ; Draw rounded rectangle using corner circles
+        ; This is a simplified version - for proper rounded rects, use RasterPrimitives
+        
+        ; Clamp radius to max (half of smaller dimension)
+        def maxR:int (to_int ((to_double width) / 2.0))
+        def halfH:int (to_int ((to_double height) / 2.0))
+        if (halfH < maxR) {
+            maxR = halfH
+        }
+        if (radius > maxR) {
+            radius = maxR
+        }
+        
+        ; Fill main body (cross shape)
+        rect.fillRect((offsetX + radius) offsetY (width - (radius * 2)) height 255 255 255 255)
+        rect.fillRect(offsetX (offsetY + radius) width (height - (radius * 2)) 255 255 255 255)
+        
+        ; Fill corners with circle approximation
+        this.fillCornerCircle(rect (offsetX + radius) (offsetY + radius) radius)
+        this.fillCornerCircle(rect (offsetX + width - radius - 1) (offsetY + radius) radius)
+        this.fillCornerCircle(rect (offsetX + radius) (offsetY + height - radius - 1) radius)
+        this.fillCornerCircle(rect (offsetX + width - radius - 1) (offsetY + height - radius - 1) radius)
+        
+        ; Create shadow
+        return (this.createShadow(rect blurRadius shadowR shadowG shadowB shadowA))
+    }
+    
+    ; Helper: Fill a circular area (for rounded corners)
+    fn fillCornerCircle:void (buf:RasterBuffer cx:int cy:int radius:int) {
+        def r2:int (radius * radius)
+        def y:int (0 - radius)
+        while (y <= radius) {
+            def x:int (0 - radius)
+            while (x <= radius) {
+                def d2:int ((x * x) + (y * y))
+                if (d2 <= r2) {
+                    buf.setPixel((cx + x) (cy + y) 255 255 255 255)
+                }
+                x = x + 1
+            }
+            y = y + 1
+        }
+    }
+}
+
+; Note: Global instances removed - create locally where needed

--- a/gallery/game_engine/v2/imaging/raster/RasterCompositing.rgr
+++ b/gallery/game_engine/v2/imaging/raster/RasterCompositing.rgr
@@ -1,0 +1,254 @@
+; RasterCompositing - Alpha blending and compositing for raster rendering
+; Provides Porter-Duff compositing operations
+
+Import "RasterBuffer.rgr"
+
+; Alpha compositing class - provides blending operations
+class RasterCompositor {
+    
+    ; Clamp a value to 0-255 range
+    fn clamp255:int (val:int) {
+        if (val < 0) {
+            return 0
+        }
+        if (val > 255) {
+            return 255
+        }
+        return val
+    }
+    
+    ; Clamp a double value to 0.0-1.0 range
+    fn clamp01:double (val:double) {
+        if (val < 0.0) {
+            return 0.0
+        }
+        if (val > 1.0) {
+            return 1.0
+        }
+        return val
+    }
+    
+    ; Blend source pixel over destination pixel (Porter-Duff Source Over)
+    ; This is the standard alpha compositing operation
+    ; Formula: out = src + dst * (1 - src.a)
+    fn blendSourceOver:void (buf:RasterBuffer x:int y:int srcR:int srcG:int srcB:int srcA:int) {
+        if ((buf.inBounds(x y)) == false) {
+            return
+        }
+        
+        ; Fast path: fully opaque source replaces destination
+        if (srcA >= 255) {
+            buf.setPixel(x y srcR srcG srcB 255)
+            return
+        }
+        
+        ; Fast path: fully transparent source has no effect
+        if (srcA <= 0) {
+            return
+        }
+        
+        ; Get destination pixel
+        def dst:RasterPixel (buf.getPixel(x y))
+        
+        ; Convert alpha to 0.0-1.0 range
+        def srcAlpha:double ((to_double srcA) / 255.0)
+        def dstAlpha:double ((to_double dst.a) / 255.0)
+        
+        ; Calculate output alpha: outA = srcA + dstA * (1 - srcA)
+        def outAlpha:double (srcAlpha + (dstAlpha * (1.0 - srcAlpha)))
+        
+        ; Avoid division by zero
+        if (outAlpha < 0.001) {
+            buf.setPixel(x y 0 0 0 0)
+            return
+        }
+        
+        ; Calculate output color components
+        ; out = (src * srcA + dst * dstA * (1 - srcA)) / outA
+        def invSrcAlpha:double (1.0 - srcAlpha)
+        
+        def outR:double (((to_double srcR) * srcAlpha) + ((to_double dst.r) * dstAlpha * invSrcAlpha))
+        def outG:double (((to_double srcG) * srcAlpha) + ((to_double dst.g) * dstAlpha * invSrcAlpha))
+        def outB:double (((to_double srcB) * srcAlpha) + ((to_double dst.b) * dstAlpha * invSrcAlpha))
+        
+        outR = outR / outAlpha
+        outG = outG / outAlpha
+        outB = outB / outAlpha
+        
+        buf.setPixel(x y (this.clamp255((to_int outR))) (this.clamp255((to_int outG))) (this.clamp255((to_int outB))) (this.clamp255((to_int (outAlpha * 255.0)))))
+    }
+    
+    ; Blend with RasterPixel object
+    fn blendPixelOver:void (buf:RasterBuffer x:int y:int src:RasterPixel) {
+        this.blendSourceOver(buf x y src.r src.g src.b src.a)
+    }
+    
+    ; Fill a rectangle with alpha blending
+    fn fillRectBlended:void (buf:RasterBuffer x:int y:int w:int h:int r:int g:int b:int a:int) {
+        def endX:int (x + w)
+        def endY:int (y + h)
+        
+        ; Clamp to bounds
+        if (x < 0) {
+            x = 0
+        }
+        if (y < 0) {
+            y = 0
+        }
+        if (endX > buf.width) {
+            endX = buf.width
+        }
+        if (endY > buf.height) {
+            endY = buf.height
+        }
+        
+        def py:int y
+        while (py < endY) {
+            def px:int x
+            while (px < endX) {
+                this.blendSourceOver(buf px py r g b a)
+                px = px + 1
+            }
+            py = py + 1
+        }
+    }
+    
+    ; Composite one buffer over another at a given position
+    fn compositeOver:void (dst:RasterBuffer src:RasterBuffer dstX:int dstY:int) {
+        def sy:int 0
+        while (sy < src.height) {
+            def sx:int 0
+            while (sx < src.width) {
+                def p:RasterPixel (src.getPixel(sx sy))
+                this.blendSourceOver(dst (dstX + sx) (dstY + sy) p.r p.g p.b p.a)
+                sx = sx + 1
+            }
+            sy = sy + 1
+        }
+    }
+    
+    ; Composite a region of source over destination
+    fn compositeRegionOver:void (dst:RasterBuffer src:RasterBuffer srcX:int srcY:int srcW:int srcH:int dstX:int dstY:int) {
+        def sy:int 0
+        while (sy < srcH) {
+            def sx:int 0
+            while (sx < srcW) {
+                def p:RasterPixel (src.getPixel((srcX + sx) (srcY + sy)))
+                this.blendSourceOver(dst (dstX + sx) (dstY + sy) p.r p.g p.b p.a)
+                sx = sx + 1
+            }
+            sy = sy + 1
+        }
+    }
+    
+    ; Multiply blend mode: out = src * dst / 255
+    ; Darkens the image - useful for shadows
+    fn blendMultiply:void (buf:RasterBuffer x:int y:int srcR:int srcG:int srcB:int srcA:int) {
+        if ((buf.inBounds(x y)) == false) {
+            return
+        }
+        
+        def dst:RasterPixel (buf.getPixel(x y))
+        
+        ; Multiply the color channels
+        def outR:int (to_int ((to_double (srcR * dst.r)) / 255.0))
+        def outG:int (to_int ((to_double (srcG * dst.g)) / 255.0))
+        def outB:int (to_int ((to_double (srcB * dst.b)) / 255.0))
+        
+        ; Blend based on source alpha
+        def srcAlpha:double ((to_double srcA) / 255.0)
+        def invAlpha:double (1.0 - srcAlpha)
+        
+        outR = (to_int (((to_double outR) * srcAlpha) + ((to_double dst.r) * invAlpha)))
+        outG = (to_int (((to_double outG) * srcAlpha) + ((to_double dst.g) * invAlpha)))
+        outB = (to_int (((to_double outB) * srcAlpha) + ((to_double dst.b) * invAlpha)))
+        
+        buf.setPixel(x y (this.clamp255(outR)) (this.clamp255(outG)) (this.clamp255(outB)) dst.a)
+    }
+    
+    ; Screen blend mode: out = 255 - (255 - src) * (255 - dst) / 255
+    ; Lightens the image
+    fn blendScreen:void (buf:RasterBuffer x:int y:int srcR:int srcG:int srcB:int srcA:int) {
+        if ((buf.inBounds(x y)) == false) {
+            return
+        }
+        
+        def dst:RasterPixel (buf.getPixel(x y))
+        
+        ; Screen the color channels (use double to avoid int division issues)
+        def scrR:int (255 - srcR)
+        def scrG:int (255 - srcG)
+        def scrB:int (255 - srcB)
+        def dstInvR:int (255 - dst.r)
+        def dstInvG:int (255 - dst.g)
+        def dstInvB:int (255 - dst.b)
+        
+        def outR:int (255 - (to_int ((to_double (scrR * dstInvR)) / 255.0)))
+        def outG:int (255 - (to_int ((to_double (scrG * dstInvG)) / 255.0)))
+        def outB:int (255 - (to_int ((to_double (scrB * dstInvB)) / 255.0)))
+        
+        ; Blend based on source alpha
+        def srcAlpha:double ((to_double srcA) / 255.0)
+        def invAlpha:double (1.0 - srcAlpha)
+        
+        outR = (to_int (((to_double outR) * srcAlpha) + ((to_double dst.r) * invAlpha)))
+        outG = (to_int (((to_double outG) * srcAlpha) + ((to_double dst.g) * invAlpha)))
+        outB = (to_int (((to_double outB) * srcAlpha) + ((to_double dst.b) * invAlpha)))
+        
+        buf.setPixel(x y (this.clamp255(outR)) (this.clamp255(outG)) (this.clamp255(outB)) dst.a)
+    }
+    
+    ; Additive blend: out = src + dst (clamped to 255)
+    ; Creates glow effects
+    fn blendAdditive:void (buf:RasterBuffer x:int y:int srcR:int srcG:int srcB:int srcA:int) {
+        if ((buf.inBounds(x y)) == false) {
+            return
+        }
+        
+        def dst:RasterPixel (buf.getPixel(x y))
+        
+        ; Scale source by alpha first
+        def srcAlpha:double ((to_double srcA) / 255.0)
+        def addR:int (to_int ((to_double srcR) * srcAlpha))
+        def addG:int (to_int ((to_double srcG) * srcAlpha))
+        def addB:int (to_int ((to_double srcB) * srcAlpha))
+        
+        ; Add to destination
+        def outR:int (dst.r + addR)
+        def outG:int (dst.g + addG)
+        def outB:int (dst.b + addB)
+        
+        buf.setPixel(x y (this.clamp255(outR)) (this.clamp255(outG)) (this.clamp255(outB)) dst.a)
+    }
+    
+    ; Pre-multiplied alpha blend (faster when source is pre-multiplied)
+    ; For pre-multiplied: out = src + dst * (1 - srcA)
+    fn blendPreMultiplied:void (buf:RasterBuffer x:int y:int srcR:int srcG:int srcB:int srcA:int) {
+        if ((buf.inBounds(x y)) == false) {
+            return
+        }
+        
+        ; Fast paths
+        if (srcA >= 255) {
+            buf.setPixel(x y srcR srcG srcB 255)
+            return
+        }
+        if (srcA <= 0) {
+            return
+        }
+        
+        def dst:RasterPixel (buf.getPixel(x y))
+        
+        def invAlpha:int (255 - srcA)
+        
+        def outR:int (srcR + (to_int ((to_double (dst.r * invAlpha)) / 255.0)))
+        def outG:int (srcG + (to_int ((to_double (dst.g * invAlpha)) / 255.0)))
+        def outB:int (srcB + (to_int ((to_double (dst.b * invAlpha)) / 255.0)))
+        def outA:int (srcA + (to_int ((to_double (dst.a * invAlpha)) / 255.0)))
+        
+        buf.setPixel(x y (this.clamp255(outR)) (this.clamp255(outG)) (this.clamp255(outB)) (this.clamp255(outA)))
+    }
+}
+
+; Note: Global compositor instance removed - causes infinite recursion
+; Create instances locally where needed

--- a/gallery/game_engine/v2/imaging/raster/RasterText.rgr
+++ b/gallery/game_engine/v2/imaging/raster/RasterText.rgr
@@ -1,0 +1,1046 @@
+; RasterText.rgr - Text rendering for raster buffers
+; Uses the existing TrueTypeFont class for font loading and metrics,
+; adds glyph outline parsing for rasterization.
+;
+; TTF Glyph outline structure:
+; - numberOfContours: if >= 0, simple glyph; if -1, composite glyph
+; - Simple glyph: contour end points, flags, x/y coordinates
+; - Points can be on-curve or off-curve (quadratic bezier control points)
+
+Import "RasterBuffer.rgr"
+Import "RasterCompositing.rgr"
+Import "RasterBlur.rgr"
+Import "../fonts/TrueTypeFont.rgr"
+Import "../fonts/FontManager.rgr"
+
+; A point in a glyph outline
+class GlyphPoint {
+    def x:double 0.0
+    def y:double 0.0
+    def onCurve:boolean true  ; true = on curve, false = control point
+    
+    fn init:void (px:double py:double on:boolean) {
+        x = px
+        y = py
+        onCurve = on
+    }
+}
+
+; A contour (closed path) in a glyph
+class GlyphContour {
+    def points:[GlyphPoint]
+    
+    Constructor () {
+        def p:[GlyphPoint]
+        points = p
+    }
+    
+    fn addPoint:void (x:double y:double onCurve:boolean) {
+        def pt:GlyphPoint (new GlyphPoint())
+        pt.init(x y onCurve)
+        push points pt
+    }
+    
+    fn numPoints:int () {
+        return (array_length points)
+    }
+}
+
+; Parsed glyph data
+class GlyphOutline {
+    def contours:[GlyphContour]
+    def xMin:double 0.0
+    def yMin:double 0.0
+    def xMax:double 0.0
+    def yMax:double 0.0
+    def advanceWidth:double 0.0
+    def leftSideBearing:double 0.0
+    
+    Constructor () {
+        def c:[GlyphContour]
+        contours = c
+    }
+    
+    fn addContour:void (contour:GlyphContour) {
+        push contours contour
+    }
+}
+
+; Edge for scanline rasterization
+class GlyphEdge {
+    def x1:double 0.0
+    def y1:double 0.0
+    def x2:double 0.0
+    def y2:double 0.0
+    def minY:double 0.0
+    def maxY:double 0.0
+    def xAtMinY:double 0.0  ; X coordinate at minY
+    def dxdy:double 0.0     ; dx/dy slope for interpolation
+    def dir:int 0           ; +1 if going down, -1 if going up (for winding)
+    
+    fn init:void (px1:double py1:double px2:double py2:double) {
+        x1 = px1
+        y1 = py1
+        x2 = px2
+        y2 = py2
+        
+        ; Note: We receive coordinates AFTER Y-flip, so the winding sense is inverted
+        ; In screen coords (Y down), we track: +1 going down, -1 going up
+        if (y1 < y2) {
+            minY = y1
+            maxY = y2
+            xAtMinY = x1
+            dir = 1   ; Edge goes downward in screen coords
+        } {
+            minY = y2
+            maxY = y1
+            xAtMinY = x2
+            dir = (0 - 1)  ; Edge goes upward in screen coords
+        }
+        
+        def dy:double (maxY - minY)
+        if (dy > 0.0001) {
+            ; Calculate slope as change in X per unit Y (always from minY to maxY)
+            if (y1 < y2) {
+                dxdy = (x2 - x1) / dy
+            } {
+                dxdy = (x1 - x2) / dy
+            }
+        } {
+            dxdy = 0.0
+        }
+    }
+    
+    ; Get X intersection at given Y
+    fn getX:double (y:double) {
+        return (xAtMinY + (dxdy * (y - minY)))
+    }
+}
+
+; Text rasterizer class
+class RasterText {
+    def font:TrueTypeFont
+    def compositor:RasterCompositor (new RasterCompositor())
+
+    ; Per-glyph diagnostic logging. OFF by default: the debug prints below sit in
+    ; the hot glyph path and flood stdout / kill throughput for real-time (UI /
+    ; game) rendering. Set true only when debugging the rasterizer itself.
+    ; (See gallery/game_engine/RENDERING_EVG.md: "strip the debug prints".)
+    def debug:boolean false
+
+    ; Edges buffer for glyph rendering (reused to avoid slice issues in Go)
+    def currentEdges:[GlyphEdge]
+    
+    ; TTF table offsets (cached)
+    def glyfOffset:int 0
+    def locaOffset:int 0
+    def locaFormat:int 0
+    
+    Constructor () {
+    }
+    
+    fn setFont:void (ttf:TrueTypeFont) {
+        font = ttf
+        this.findTableOffsets()
+    }
+    
+    ; Measure text width using the current font
+    fn measureTextWidth:double (text:string fontSize:double) {
+        if (font.unitsPerEm <= 0) {
+            return 0.0
+        }
+        return (font.measureText(text fontSize))
+    }
+    
+    fn findTableOffsets:void () {
+        ; Find glyf and loca table offsets
+        def i:int 0
+        def numTables:int (array_length font.tables)
+        while (i < numTables) {
+            def t:TTFTableRecord (itemAt font.tables i)
+            if (t.tag == "glyf") {
+                glyfOffset = t.offset
+            }
+            if (t.tag == "loca") {
+                locaOffset = t.offset
+            }
+            i = i + 1
+        }
+        locaFormat = font.indexToLocFormat
+    }
+    
+    ; Get glyph offset in glyf table
+    fn getGlyphOffset:int (glyphIndex:int) {
+        if (locaFormat == 0) {
+            ; Short format: offsets are 16-bit, multiply by 2
+            def off:int (locaOffset + (glyphIndex * 2))
+            def offset16:int (this.readUInt16(off))
+            return (offset16 * 2)
+        }
+        ; Long format: offsets are 32-bit
+        def off:int (locaOffset + (glyphIndex * 4))
+        return (this.readUInt32(off))
+    }
+    
+    ; Get glyph length
+    fn getGlyphLength:int (glyphIndex:int) {
+        def start:int (this.getGlyphOffset(glyphIndex))
+        def end:int (this.getGlyphOffset(glyphIndex + 1))
+        return (end - start)
+    }
+    
+    ; Parse a glyph outline
+    fn parseGlyph:GlyphOutline (glyphIndex:int fontSize:double) {
+        def outline:GlyphOutline (new GlyphOutline())
+        
+        ; Calculate scale for this font size
+        def scale:double (fontSize / (to_double font.unitsPerEm))
+        
+        def glyphLen:int (this.getGlyphLength(glyphIndex))
+        if (glyphLen == 0) {
+            ; Empty glyph (space, etc) - still need advance width!
+            outline.advanceWidth = ((to_double (font.getGlyphWidth(glyphIndex))) * scale)
+            return outline
+        }
+        
+        def off:int (glyfOffset + (this.getGlyphOffset(glyphIndex)))
+        
+        ; Read glyph header
+        def numberOfContours:int (this.readInt16(off))
+        outline.xMin = (to_double (this.readInt16(off + 2)))
+        outline.yMin = (to_double (this.readInt16(off + 4)))
+        outline.xMax = (to_double (this.readInt16(off + 6)))
+        outline.yMax = (to_double (this.readInt16(off + 8)))
+        
+        if (numberOfContours < 0) {
+            ; Composite glyph - skip for now (TODO: implement)
+            return outline
+        }
+        
+        if (numberOfContours == 0) {
+            return outline
+        }
+        
+        ; Read contour end points
+        def endPts:[int]
+        def i:int 0
+        while (i < numberOfContours) {
+            def endPt:int (this.readUInt16(off + 10 + (i * 2)))
+            push endPts endPt
+            i = i + 1
+        }
+        
+        ; Skip instructions
+        def instrLen:int (this.readUInt16(off + 10 + (numberOfContours * 2)))
+        def dataOff:int (off + 10 + (numberOfContours * 2) + 2 + instrLen)
+        
+        ; Total number of points
+        def lastEndPt:int (itemAt endPts (numberOfContours - 1))
+        def numPoints:int (lastEndPt + 1)
+        
+        ; Safety check - limit points to prevent infinite loops
+        if (numPoints > 10000) {
+            if debug { print ("Warning: Too many points in glyph: " + (to_string numPoints)) }
+            return outline
+        }
+        
+        ; Read flags
+        def flags:[int]
+        def flagOff:int dataOff
+        i = 0
+        while (i < numPoints) {
+            def flag:int (this.readUInt8(flagOff))
+            push flags flag
+            flagOff = flagOff + 1
+            i = i + 1
+            
+            ; Check repeat flag (bit 3)
+            if ((bit_and flag 8) != 0) {
+                def repeatCount:int (this.readUInt8(flagOff))
+                flagOff = flagOff + 1
+                def j:int 0
+                while ((j < repeatCount) && (i < numPoints)) {
+                    push flags flag
+                    j = j + 1
+                    i = i + 1
+                }
+            }
+        }
+        
+        ; Read X coordinates
+        def xCoords:[int]
+        def xOff:int flagOff
+        def x:int 0
+        i = 0
+        while (i < numPoints) {
+            def flag:int (itemAt flags i)
+            def xShort:boolean ((bit_and flag 2) != 0)
+            def xSame:boolean ((bit_and flag 16) != 0)
+            
+            if xShort {
+                def dx:int (this.readUInt8(xOff))
+                xOff = xOff + 1
+                if xSame {
+                    x = x + dx
+                } {
+                    x = x - dx
+                }
+            } {
+                if (xSame == false) {
+                    def dx:int (this.readInt16(xOff))
+                    xOff = xOff + 2
+                    x = x + dx
+                }
+                ; if xSame, x stays the same
+            }
+            push xCoords x
+            i = i + 1
+        }
+        
+        ; Read Y coordinates
+        def yCoords:[int]
+        def yOff:int xOff
+        def y:int 0
+        i = 0
+        while (i < numPoints) {
+            def flag:int (itemAt flags i)
+            def yShort:boolean ((bit_and flag 4) != 0)
+            def ySame:boolean ((bit_and flag 32) != 0)
+            
+            if yShort {
+                def dy:int (this.readUInt8(yOff))
+                yOff = yOff + 1
+                if ySame {
+                    y = y + dy
+                } {
+                    y = y - dy
+                }
+            } {
+                if (ySame == false) {
+                    def dy:int (this.readInt16(yOff))
+                    yOff = yOff + 2
+                    y = y + dy
+                }
+            }
+            push yCoords y
+            i = i + 1
+        }
+        
+        ; Scale factor
+        def scale:double (fontSize / (to_double font.unitsPerEm))
+        
+        ; Build contours
+        def startPt:int 0
+        def contourIdx:int 0
+        while (contourIdx < numberOfContours) {
+            def endPt:int (itemAt endPts contourIdx)
+            def contour:GlyphContour (new GlyphContour())
+            
+            def ptIdx:int startPt
+            while (ptIdx <= endPt) {
+                def px:double ((to_double (itemAt xCoords ptIdx)) * scale)
+                def py:double ((to_double (itemAt yCoords ptIdx)) * scale)
+                def flag:int (itemAt flags ptIdx)
+                def onCurve:boolean ((bit_and flag 1) != 0)
+                
+                contour.addPoint(px py onCurve)
+                ptIdx = ptIdx + 1
+            }
+            
+            outline.addContour(contour)
+            startPt = endPt + 1
+            contourIdx = contourIdx + 1
+        }
+        
+        ; Get advance width
+        outline.advanceWidth = ((to_double (font.getGlyphWidth(glyphIndex))) * scale)
+        
+        return outline
+    }
+    
+    ; Render a glyph outline to buffer (anti-aliased)
+    fn renderGlyph:void (buf:RasterBuffer outline:GlyphOutline x:double y:double r:int g:int b:int a:int) {
+        ; Convert outline to edges
+        ; Clear and reuse the instance-level edges buffer
+        def newEdges:[GlyphEdge]
+        currentEdges = newEdges
+        
+        def numContours:int (array_length outline.contours)
+        if debug { print ("  renderGlyph: numContours=" + (to_string numContours) + " pos=(" + (to_string x) + "," + (to_string y) + ")") }
+        def cIdx:int 0
+        while (cIdx < numContours) {
+            def contour:GlyphContour (itemAt outline.contours cIdx)
+            def numPts:int (contour.numPoints())
+            if debug { print ("    contour " + (to_string cIdx) + ": numPoints=" + (to_string numPts)) }
+            
+            if (numPts >= 2) {
+                ; Flatten curves and create edges - uses currentEdges field
+                this.flattenContourToField(contour x y)
+            }
+            cIdx = cIdx + 1
+        }
+        
+        if debug { print ("    total edges after flatten: " + (to_string (array_length currentEdges))) }
+        
+        ; Anti-aliased scanline fill using edges
+        this.scanlineFillAA(buf currentEdges r g b a)
+    }
+    
+    ; Render a glyph outline to buffer (no anti-aliasing, faster)
+    fn renderGlyphFast:void (buf:RasterBuffer outline:GlyphOutline x:double y:double r:int g:int b:int a:int) {
+        ; Convert outline to edges
+        def edges:[GlyphEdge]
+        
+        def numContours:int (array_length outline.contours)
+        def cIdx:int 0
+        while (cIdx < numContours) {
+            def contour:GlyphContour (itemAt outline.contours cIdx)
+            def numPts:int (contour.numPoints())
+            
+            if (numPts >= 2) {
+                ; Flatten curves and create edges
+                this.flattenContour(contour edges x y)
+            }
+            cIdx = cIdx + 1
+        }
+        
+        ; Standard scanline fill (faster but aliased)
+        this.scanlineFill(buf edges r g b a)
+    }
+    
+    ; Flatten a contour (convert curves to line segments)
+    ; Returns edges that form a closed polygon
+    fn flattenContour:void (contour:GlyphContour edges:[GlyphEdge] offsetX:double offsetY:double) {
+        def numPts:int (contour.numPoints())
+        if (numPts < 2) {
+            return
+        }
+        
+        ; Find the first on-curve point (or implicit one)
+        def startX:double 0.0
+        def startY:double 0.0
+        def firstPt:GlyphPoint (itemAt contour.points 0)
+        
+        if (firstPt.onCurve) {
+            startX = firstPt.x + offsetX
+            startY = offsetY - firstPt.y
+        } {
+            ; First point is off-curve, find an implicit on-curve point
+            def lastPt:GlyphPoint (itemAt contour.points (numPts - 1))
+            if (lastPt.onCurve) {
+                startX = lastPt.x + offsetX
+                startY = offsetY - lastPt.y
+            } {
+                ; Both first and last are off-curve - use midpoint
+                startX = ((firstPt.x + lastPt.x) / 2.0) + offsetX
+                startY = offsetY - ((firstPt.y + lastPt.y) / 2.0)
+            }
+        }
+        
+        def currX:double startX
+        def currY:double startY
+        
+        def i:int 0
+        while (i < numPts) {
+            def pt:GlyphPoint (itemAt contour.points i)
+            def nextIdx:int ((i + 1) % numPts)
+            def nextPt:GlyphPoint (itemAt contour.points nextIdx)
+            
+            if (pt.onCurve) {
+                ; On-curve point - check what comes next
+                if (nextPt.onCurve) {
+                    ; Line to next on-curve point
+                    def nx:double (nextPt.x + offsetX)
+                    def ny:double (offsetY - nextPt.y)
+                    this.addEdge(edges currX currY nx ny)
+                    currX = nx
+                    currY = ny
+                }
+                ; If next is off-curve, do nothing - we'll handle the curve when we process that point
+            } {
+                ; Off-curve point - emit a quadratic bezier curve
+                ; Start point is current position
+                def p0x:double currX
+                def p0y:double currY
+                
+                ; Control point is this off-curve point
+                def p1x:double (pt.x + offsetX)
+                def p1y:double (offsetY - pt.y)
+                
+                ; End point - next on-curve, or implicit midpoint if next is also off-curve
+                def p2x:double 0.0
+                def p2y:double 0.0
+                if (nextPt.onCurve) {
+                    p2x = nextPt.x + offsetX
+                    p2y = offsetY - nextPt.y
+                } {
+                    ; Implicit on-curve midpoint
+                    p2x = ((pt.x + nextPt.x) / 2.0) + offsetX
+                    p2y = offsetY - ((pt.y + nextPt.y) / 2.0)
+                }
+                
+                ; Flatten the quadratic bezier curve
+                def segments:int 8
+                def j:int 1
+                while (j <= segments) {
+                    def t:double ((to_double j) / (to_double segments))
+                    def invT:double (1.0 - t)
+                    
+                    def nx:double ((invT * invT * p0x) + (2.0 * invT * t * p1x) + (t * t * p2x))
+                    def ny:double ((invT * invT * p0y) + (2.0 * invT * t * p1y) + (t * t * p2y))
+                    
+                    this.addEdge(edges currX currY nx ny)
+                    currX = nx
+                    currY = ny
+                    j = j + 1
+                }
+            }
+            i = i + 1
+        }
+        
+        ; Close the contour if needed (connect back to start)
+        def dx:double (currX - startX)
+        def dy:double (currY - startY)
+        if (dx < 0.0) {
+            dx = 0.0 - dx
+        }
+        if (dy < 0.0) {
+            dy = 0.0 - dy
+        }
+        if ((dx > 0.01) || (dy > 0.01)) {
+            this.addEdge(edges currX currY startX startY)
+        }
+    }
+    
+    ; Add an edge (skip only truly horizontal edges)
+    fn addEdge:void (edges:[GlyphEdge] x1:double y1:double x2:double y2:double) {
+        def dy:double (y2 - y1)
+        if (dy < 0.0) {
+            dy = 0.0 - dy
+        }
+        ; Only skip if truly horizontal (dy < 0.001 pixels)
+        ; Previously 0.1 was too aggressive - caused artifacts at horizontal features
+        if (dy < 0.001) {
+            return  ; Skip truly horizontal edges
+        }
+        
+        def edge:GlyphEdge (new GlyphEdge())
+        edge.init(x1 y1 x2 y2)
+        push edges edge
+    }
+    
+    ; Add an edge to the currentEdges field (avoids Go slice pass-by-value issue)
+    fn addEdgeToField:void (x1:double y1:double x2:double y2:double) {
+        def dy:double (y2 - y1)
+        if (dy < 0.0) {
+            dy = 0.0 - dy
+        }
+        if (dy < 0.001) {
+            return  ; Skip truly horizontal edges
+        }
+        
+        def edge:GlyphEdge (new GlyphEdge())
+        edge.init(x1 y1 x2 y2)
+        push currentEdges edge
+    }
+    
+    ; Flatten a contour to currentEdges field (avoids Go slice pass-by-value issue)
+    fn flattenContourToField:void (contour:GlyphContour offsetX:double offsetY:double) {
+        def numPts:int (contour.numPoints())
+        if (numPts < 2) {
+            return
+        }
+        
+        ; Find the first on-curve point (or implicit one)
+        def startX:double 0.0
+        def startY:double 0.0
+        def firstPt:GlyphPoint (itemAt contour.points 0)
+        
+        if (firstPt.onCurve) {
+            startX = firstPt.x + offsetX
+            startY = offsetY - firstPt.y
+        } {
+            ; First point is off-curve, find an implicit on-curve point
+            def lastPt:GlyphPoint (itemAt contour.points (numPts - 1))
+            if (lastPt.onCurve) {
+                startX = lastPt.x + offsetX
+                startY = offsetY - lastPt.y
+            } {
+                ; Both first and last are off-curve - use midpoint
+                startX = ((firstPt.x + lastPt.x) / 2.0) + offsetX
+                startY = offsetY - ((firstPt.y + lastPt.y) / 2.0)
+            }
+        }
+        
+        def currX:double startX
+        def currY:double startY
+        
+        def i:int 0
+        while (i < numPts) {
+            def pt:GlyphPoint (itemAt contour.points i)
+            def nextIdx:int ((i + 1) % numPts)
+            def nextPt:GlyphPoint (itemAt contour.points nextIdx)
+            
+            if (pt.onCurve) {
+                ; On-curve point - check what comes next
+                if (nextPt.onCurve) {
+                    ; Line to next on-curve point
+                    def nx:double (nextPt.x + offsetX)
+                    def ny:double (offsetY - nextPt.y)
+                    this.addEdgeToField(currX currY nx ny)
+                    currX = nx
+                    currY = ny
+                }
+            } {
+                ; Off-curve point - emit a quadratic bezier curve
+                def p0x:double currX
+                def p0y:double currY
+                def p1x:double (pt.x + offsetX)
+                def p1y:double (offsetY - pt.y)
+                
+                def p2x:double 0.0
+                def p2y:double 0.0
+                if (nextPt.onCurve) {
+                    p2x = nextPt.x + offsetX
+                    p2y = offsetY - nextPt.y
+                } {
+                    ; Implicit on-curve midpoint
+                    p2x = ((pt.x + nextPt.x) / 2.0) + offsetX
+                    p2y = offsetY - ((pt.y + nextPt.y) / 2.0)
+                }
+                
+                ; Flatten the quadratic bezier curve
+                def segments:int 8
+                def j:int 1
+                while (j <= segments) {
+                    def t:double ((to_double j) / (to_double segments))
+                    def invT:double (1.0 - t)
+                    
+                    def nx:double ((invT * invT * p0x) + (2.0 * invT * t * p1x) + (t * t * p2x))
+                    def ny:double ((invT * invT * p0y) + (2.0 * invT * t * p1y) + (t * t * p2y))
+                    
+                    this.addEdgeToField(currX currY nx ny)
+                    currX = nx
+                    currY = ny
+                    j = j + 1
+                }
+            }
+            i = i + 1
+        }
+        
+        ; Close the contour if needed (connect back to start)
+        def dx:double (currX - startX)
+        def dy:double (currY - startY)
+        if (dx < 0.0) {
+            dx = 0.0 - dx
+        }
+        if (dy < 0.0) {
+            dy = 0.0 - dy
+        }
+        if ((dx > 0.01) || (dy > 0.01)) {
+            this.addEdgeToField(currX currY startX startY)
+        }
+    }
+
+    ; Flatten a quadratic bezier curve
+    fn flattenQuadBezier:void (edges:[GlyphEdge] x0:double y0:double x1:double y1:double x2:double y2:double segments:int) {
+        def prevX:double x0
+        def prevY:double y0
+        
+        def i:int 1
+        while (i <= segments) {
+            def t:double ((to_double i) / (to_double segments))
+            def invT:double (1.0 - t)
+            
+            ; Quadratic bezier: B(t) = (1-t)²P0 + 2(1-t)tP1 + t²P2
+            def currX:double ((invT * invT * x0) + (2.0 * invT * t * x1) + (t * t * x2))
+            def currY:double ((invT * invT * y0) + (2.0 * invT * t * y1) + (t * t * y2))
+            
+            this.addEdge(edges prevX prevY currX currY)
+            
+            prevX = currX
+            prevY = currY
+            i = i + 1
+        }
+    }
+    
+    ; Scanline fill using even-odd rule
+    fn scanlineFill:void (buf:RasterBuffer edges:[GlyphEdge] r:int g:int b:int a:int) {
+        def numEdges:int (array_length edges)
+        if (numEdges == 0) {
+            return
+        }
+        
+        ; Find bounding box
+        def minY:double 99999.0
+        def maxY:double (0.0 - 99999.0)
+        def i:int 0
+        while (i < numEdges) {
+            def e:GlyphEdge (itemAt edges i)
+            if (e.minY < minY) {
+                minY = e.minY
+            }
+            if (e.maxY > maxY) {
+                maxY = e.maxY
+            }
+            i = i + 1
+        }
+        
+        ; Clamp to buffer
+        def startY:int (to_int minY)
+        def endY:int (to_int maxY)
+        if (startY < 0) {
+            startY = 0
+        }
+        if (endY >= buf.height) {
+            endY = buf.height - 1
+        }
+        
+        ; Process each scanline
+        def scanY:int startY
+        while (scanY <= endY) {
+            def y:double ((to_double scanY) + 0.5)
+            
+            ; Find intersections with active edges
+            def intersections:[double]
+            
+            i = 0
+            while (i < numEdges) {
+                def e:GlyphEdge (itemAt edges i)
+                if ((y >= e.minY) && (y < e.maxY)) {
+                    def ix:double (e.getX(y))
+                    push intersections ix
+                }
+                i = i + 1
+            }
+            
+            ; Sort intersections
+            this.sortDoubles(intersections)
+            
+            ; Fill between pairs
+            def numInt:int (array_length intersections)
+            def j:int 0
+            while ((j + 1) < numInt) {
+                def x1:int (to_int (itemAt intersections j))
+                def x2:int (to_int (itemAt intersections (j + 1)))
+                
+                ; Clamp to buffer
+                if (x1 < 0) {
+                    x1 = 0
+                }
+                if (x2 >= buf.width) {
+                    x2 = buf.width - 1
+                }
+                
+                ; Fill scanline segment
+                def px:int x1
+                while (px <= x2) {
+                    compositor.blendSourceOver(buf px scanY r g b a)
+                    px = px + 1
+                }
+                
+                j = j + 2
+            }
+            
+            scanY = scanY + 1
+        }
+    }
+    
+    ; Anti-aliased scanline fill using subpixel sampling
+    ; Uses 4x4 grid (16 samples per pixel) for coverage calculation
+    fn scanlineFillAA:void (buf:RasterBuffer edges:[GlyphEdge] r:int g:int b:int a:int) {
+        def numEdges:int (array_length edges)
+        if (numEdges == 0) {
+            if debug { print ("    scanlineFillAA: no edges, returning early!") }
+            return
+        }
+        
+        ; Find bounding box
+        def minY:double 99999.0
+        def maxY:double (0.0 - 99999.0)
+        def minX:double 99999.0
+        def maxX:double (0.0 - 99999.0)
+        def i:int 0
+        while (i < numEdges) {
+            def e:GlyphEdge (itemAt edges i)
+            if (e.minY < minY) {
+                minY = e.minY
+            }
+            if (e.maxY > maxY) {
+                maxY = e.maxY
+            }
+            if (e.x1 < minX) {
+                minX = e.x1
+            }
+            if (e.x2 < minX) {
+                minX = e.x2
+            }
+            if (e.x1 > maxX) {
+                maxX = e.x1
+            }
+            if (e.x2 > maxX) {
+                maxX = e.x2
+            }
+            i = i + 1
+        }
+        
+        if debug { print ("    scanlineFillAA: " + (to_string numEdges) + " edges, bbox=(" + (to_string minX) + "," + (to_string minY) + ")-(" + (to_string maxX) + "," + (to_string maxY) + ")") }
+        
+        ; Clamp to buffer with 1 pixel margin
+        def startY:int ((to_int minY) - 1)
+        def endY:int ((to_int maxY) + 1)
+        def startX:int ((to_int minX) - 1)
+        def endX:int ((to_int maxX) + 1)
+        if (startY < 0) {
+            startY = 0
+        }
+        if (endY >= buf.height) {
+            endY = buf.height - 1
+        }
+        if (startX < 0) {
+            startX = 0
+        }
+        if (endX >= buf.width) {
+            endX = buf.width - 1
+        }
+        
+        if debug { print ("    scanlineFillAA: clamped range X=" + (to_string startX) + "-" + (to_string endX) + " Y=" + (to_string startY) + "-" + (to_string endY)) }
+        
+        ; Subpixel offsets for 4x4 grid
+        def subStep:double 0.25
+        def subOffset:double 0.125
+        def samplesPerPixel:double 16.0
+        
+        ; Small epsilon to avoid vertex coincidence issues
+        def epsilon:double 0.0001
+        
+        ; Process each pixel in bounding box
+        def scanY:int startY
+        while (scanY <= endY) {
+            def scanX:int startX
+            while (scanX <= endX) {
+                ; Count samples inside the shape
+                def coverage:int 0
+                
+                ; 4x4 subpixel grid
+                def sy:int 0
+                while (sy < 4) {
+                    ; Y position with small offset to avoid hitting vertices exactly
+                    def sampleY:double ((to_double scanY) + subOffset + ((to_double sy) * subStep))
+                    
+                    ; Check each sample point in X
+                    def sx:int 0
+                    while (sx < 4) {
+                        def sampleX:double ((to_double scanX) + subOffset + ((to_double sx) * subStep))
+                        
+                        ; Non-zero winding rule: sum winding contributions from all edges
+                        def winding:int 0
+                        i = 0
+                        while (i < numEdges) {
+                            def e:GlyphEdge (itemAt edges i)
+                            ; Check if edge crosses the horizontal ray from sample point going left to -infinity
+                            ; Edge must span the Y coordinate
+                            if ((sampleY >= e.minY) && (sampleY < e.maxY)) {
+                                ; Get X intersection
+                                def edgeX:double (e.getX(sampleY))
+                                ; If edge is to the LEFT of sample point, it crosses the ray
+                                if (edgeX < sampleX) {
+                                    ; Add winding contribution based on edge direction
+                                    winding = winding + e.dir
+                                }
+                            }
+                            i = i + 1
+                        }
+                        
+                        ; Inside if winding is non-zero
+                        if (winding != 0) {
+                            coverage = coverage + 1
+                        }
+                        sx = sx + 1
+                    }
+                    sy = sy + 1
+                }
+                
+                ; Apply coverage as alpha
+                if (coverage > 0) {
+                    def coverageAlpha:int (to_int (((to_double coverage) / samplesPerPixel) * (to_double a)))
+                    compositor.blendSourceOver(buf scanX scanY r g b coverageAlpha)
+                }
+                
+                scanX = scanX + 1
+            }
+            scanY = scanY + 1
+        }
+    }
+    
+    ; Sort intersections along with their winding directions
+    fn sortIntersections:void (arr:[double] dirs:[int]) {
+        def n:int (array_length arr)
+        def i:int 0
+        while (i < n) {
+            def j:int 0
+            while (j < (n - i - 1)) {
+                def v1:double (itemAt arr j)
+                def v2:double (itemAt arr (j + 1))
+                if (v1 > v2) {
+                    ; Swap both arrays
+                    set arr j v2
+                    set arr (j + 1) v1
+                    def d1:int (itemAt dirs j)
+                    def d2:int (itemAt dirs (j + 1))
+                    set dirs j d2
+                    set dirs (j + 1) d1
+                }
+                j = j + 1
+            }
+            i = i + 1
+        }
+    }
+    
+    ; Simple bubble sort for intersections (small arrays)
+    fn sortDoubles:void (arr:[double]) {
+        def n:int (array_length arr)
+        def i:int 0
+        while (i < n) {
+            def j:int 0
+            while (j < (n - i - 1)) {
+                def v1:double (itemAt arr j)
+                def v2:double (itemAt arr (j + 1))
+                if (v1 > v2) {
+                    set arr j v2
+                    set arr (j + 1) v1
+                }
+                j = j + 1
+            }
+            i = i + 1
+        }
+    }
+    
+    ; Render text string
+    fn renderText:void (buf:RasterBuffer text:string x:double y:double fontSize:double r:int g:int b:int a:int) {
+        def currX:double x
+        def len:int (strlen text)
+        def i:int 0
+        
+        ; Debug: check if font is loaded
+        if (font.unitsPerEm <= 0) {
+            if debug { print ("ERROR: Font not loaded in RasterText! unitsPerEm=" + (to_string font.unitsPerEm)) }
+            return
+        }
+        
+        ; Get baseline offset (ascender in pixels)
+        def baseline:double (font.getAscender(fontSize))
+        def renderY:double (y + baseline)
+        
+        if debug { print ("RasterText.renderText: text='" + text + "' pos=(" + (to_string x) + "," + (to_string y) + ") fontSize=" + (to_string fontSize) + " baseline=" + (to_string baseline) + " renderY=" + (to_string renderY)) }
+        if debug { print ("RasterText.renderText: color=RGB(" + (to_string r) + "," + (to_string g) + "," + (to_string b) + ") alpha=" + (to_string a) + " bufSize=" + (to_string buf.width) + "x" + (to_string buf.height)) }
+        
+        while (i < len) {
+            def ch:int (charAt text i)
+            def glyphIdx:int (font.getGlyphIndex(ch))
+            
+            def outline:GlyphOutline (this.parseGlyph(glyphIdx fontSize))
+            
+            ; Debug first character
+            if (i == 0) {
+                if debug { print ("  First char: code=" + (to_string ch) + " glyphIdx=" + (to_string glyphIdx) + " numContours=" + (to_string (array_length outline.contours)) + " advanceWidth=" + (to_string outline.advanceWidth)) }
+            }
+            
+            this.renderGlyph(buf outline currX renderY r g b a)
+            
+            ; Advance
+            currX = currX + outline.advanceWidth
+            i = i + 1
+        }
+    }
+    
+    ; Render text with shadow
+    fn renderTextWithShadow:void (buf:RasterBuffer text:string x:double y:double fontSize:double textR:int textG:int textB:int textA:int shadowR:int shadowG:int shadowB:int shadowA:int shadowOffX:double shadowOffY:double blurRadius:int) {
+        ; First, render shadow to a temporary buffer
+        def shadowBuf:RasterBuffer (new RasterBuffer())
+        def margin:int (blurRadius * 2)
+        def textWidth:double (font.measureText(text fontSize))
+        def textHeight:double (font.getLineHeight(fontSize))
+        
+        def bufW:int ((to_int textWidth) + margin + margin + 10)
+        def bufH:int ((to_int textHeight) + margin + margin + 10)
+        shadowBuf.create(bufW bufH)
+        
+        ; Render text to shadow buffer
+        this.renderText(shadowBuf text (to_double margin) (to_double margin) fontSize shadowR shadowG shadowB 255)
+        
+        ; Blur the shadow
+        if (blurRadius > 0) {
+            def blur:RasterBlur (new RasterBlur())
+            def blurred:RasterBuffer (blur.gaussianApproxBlur(shadowBuf blurRadius))
+            
+            ; Adjust shadow alpha
+            def py:int 0
+            while (py < blurred.height) {
+                def px:int 0
+                while (px < blurred.width) {
+                    def p:RasterPixel (blurred.getPixel(px py))
+                    def newA:int (to_int ((to_double (p.a * shadowA)) / 255.0))
+                    blurred.setPixel(px py p.r p.g p.b newA)
+                    px = px + 1
+                }
+                py = py + 1
+            }
+            
+            ; Composite shadow onto main buffer
+            def shadowX:int ((to_int (x + shadowOffX)) - margin)
+            def shadowY:int ((to_int (y + shadowOffY)) - margin)
+            compositor.compositeOver(buf blurred shadowX shadowY)
+        } {
+            ; No blur, just composite
+            def shadowX:int ((to_int (x + shadowOffX)) - margin)
+            def shadowY:int ((to_int (y + shadowOffY)) - margin)
+            
+            ; Adjust alpha
+            def py:int 0
+            while (py < shadowBuf.height) {
+                def px:int 0
+                while (px < shadowBuf.width) {
+                    def p:RasterPixel (shadowBuf.getPixel(px py))
+                    def newA:int (to_int ((to_double (p.a * shadowA)) / 255.0))
+                    shadowBuf.setPixel(px py p.r p.g p.b newA)
+                    px = px + 1
+                }
+                py = py + 1
+            }
+            
+            compositor.compositeOver(buf shadowBuf shadowX shadowY)
+        }
+        
+        ; Render main text on top
+        this.renderText(buf text x y fontSize textR textG textB textA)
+    }
+    
+    ; ============ Binary reading helpers ============
+    
+    fn readUInt8:int (offset:int) {
+        return (buffer_get font.fontData offset)
+    }
+    
+    fn readUInt16:int (offset:int) {
+        def b1:int (buffer_get font.fontData offset)
+        def b2:int (buffer_get font.fontData (offset + 1))
+        return ((b1 * 256) + b2)
+    }
+    
+    fn readInt16:int (offset:int) {
+        def val:int (this.readUInt16(offset))
+        if (val >= 32768) {
+            return (val - 65536)
+        }
+        return val
+    }
+    
+    fn readUInt32:int (offset:int) {
+        def b1:int (buffer_get font.fontData offset)
+        def b2:int (buffer_get font.fontData (offset + 1))
+        def b3:int (buffer_get font.fontData (offset + 2))
+        def b4:int (buffer_get font.fontData (offset + 3))
+        return (((((b1 * 256) + b2) * 256) + b3) * 256 + b4)
+    }
+}

--- a/gallery/game_engine/v2/menu/RgLauncherUi.rgr
+++ b/gallery/game_engine/v2/menu/RgLauncherUi.rgr
@@ -1,0 +1,129 @@
+; ==============================================================================
+; RgLauncherUi — the rich EVG/UI launcher screen (engine chrome).
+; ==============================================================================
+; Built on the existing v2 UI layer (UILayer + UITextRenderer + SoftCanvas): a
+; title, a subtitle, category cards (Games / Tests) with a moving selection
+; highlight, and a footer hint — the v1 launcher screen. Renders headlessly into
+; a SoftCanvas whose raw() RGBA the SDL host presents; no game logic, and it does
+; not touch ranger:core (this is engine chrome, like RgGameHost — GAMES stay
+; TSX-only).
+;
+; Input is logical (moveSelection / activate); the SDL host maps physical keys.
+; ==============================================================================
+
+Import "../ui/UILayer.rgr"
+Import "../framebuffer.rgr"
+Import "../evg/EVGColor.rgr"
+
+; one selectable category (id is the launch target / route)
+class RgLauncherCat {
+    def label:string ""
+    def route:string ""
+    def card:UIBox (new UIBox)
+}
+
+class RgLauncherUi {
+    def canvas:SoftCanvas (new SoftCanvas)
+    def layer:UILayer (new UILayer)
+    def w:int 0
+    def h:int 0
+    def selected:int 0
+    def cats:[RgLauncherCat]
+
+    fn addCategory:void (label:string route:string cx:int cy:int cw:int ch:int) {
+        def c:RgLauncherCat (new RgLauncherCat)
+        c.label = label
+        c.route = route
+        c.card.text = label
+        c.card.fontSize = 20.0
+        c.card.setBounds(cx cy cw ch)
+        this.layer.add(c.card)
+        push this.cats c
+    }
+
+    fn init:void (width:int height:int) {
+        this.w = width
+        this.h = height
+        this.canvas.init(width height)
+        this.layer.attach(this.canvas)
+        ; real TTF if present; UITextRenderer falls back to its 3x5 bitmap font.
+        this.layer.ctx.tr.addFontDir("gallery/pdf_writer/assets/fonts")
+
+        def cx:int (idiv width 2)
+
+        def title:UILabel (new UILabel)
+        title.text = "Ranger"
+        title.fontSize = 40.0
+        title.setBounds((cx - 90) (idiv height 12) 180 48)
+        this.layer.add(title)
+
+        def sub:UILabel (new UILabel)
+        sub.text = "valitse kategoria"
+        sub.fontSize = 16.0
+        sub.setBounds((cx - 80) (idiv height 5) 160 20)
+        this.layer.add(sub)
+
+        ; two category cards, centred
+        def cardW:int (idiv width 4)
+        def cardH:int cardW
+        def gap:int 24
+        def totalW:int ((cardW * 2) + gap)
+        def startX:int (cx - (idiv totalW 2))
+        def cardY:int (idiv height 3)
+        this.addCategory("Games" "games" startX cardY cardW cardH)
+        this.addCategory("Tests" "tests" (startX + cardW + gap) cardY cardW cardH)
+
+        def footer:UILabel (new UILabel)
+        footer.text = "A avaa, nuolet liikkuvat"
+        footer.fontSize = 13.0
+        footer.setBounds((cx - 110) (height - (idiv height 10)) 220 16)
+        this.layer.add(footer)
+
+        this.highlight()
+    }
+
+    ; the selected card takes the accent fill; the rest a muted panel fill.
+    fn highlight:void () {
+        def n:int (array_length this.cats)
+        def i 0
+        while (i < n) {
+            def c:RgLauncherCat (itemAt this.cats i)
+            if (i == this.selected) {
+                def accent:EVGColor (EVGColor.rgba(255 190 70 1.0))
+                c.card.setFill(accent)
+            } {
+                def muted:EVGColor (EVGColor.rgba(40 48 74 0.9))
+                c.card.setFill(muted)
+            }
+            i = (i + 1)
+        }
+    }
+
+    fn moveSelection:void (dir:int) {
+        def n:int (array_length this.cats)
+        if (n == 0) { return }
+        def s:int (this.selected + dir)
+        if (s < 0) { s = 0 }
+        if (s >= n) { s = (n - 1) }
+        this.selected = s
+        this.highlight()
+    }
+
+    fn selectedLabel:string () {
+        if ((array_length this.cats) == 0) { return "" }
+        def c:RgLauncherCat (itemAt this.cats this.selected)
+        return c.label
+    }
+    fn selectedRoute:string () {
+        if ((array_length this.cats) == 0) { return "" }
+        def c:RgLauncherCat (itemAt this.cats this.selected)
+        return c.route
+    }
+    fn categoryCount:int () { return (array_length this.cats) }
+
+    fn render:void () {
+        this.canvas.clear(16 18 34)   ; night background (v1 launcher)
+        this.layer.render()
+    }
+    fn raw:buffer () { return (this.canvas.raw()) }
+}

--- a/gallery/game_engine/v2/menu/RgLauncherUi.rgr
+++ b/gallery/game_engine/v2/menu/RgLauncherUi.rgr
@@ -1,25 +1,38 @@
 ; ==============================================================================
 ; RgLauncherUi — the rich EVG/UI launcher screen (engine chrome).
 ; ==============================================================================
-; Built on the existing v2 UI layer (UILayer + UITextRenderer + SoftCanvas): a
-; title, a subtitle, category cards (Games / Tests) with a moving selection
-; highlight, and a footer hint — the v1 launcher screen. Renders headlessly into
-; a SoftCanvas whose raw() RGBA the SDL host presents; no game logic, and it does
-; not touch ranger:core (this is engine chrome, like RgGameHost — GAMES stay
-; TSX-only).
+; Built on the self-contained v2 UI layer (UILayer + UITextRenderer + SoftCanvas
+; + fonts, all under v2): a title, a subtitle, a row of cards with a moving
+; accent highlight, and a footer hint — the v1 launcher screen. It has TWO pages:
+;   page 0  CATEGORIES ("valitse kategoria")  — Games / Tests
+;   page 1  ENTRIES     (the chosen category) — the games/tests in it
+; Renders headlessly into a SoftCanvas whose raw() RGBA the SDL host presents.
 ;
-; Input is logical (moveSelection / activate); the SDL host maps physical keys.
+; It is engine chrome, like RgGameHost: NO game logic, and it does not touch
+; ranger:core (GAMES stay TSX-only). Input is logical (moveSelection / activate /
+; back); the SDL host maps physical keys. On activating an entry the host reads
+; selectedDir()/selectedFile() and hands off through the same generic
+; RgGameHost.load the tests use — the launcher never launches anything itself.
 ; ==============================================================================
 
 Import "../ui/UILayer.rgr"
 Import "../framebuffer.rgr"
 Import "../evg/EVGColor.rgr"
 
-; one selectable category (id is the launch target / route)
+; one launchable entry inside a category (dir/file is the game folder handoff)
+class RgLauncherEntry {
+    def label:string ""
+    def dir:string ""
+    def file:string ""
+    def card:UIBox (new UIBox)
+}
+
+; one selectable category (route is the logical id; entries are its games)
 class RgLauncherCat {
     def label:string ""
     def route:string ""
     def card:UIBox (new UIBox)
+    def entries:[RgLauncherEntry]
 }
 
 class RgLauncherUi {
@@ -27,18 +40,42 @@ class RgLauncherUi {
     def layer:UILayer (new UILayer)
     def w:int 0
     def h:int 0
-    def selected:int 0
-    def cats:[RgLauncherCat]
 
-    fn addCategory:void (label:string route:string cx:int cy:int cw:int ch:int) {
+    def page:int 0        ; 0 = categories, 1 = entries
+    def selected:int 0    ; index within the CURRENT page
+    def activeCat:int 0   ; which category's entries page 1 shows
+
+    def cats:[RgLauncherCat]
+    def sub:UILabel (new UILabel)
+    def footer:UILabel (new UILabel)
+
+    ; ---- construction --------------------------------------------------------
+    fn addCategory:RgLauncherCat (label:string route:string) {
         def c:RgLauncherCat (new RgLauncherCat)
         c.label = label
         c.route = route
         c.card.text = label
         c.card.fontSize = 20.0
-        c.card.setBounds(cx cy cw ch)
-        this.layer.add(c.card)
         push this.cats c
+        return c
+    }
+
+    fn addEntry:void (c:RgLauncherCat label:string dir:string file:string) {
+        def e:RgLauncherEntry (new RgLauncherEntry)
+        e.label = label
+        e.dir = dir
+        e.file = file
+        e.card.text = label
+        e.card.fontSize = 18.0
+        push c.entries e
+    }
+
+    ; lay out `n` cards centred in the card row, calling back is inlined here:
+    ; returns the startX so the caller can position each card by index.
+    fn rowStartX:int (n:int cardW:int gap:int) {
+        def cx:int (idiv this.w 2)
+        def totalW:int ((cardW * n) + (gap * (n - 1)))
+        return (cx - (idiv totalW 2))
     }
 
     fn init:void (width:int height:int) {
@@ -57,50 +94,129 @@ class RgLauncherUi {
         title.setBounds((cx - 90) (idiv height 12) 180 48)
         this.layer.add(title)
 
-        def sub:UILabel (new UILabel)
-        sub.text = "valitse kategoria"
-        sub.fontSize = 16.0
-        sub.setBounds((cx - 80) (idiv height 5) 160 20)
-        this.layer.add(sub)
+        this.sub.text = "valitse kategoria"
+        this.sub.fontSize = 16.0
+        this.sub.setBounds((cx - 90) (idiv height 5) 180 20)
+        this.layer.add(this.sub)
 
-        ; two category cards, centred
+        ; ---- the catalog (engine chrome config, not game logic) -------------
+        def games:RgLauncherCat (this.addCategory("Games" "games"))
+        this.addEntry(games "Pomppija" "gallery/game_engine/v2/games/ylos2" "index.tsx")
+        this.addEntry(games "Chess"    "gallery/game_engine/v2/games/chess"  "index.tsx")
+        this.addEntry(games "Breakout" "gallery/game_engine/v2/games/breakout" "index.tsx")
+
+        def tests:RgLauncherCat (this.addCategory("Tests" "tests"))
+        this.addEntry(tests "Sprites" "gallery/game_engine/v2/tests/sprite_char" "index.tsx")
+
+        ; ---- lay out the category cards (page 0) ----------------------------
         def cardW:int (idiv width 4)
         def cardH:int cardW
         def gap:int 24
-        def totalW:int ((cardW * 2) + gap)
-        def startX:int (cx - (idiv totalW 2))
         def cardY:int (idiv height 3)
-        this.addCategory("Games" "games" startX cardY cardW cardH)
-        this.addCategory("Tests" "tests" (startX + cardW + gap) cardY cardW cardH)
-
-        def footer:UILabel (new UILabel)
-        footer.text = "A avaa, nuolet liikkuvat"
-        footer.fontSize = 13.0
-        footer.setBounds((cx - 110) (height - (idiv height 10)) 220 16)
-        this.layer.add(footer)
-
-        this.highlight()
-    }
-
-    ; the selected card takes the accent fill; the rest a muted panel fill.
-    fn highlight:void () {
-        def n:int (array_length this.cats)
+        def nCats:int (array_length this.cats)
+        def startX:int (this.rowStartX(nCats cardW gap))
         def i 0
-        while (i < n) {
+        while (i < nCats) {
             def c:RgLauncherCat (itemAt this.cats i)
-            if (i == this.selected) {
-                def accent:EVGColor (EVGColor.rgba(255 190 70 1.0))
-                c.card.setFill(accent)
-            } {
-                def muted:EVGColor (EVGColor.rgba(40 48 74 0.9))
-                c.card.setFill(muted)
+            def cxi:int (startX + (i * (cardW + gap)))
+            c.card.setBounds(cxi cardY cardW cardH)
+            this.layer.add(c.card)
+            ; ---- lay out that category's entry cards (page 1), hidden -------
+            def ents:[RgLauncherEntry] c.entries
+            def ne:int (array_length ents)
+            def eCardW:int (idiv width 5)
+            def eGap:int 20
+            def eStartX:int (this.rowStartX(ne eCardW eGap))
+            def j 0
+            while (j < ne) {
+                def e:RgLauncherEntry (itemAt ents j)
+                def exj:int (eStartX + (j * (eCardW + eGap)))
+                e.card.setBounds(exj cardY eCardW cardH)
+                e.card.visible = false
+                this.layer.add(e.card)
+                j = (j + 1)
             }
             i = (i + 1)
         }
+
+        this.footer.text = "A avaa, nuolet liikkuvat"
+        this.footer.fontSize = 13.0
+        this.footer.setBounds((cx - 110) (height - (idiv height 10)) 220 16)
+        this.layer.add(this.footer)
+
+        this.selected = 0
+        this.applyPage()
     }
 
+    ; ---- page state ----------------------------------------------------------
+    ; how many cards the current page navigates over
+    fn pageCount:int () {
+        if (this.page == 0) { return (array_length this.cats) }
+        def c:RgLauncherCat (itemAt this.cats this.activeCat)
+        return (array_length c.entries)
+    }
+
+    ; set card visibility for the current page and re-apply the accent highlight
+    fn applyPage:void () {
+        def nCats:int (array_length this.cats)
+        def i 0
+        while (i < nCats) {
+            def c:RgLauncherCat (itemAt this.cats i)
+            def catVisible:boolean (this.page == 0)
+            c.card.visible = catVisible
+            def ents:[RgLauncherEntry] c.entries
+            def ne:int (array_length ents)
+            def j 0
+            while (j < ne) {
+                def e:RgLauncherEntry (itemAt ents j)
+                def show:boolean false
+                if (this.page == 1) {
+                    if (i == this.activeCat) { show = true }
+                }
+                e.card.visible = show
+                j = (j + 1)
+            }
+            i = (i + 1)
+        }
+        if (this.page == 0) {
+            this.sub.text = "valitse kategoria"
+            this.footer.text = "A avaa, nuolet liikkuvat"
+        } {
+            def ac:RgLauncherCat (itemAt this.cats this.activeCat)
+            this.sub.text = ac.label
+            this.footer.text = "A valitsee, B takaisin"
+        }
+        this.highlight()
+    }
+
+    ; the selected card takes the (opaque) accent fill; the rest a muted panel.
+    fn highlight:void () {
+        def accent:EVGColor (EVGColor.rgba(255 190 70 1.0))
+        def muted:EVGColor (EVGColor.rgba(40 48 74 0.9))
+        if (this.page == 0) {
+            def n:int (array_length this.cats)
+            def i 0
+            while (i < n) {
+                def c:RgLauncherCat (itemAt this.cats i)
+                if (i == this.selected) { c.card.setFill(accent) } { c.card.setFill(muted) }
+                i = (i + 1)
+            }
+            return
+        }
+        def ac:RgLauncherCat (itemAt this.cats this.activeCat)
+        def ents:[RgLauncherEntry] ac.entries
+        def ne:int (array_length ents)
+        def k 0
+        while (k < ne) {
+            def e:RgLauncherEntry (itemAt ents k)
+            if (k == this.selected) { e.card.setFill(accent) } { e.card.setFill(muted) }
+            k = (k + 1)
+        }
+    }
+
+    ; ---- logical navigation (host maps physical keys) ------------------------
     fn moveSelection:void (dir:int) {
-        def n:int (array_length this.cats)
+        def n:int (this.pageCount())
         if (n == 0) { return }
         def s:int (this.selected + dir)
         if (s < 0) { s = 0 }
@@ -109,18 +225,63 @@ class RgLauncherUi {
         this.highlight()
     }
 
-    fn selectedLabel:string () {
-        if ((array_length this.cats) == 0) { return "" }
-        def c:RgLauncherCat (itemAt this.cats this.selected)
-        return c.label
+    ; page 0: enter the chosen category (returns 0, nothing to launch).
+    ; page 1: returns 1 — the host reads selectedDir()/selectedFile() to hand off.
+    fn activate:int () {
+        if (this.page == 0) {
+            this.activeCat = this.selected
+            this.page = 1
+            this.selected = 0
+            this.applyPage()
+            return 0
+        }
+        return 1
     }
+
+    fn back:void () {
+        if (this.page == 1) {
+            this.page = 0
+            this.selected = this.activeCat
+            this.applyPage()
+        }
+    }
+
+    ; ---- queries -------------------------------------------------------------
+    fn categoryCount:int () { return (array_length this.cats) }
+    fn currentPage:int () { return this.page }
+
+    fn selectedLabel:string () {
+        if (this.page == 0) {
+            if ((array_length this.cats) == 0) { return "" }
+            def c:RgLauncherCat (itemAt this.cats this.selected)
+            return c.label
+        }
+        def ac:RgLauncherCat (itemAt this.cats this.activeCat)
+        def e:RgLauncherEntry (itemAt ac.entries this.selected)
+        return e.label
+    }
+
     fn selectedRoute:string () {
         if ((array_length this.cats) == 0) { return "" }
         def c:RgLauncherCat (itemAt this.cats this.selected)
         return c.route
     }
-    fn categoryCount:int () { return (array_length this.cats) }
 
+    ; the game-folder handoff target of the selected ENTRY (page 1); "" on page 0
+    fn selectedDir:string () {
+        if (this.page == 0) { return "" }
+        def ac:RgLauncherCat (itemAt this.cats this.activeCat)
+        def e:RgLauncherEntry (itemAt ac.entries this.selected)
+        return e.dir
+    }
+    fn selectedFile:string () {
+        if (this.page == 0) { return "" }
+        def ac:RgLauncherCat (itemAt this.cats this.activeCat)
+        def e:RgLauncherEntry (itemAt ac.entries this.selected)
+        return e.file
+    }
+
+    ; ---- present -------------------------------------------------------------
     fn render:void () {
         this.canvas.clear(16 18 34)   ; night background (v1 launcher)
         this.layer.render()

--- a/gallery/game_engine/v2/menu/tests/launcher_ui_test.rgr
+++ b/gallery/game_engine/v2/menu/tests/launcher_ui_test.rgr
@@ -95,6 +95,47 @@ class LauncherUiTest {
         def leftAccentB:int (LauncherUiTest.countColor(ui 0 0 240 270 255 190 70))
         t.eqInt("Games card no longer accent" leftAccentB 0)
 
+        ; ---- two-level navigation + game handoff ---------------------------
+        def ui2:RgLauncherUi (new RgLauncherUi)
+        ui2.init(480 270)
+        t.eqInt("starts on the category page" (ui2.currentPage()) 0)
+        t.eqStr("no handoff target on the category page" (ui2.selectedDir()) "")
+
+        ; enter the Games category: activate returns 0 (nothing to launch yet)
+        def a0:int (ui2.activate())
+        t.eqInt("activating a category does not launch" a0 0)
+        t.eqInt("now on the entries page" (ui2.currentPage()) 1)
+        t.eqStr("first Games entry is Pomppija" (ui2.selectedLabel()) "Pomppija")
+        t.eqStr("Pomppija handoff dir" (ui2.selectedDir()) "gallery/game_engine/v2/games/ylos2")
+        t.eqStr("Pomppija handoff file" (ui2.selectedFile()) "index.tsx")
+
+        ; navigate the entries and clamp at the end (Games has 3)
+        ui2.moveSelection(1)
+        t.eqStr("second Games entry is Chess" (ui2.selectedLabel()) "Chess")
+        ui2.moveSelection(9)
+        t.eqStr("entries clamp at Breakout" (ui2.selectedLabel()) "Breakout")
+
+        ; activating an entry reports launch (1); the host reads dir/file
+        def a1:int (ui2.activate())
+        t.eqInt("activating an entry hands off" a1 1)
+        t.eqStr("Breakout handoff dir" (ui2.selectedDir()) "gallery/game_engine/v2/games/breakout")
+
+        ; back returns to the category page, on the category we came from
+        ui2.back()
+        t.eqInt("back to the category page" (ui2.currentPage()) 0)
+        t.eqStr("restored to the Games category" (ui2.selectedLabel()) "Games")
+
+        ; a different category yields a different entry set
+        ui2.moveSelection(1)
+        def a2:int (ui2.activate())
+        t.eqStr("Tests category entry is Sprites" (ui2.selectedLabel()) "Sprites")
+        t.eqStr("Sprites handoff dir" (ui2.selectedDir()) "gallery/game_engine/v2/tests/sprite_char")
+
+        ; page 1 renders the entry cards (accent present somewhere)
+        ui2.render()
+        def entAccent:int (LauncherUiTest.countColor(ui2 0 0 480 270 255 190 70))
+        t.ok("entry page renders an accent card" (entAccent > 0))
+
         t.summary()
     }
 }

--- a/gallery/game_engine/v2/menu/tests/launcher_ui_test.rgr
+++ b/gallery/game_engine/v2/menu/tests/launcher_ui_test.rgr
@@ -1,0 +1,100 @@
+; ==============================================================================
+; launcher_ui_test — the rich EVG/UI launcher screen renders + navigates.
+; ==============================================================================
+; Asserts the launcher composes its categories, that selection navigation moves
+; (and clamps), that rendering actually draws pixels into the SoftCanvas, and
+; that the accent highlight follows the selected card (Games -> Tests). Reads
+; the rendered RGBA back out of canvas.raw(), so it exercises the real UI text /
+; panel raster path, not just the model.
+; ==============================================================================
+
+Import "../RgLauncherUi.rgr"
+Import "../../tests/harness/RgTest.rgr"
+
+class LauncherUiTest {
+    ; count pixels of colour (r,g,b) inside a rect of the launcher's RGBA canvas
+    sfn countColor:int (ui:RgLauncherUi x0:int y0:int x1:int y1:int r:int g:int b:int) {
+        def buf:buffer (ui.raw())
+        def w:int ui.w
+        def n 0
+        def y y0
+        while (y < y1) {
+            def x x0
+            while (x < x1) {
+                def off:int (((y * w) + x) * 4)
+                def pr:int (buffer_get buf off)
+                def pg:int (buffer_get buf (off + 1))
+                def pb:int (buffer_get buf (off + 2))
+                if (pr == r) {
+                    if (pg == g) {
+                        if (pb == b) { n = (n + 1) }
+                    }
+                }
+                x = (x + 1)
+            }
+            y = (y + 1)
+        }
+        return n
+    }
+
+    ; any pixel not the night background (16,18,34) in the whole canvas
+    sfn nonBackground:int (ui:RgLauncherUi) {
+        def buf:buffer (ui.raw())
+        def total:int (ui.w * ui.h)
+        def n 0
+        def i 0
+        while (i < total) {
+            def off:int (i * 4)
+            def pr:int (buffer_get buf off)
+            def pg:int (buffer_get buf (off + 1))
+            def pb:int (buffer_get buf (off + 2))
+            def bg:boolean false
+            if (pr == 16) {
+                if (pg == 18) {
+                    if (pb == 34) { bg = true }
+                }
+            }
+            if (bg == false) { n = (n + 1) }
+            i = (i + 1)
+        }
+        return n
+    }
+
+    sfn m@(main):void () {
+        def t:RgTest (RgTest.forSuite("menu/launcher_ui (EVG/UI launcher)"))
+        def ui:RgLauncherUi (new RgLauncherUi)
+        ui.init(480 270)
+
+        ; ---- categories + navigation model ---------------------------------
+        t.eqInt("two categories" (ui.categoryCount()) 2)
+        t.eqStr("Games selected first" (ui.selectedLabel()) "Games")
+        t.eqStr("route is games" (ui.selectedRoute()) "games")
+        ui.moveSelection(1)
+        t.eqStr("right selects Tests" (ui.selectedLabel()) "Tests")
+        ui.moveSelection(1)
+        t.eqStr("right clamps at the last category" (ui.selectedLabel()) "Tests")
+        ui.moveSelection(0 - 5)
+        t.eqStr("left clamps back to Games" (ui.selectedLabel()) "Games")
+
+        ; ---- it actually renders pixels ------------------------------------
+        ui.render()
+        t.ok("something was drawn into the canvas" ((LauncherUiTest.nonBackground(ui)) > 0))
+
+        ; ---- accent highlight follows the selection ------------------------
+        ; Games selected: accent (255,190,70) appears in the LEFT half.
+        def leftAccent:int (LauncherUiTest.countColor(ui 0 0 240 270 255 190 70))
+        t.ok("selected (Games) card is accent-filled on the left" (leftAccent > 0))
+        def rightAccentA:int (LauncherUiTest.countColor(ui 240 0 480 270 255 190 70))
+        t.eqInt("the right (Tests) card is NOT accent while Games selected" rightAccentA 0)
+
+        ; select Tests, re-render: accent moves to the RIGHT half.
+        ui.moveSelection(1)
+        ui.render()
+        def rightAccentB:int (LauncherUiTest.countColor(ui 240 0 480 270 255 190 70))
+        t.ok("selecting Tests moves the accent to the right card" (rightAccentB > 0))
+        def leftAccentB:int (LauncherUiTest.countColor(ui 0 0 240 270 255 190 70))
+        t.eqInt("Games card no longer accent" leftAccentB 0)
+
+        t.summary()
+    }
+}

--- a/gallery/game_engine/v2/model3d/Model3dGlUploader.rgr
+++ b/gallery/game_engine/v2/model3d/Model3dGlUploader.rgr
@@ -21,7 +21,7 @@
 ; ==============================================================================
 
 Import "Model3dScriptBridge.rgr"
-Import "../gfx_sdl.rgr"
+Import "../runtime/sdl/gfx_sdl.rgr"
 
 class Model3dGlUploader extends Mesh3dUploader {
     def glEnabled:boolean true

--- a/gallery/game_engine/v2/render/backends/software/RgSoftwareRenderer2D.rgr
+++ b/gallery/game_engine/v2/render/backends/software/RgSoftwareRenderer2D.rgr
@@ -67,6 +67,29 @@ class RgFramebuffer {
         set this.pixels ((py * this.width) + px) color
     }
 
+    ; Pack the 0xRRGGBB int grid into a tightly-packed RGBA byte buffer
+    ; (w*h*4, opaque) — the format the native present operators (gfx_present /
+    ; gfx_present_split, SDL_PIXELFORMAT_RGBA32) expect. Pure conversion;
+    ; testable headlessly, independent of any window.
+    fn toRgbaBuffer:buffer () {
+        def n:int (this.width * this.height)
+        def buf:buffer (buffer_alloc (n * 4))
+        def i 0
+        while (i < n) {
+            def c:int (itemAt this.pixels i)
+            def r:int (idiv c 65536)
+            def g:int (idiv (c - (r * 65536)) 256)
+            def b:int ((c - (r * 65536)) - (g * 256))
+            def o:int (i * 4)
+            buffer_set buf o r
+            buffer_set buf (o + 1) g
+            buffer_set buf (o + 2) b
+            buffer_set buf (o + 3) 255
+            i = (i + 1)
+        }
+        return buf
+    }
+
     ; ---- immediate-mode fills (v1 SoftCanvas parity, 0xRRGGBB grid) ----------
     ; Clipped opaque rectangle. Mirrors SoftCanvas.fillRect (framebuffer.rgr):
     ; the static-environment primitive the game paints platforms/sky/flag with.

--- a/gallery/game_engine/v2/rgba_fast_blit.rgr
+++ b/gallery/game_engine/v2/rgba_fast_blit.rgr
@@ -1,0 +1,234 @@
+; ==============================================================================
+; rgba_fast_blit — buffer-level RGBA blit for real-time compositing.
+; ==============================================================================
+; Avoids per-pixel Color / RasterPixel allocations. Uses direct buffer byte
+; access and integer source-over blending for partial alpha.
+
+Import "imaging/jpeg/ImageBuffer.rgr"
+Import "imaging/raster/RasterBuffer.rgr"
+
+class RgbaFastBlit {
+    fn clamp255:int (n:int) {
+        if (n < 0) {
+            return 0
+        }
+        if (n > 255) {
+            return 255
+        }
+        return n
+    }
+
+    fn div256:int (n:int) {
+        return (bit_shr n 8)
+    }
+
+    fn blendChan:int (src:int dst:int srcA:int invA:int) {
+        def mix:int ((src * srcA) + (dst * invA))
+        def scaled:int (this.div256(mix))
+        return (this.clamp255(scaled))
+    }
+
+    ; Porter-Duff source-over at a byte offset in dstBuf (RGBA layout).
+    fn blendOverBytes:void (dstBuf:buffer dstOff:int srcR:int srcG:int srcB:int srcA:int) {
+        if (srcA <= 0) {
+            return
+        }
+        if (srcA >= 255) {
+            buffer_set dstBuf dstOff srcR
+            buffer_set dstBuf (dstOff + 1) srcG
+            buffer_set dstBuf (dstOff + 2) srcB
+            buffer_set dstBuf (dstOff + 3) 255
+            return
+        }
+
+        def dstA:int (buffer_get dstBuf (dstOff + 3))
+        if (dstA <= 0) {
+            buffer_set dstBuf dstOff srcR
+            buffer_set dstBuf (dstOff + 1) srcG
+            buffer_set dstBuf (dstOff + 2) srcB
+            buffer_set dstBuf (dstOff + 3) srcA
+            return
+        }
+
+        def invA:int (255 - srcA)
+        def dstR:int (buffer_get dstBuf dstOff)
+        def dstG:int (buffer_get dstBuf (dstOff + 1))
+        def dstB:int (buffer_get dstBuf (dstOff + 2))
+
+        def outR:int (this.blendChan(srcR dstR srcA invA))
+        def outG:int (this.blendChan(srcG dstG srcA invA))
+        def outB:int (this.blendChan(srcB dstB srcA invA))
+        def alphaMix:int (this.div256(dstA * invA))
+        def outA:int (this.clamp255(srcA + alphaMix))
+
+        buffer_set dstBuf dstOff outR
+        buffer_set dstBuf (dstOff + 1) outG
+        buffer_set dstBuf (dstOff + 2) outB
+        buffer_set dstBuf (dstOff + 3) outA
+    }
+
+    fn copyOpaquePixel:void (dstBuf:buffer dstOff:int srcBuf:buffer srcOff:int) {
+        buffer_set dstBuf dstOff (buffer_get srcBuf srcOff)
+        buffer_set dstBuf (dstOff + 1) (buffer_get srcBuf (srcOff + 1))
+        buffer_set dstBuf (dstOff + 2) (buffer_get srcBuf (srcOff + 2))
+        buffer_set dstBuf (dstOff + 3) 255
+    }
+
+    fn copyOpaquePixelRaster:void (dest:RasterBuffer dstOff:int srcBuf:buffer srcOff:int) {
+        buffer_set dest.pixels dstOff (buffer_get srcBuf srcOff)
+        buffer_set dest.pixels (dstOff + 1) (buffer_get srcBuf (srcOff + 1))
+        buffer_set dest.pixels (dstOff + 2) (buffer_get srcBuf (srcOff + 2))
+        buffer_set dest.pixels (dstOff + 3) 255
+    }
+
+    fn blendOverBytesRaster:void (dest:RasterBuffer dstOff:int srcR:int srcG:int srcB:int srcA:int) {
+        if (srcA <= 0) {
+            return
+        }
+        if (srcA >= 255) {
+            buffer_set dest.pixels dstOff srcR
+            buffer_set dest.pixels (dstOff + 1) srcG
+            buffer_set dest.pixels (dstOff + 2) srcB
+            buffer_set dest.pixels (dstOff + 3) 255
+            return
+        }
+
+        def dstA:int (buffer_get dest.pixels (dstOff + 3))
+        if (dstA <= 0) {
+            buffer_set dest.pixels dstOff srcR
+            buffer_set dest.pixels (dstOff + 1) srcG
+            buffer_set dest.pixels (dstOff + 2) srcB
+            buffer_set dest.pixels (dstOff + 3) srcA
+            return
+        }
+
+        def invA:int (255 - srcA)
+        def dstR:int (buffer_get dest.pixels dstOff)
+        def dstG:int (buffer_get dest.pixels (dstOff + 1))
+        def dstB:int (buffer_get dest.pixels (dstOff + 2))
+
+        def outR:int (this.blendChan(srcR dstR srcA invA))
+        def outG:int (this.blendChan(srcG dstG srcA invA))
+        def outB:int (this.blendChan(srcB dstB srcA invA))
+        def alphaMix:int (this.div256(dstA * invA))
+        def outA:int (this.clamp255(srcA + alphaMix))
+
+        buffer_set dest.pixels dstOff outR
+        buffer_set dest.pixels (dstOff + 1) outG
+        buffer_set dest.pixels (dstOff + 2) outB
+        buffer_set dest.pixels (dstOff + 3) outA
+    }
+
+    ; First layer onto a cleared buffer: copy source pixels, no blending.
+    fn blitFirstLayer:void (dest:RasterBuffer src:ImageBuffer dx:int dy:int) {
+        def srcBuf:buffer (src.getRawBuffer())
+        def destW:int (dest.width)
+        def srcW:int (src.width)
+        def sh:int (src.height)
+        def sw:int (src.width)
+
+        def y 0
+        while (y < sh) {
+            def srcRowOff:int (y * srcW * 4)
+            def dstRowOff:int (((dy + y) * destW) + dx) * 4
+            def x 0
+            while (x < sw) {
+                def sOff:int (srcRowOff + (x * 4))
+                def srcA:int (buffer_get srcBuf (sOff + 3))
+                if (srcA > 0) {
+                    def dOff:int (dstRowOff + (x * 4))
+                    if (srcA >= 255) {
+                        this.copyOpaquePixelRaster(dest dOff srcBuf sOff)
+                    } {
+                        buffer_set dest.pixels dOff (buffer_get srcBuf sOff)
+                        buffer_set dest.pixels (dOff + 1) (buffer_get srcBuf (sOff + 1))
+                        buffer_set dest.pixels (dOff + 2) (buffer_get srcBuf (sOff + 2))
+                        buffer_set dest.pixels (dOff + 3) srcA
+                    }
+                }
+                x = (x + 1)
+            }
+            y = (y + 1)
+        }
+    }
+
+    fn blitRect:void (dest:RasterBuffer src:ImageBuffer sx:int sy:int sw:int sh:int dx:int dy:int) {
+        def srcBuf:buffer (src.getRawBuffer())
+        def destW:int (dest.width)
+        def srcW:int (src.width)
+
+        def y 0
+        while (y < sh) {
+            def srcRowOff:int ((((sy + y) * srcW) + sx) * 4)
+            def dstRowOff:int ((((dy + y) * destW) + dx) * 4)
+            def x 0
+            while (x < sw) {
+                def sOff:int (srcRowOff + (x * 4))
+                def srcA:int (buffer_get srcBuf (sOff + 3))
+                if (srcA > 0) {
+                    def dOff:int (dstRowOff + (x * 4))
+                    if (srcA >= 255) {
+                        this.copyOpaquePixelRaster(dest dOff srcBuf sOff)
+                        x = (x + 1)
+                    } {
+                        this.blendOverBytesRaster(dest dOff
+                            (buffer_get srcBuf sOff)
+                            (buffer_get srcBuf (sOff + 1))
+                            (buffer_get srcBuf (sOff + 2))
+                            srcA)
+                        x = (x + 1)
+                    }
+                } {
+                    x = (x + 1)
+                }
+            }
+            y = (y + 1)
+        }
+    }
+
+    fn blitImage:void (dest:RasterBuffer src:ImageBuffer dx:int dy:int) {
+        this.blitRect(dest src 0 0 src.width src.height dx dy)
+    }
+
+    ; Alpha-composite a source sub-rectangle straight into a raw destination
+    ; buffer (RGBA8888, width destW). Unlike blitRect(dest:RasterBuffer ...),
+    ; the destination is a `buffer` passed by reference, so it works when the
+    ; caller only has the raw pixel bytes (SoftCanvas.px). This is the C++-safe
+    ; path: wrapping the canvas bytes in a temporary RasterBuffer copies the
+    ; std::vector under C++ value semantics and silently drops the writes.
+    fn blitRectBuf:void (dstBuf:buffer destW:int src:ImageBuffer sx:int sy:int sw:int sh:int dx:int dy:int) {
+        def srcBuf:buffer (src.getRawBuffer())
+        def srcW:int (src.width)
+        def y 0
+        while (y < sh) {
+            def srcRowOff:int ((((sy + y) * srcW) + sx) * 4)
+            def dstRowOff:int ((((dy + y) * destW) + dx) * 4)
+            def x 0
+            while (x < sw) {
+                def sOff:int (srcRowOff + (x * 4))
+                def srcA:int (buffer_get srcBuf (sOff + 3))
+                if (srcA > 0) {
+                    def dOff:int (dstRowOff + (x * 4))
+                    if (srcA >= 255) {
+                        ; opaque: direct copy. Writing dstBuf here (buffer_set)
+                        ; also marks the parameter as mutated so it is emitted as
+                        ; a non-const C++ reference (works without the transitive
+                        ; mutable-ref compiler pass).
+                        buffer_set dstBuf dOff (buffer_get srcBuf sOff)
+                        buffer_set dstBuf (dOff + 1) (buffer_get srcBuf (sOff + 1))
+                        buffer_set dstBuf (dOff + 2) (buffer_get srcBuf (sOff + 2))
+                        buffer_set dstBuf (dOff + 3) 255
+                    } {
+                        this.blendOverBytes(dstBuf dOff
+                            (buffer_get srcBuf sOff)
+                            (buffer_get srcBuf (sOff + 1))
+                            (buffer_get srcBuf (sOff + 2))
+                            srcA)
+                    }
+                }
+                x = (x + 1)
+            }
+            y = (y + 1)
+        }
+    }
+}

--- a/gallery/game_engine/v2/runtime/sdl/README.md
+++ b/gallery/game_engine/v2/runtime/sdl/README.md
@@ -1,0 +1,60 @@
+# runtime/sdl — native SDL2 host (macOS / Pi)
+
+The single native platform boundary of the v2 2D stack. It drives the **same
+generic** `RgGameHost` + registry bridge + `Rg2DPresenter` the headless tests
+use, adding a real window, real input, and real haptics — with **no game
+knowledge** and **no additions to `ranger:core`**.
+
+## Boundary (what does NOT leak)
+
+- The guest (`.tsx`) reaches input/audio/etc. through `runtime.*` exactly as in
+  the headless build — it never sees SDL, a window, or a pad.
+- `ranger:core` is unchanged; it lowers to the same `rgcore_*` commands.
+- `RgSdlGameHost` only feeds the **host-side** devices (`bridge.input.setAction`
+  from the SDL mask) and reads **host-side** state (the `RgFramebuffer`, the
+  recorded rumble) to forward to SDL. Game logic stays in the `.tsx`.
+- The physical-key → logical-action map (`mapMask`) is host input *config*, not
+  game logic; a game only ever sees logical actions (`left`, `jump`, …).
+
+## Files
+
+- `RgSdlGameHost.rgr` — the driver: open window, loop (poll input → actions →
+  `host.frame` → present split → forward rumble), honour the launcher handoff.
+- `RgSdlMain.rgr` — native entry; boots the launcher menu (engine infra, not a
+  game — games remain `.tsx`-only).
+- `../../../gfx_sdl.rgr` — the native `gfx_*` operators (SDL2). They carry both
+  `cpp` and `es6` templates, so this host **compiles and runs headlessly as a
+  no-op**; the real window exists only in the native build.
+
+## Input map (default keyboard)
+
+`gfx_input_source_mask(source)` bits → actions: `16`→left, `32`→right, `1`→up,
+`2`→down, `4`→action, and jump = up | action. Source `0` = P1 (WASD/Space),
+source `1` = P2 (arrows); `2..9` = gamepads.
+
+## Build + run on macOS
+
+Prereq: SDL2 (`brew install sdl2`). From the repo root:
+
+```sh
+# 1. Ranger -> C++
+node bin/output.js -cpp gallery/game_engine/v2/runtime/sdl/RgSdlMain.rgr \
+  -d=build/sdl -o=RgSdlMain.cpp
+
+# 2. C++ -> binary, linked against SDL2 (uses gfx_sdl's rgfx_* shim)
+clang++ -std=c++17 -O2 build/sdl/RgSdlMain.cpp \
+  $(sdl2-config --cflags --libs) -o build/sdl/ranger-v2
+
+# 3. run from the repo root (assets resolve relative to CWD via pkg://)
+./build/sdl/ranger-v2
+```
+
+A window opens on the launcher; pick a game (e.g. Pomppija/ylos2). WASD + Space
+drives P1, arrows drive P2; a game's `runtime.input.player(i).rumble(...)` calls
+reach the pad through `gfx_rumble_pad`.
+
+> The final SDL2 **link** needs SDL2 headers, which are absent in CI — so the
+> headless suite compile-checks the host and tests its pure seams
+> (`tests/sdl/sdl_host_test`: framebuffer→RGBA pack + input map), and the live
+> window run happens on a machine with SDL2. Audio playback additionally needs
+> the score/one-shot synth (a `gfx_audio_*` sink) — a separate follow-up.

--- a/gallery/game_engine/v2/runtime/sdl/README.md
+++ b/gallery/game_engine/v2/runtime/sdl/README.md
@@ -18,10 +18,17 @@ knowledge** and **no additions to `ranger:core`**.
 
 ## Files
 
-- `RgSdlGameHost.rgr` — the driver: open window, loop (poll input → actions →
-  `host.frame` → present split → forward rumble), honour the launcher handoff.
-- `RgSdlMain.rgr` — native entry; boots the launcher menu (engine infra, not a
+- `RgSdlGameHost.rgr` — the driver. Two entry loops share one window/present
+  path: `runLauncher()` (present the rich launcher canvas via `gfx_present`,
+  navigate on key-press *edges*, hand off the chosen game to `run`) and `run`
+  (poll input → actions → `host.frame` → present split → forward rumble, honour
+  the guest launch handoff). `launcherStep`/`mapMask`/`edge`/`toRgbaBuffer` are
+  pure host-input/present seams, unit-tested headlessly.
+- `RgSdlMain.rgr` — native entry; calls `runLauncher()` (engine chrome, not a
   game — games remain `.tsx`-only).
+- `../../menu/RgLauncherUi.rgr` — the launcher screen itself (title, subtitle,
+  category cards → game cards, moving accent). Renders into a SoftCanvas through
+  the **self-contained** v2 UI/EVG/font stack (nothing imported outside `v2/`).
 - `../../../gfx_sdl.rgr` — the native `gfx_*` operators (SDL2). They carry both
   `cpp` and `es6` templates, so this host **compiles and runs headlessly as a
   no-op**; the real window exists only in the native build.
@@ -32,29 +39,34 @@ knowledge** and **no additions to `ranger:core`**.
 `2`→down, `4`→action, and jump = up | action. Source `0` = P1 (WASD/Space),
 source `1` = P2 (arrows); `2..9` = gamepads.
 
+In the launcher these bits drive the menu on rising edges (a tap moves once):
+`16`/`32` move the selection, `4` selects (category → game list → launch), `2`
+goes back a page.
+
 ## Build + run on macOS
 
 Prereq: SDL2 (`brew install sdl2`). From the repo root:
 
 ```sh
-# 1. Ranger -> C++
-node bin/output.js -cpp gallery/game_engine/v2/runtime/sdl/RgSdlMain.rgr \
-  -d=build/sdl -o=RgSdlMain.cpp
-
-# 2. C++ -> binary, linked against SDL2 (uses gfx_sdl's rgfx_* shim)
-clang++ -std=c++17 -O2 build/sdl/RgSdlMain.cpp \
-  $(sdl2-config --cflags --libs) -o build/sdl/ranger-v2
-
-# 3. run from the repo root (assets resolve relative to CWD via pkg://)
-./build/sdl/ranger-v2
+npm run engine:game-sdl:launcher:v2
 ```
 
-A window opens on the launcher; pick a game (e.g. Pomppija/ylos2). WASD + Space
-drives P1, arrows drive P2; a game's `runtime.input.player(i).rumble(...)` calls
-reach the pad through `gfx_rumble_pad`.
+That runs `scripts/build-sdl-v2.sh`, which (1) compiles `RgSdlMain.rgr` to C++
+(`RANGER_LIB=… node bin/output.js -l=cpp … -o RgSdlMain.cpp`) and (2) links it
+against SDL2 + OpenGL into `tmp/sdl-v2/ranger-v2`, then launches it. Unlike the
+v1 game runner, the v2 host needs **no wasm3 and no libcurl** — only the
+operators it actually calls are emitted (all `SDL2/SDL.h`); GL is pulled in only
+by `gfx_sdl.rgr`'s shared prelude.
+
+A window opens on the launcher: arrows move, Space/`A` selects (Games → pick a
+game → launch), `S` goes back, Q/Esc quits. WASD + Space drives P1 in-game,
+arrows drive P2; a game's `runtime.input.player(i).rumble(...)` calls reach the
+pad through `gfx_rumble_pad`.
 
 > The final SDL2 **link** needs SDL2 headers, which are absent in CI — so the
-> headless suite compile-checks the host and tests its pure seams
-> (`tests/sdl/sdl_host_test`: framebuffer→RGBA pack + input map), and the live
-> window run happens on a machine with SDL2. Audio playback additionally needs
-> the score/one-shot synth (a `gfx_audio_*` sink) — a separate follow-up.
+> headless suite compile-checks the host, validates the Ranger→C++ codegen, and
+> tests its pure seams (`tests/sdl/sdl_host_test`: framebuffer→RGBA pack, input
+> map, launcher-nav edges; `menu/tests/launcher_ui_test`: the rendered launcher
+> screen). The live window run happens on a machine with SDL2. Audio playback
+> additionally needs the score/one-shot synth (a `gfx_audio_*` sink) — a
+> separate follow-up.

--- a/gallery/game_engine/v2/runtime/sdl/README.md
+++ b/gallery/game_engine/v2/runtime/sdl/README.md
@@ -63,10 +63,19 @@ game → launch), `S` goes back, Q/Esc quits. WASD + Space drives P1 in-game,
 arrows drive P2; a game's `runtime.input.player(i).rumble(...)` calls reach the
 pad through `gfx_rumble_pad`.
 
+## Audio
+
+A guest's `runtime.audio.music.play(score)` is recorded on the bridge
+(`rgcore_music_play`); the host owns playback. `initAudio()` opens the SDL audio
+device and builds the synth; `pumpAudio(dt)` (called each game frame) picks up a
+newly-played score, ticks its beat schedule, and each due note synthesises PCM
+that `RgSdlAudioSink` queues via `gfx_audio_queue`. The synth/parser stack lives
+under `v2/audio` (`game_soundscore` + `game_audio`, self-contained). The guest
+only ever said "play" — the schedule clock, synth, and device are all host-side.
+
 > The final SDL2 **link** needs SDL2 headers, which are absent in CI — so the
 > headless suite compile-checks the host, validates the Ranger→C++ codegen, and
 > tests its pure seams (`tests/sdl/sdl_host_test`: framebuffer→RGBA pack, input
-> map, launcher-nav edges; `menu/tests/launcher_ui_test`: the rendered launcher
-> screen). The live window run happens on a machine with SDL2. Audio playback
-> additionally needs the score/one-shot synth (a `gfx_audio_*` sink) — a
-> separate follow-up.
+> map, launcher-nav edges, the music pump; `menu/tests/launcher_ui_test`: the
+> rendered launcher screen; `audio/tests/audio_score_test`: parse→schedule→PCM).
+> The live window + audible output happen on a machine with SDL2.

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
@@ -26,6 +26,7 @@
 
 Import "../game_host/RgGameHost.rgr"
 Import "../game_host/Rg2DPresenter.rgr"
+Import "../../menu/RgLauncherUi.rgr"
 Import "../../../gfx_sdl.rgr"
 
 class RgSdlGameHost {
@@ -74,6 +75,69 @@ class RgSdlGameHost {
         def dL:int (Rg2DPresenter.presentTextured(this.host.bridge 0 fbL this.sky))
         def dR:int (Rg2DPresenter.presentTextured(this.host.bridge 1 fbR this.sky))
         gfx_present_split (fbL.toRgbaBuffer()) (fbR.toRgbaBuffer()) this.paneW this.paneH
+    }
+
+    ; Rising edge of `bit` between the previous and current input mask. PURE host
+    ; input config — used to drive the launcher menu on key-press edges (not held
+    ; state), so a single tap moves the selection once. Testable with two masks.
+    fn edge:boolean (prev:int cur:int bit:int) {
+        def wasSet:boolean ((bit_and prev bit) != 0)
+        def isSet:boolean ((bit_and cur bit) != 0)
+        return (isSet && (wasSet == false))
+    }
+
+    ; Advance the launcher menu one step from an input-mask edge transition:
+    ;   left(16)/right(32) edge -> moveSelection ; down(2) edge -> back ;
+    ;   action(4) edge -> activate. Returns 1 when an ENTRY was activated (the
+    ;   caller reads ui.selectedDir()/selectedFile() and hands off), else 0.
+    ; This is the launcher's whole input contract — no gfx, no game, testable.
+    fn launcherStep:int (prev:int cur:int ui:RgLauncherUi) {
+        if (this.edge(prev cur 16)) { ui.moveSelection(0 - 1) }
+        if (this.edge(prev cur 32)) { ui.moveSelection(1) }
+        if (this.edge(prev cur 2))  { ui.back() }
+        if (this.edge(prev cur 4)) {
+            def r:int (ui.activate())
+            if (r == 1) { return 1 }
+        }
+        return 0
+    }
+
+    ; Open a window on the rich launcher screen (engine chrome), navigate it, and
+    ; hand off to the chosen game through the SAME generic run() the tests use.
+    ; Single-surface present (gfx_present) of the launcher's SoftCanvas RGBA — the
+    ; launcher is not split. Native-only loop (gfx_* stub to no-ops under es6).
+    fn runLauncher:int () {
+        def lw:int (this.paneW * 2)
+        def lh:int this.paneH
+        if ((gfx_open "Ranger" lw lh) == 0) { return 0 }
+        def ui:RgLauncherUi (new RgLauncherUi)
+        ui.init(lw lh)
+        def prev:int 0
+        def go:boolean true
+        while go {
+            gfx_input_poll
+            def m:int (gfx_input_source_mask 0)
+            def launch:int (this.launcherStep(prev m ui))
+            prev = m
+            if (launch == 1) {
+                def d:string (ui.selectedDir())
+                def f:string (ui.selectedFile())
+                gfx_close
+                def _g:int (this.run(d f))
+                ; back from the game: reopen the launcher and resume on categories
+                gfx_clear_should_close
+                if ((gfx_open "Ranger" lw lh) == 0) { return 1 }
+                ui.back()
+                prev = 0
+            } {
+                ui.render()
+                gfx_present (ui.raw()) lw lh
+                gfx_delay 16
+                if (gfx_should_close) { go = false }
+            }
+        }
+        gfx_close
+        return 1
     }
 
     ; Open a window and run the game loop until the window closes. Generic: the

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
@@ -27,7 +27,22 @@
 Import "../game_host/RgGameHost.rgr"
 Import "../game_host/Rg2DPresenter.rgr"
 Import "../../menu/RgLauncherUi.rgr"
+Import "../../audio/game_soundscore.rgr"
 Import "../../../gfx_sdl.rgr"
+
+; The SDL audio sink: the score synth calls onSynthPlay with a PCM buffer as each
+; note fires; we hand that straight to SDL's queued audio device. Under es6 the
+; gfx_audio_* operators stub to no-ops, so the sink is inert headlessly (the note
+; still "starts" in the player — only the physical output is native).
+class RgSdlAudioSink {
+    Extends(GameAudioSink)
+    fn onSynthPlay:void (soundId:string sampleRate:int sampleCount:int pcm:buffer) {
+        gfx_audio_queue pcm (sampleCount * 2)   ; 16-bit mono
+    }
+    fn onClearQueue:void () {
+        gfx_audio_clear
+    }
+}
 
 class RgSdlGameHost {
     def host:RgGameHost (new RgGameHost)
@@ -38,6 +53,13 @@ class RgSdlGameHost {
     ; last observed haptic counts, to forward only NEW rumble commands to SDL
     def lastRumble0:int 0
     def lastRumble1:int 0
+    ; host-side music playback: the guest's runtime.audio.music.play(score) is
+    ; recorded on the bridge; the host owns the synth + schedule clock and pushes
+    ; PCM to SDL. (Nothing here is game logic; the guest only ever said "play".)
+    def musicAudio:GameAudio (new GameAudio)
+    def music:SoundScorePlayer (new SoundScorePlayer)
+    def audioReady:boolean false
+    def lastScore:string ""
 
     ; Map a raw input source bitmask to logical actions for one player and feed
     ; the host input device. PURE host-input config (no gfx, no game): bits are
@@ -75,6 +97,38 @@ class RgSdlGameHost {
         def dL:int (Rg2DPresenter.presentTextured(this.host.bridge 0 fbL this.sky))
         def dR:int (Rg2DPresenter.presentTextured(this.host.bridge 1 fbR this.sky))
         gfx_present_split (fbL.toRgbaBuffer()) (fbR.toRgbaBuffer()) this.paneW this.paneH
+    }
+
+    ; Bring up the host synth once: build its frequency tables, open the SDL audio
+    ; device, and route synthesised PCM to it. Idempotent; native device is a
+    ; no-op under es6.
+    fn initAudio:void () {
+        if (this.audioReady) { return }
+        this.musicAudio.init()
+        def sink:RgSdlAudioSink (new RgSdlAudioSink)
+        this.musicAudio.sink = sink
+        this.music.audio = this.musicAudio
+        def _o:int (gfx_audio_open 44100)
+        this.audioReady = true
+    }
+
+    ; Advance host music one frame: pick up a newly play()'d score recorded on the
+    ; bridge (the guest called runtime.audio.music.play), then tick the schedule —
+    ; each due note synthesises and queues PCM through the sink. Returns the
+    ; running note-start count so the wiring is testable without an audio device.
+    fn pumpAudio:int (dtMs:int) {
+        def b:RgRegistryBridge this.host.bridge
+        if (b.musicPlaying) {
+            if (b.musicScore != this.lastScore) {
+                this.music.load(b.musicScore)
+                this.music.play(true)
+                this.lastScore = b.musicScore
+            }
+            this.music.tick(dtMs)
+        } {
+            if (this.music.isPlaying()) { this.music.stop() }
+        }
+        return this.music.noteStarts
     }
 
     ; Rising edge of `bit` between the previous and current input mask. PURE host
@@ -152,6 +206,7 @@ class RgSdlGameHost {
             gfx_close
             return 0
         }
+        this.initAudio()
         def fbL:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
         def fbR:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
         def go:boolean true
@@ -161,6 +216,7 @@ class RgSdlGameHost {
             this.mapMask(1 (gfx_input_source_mask 1))
             this.host.frame(33.333)
             this.forwardRumble()
+            def _n:int (this.pumpAudio(33))
             ; generic launcher -> game handoff (no launcher-specific code)
             if ((strlen (this.host.launchRequest())) > 0) {
                 this.host.loadLaunched()

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
@@ -18,7 +18,7 @@
 ;   presenter         Rg2DPresenter → RgFramebuffer        — this host packs to
 ;                     RGBA and presents via gfx_present_split
 ;
-; The gfx_* operators (gfx_sdl.rgr) have es6 stubs, so this file COMPILES and
+; The gfx_* operators (v2-local gfx_sdl.rgr) have es6 stubs, so this file COMPILES and
 ; runs headlessly as a no-op; the real window exists only in the native (C++
 ; + SDL2) build. Input map (physical bit -> logical action) is host config, not
 ; game logic — a game only ever sees logical actions.
@@ -28,7 +28,7 @@ Import "../game_host/RgGameHost.rgr"
 Import "../game_host/Rg2DPresenter.rgr"
 Import "../../menu/RgLauncherUi.rgr"
 Import "../../audio/game_soundscore.rgr"
-Import "../../../gfx_sdl.rgr"
+Import "./gfx_sdl.rgr"
 
 ; The SDL audio sink: the score synth calls onSynthPlay with a PCM buffer as each
 ; note fires; we hand that straight to SDL's queued audio device. Under es6 the

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
@@ -1,0 +1,113 @@
+; ==============================================================================
+; RgSdlGameHost — native SDL2 driver for the generic v2 game host.
+; ==============================================================================
+; The ONLY native platform boundary of the v2 2D stack. It drives the SAME
+; generic RgGameHost + registry bridge + Rg2DPresenter the headless tests use,
+; adding a real window, real input, and real haptics. It contains NO game
+; knowledge (it runs any game folder), and it does NOT touch ranger:core: the
+; guest reaches input/audio/etc. through the capability root exactly as before;
+; this host only feeds the host-side devices (bridge.input) and reads the
+; host-side framebuffer. Game logic never leaks here, and no platform concept
+; leaks into the guest API.
+;
+; Boundary map:
+;   guest (.tsx)      runtime.input.player(i).isDown(...)  — unchanged
+;   ranger:core       lowers to rgcore_input_* commands    — unchanged
+;   bridge devices    RgInput records action/haptic state  — this host feeds
+;                     it from SDL, and reads recorded rumble to forward to SDL
+;   presenter         Rg2DPresenter → RgFramebuffer        — this host packs to
+;                     RGBA and presents via gfx_present_split
+;
+; The gfx_* operators (gfx_sdl.rgr) have es6 stubs, so this file COMPILES and
+; runs headlessly as a no-op; the real window exists only in the native (C++
+; + SDL2) build. Input map (physical bit -> logical action) is host config, not
+; game logic — a game only ever sees logical actions.
+; ==============================================================================
+
+Import "../game_host/RgGameHost.rgr"
+Import "../game_host/Rg2DPresenter.rgr"
+Import "../../../gfx_sdl.rgr"
+
+class RgSdlGameHost {
+    def host:RgGameHost (new RgGameHost)
+    def paneW:int 480
+    def paneH:int 270
+    ; base sky colour behind the world-space gradient bands
+    def sky:int 5215951      ; 0x4f96cf
+    ; last observed haptic counts, to forward only NEW rumble commands to SDL
+    def lastRumble0:int 0
+    def lastRumble1:int 0
+
+    ; Map a raw input source bitmask to logical actions for one player and feed
+    ; the host input device. PURE host-input config (no gfx, no game): bits are
+    ; 1 up · 2 down · 4 action · 8 quit · 16 left · 32 right (gfx_sdl mask
+    ; layout). Testable directly with a synthetic mask.
+    fn mapMask:void (player:int m:int) {
+        this.host.bridge.input.setAction(player "left" ((bit_and m 16) != 0))
+        this.host.bridge.input.setAction(player "right" ((bit_and m 32) != 0))
+        this.host.bridge.input.setAction(player "up" ((bit_and m 1) != 0))
+        this.host.bridge.input.setAction(player "down" ((bit_and m 2) != 0))
+        def jump:boolean (((bit_and m 1) != 0) || ((bit_and m 4) != 0))
+        this.host.bridge.input.setAction(player "jump" jump)
+        this.host.bridge.input.setAction(player "action" ((bit_and m 4) != 0))
+    }
+
+    ; Forward newly-recorded haptic commands (bridge.input records what the guest
+    ; requested via runtime.input.player(i).rumble) to the physical pad. Reads
+    ; host device state only; the guest never knows a pad exists.
+    fn forwardRumble:void () {
+        def r0:int (this.host.bridge.input.rumbleCount(0))
+        if (r0 > this.lastRumble0) {
+            gfx_rumble_pad 0 (this.host.bridge.input.lastRumbleStrength(0)) 120
+            this.lastRumble0 = r0
+        }
+        def r1:int (this.host.bridge.input.rumbleCount(1))
+        if (r1 > this.lastRumble1) {
+            gfx_rumble_pad 1 (this.host.bridge.input.lastRumbleStrength(1)) 120
+            this.lastRumble1 = r1
+        }
+    }
+
+    ; Present both panes to the window: each pane rasterises through the generic
+    ; presenter into an RgFramebuffer, packs to RGBA, and blits side-by-side.
+    fn present:void (fbL:RgFramebuffer fbR:RgFramebuffer) {
+        def dL:int (Rg2DPresenter.presentTextured(this.host.bridge 0 fbL this.sky))
+        def dR:int (Rg2DPresenter.presentTextured(this.host.bridge 1 fbR this.sky))
+        gfx_present_split (fbL.toRgbaBuffer()) (fbR.toRgbaBuffer()) this.paneW this.paneH
+    }
+
+    ; Open a window and run the game loop until the window closes. Generic: the
+    ; game is a folder of .tsx (dir/file). Honours the guest launch(path) request
+    ; generically (menu -> game) via the same RgGameHost handoff the tests use.
+    fn run:int (dir:string file:string) {
+        def title:string ("Ranger v2 — " + file)
+        if ((gfx_open title (this.paneW * 2) this.paneH) == 0) {
+            return 0
+        }
+        if ((this.host.load(dir file)) == false) {
+            gfx_close
+            return 0
+        }
+        def fbL:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
+        def fbR:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
+        def go:boolean true
+        while go {
+            gfx_input_poll
+            this.mapMask(0 (gfx_input_source_mask 0))
+            this.mapMask(1 (gfx_input_source_mask 1))
+            this.host.frame(33.333)
+            this.forwardRumble()
+            ; generic launcher -> game handoff (no launcher-specific code)
+            if ((strlen (this.host.launchRequest())) > 0) {
+                this.host.loadLaunched()
+                this.lastRumble0 = 0
+                this.lastRumble1 = 0
+            }
+            this.present(fbL fbR)
+            gfx_delay 16
+            if (gfx_should_close) { go = false }
+        }
+        gfx_close
+        return 1
+    }
+}

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlMain.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlMain.rgr
@@ -1,0 +1,20 @@
+; ==============================================================================
+; RgSdlMain — native entry point for the v2 SDL2 build.
+; ==============================================================================
+; Boots the generic SDL host on the LAUNCHER menu (engine infrastructure, not a
+; game). The launcher hands off to a chosen game through the same generic
+; RgGameHost.launch mechanism the tests exercise — so adding a game still needs
+; only its .tsx folder, never a native entry of its own.
+;
+; Native build (macOS): compile this to C++ and link SDL2 — see README.md.
+; Under es6 the gfx_* operators stub out, so this main is a headless no-op.
+; ==============================================================================
+
+Import "RgSdlGameHost.rgr"
+
+class RgSdlMain {
+    sfn m@(main):void () {
+        def h:RgSdlGameHost (new RgSdlGameHost)
+        def _r:int (h.run("gallery/game_engine/v2/menu" "launcher.tsx"))
+    }
+}

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlMain.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlMain.rgr
@@ -15,6 +15,6 @@ Import "RgSdlGameHost.rgr"
 class RgSdlMain {
     sfn m@(main):void () {
         def h:RgSdlGameHost (new RgSdlGameHost)
-        def _r:int (h.run("gallery/game_engine/v2/menu" "launcher.tsx"))
+        def _r:int (h.runLauncher())
     }
 }

--- a/gallery/game_engine/v2/runtime/sdl/gfx_sdl.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/gfx_sdl.rgr
@@ -1,0 +1,3206 @@
+; ==============================================================================
+; gfx_sdl - native window / present operators backed by SDL2.
+; ==============================================================================
+;
+; These operators are the ONLY platform boundary of the native PoC. Their `cpp`
+; templates call a tiny C shim (emitted once as an "after_imports" polyfill) that
+; wraps SDL2: create a window + renderer + a streaming RGBA texture, upload the
+; RGBA framebuffer each frame, present it, and pump keyboard/quit events.
+;
+; Because the shim is defined here (a user file), NO change to compiler/Lang.rgr
+; is required - Ranger lets any file declare operators with target templates.
+;
+; The RGBA byte order matches SoftCanvas (SDL_PIXELFORMAT_RGBA32 == R,G,B,A in
+; memory), so `gfx_present (canvas.raw()) w h` blits the frame directly.
+;
+; Build (macOS / Linux): see scripts/build-game-sdl.sh. On the Raspberry Pi the same
+; SDL2 backend drives the HDMI framebuffer via KMS/DRM.
+;
+; Default present path: OpenGL 2.1 / GLES2 via gfx_open_gpu (game_sdl_runner).
+; Pass --software to force the SDL_Renderer texture-upload path instead.
+;
+; es6 templates are harmless stubs so the file still type-checks for the web
+; target; the real window only exists in the native (C++) build.
+; ==============================================================================
+
+operators {
+
+    ; Open a window with an RGBA streaming texture of the given size.
+    ; Returns 1 on success, 0 on failure.
+    gfx_open _:int (title:string w:int h:int) {
+        templates {
+            cpp ( "rgfx_open(" (e 1) ", " (e 2) ", " (e 3) ")"
+                  (imp "<SDL2/SDL.h>") (imp "<cstdint>") (imp "<string>") (imp "<cstdio>") (imp "<cstdlib>") (imp "<cstring>") (imp "<unistd.h>")
+
+                )
+            es6 ( "0" )
+        }
+    }
+
+    ; Upload a tightly-packed RGBA (w*h*4 bytes) frame and present it.
+    gfx_present _:void (pixels:buffer w:int h:int) {
+        templates {
+            cpp ( "rgfx_present(" (e 1) ".data(), " (e 2) ", " (e 3) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Actual output surface width/height in pixels (0 in es6). Lets a UI render at
+    ; native resolution rather than a small upscaled buffer.
+    gfx_surface_width _:int () {
+        templates {
+            cpp ( "rgfx_surface_dim(1)" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+    gfx_surface_height _:int () {
+        templates {
+            cpp ( "rgfx_surface_dim(0)" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+
+    ; Present two full-res panes side-by-side, GPU-scaled into each window half.
+    ; left/right are w*h*4 RGBA buffers; the GPU downscale replaces the CPU blit.
+    gfx_present_split _:void (left:buffer right:buffer w:int h:int) {
+        templates {
+            cpp ( "rgfx_present_split(" (e 1) ".data(), " (e 2) ".data(), " (e 3) ", " (e 4) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Pump events and return a bitmask of currently-pressed buttons:
+    ;   1 = up, 2 = down, 4 = action, 8 = quit/back (Q or Esc), 16 = left, 32 = right
+    ; Player-1 keyboard only (W/S/A/D/Space/Q/Esc). Use gfx_input_source_mask for
+    ; arrows, gamepads, and multi-player mapping via game_input.rgr.
+    gfx_poll_mask _:int () {
+        templates {
+            cpp ( "rgfx_poll_mask()" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+
+    ; Refresh keyboard + up to 8 SDL GameController sources.
+    gfx_input_poll _:void () {
+        templates {
+            cpp ( "rgfx_input_poll()" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Raw input source mask. Sources: 0=keyboard P1, 1=keyboard P2 (arrows),
+    ; 2..9 = gamepad 0..7. Bits: 1 up, 2 down, 4 action/A, 8 quit, 16 left,
+    ; 32 right, 64 B, 128 X, 256 Y, 512 start, 1024 select/back.
+    gfx_input_source_mask _:int (source:int) {
+        templates {
+            cpp ( "rgfx_input_source_mask(" (e 1) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+
+    ; Number of connected SDL GameController devices.
+    gfx_input_pad_count _:int () {
+        templates {
+            cpp ( "rgfx_input_pad_count()" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+
+    ; --- mouse pointer (updated by gfx_input_poll / rgfx_pump_events) ----------
+    ; Position is in window pixels; call after gfx_input_poll each frame.
+    gfx_mouse_x _:int () {
+        templates {
+            cpp ( "g_rgfx_mouse_x" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+    gfx_mouse_y _:int () {
+        templates {
+            cpp ( "g_rgfx_mouse_y" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+    ; Button bitmask: 1 = left, 2 = right, 4 = middle.
+    gfx_mouse_buttons _:int () {
+        templates {
+            cpp ( "g_rgfx_mouse_btn" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+    ; Accumulated wheel notches since the last read (positive = scroll up); reads
+    ; and clears the accumulator.
+    gfx_mouse_wheel _:int () {
+        templates {
+            cpp ( "([]{ int w = g_rgfx_wheel; g_rgfx_wheel = 0; return w; }())" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+
+    ; Swap the GL back buffer to the window (present a GPU-drawn frame). Use after
+    ; drawing directly with the GL backend (three_gl's rgl_*), not the 2D path.
+    gfx_gl_swap _:void () {
+        templates {
+            cpp ( "rgfx_gpu_finish_frame()" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Rumble connected gamepad(s). pad=-1 all pads; strength 0..65535; duration ms.
+    gfx_rumble_pad _:void (padIdx:int strength:int durationMs:int) {
+        templates {
+            cpp ( "rgfx_pad_rumble(" (e 1) ", (Uint16)" (e 2) ", (Uint16)" (e 2) ", (Uint32)" (e 3) ")"
+                (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; True once the window received a quit / close request.
+    gfx_should_close _:boolean () {
+        templates {
+            cpp ( "(rgfx_should_close() != 0)" (imp "<SDL2/SDL.h>") (imp "<cstdint>") (imp "<string>") (imp "<cstdio>") (imp "<cstdlib>") (imp "<cstring>") (imp "<unistd.h>")
+(polyfill "after_imports" "
+static SDL_Window*   g_rgfx_win = nullptr;
+static SDL_Renderer* g_rgfx_ren = nullptr;
+static SDL_Texture*  g_rgfx_tex = nullptr;
+static SDL_AudioDeviceID g_rgfx_audio = 0;
+static int g_rgfx_audio_channels = 1;
+static int g_rgfx_audio_freq = 44100;
+static int g_rgfx_should_close = 0;
+static int g_rgfx_fullscreen = 0;
+
+// Mouse pointer state (SDL has no polling helper for a persistent cursor in this
+// wrapper, so we track it from events). Position is in window pixels; buttons is
+// a bitmask (1=left, 2=right, 4=middle); wheel accumulates notches until read.
+static int g_rgfx_mouse_x = 0;
+static int g_rgfx_mouse_y = 0;
+static int g_rgfx_mouse_btn = 0;
+static int g_rgfx_wheel = 0;
+
+#define RGFX_MAX_PADS 8
+#define RGFX_SRC_KB_P1 0
+#define RGFX_SRC_KB_P2 1
+#define RGFX_SRC_PAD0 2
+#define RGFX_SRC_COUNT 10
+
+#define RGFX_UP    1
+#define RGFX_DOWN  2
+#define RGFX_ACT   4
+#define RGFX_QUIT  8
+#define RGFX_LEFT  16
+#define RGFX_RIGHT 32
+#define RGFX_B     64
+#define RGFX_X     128
+#define RGFX_Y     256
+#define RGFX_START 512
+#define RGFX_SELECT 1024
+
+static SDL_GameController* g_pads[RGFX_MAX_PADS];
+static SDL_Joystick* g_joys[RGFX_MAX_PADS];
+static int g_pad_gc[RGFX_MAX_PADS];
+static int g_pad_count = 0;
+static int g_src_mask[RGFX_SRC_COUNT];
+
+static void rgfx_close_pad_slot(int idx) {
+    if (idx < 0 || idx >= g_pad_count) { return; }
+    if (g_pad_gc[idx]) {
+        if (g_pads[idx] != nullptr) { SDL_GameControllerClose(g_pads[idx]); }
+    } else {
+        if (g_joys[idx] != nullptr) { SDL_JoystickClose(g_joys[idx]); }
+    }
+    g_pads[idx] = nullptr;
+    g_joys[idx] = nullptr;
+    g_pad_gc[idx] = 0;
+    for (int j = idx + 1; j < g_pad_count; ++j) {
+        g_pads[j - 1] = g_pads[j];
+        g_joys[j - 1] = g_joys[j];
+        g_pad_gc[j - 1] = g_pad_gc[j];
+    }
+    if (g_pad_count > 0) {
+        g_pads[g_pad_count - 1] = nullptr;
+        g_joys[g_pad_count - 1] = nullptr;
+        g_pad_gc[g_pad_count - 1] = 0;
+        --g_pad_count;
+    }
+}
+
+static void rgfx_remove_pad_by_joystick_id(SDL_JoystickID jid) {
+    for (int i = 0; i < g_pad_count; ++i) {
+        SDL_Joystick* js = nullptr;
+        if (g_pad_gc[i] && g_pads[i] != nullptr) {
+            js = SDL_GameControllerGetJoystick(g_pads[i]);
+        } else if (!g_pad_gc[i]) {
+            js = g_joys[i];
+        }
+        if (js != nullptr && SDL_JoystickInstanceID(js) == jid) {
+            rgfx_close_pad_slot(i);
+            break;
+        }
+    }
+}
+
+static void rgfx_open_pad_index(int jsIndex) {
+    if (g_pad_count >= RGFX_MAX_PADS) { return; }
+    const SDL_JoystickID devId = SDL_JoystickGetDeviceInstanceID(jsIndex);
+    for (int i = 0; i < g_pad_count; ++i) {
+        SDL_Joystick* js = nullptr;
+        if (g_pad_gc[i] && g_pads[i] != nullptr) {
+            js = SDL_GameControllerGetJoystick(g_pads[i]);
+        } else {
+            js = g_joys[i];
+        }
+        if (js != nullptr && SDL_JoystickInstanceID(js) == devId) { return; }
+    }
+    if (SDL_IsGameController(jsIndex)) {
+        SDL_GameController* c = SDL_GameControllerOpen(jsIndex);
+        if (c == nullptr) { return; }
+        g_pads[g_pad_count] = c;
+        g_joys[g_pad_count] = nullptr;
+        g_pad_gc[g_pad_count] = 1;
+        ++g_pad_count;
+        return;
+    }
+    SDL_Joystick* j = SDL_JoystickOpen(jsIndex);
+    if (j == nullptr) { return; }
+    g_pads[g_pad_count] = nullptr;
+    g_joys[g_pad_count] = j;
+    g_pad_gc[g_pad_count] = 0;
+    ++g_pad_count;
+}
+
+static void rgfx_scan_pads() {
+    for (int i = g_pad_count - 1; i >= 0; --i) {
+        rgfx_close_pad_slot(i);
+    }
+    g_pad_count = 0;
+    const int n = SDL_NumJoysticks();
+    for (int i = 0; i < n && g_pad_count < RGFX_MAX_PADS; ++i) {
+        rgfx_open_pad_index(i);
+    }
+    fprintf(stderr, \"[rgfx] gamepads: %d / joysticks: %d\\n\", g_pad_count, n);
+}
+
+static int rgfx_map_joy(SDL_Joystick* joy) {
+    if (joy == nullptr) { return 0; }
+    int m = 0;
+    if (SDL_JoystickNumAxes(joy) > 0) {
+        const Sint16 lx = SDL_JoystickGetAxis(joy, 0);
+        if (lx < -8000) { m |= RGFX_LEFT; }
+        if (lx > 8000) { m |= RGFX_RIGHT; }
+    }
+    if (SDL_JoystickNumAxes(joy) > 1) {
+        const Sint16 ly = SDL_JoystickGetAxis(joy, 1);
+        if (ly < -8000) { m |= RGFX_UP; }
+        if (ly > 8000) { m |= RGFX_DOWN; }
+    }
+    if (SDL_JoystickNumHats(joy) > 0) {
+        const Uint8 hat = SDL_JoystickGetHat(joy, 0);
+        if ((hat & SDL_HAT_UP) != 0) { m |= RGFX_UP; }
+        if ((hat & SDL_HAT_DOWN) != 0) { m |= RGFX_DOWN; }
+        if ((hat & SDL_HAT_LEFT) != 0) { m |= RGFX_LEFT; }
+        if ((hat & SDL_HAT_RIGHT) != 0) { m |= RGFX_RIGHT; }
+    }
+    const int btnCount = SDL_JoystickNumButtons(joy);
+    if (btnCount > 0 && SDL_JoystickGetButton(joy, 0)) { m |= RGFX_ACT; }
+    if (btnCount > 1 && SDL_JoystickGetButton(joy, 1)) { m |= RGFX_B; }
+    if (btnCount > 2 && SDL_JoystickGetButton(joy, 2)) { m |= RGFX_X; }
+    if (btnCount > 3 && SDL_JoystickGetButton(joy, 3)) { m |= RGFX_Y; }
+    if (btnCount > 6 && SDL_JoystickGetButton(joy, 6)) { m |= RGFX_START; }
+    if (btnCount > 7 && SDL_JoystickGetButton(joy, 7)) { m |= RGFX_SELECT; }
+    return m;
+}
+
+static int rgfx_map_pad(SDL_GameController* pad) {
+    if (pad == nullptr) { return 0; }
+    int m = 0;
+    if (SDL_GameControllerGetButton(pad, SDL_CONTROLLER_BUTTON_DPAD_UP)) { m |= RGFX_UP; }
+    if (SDL_GameControllerGetButton(pad, SDL_CONTROLLER_BUTTON_DPAD_DOWN)) { m |= RGFX_DOWN; }
+    if (SDL_GameControllerGetButton(pad, SDL_CONTROLLER_BUTTON_DPAD_LEFT)) { m |= RGFX_LEFT; }
+    if (SDL_GameControllerGetButton(pad, SDL_CONTROLLER_BUTTON_DPAD_RIGHT)) { m |= RGFX_RIGHT; }
+    if (SDL_GameControllerGetButton(pad, SDL_CONTROLLER_BUTTON_A)) { m |= RGFX_ACT; }
+    if (SDL_GameControllerGetButton(pad, SDL_CONTROLLER_BUTTON_B)) { m |= RGFX_B; }
+    if (SDL_GameControllerGetButton(pad, SDL_CONTROLLER_BUTTON_X)) { m |= RGFX_X; }
+    if (SDL_GameControllerGetButton(pad, SDL_CONTROLLER_BUTTON_Y)) { m |= RGFX_Y; }
+    if (SDL_GameControllerGetButton(pad, SDL_CONTROLLER_BUTTON_START)) { m |= RGFX_START; }
+    if (SDL_GameControllerGetButton(pad, SDL_CONTROLLER_BUTTON_BACK)) { m |= RGFX_SELECT; }
+    const Sint16 ly = SDL_GameControllerGetAxis(pad, SDL_CONTROLLER_AXIS_LEFTY);
+    const Sint16 lx = SDL_GameControllerGetAxis(pad, SDL_CONTROLLER_AXIS_LEFTX);
+    if (ly < -8000) { m |= RGFX_UP; }
+    if (ly > 8000) { m |= RGFX_DOWN; }
+    if (lx < -8000) { m |= RGFX_LEFT; }
+    if (lx > 8000) { m |= RGFX_RIGHT; }
+    return m;
+}
+
+static void rgfx_set_fullscreen(int on) {
+    if (g_rgfx_win == nullptr) { return; }
+    Uint32 flags = on ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0;
+    SDL_SetWindowFullscreen(g_rgfx_win, flags);
+    g_rgfx_fullscreen = on ? 1 : 0;
+}
+static int rgfx_toggle_fullscreen() {
+    rgfx_set_fullscreen(g_rgfx_fullscreen ? 0 : 1);
+    return g_rgfx_fullscreen;
+}
+static int rgfx_is_fullscreen() { return g_rgfx_fullscreen; }
+
+static void rgfx_pump_events() {
+    SDL_Event ev;
+    while (SDL_PollEvent(&ev)) {
+        if (ev.type == SDL_QUIT) { g_rgfx_should_close = 1; }
+        if (ev.type == SDL_MOUSEMOTION) {
+            g_rgfx_mouse_x = ev.motion.x;
+            g_rgfx_mouse_y = ev.motion.y;
+        }
+        if (ev.type == SDL_MOUSEBUTTONDOWN) {
+            g_rgfx_mouse_x = ev.button.x;
+            g_rgfx_mouse_y = ev.button.y;
+            if (ev.button.button == SDL_BUTTON_LEFT) { g_rgfx_mouse_btn |= 1; }
+            if (ev.button.button == SDL_BUTTON_RIGHT) { g_rgfx_mouse_btn |= 2; }
+            if (ev.button.button == SDL_BUTTON_MIDDLE) { g_rgfx_mouse_btn |= 4; }
+        }
+        if (ev.type == SDL_MOUSEBUTTONUP) {
+            if (ev.button.button == SDL_BUTTON_LEFT) { g_rgfx_mouse_btn &= ~1; }
+            if (ev.button.button == SDL_BUTTON_RIGHT) { g_rgfx_mouse_btn &= ~2; }
+            if (ev.button.button == SDL_BUTTON_MIDDLE) { g_rgfx_mouse_btn &= ~4; }
+        }
+        if (ev.type == SDL_MOUSEWHEEL) {
+            int wy = ev.wheel.y;
+            if (ev.wheel.direction == SDL_MOUSEWHEEL_FLIPPED) { wy = -wy; }
+            g_rgfx_wheel += wy;
+        }
+        if (ev.type == SDL_CONTROLLERDEVICEADDED) {
+            rgfx_open_pad_index((int) ev.cdevice.which);
+        }
+        if (ev.type == SDL_JOYDEVICEADDED) {
+            rgfx_open_pad_index((int) ev.jdevice.which);
+        }
+        if (ev.type == SDL_CONTROLLERDEVICEREMOVED) {
+            rgfx_remove_pad_by_joystick_id(ev.cdevice.which);
+        }
+        if (ev.type == SDL_JOYDEVICEREMOVED) {
+            rgfx_remove_pad_by_joystick_id(ev.jdevice.which);
+        }
+        if (ev.type == SDL_KEYDOWN) {
+            if (ev.key.keysym.sym == SDLK_F11) {
+                rgfx_toggle_fullscreen();
+            }
+            if (ev.key.keysym.sym == SDLK_RETURN) {
+                if ((ev.key.keysym.mod & KMOD_ALT) || (ev.key.keysym.mod & KMOD_GUI)) {
+                    rgfx_toggle_fullscreen();
+                }
+            }
+            if (ev.key.keysym.sym == SDLK_ESCAPE) {
+                if (g_rgfx_fullscreen) {
+                    rgfx_set_fullscreen(0);
+                }
+            }
+        }
+    }
+}
+
+static void rgfx_input_recompute() {
+    for (int i = 0; i < RGFX_SRC_COUNT; ++i) { g_src_mask[i] = 0; }
+    const Uint8* ks = SDL_GetKeyboardState(nullptr);
+    int kb1 = 0;
+    if (ks[SDL_SCANCODE_W]) { kb1 |= RGFX_UP; }
+    if (ks[SDL_SCANCODE_S]) { kb1 |= RGFX_DOWN; }
+    if (ks[SDL_SCANCODE_A]) { kb1 |= RGFX_LEFT; }
+    if (ks[SDL_SCANCODE_D]) { kb1 |= RGFX_RIGHT; }
+    if (ks[SDL_SCANCODE_SPACE]) { kb1 |= RGFX_ACT; }
+    if (ks[SDL_SCANCODE_Q]) { kb1 |= RGFX_QUIT; }
+    if (ks[SDL_SCANCODE_ESCAPE]) { kb1 |= RGFX_QUIT; }
+    g_src_mask[RGFX_SRC_KB_P1] = kb1;
+
+    int kb2 = 0;
+    if (ks[SDL_SCANCODE_UP]) { kb2 |= RGFX_UP; }
+    if (ks[SDL_SCANCODE_DOWN]) { kb2 |= RGFX_DOWN; }
+    if (ks[SDL_SCANCODE_LEFT]) { kb2 |= RGFX_LEFT; }
+    if (ks[SDL_SCANCODE_RIGHT]) { kb2 |= RGFX_RIGHT; }
+    if (ks[SDL_SCANCODE_RETURN]) { kb2 |= RGFX_ACT; }
+    g_src_mask[RGFX_SRC_KB_P2] = kb2;
+
+    for (int i = 0; i < g_pad_count && i < RGFX_MAX_PADS; ++i) {
+        if (g_pad_gc[i]) {
+            g_src_mask[RGFX_SRC_PAD0 + i] = rgfx_map_pad(g_pads[i]);
+        } else {
+            g_src_mask[RGFX_SRC_PAD0 + i] = rgfx_map_joy(g_joys[i]);
+        }
+    }
+}
+
+static void rgfx_pad_rumble(int padIdx, Uint16 low, Uint16 high, Uint32 durationMs) {
+    if (padIdx < 0) {
+        for (int i = 0; i < g_pad_count && i < RGFX_MAX_PADS; ++i) {
+            if (g_pad_gc[i] && g_pads[i] != nullptr) {
+                SDL_GameControllerRumble(g_pads[i], low, high, durationMs);
+            }
+        }
+        return;
+    }
+    if (padIdx >= 0 && padIdx < g_pad_count && padIdx < RGFX_MAX_PADS) {
+        if (g_pad_gc[padIdx] && g_pads[padIdx] != nullptr) {
+            SDL_GameControllerRumble(g_pads[padIdx], low, high, durationMs);
+        }
+    }
+}
+
+static void rgfx_input_poll() {
+    rgfx_pump_events();
+    rgfx_input_recompute();
+}
+
+static int rgfx_str_icontains(const char* hay, const char* needle) {
+    if (hay == nullptr || needle == nullptr) { return 0; }
+    const int nlen = (int) strlen(needle);
+    if (nlen <= 0) { return 0; }
+    for (const char* p = hay; *p != '\\0'; ++p) {
+        int ok = 1;
+        for (int i = 0; i < nlen; ++i) {
+            char a = p[i];
+            char b = needle[i];
+            if (a >= 'A' && a <= 'Z') { a = (char) (a + 32); }
+            if (b >= 'A' && b <= 'Z') { b = (char) (b + 32); }
+            if (a != b) { ok = 0; break; }
+        }
+        if (ok) { return 1; }
+    }
+    return 0;
+}
+
+static int rgfx_using_pulse_driver() {
+    const char* drv = getenv(\"SDL_AUDIODRIVER\");
+    if (drv == nullptr || drv[0] == '\\0') { return 0; }
+    if (rgfx_str_icontains(drv, \"pulse\")) { return 1; }
+    if (rgfx_str_icontains(drv, \"pipewire\")) { return 1; }
+    return 0;
+}
+
+static void rgfx_prepare_audio_env() {
+    // PipeWire/Pulse socket lives at $XDG_RUNTIME_DIR/pulse/native; when launched
+    // over SSH this is often unset, so the pulse driver falls back to dummy.
+    const char* xrd = getenv(\"XDG_RUNTIME_DIR\");
+    if (xrd == nullptr || xrd[0] == '\\0') {
+        char buf[64];
+        snprintf(buf, sizeof(buf), \"/run/user/%d\", (int) getuid());
+        SDL_setenv(\"XDG_RUNTIME_DIR\", buf, 1);
+        fprintf(stderr, \"[rgfx] XDG_RUNTIME_DIR=%s (auto)\\n\", buf);
+    }
+    const char* dev = getenv(\"RANGER_AUDIO_DEVICE\");
+    if (dev != nullptr && dev[0] != '\\0') {
+        SDL_setenv(\"SDL_AUDIODRIVER\", \"alsa\", 1);
+        fprintf(stderr, \"[rgfx] RANGER_AUDIO_DEVICE=%s → SDL_AUDIODRIVER=alsa\\n\", dev);
+        return;
+    }
+    const char* existing = getenv(\"SDL_AUDIODRIVER\");
+    if (existing != nullptr && existing[0] != '\\0') {
+        fprintf(stderr, \"[rgfx] SDL_AUDIODRIVER=%s (from env)\\n\", existing);
+        return;
+    }
+    const char* ranger = getenv(\"RANGER_SDL_AUDIO_DRIVER\");
+    if (ranger != nullptr && ranger[0] != '\\0') {
+        SDL_setenv(\"SDL_AUDIODRIVER\", ranger, 1);
+        fprintf(stderr, \"[rgfx] SDL_AUDIODRIVER=%s (RANGER_SDL_AUDIO_DRIVER)\\n\", ranger);
+        return;
+    }
+#if defined(__linux__)
+    // Prefer pulse (PipeWire-Pulse); SDL2 falls through the list if the first
+    // driver cannot connect, so alsa still works on setups without PipeWire.
+    SDL_setenv(\"SDL_AUDIODRIVER\", \"pulse,pipewire,alsa\", 1);
+    fprintf(stderr, \"[rgfx] SDL_AUDIODRIVER=pulse,pipewire,alsa (linux default)\\n\");
+#endif
+}
+
+static void rgfx_log_audio_devices() {
+    const int n = SDL_GetNumAudioDevices(0);
+    fprintf(stderr, \"[rgfx] SDL playback devices: %d\\n\", n);
+    int i = 0;
+    while (i < n) {
+        const char* name = SDL_GetAudioDeviceName(i, 0);
+        if (name != nullptr) {
+            fprintf(stderr, \"[rgfx]   [%d] %s\\n\", i, name);
+        }
+        i = (i + 1);
+    }
+    if (n <= 0) {
+        fprintf(stderr, \"[rgfx]   (none — try: SDL_AUDIODRIVER=pulse or apt install libsdl2-2.0-0)\\n\");
+    }
+}
+
+static int rgfx_audio_dummy_only() {
+    const int n = SDL_GetNumAudioDevices(0);
+    if (n <= 0) { return 1; }
+    int i = 0;
+    while (i < n) {
+        const char* name = SDL_GetAudioDeviceName(i, 0);
+        if (name != nullptr) {
+            if (!rgfx_str_icontains(name, \"dummy\")) { return 0; }
+        }
+        i = (i + 1);
+    }
+    return 1;
+}
+
+static void rgfx_audio_reinit_driver(const char* driver) {
+    if (g_rgfx_audio != 0) {
+        SDL_CloseAudioDevice(g_rgfx_audio);
+        g_rgfx_audio = 0;
+    }
+    SDL_AudioQuit();
+    SDL_setenv(\"SDL_AUDIODRIVER\", driver, 1);
+    if (SDL_InitSubSystem(SDL_INIT_AUDIO) != 0) {
+        fprintf(stderr, \"[rgfx] SDL_InitSubSystem(AUDIO) failed: %s\\n\", SDL_GetError());
+    } {
+        fprintf(stderr, \"[rgfx] audio driver: %s\\n\", driver);
+    }
+}
+
+static int rgfx_try_alsa_audidev(int sampleRate, const char* audidev);
+
+static const char* rgfx_pick_audio_device() {
+    // Pulse/PipeWire: use system default sink (wpctl / taskbar HDMI selection).
+    if (rgfx_using_pulse_driver()) { return nullptr; }
+    const int n = SDL_GetNumAudioDevices(0);
+    int i = 0;
+    while (i < n) {
+        const char* name = SDL_GetAudioDeviceName(i, 0);
+        if (name != nullptr) {
+            if (rgfx_str_icontains(name, \"hdmi\")) { return name; }
+            if (rgfx_str_icontains(name, \"vc4\")) { return name; }
+        }
+        i = (i + 1);
+    }
+    return nullptr;
+}
+
+static int rgfx_try_open_audio_device(int sampleRate, const char* dev, int channels) {
+    SDL_AudioSpec want, have;
+    SDL_zero(want);
+    want.freq = sampleRate > 0 ? sampleRate : 22050;
+    want.format = AUDIO_S16SYS;
+    want.channels = (Uint8) channels;
+    want.samples = 512;
+    want.callback = nullptr;
+    want.userdata = nullptr;
+    SDL_AudioDeviceID id = SDL_OpenAudioDevice(dev, 0, &want, &have, 0);
+    if (id == 0) {
+        fprintf(stderr, \"[rgfx] audio open failed (%s, %d ch): %s\\n\",
+            dev != nullptr ? dev : \"default\", channels, SDL_GetError());
+        return 0;
+    }
+    g_rgfx_audio = id;
+    g_rgfx_audio_channels = have.channels > 0 ? have.channels : 1;
+    g_rgfx_audio_freq = have.freq > 0 ? have.freq : want.freq;
+    const char* label = dev;
+    if (label == nullptr) {
+        const char* ad = getenv(\"AUDIODEV\");
+        if (ad != nullptr && ad[0] != '\\0') { label = ad; }
+    }
+    if (label == nullptr) { label = \"(default)\"; }
+    fprintf(stderr, \"[rgfx] audio opened: %s @ %d Hz, %d ch\\n\",
+        label, have.freq, have.channels);
+    SDL_PauseAudioDevice(g_rgfx_audio, 0);
+    return 1;
+}
+
+static void rgfx_close_audio_device() {
+    if (g_rgfx_audio != 0) {
+        SDL_CloseAudioDevice(g_rgfx_audio);
+        g_rgfx_audio = 0;
+    }
+    g_rgfx_audio_channels = 1;
+    g_rgfx_audio_freq = 44100;
+}
+
+static int rgfx_try_alsa_audidev(int sampleRate, const char* audidev) {
+    rgfx_close_audio_device();
+    SDL_setenv(\"AUDIODEV\", audidev, 1);
+    fprintf(stderr, \"[rgfx] trying AUDIODEV=%s\\n\", audidev);
+    if (rgfx_try_open_audio_device(sampleRate, nullptr, 2)) { return 1; }
+    rgfx_close_audio_device();
+    SDL_setenv(\"AUDIODEV\", audidev, 1);
+    return rgfx_try_open_audio_device(sampleRate, nullptr, 1);
+}
+
+static int rgfx_audio_open(int sampleRate) {
+    if (g_rgfx_audio != 0) { return 1; }
+
+    const char* envDev = getenv(\"RANGER_AUDIO_DEVICE\");
+    if (envDev != nullptr && envDev[0] != '\\0') {
+        if (rgfx_using_pulse_driver()) {
+            rgfx_audio_reinit_driver(\"alsa\");
+        }
+        rgfx_log_audio_devices();
+        if (rgfx_try_alsa_audidev(sampleRate, envDev)) { return 1; }
+        fprintf(stderr, \"[rgfx] audio: RANGER_AUDIO_DEVICE failed: %s\\n\", envDev);
+        return 0;
+    }
+
+    rgfx_log_audio_devices();
+
+    if (rgfx_audio_dummy_only()) {
+        fprintf(stderr, \"[rgfx] Pulse/PipeWire unavailable (Dummy Output)\\n\");
+        fprintf(stderr, \"[rgfx] set RANGER_AUDIO_DEVICE=plughw:N,0 (see: aplay -l)\\n\");
+        return 0;
+    }
+
+    const char* dev = rgfx_pick_audio_device();
+    if (rgfx_try_open_audio_device(sampleRate, dev, 2)) { return 1; }
+    if (rgfx_try_open_audio_device(sampleRate, dev, 1)) { return 1; }
+    if (dev != nullptr) {
+        if (rgfx_try_open_audio_device(sampleRate, nullptr, 2)) { return 1; }
+        if (rgfx_try_open_audio_device(sampleRate, nullptr, 1)) { return 1; }
+    }
+
+    fprintf(stderr, \"[rgfx] audio: no device — set RANGER_AUDIO_DEVICE=plughw:N,0 (aplay -l)\\n\");
+    return 0;
+}
+#include <vector>
+static void rgfx_audio_queue(const uint8_t* pcm, int byteCount) {
+    if (g_rgfx_audio == 0) { return; }
+    if (pcm == nullptr || byteCount <= 0) { return; }
+    if (g_rgfx_audio_channels <= 1) {
+        SDL_QueueAudio(g_rgfx_audio, pcm, (Uint32) byteCount);
+        return;
+    }
+    int monoSamples = byteCount / 2;
+    if (monoSamples <= 0) { return; }
+    std::vector<uint8_t> stereo((size_t)monoSamples * 4u);
+    int i = 0;
+    while (i < monoSamples) {
+        int off = i * 2;
+        stereo[(size_t)i * 4u] = pcm[off];
+        stereo[(size_t)i * 4u + 1u] = pcm[off + 1];
+        stereo[(size_t)i * 4u + 2u] = pcm[off];
+        stereo[(size_t)i * 4u + 3u] = pcm[off + 1];
+        i = i + 1;
+    }
+    SDL_QueueAudio(g_rgfx_audio, stereo.data(), (Uint32)((size_t)monoSamples * 4u));
+}
+static void rgfx_audio_clear() {
+    if (g_rgfx_audio != 0) { SDL_ClearQueuedAudio(g_rgfx_audio); }
+}
+static int rgfx_audio_sample_rate() {
+    return g_rgfx_audio_freq;
+}
+#include <vector>
+#include <cmath>
+#include <map>
+#include <string>
+#if defined(__APPLE__)
+#include <OpenGL/gl3.h>
+#elif defined(__arm__) || defined(__aarch64__)
+// Raspberry Pi / embedded: OpenGL ES 2.0 (prototypes are exported directly).
+#include <GLES2/gl2.h>
+#else
+// Desktop Linux (Mesa): GL 2.0 entry points live in glext; ask for prototypes
+// so glCreateShader/glBufferData/glVertexAttribPointer resolve at link time.
+#define GL_GLEXT_PROTOTYPES 1
+#include <GL/gl.h>
+#include <GL/glext.h>
+#endif
+
+static int g_rgfx_gpu_mode = 0;
+static SDL_GLContext g_rgfx_glctx = nullptr;
+
+static void rgfx_gl_ensure_current() {
+    if (g_rgfx_gpu_mode && g_rgfx_win != nullptr && g_rgfx_glctx != nullptr) {
+        SDL_GL_MakeCurrent(g_rgfx_win, g_rgfx_glctx);
+    }
+}
+
+static GLuint g_rgfx_gl_program = 0;
+static GLint g_rgfx_gl_pos_attr = 0;
+static GLint g_rgfx_gl_uv_attr = 0;
+static GLint g_rgfx_gl_tex_uniform = 0;
+static GLuint g_rgfx_gl_vbo = 0;
+static GLuint g_rgfx_base_tex = 0;
+static GLuint g_rgfx_base_tex_r = 0;
+static int g_rgfx_base_tex_w = 0;
+static int g_rgfx_base_tex_h = 0;
+static int g_rgfx_base_tex_r_w = 0;
+static int g_rgfx_base_tex_r_h = 0;
+static int g_rgfx_fb_w = 0;
+static int g_rgfx_fb_h = 0;
+static std::vector<GLuint> g_rgfx_gl_textures;
+
+// GPU-side phase profiler (enable with RANGER_GFX_PROFILE=1). Splits the present
+// path into base-texture upload, sprite overlay, particle overlay, and buffer
+// swap (vsync/GPU wait) so ARM bottlenecks can be told apart from CPU update.
+static int g_rgfx_prof_enabled = -1;
+static Uint64 g_rgfx_prof_freq = 0;
+static double g_rgfx_prof_upload_ms = 0.0;
+static double g_rgfx_prof_sprite_ms = 0.0;
+static double g_rgfx_prof_particle_ms = 0.0;
+static double g_rgfx_prof_swap_ms = 0.0;
+static int g_rgfx_prof_frames = 0;
+
+static bool rgfx_prof_on() {
+    if (g_rgfx_prof_enabled < 0) {
+        const char* e = getenv(\"RANGER_GFX_PROFILE\");
+        g_rgfx_prof_enabled = (e != nullptr && e[0] != '\\0' && e[0] != '0') ? 1 : 0;
+        g_rgfx_prof_freq = SDL_GetPerformanceFrequency();
+    }
+    return g_rgfx_prof_enabled == 1;
+}
+
+static Uint64 rgfx_prof_now() {
+    return rgfx_prof_on() ? SDL_GetPerformanceCounter() : 0;
+}
+
+static double rgfx_prof_ms(Uint64 a, Uint64 b) {
+    if (g_rgfx_prof_freq == 0) { return 0.0; }
+    return (double) (b - a) * 1000.0 / (double) g_rgfx_prof_freq;
+}
+
+// Upload a full-frame RGBA image into a reused texture. Uses glTexSubImage2D once
+// the storage is allocated (avoids a per-frame realloc) and always sets
+// CLAMP_TO_EDGE, which GLES2 requires for NPOT textures like 480x270 panes
+// (default GL_REPEAT leaves the texture incomplete → black on the Pi).
+static void rgfx_upload_frame_tex(GLuint tex, int* allocW, int* allocH,
+    const uint8_t* pixels, int w, int h, GLint filter) {
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    if (*allocW == w && *allocH == h) {
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    } else {
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+        *allocW = w;
+        *allocH = h;
+    }
+}
+
+struct RgfxGpuParticle {
+    float x, y, size;
+    uint8_t r, g, b, a;
+};
+struct RgfxGpuParticleQueue {
+    std::vector<RgfxGpuParticle> items;
+    int fbW = 0;
+    int fbH = 0;
+};
+static RgfxGpuParticleQueue g_rgfx_particle_queues[3];
+static int g_rgfx_active_particle_queue = 0;
+
+struct RgfxGpuSprite {
+    int texId;
+    int atlasW, atlasH;
+    int sx, sy, sw, sh;
+    float px, py;
+    float dw, dh;
+    float angleDeg;
+    int usePivot;
+};
+struct RgfxGpuSpriteQueue {
+    std::vector<RgfxGpuSprite> items;
+    int fbW = 0;
+    int fbH = 0;
+};
+// Queue 0 = normal/solo, queue 1 = split left, queue 2 = split right.
+static RgfxGpuSpriteQueue g_rgfx_sprite_queues[3];
+static int g_rgfx_active_sprite_queue = 0;
+static GLuint g_rgfx_part_program = 0;
+static GLint g_rgfx_part_corner_attr = 0;
+static GLint g_rgfx_part_center_attr = 0;
+static GLint g_rgfx_part_size_attr = 0;
+static GLint g_rgfx_part_color_attr = 0;
+static GLint g_rgfx_part_res_uniform = 0;
+static GLuint g_rgfx_part_vbo = 0;
+
+// GPU UI-effect overlay (glow on a node rect + whole-screen pulse). Each item is
+// a rectangle drawn as an additive soft blob: aCorner spans [-1,1], the fragment
+// applies a radial feather so a node glow reads as a soft halo and a fullscreen
+// item reads as a colour wash brightest at centre. Driven by the host UIAnimator
+// via gfx_fx_push_glow / gfx_fx_push_screen; composited in rgfx_present().
+struct RgfxFxItem {
+    float cx, cy;      // centre, pixels
+    float hx, hy;      // half-extent, pixels
+    uint8_t r, g, b, a;
+    float feather;     // 0..1 edge softness (small = crisp, large = soft blob)
+};
+static std::vector<RgfxFxItem> g_rgfx_fx_items;
+static int g_rgfx_fx_fbW = 0;
+static int g_rgfx_fx_fbH = 0;
+static GLuint g_rgfx_fx_program = 0;
+static GLint g_rgfx_fx_corner_attr = 0;
+static GLint g_rgfx_fx_center_attr = 0;
+static GLint g_rgfx_fx_half_attr = 0;
+static GLint g_rgfx_fx_color_attr = 0;
+static GLint g_rgfx_fx_feather_attr = 0;
+static GLint g_rgfx_fx_res_uniform = 0;
+static GLuint g_rgfx_fx_vbo = 0;
+
+static int rgfx_gpu_queue_index(int pane) {
+    if (pane == 0) { return 1; }
+    if (pane == 1) { return 2; }
+    return 0;
+}
+
+// --- R1b: 2D ortho camera per sprite queue (pan / zoom / rotation) ----------
+// Applied on the GPU as a 4x4 view-projection uniform (rgfx_cam_gl_init)
+// instead of baking NDC coordinates on the CPU. Pan follows the game_camera
+// convention (screen = world - cam); zoom/rotation act about the pane centre.
+// Defaults are the identity, so games that never touch the camera keep the
+// exact framing they had before. The bisect fallbacks (RANGER_GFX_SPRITE_BATCH=0,
+// RANGER_GFX_SPRITE_CAMERA=0) ignore the camera by design.
+struct RgfxGpuCamera2D {
+    float x = 0.f;
+    float y = 0.f;
+    float zoom = 1.f;
+    float rotDeg = 0.f;
+    int enabled = 0;
+};
+static RgfxGpuCamera2D g_rgfx_cameras[3];
+static GLuint g_rgfx_cam_program = 0;
+static GLint g_rgfx_cam_pos_attr = 0;
+static GLint g_rgfx_cam_uv_attr = 0;
+static GLint g_rgfx_cam_tex_uniform = 0;
+static GLint g_rgfx_cam_vp_uniform = 0;
+
+static void rgfx_gpu_camera_set(int pane, float x, float y, float zoom, float rotDeg) {
+    RgfxGpuCamera2D& c = g_rgfx_cameras[rgfx_gpu_queue_index(pane)];
+    c.x = x;
+    c.y = y;
+    c.zoom = (zoom > 0.f) ? zoom : 1.f;
+    c.rotDeg = rotDeg;
+    c.enabled = 1;
+}
+
+static void rgfx_gpu_camera_reset(int pane) {
+    g_rgfx_cameras[rgfx_gpu_queue_index(pane)] = RgfxGpuCamera2D();
+}
+
+static GLuint rgfx_gl_compile(GLenum type, const char* src) {
+    GLuint s = glCreateShader(type);
+    glShaderSource(s, 1, &src, nullptr);
+    glCompileShader(s);
+    GLint ok = GL_FALSE;
+    glGetShaderiv(s, GL_COMPILE_STATUS, &ok);
+    if (ok != GL_TRUE) {
+        char log[1024];
+        GLsizei len = 0;
+        glGetShaderInfoLog(s, (GLsizei) sizeof(log), &len, log);
+        SDL_Log(\"[rgfx] GL shader compile failed: %.*s\", (int) len, log);
+        glDeleteShader(s);
+        return 0;
+    }
+    return s;
+}
+
+static int rgfx_gl_init() {
+    if (g_rgfx_gl_program != 0) { return 1; }
+#if (defined(__arm__) || defined(__aarch64__)) && !defined(__APPLE__)
+    const char* vs =
+        \"attribute vec2 aPos;\\n\"
+        \"attribute vec2 aUv;\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"void main() { gl_Position = vec4(aPos, 0.0, 1.0); vUv = aUv; }\\n\";
+    const char* fs =
+        \"precision mediump float;\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"uniform sampler2D uTex;\\n\"
+        \"void main() { gl_FragColor = texture2D(uTex, vUv); }\\n\";
+#else
+    const char* vs =
+        \"#version 120\\n\"
+        \"attribute vec2 aPos;\\n\"
+        \"attribute vec2 aUv;\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"void main() { gl_Position = vec4(aPos, 0.0, 1.0); vUv = aUv; }\\n\";
+    const char* fs =
+        \"#version 120\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"uniform sampler2D uTex;\\n\"
+        \"void main() { gl_FragColor = texture2D(uTex, vUv); }\\n\";
+#endif
+    GLuint vsId = rgfx_gl_compile(GL_VERTEX_SHADER, vs);
+    GLuint fsId = rgfx_gl_compile(GL_FRAGMENT_SHADER, fs);
+    if (vsId == 0 || fsId == 0) {
+        if (vsId != 0) { glDeleteShader(vsId); }
+        if (fsId != 0) { glDeleteShader(fsId); }
+        return 0;
+    }
+    g_rgfx_gl_program = glCreateProgram();
+    glAttachShader(g_rgfx_gl_program, vsId);
+    glAttachShader(g_rgfx_gl_program, fsId);
+    glLinkProgram(g_rgfx_gl_program);
+    GLint linked = GL_FALSE;
+    glGetProgramiv(g_rgfx_gl_program, GL_LINK_STATUS, &linked);
+    glDeleteShader(vsId);
+    glDeleteShader(fsId);
+    if (linked != GL_TRUE) {
+        char log[1024];
+        GLsizei len = 0;
+        glGetProgramInfoLog(g_rgfx_gl_program, (GLsizei) sizeof(log), &len, log);
+        SDL_Log(\"[rgfx] GL program link failed: %.*s\", (int) len, log);
+        glDeleteProgram(g_rgfx_gl_program);
+        g_rgfx_gl_program = 0;
+        return 0;
+    }
+    g_rgfx_gl_pos_attr = glGetAttribLocation(g_rgfx_gl_program, \"aPos\");
+    g_rgfx_gl_uv_attr = glGetAttribLocation(g_rgfx_gl_program, \"aUv\");
+    g_rgfx_gl_tex_uniform = glGetUniformLocation(g_rgfx_gl_program, \"uTex\");
+    glGenBuffers(1, &g_rgfx_gl_vbo);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    return 1;
+}
+
+static int rgfx_open_gpu(const std::string& title, int w, int h) {
+    rgfx_prepare_audio_env();
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK) != 0) { return 0; }
+    rgfx_scan_pads();
+#if (defined(__arm__) || defined(__aarch64__)) && !defined(__APPLE__)
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+#else
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+#endif
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    // Depth buffer for the 3D mesh path (render=3d / Wasm3dRunner). Harmless for
+    // the 2D sprite path, which leaves GL_DEPTH_TEST disabled.
+    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+    g_rgfx_win = SDL_CreateWindow(title.c_str(),
+        SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, w, h,
+        SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
+    if (g_rgfx_win == nullptr) {
+        // Leave the GL request state clean so the software fallback can open a
+        // plain window + SDL_Renderer instead.
+        SDL_GL_ResetAttributes();
+        return 0;
+    }
+    g_rgfx_glctx = SDL_GL_CreateContext(g_rgfx_win);
+    if (g_rgfx_glctx == nullptr) {
+        // Destroy the OpenGL window before falling back; otherwise it lingers as
+        // an unfocusable ghost while the software path opens a second window.
+        SDL_DestroyWindow(g_rgfx_win);
+        g_rgfx_win = nullptr;
+        SDL_GL_ResetAttributes();
+        return 0;
+    }
+    SDL_GL_SetSwapInterval(1);
+    g_rgfx_gpu_mode = 1;
+    g_rgfx_fb_w = w;
+    g_rgfx_fb_h = h;
+    if (rgfx_gl_init()) { return 1; }
+    SDL_GL_DeleteContext(g_rgfx_glctx);
+    g_rgfx_glctx = nullptr;
+    SDL_DestroyWindow(g_rgfx_win);
+    g_rgfx_win = nullptr;
+    g_rgfx_gpu_mode = 0;
+    SDL_GL_ResetAttributes();
+    return 0;
+}
+
+static GLuint rgfx_gl_make_tex(const uint8_t* pixels, int w, int h) {
+    GLuint tex = 0;
+    glGenTextures(1, &tex);
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    return tex;
+}
+
+static int rgfx_gpu_upload_texture(const uint8_t* pixels, int w, int h) {
+    if (!g_rgfx_gpu_mode || pixels == nullptr || w <= 0 || h <= 0) { return 0; }
+    rgfx_gl_ensure_current();
+    GLuint tex = rgfx_gl_make_tex(pixels, w, h);
+    g_rgfx_gl_textures.push_back(tex);
+    return (int) g_rgfx_gl_textures.size();
+}
+
+static int rgfx_particles_gl_init() {
+    if (g_rgfx_part_program != 0) { return 1; }
+#if (defined(__arm__) || defined(__aarch64__)) && !defined(__APPLE__)
+    const char* vs =
+        \"attribute vec2 aCorner;\\n\"
+        \"attribute vec2 aCenter;\\n\"
+        \"attribute float aSize;\\n\"
+        \"attribute vec4 aColor;\\n\"
+        \"uniform vec2 uResolution;\\n\"
+        \"varying vec2 vCorner;\\n\"
+        \"varying vec4 vColor;\\n\"
+        \"void main() {\\n\"
+        \"  vec2 pix = aCenter + aCorner * aSize;\\n\"
+        \"  vec2 ndc;\\n\"
+        \"  ndc.x = (pix.x / uResolution.x) * 2.0 - 1.0;\\n\"
+        \"  ndc.y = 1.0 - (pix.y / uResolution.y) * 2.0;\\n\"
+        \"  gl_Position = vec4(ndc, 0.0, 1.0);\\n\"
+        \"  vCorner = aCorner;\\n\"
+        \"  vColor = aColor;\\n\"
+        \"}\\n\";
+    const char* fs =
+        \"precision mediump float;\\n\"
+        \"varying vec2 vCorner;\\n\"
+        \"varying vec4 vColor;\\n\"
+        \"void main() {\\n\"
+        \"  float d = dot(vCorner, vCorner);\\n\"
+        \"  if (d > 1.0) discard;\\n\"
+        \"  float soft = 1.0 - d;\\n\"
+        \"  float core = 1.0 - smoothstep(0.0, 0.22, d);\\n\"
+        \"  float alpha = vColor.a * soft * soft;\\n\"
+        \"  vec3 rgb = vColor.rgb * (1.0 + core * 0.7);\\n\"
+        \"  gl_FragColor = vec4(rgb, alpha);\\n\"
+        \"}\\n\";
+#else
+    const char* vs =
+        \"#version 120\\n\"
+        \"attribute vec2 aCorner;\\n\"
+        \"attribute vec2 aCenter;\\n\"
+        \"attribute float aSize;\\n\"
+        \"attribute vec4 aColor;\\n\"
+        \"uniform vec2 uResolution;\\n\"
+        \"varying vec2 vCorner;\\n\"
+        \"varying vec4 vColor;\\n\"
+        \"void main() {\\n\"
+        \"  vec2 pix = aCenter + aCorner * aSize;\\n\"
+        \"  vec2 ndc;\\n\"
+        \"  ndc.x = (pix.x / uResolution.x) * 2.0 - 1.0;\\n\"
+        \"  ndc.y = 1.0 - (pix.y / uResolution.y) * 2.0;\\n\"
+        \"  gl_Position = vec4(ndc, 0.0, 1.0);\\n\"
+        \"  vCorner = aCorner;\\n\"
+        \"  vColor = aColor;\\n\"
+        \"}\\n\";
+    const char* fs =
+        \"#version 120\\n\"
+        \"varying vec2 vCorner;\\n\"
+        \"varying vec4 vColor;\\n\"
+        \"void main() {\\n\"
+        \"  float d = dot(vCorner, vCorner);\\n\"
+        \"  if (d > 1.0) discard;\\n\"
+        \"  float soft = 1.0 - d;\\n\"
+        \"  float core = 1.0 - smoothstep(0.0, 0.22, d);\\n\"
+        \"  float alpha = vColor.a * soft * soft;\\n\"
+        \"  vec3 rgb = vColor.rgb * (1.0 + core * 0.7);\\n\"
+        \"  gl_FragColor = vec4(rgb, alpha);\\n\"
+        \"}\\n\";
+#endif
+    GLuint vsId = rgfx_gl_compile(GL_VERTEX_SHADER, vs);
+    GLuint fsId = rgfx_gl_compile(GL_FRAGMENT_SHADER, fs);
+    if (vsId == 0 || fsId == 0) {
+        if (vsId != 0) { glDeleteShader(vsId); }
+        if (fsId != 0) { glDeleteShader(fsId); }
+        return 0;
+    }
+    g_rgfx_part_program = glCreateProgram();
+    glAttachShader(g_rgfx_part_program, vsId);
+    glAttachShader(g_rgfx_part_program, fsId);
+    glLinkProgram(g_rgfx_part_program);
+    GLint linked = GL_FALSE;
+    glGetProgramiv(g_rgfx_part_program, GL_LINK_STATUS, &linked);
+    glDeleteShader(vsId);
+    glDeleteShader(fsId);
+    if (linked != GL_TRUE) {
+        char log[1024];
+        GLsizei len = 0;
+        glGetProgramInfoLog(g_rgfx_part_program, (GLsizei) sizeof(log), &len, log);
+        SDL_Log(\"[rgfx] particle program link failed: %.*s\", (int) len, log);
+        glDeleteProgram(g_rgfx_part_program);
+        g_rgfx_part_program = 0;
+        return 0;
+    }
+    g_rgfx_part_corner_attr = glGetAttribLocation(g_rgfx_part_program, \"aCorner\");
+    g_rgfx_part_center_attr = glGetAttribLocation(g_rgfx_part_program, \"aCenter\");
+    g_rgfx_part_size_attr = glGetAttribLocation(g_rgfx_part_program, \"aSize\");
+    g_rgfx_part_color_attr = glGetAttribLocation(g_rgfx_part_program, \"aColor\");
+    g_rgfx_part_res_uniform = glGetUniformLocation(g_rgfx_part_program, \"uResolution\");
+    glGenBuffers(1, &g_rgfx_part_vbo);
+    return 1;
+}
+
+static void rgfx_particles_begin(int w, int h, int pane) {
+    g_rgfx_active_particle_queue = rgfx_gpu_queue_index(pane);
+    RgfxGpuParticleQueue& q = g_rgfx_particle_queues[g_rgfx_active_particle_queue];
+    q.items.clear();
+    q.fbW = w;
+    q.fbH = h;
+}
+
+static void rgfx_particles_push(float x, float y, float size, int r, int g, int b, int a) {
+    if (a <= 0 || size <= 0.f) { return; }
+    RgfxGpuParticle p;
+    p.x = x; p.y = y; p.size = size;
+    p.r = (uint8_t) r; p.g = (uint8_t) g; p.b = (uint8_t) b; p.a = (uint8_t) a;
+    g_rgfx_particle_queues[g_rgfx_active_particle_queue].items.push_back(p);
+}
+
+static void rgfx_particles_draw_queue(int queueIndex, int viewportX, int viewportW, int viewportH) {
+    RgfxGpuParticleQueue& q = g_rgfx_particle_queues[queueIndex];
+    if (q.items.empty() || q.fbW <= 0 || q.fbH <= 0 || viewportW <= 0 || viewportH <= 0) { return; }
+    if (!g_rgfx_gpu_mode) { return; }
+    if (!rgfx_particles_gl_init()) { return; }
+    glViewport(viewportX, 0, viewportW, viewportH);
+    static const float corners[6][2] = {
+        {-1.f, -1.f}, {1.f, -1.f}, {1.f, 1.f},
+        {-1.f, -1.f}, {1.f, 1.f}, {-1.f, 1.f}
+    };
+    std::vector<float> verts;
+    verts.reserve(q.items.size() * 6u * 9u);
+    for (const RgfxGpuParticle& p : q.items) {
+        float cr = p.r / 255.f, cg = p.g / 255.f, cb = p.b / 255.f, ca = p.a / 255.f;
+        for (int i = 0; i < 6; ++i) {
+            verts.push_back(corners[i][0]);
+            verts.push_back(corners[i][1]);
+            verts.push_back(p.x);
+            verts.push_back(p.y);
+            verts.push_back(p.size);
+            verts.push_back(cr);
+            verts.push_back(cg);
+            verts.push_back(cb);
+            verts.push_back(ca);
+        }
+    }
+    glUseProgram(g_rgfx_part_program);
+    glUniform2f((GLint) g_rgfx_part_res_uniform, (float) q.fbW, (float) q.fbH);
+    glBindBuffer(GL_ARRAY_BUFFER, g_rgfx_part_vbo);
+    glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) (verts.size() * sizeof(float)), verts.data(), GL_DYNAMIC_DRAW);
+    const GLsizei stride = (GLsizei) (9 * sizeof(float));
+    glEnableVertexAttribArray((GLuint) g_rgfx_part_corner_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_part_corner_attr, 2, GL_FLOAT, GL_FALSE, stride, (void*) 0);
+    glEnableVertexAttribArray((GLuint) g_rgfx_part_center_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_part_center_attr, 2, GL_FLOAT, GL_FALSE, stride, (void*) (2 * sizeof(float)));
+    glEnableVertexAttribArray((GLuint) g_rgfx_part_size_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_part_size_attr, 1, GL_FLOAT, GL_FALSE, stride, (void*) (4 * sizeof(float)));
+    glEnableVertexAttribArray((GLuint) g_rgfx_part_color_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_part_color_attr, 4, GL_FLOAT, GL_FALSE, stride, (void*) (5 * sizeof(float)));
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+    glDrawArrays(GL_TRIANGLES, 0, (GLsizei) (q.items.size() * 6));
+    q.items.clear();
+}
+
+static void rgfx_particles_draw_overlay() {
+    rgfx_particles_draw_queue(0, 0, g_rgfx_fb_w, g_rgfx_fb_h);
+}
+
+// ---- GPU UI-effect overlay (glow / pulse) ---------------------------------
+static int rgfx_fx_gl_init() {
+    if (g_rgfx_fx_program != 0) { return 1; }
+#if (defined(__arm__) || defined(__aarch64__)) && !defined(__APPLE__)
+    const char* vs =
+        \"attribute vec2 aCorner;\\n\"
+        \"attribute vec2 aCenter;\\n\"
+        \"attribute vec2 aHalf;\\n\"
+        \"attribute vec4 aColor;\\n\"
+        \"attribute float aFeather;\\n\"
+        \"uniform vec2 uResolution;\\n\"
+        \"varying vec2 vCorner;\\n\"
+        \"varying vec4 vColor;\\n\"
+        \"varying float vFeather;\\n\"
+        \"void main() {\\n\"
+        \"  vec2 pix = aCenter + aCorner * aHalf;\\n\"
+        \"  vec2 ndc;\\n\"
+        \"  ndc.x = (pix.x / uResolution.x) * 2.0 - 1.0;\\n\"
+        \"  ndc.y = 1.0 - (pix.y / uResolution.y) * 2.0;\\n\"
+        \"  gl_Position = vec4(ndc, 0.0, 1.0);\\n\"
+        \"  vCorner = aCorner;\\n\"
+        \"  vColor = aColor;\\n\"
+        \"  vFeather = aFeather;\\n\"
+        \"}\\n\";
+    const char* fs =
+        \"precision mediump float;\\n\"
+        \"varying vec2 vCorner;\\n\"
+        \"varying vec4 vColor;\\n\"
+        \"varying float vFeather;\\n\"
+        \"void main() {\\n\"
+        \"  float d = length(vCorner);\\n\"
+        \"  float edge = 1.0 - vFeather;\\n\"
+        \"  float m = 1.0 - smoothstep(edge, 1.0, d);\\n\"
+        \"  if (m <= 0.0) discard;\\n\"
+        \"  gl_FragColor = vec4(vColor.rgb, vColor.a * m);\\n\"
+        \"}\\n\";
+#else
+    const char* vs =
+        \"#version 120\\n\"
+        \"attribute vec2 aCorner;\\n\"
+        \"attribute vec2 aCenter;\\n\"
+        \"attribute vec2 aHalf;\\n\"
+        \"attribute vec4 aColor;\\n\"
+        \"attribute float aFeather;\\n\"
+        \"uniform vec2 uResolution;\\n\"
+        \"varying vec2 vCorner;\\n\"
+        \"varying vec4 vColor;\\n\"
+        \"varying float vFeather;\\n\"
+        \"void main() {\\n\"
+        \"  vec2 pix = aCenter + aCorner * aHalf;\\n\"
+        \"  vec2 ndc;\\n\"
+        \"  ndc.x = (pix.x / uResolution.x) * 2.0 - 1.0;\\n\"
+        \"  ndc.y = 1.0 - (pix.y / uResolution.y) * 2.0;\\n\"
+        \"  gl_Position = vec4(ndc, 0.0, 1.0);\\n\"
+        \"  vCorner = aCorner;\\n\"
+        \"  vColor = aColor;\\n\"
+        \"  vFeather = aFeather;\\n\"
+        \"}\\n\";
+    const char* fs =
+        \"#version 120\\n\"
+        \"varying vec2 vCorner;\\n\"
+        \"varying vec4 vColor;\\n\"
+        \"varying float vFeather;\\n\"
+        \"void main() {\\n\"
+        \"  float d = length(vCorner);\\n\"
+        \"  float edge = 1.0 - vFeather;\\n\"
+        \"  float m = 1.0 - smoothstep(edge, 1.0, d);\\n\"
+        \"  if (m <= 0.0) discard;\\n\"
+        \"  gl_FragColor = vec4(vColor.rgb, vColor.a * m);\\n\"
+        \"}\\n\";
+#endif
+    GLuint vsId = rgfx_gl_compile(GL_VERTEX_SHADER, vs);
+    GLuint fsId = rgfx_gl_compile(GL_FRAGMENT_SHADER, fs);
+    if (vsId == 0 || fsId == 0) {
+        if (vsId != 0) { glDeleteShader(vsId); }
+        if (fsId != 0) { glDeleteShader(fsId); }
+        return 0;
+    }
+    g_rgfx_fx_program = glCreateProgram();
+    glAttachShader(g_rgfx_fx_program, vsId);
+    glAttachShader(g_rgfx_fx_program, fsId);
+    glLinkProgram(g_rgfx_fx_program);
+    GLint linked = GL_FALSE;
+    glGetProgramiv(g_rgfx_fx_program, GL_LINK_STATUS, &linked);
+    glDeleteShader(vsId);
+    glDeleteShader(fsId);
+    if (linked != GL_TRUE) {
+        char log[1024];
+        GLsizei len = 0;
+        glGetProgramInfoLog(g_rgfx_fx_program, (GLsizei) sizeof(log), &len, log);
+        SDL_Log(\"[rgfx] fx program link failed: %.*s\", (int) len, log);
+        glDeleteProgram(g_rgfx_fx_program);
+        g_rgfx_fx_program = 0;
+        return 0;
+    }
+    g_rgfx_fx_corner_attr = glGetAttribLocation(g_rgfx_fx_program, \"aCorner\");
+    g_rgfx_fx_center_attr = glGetAttribLocation(g_rgfx_fx_program, \"aCenter\");
+    g_rgfx_fx_half_attr = glGetAttribLocation(g_rgfx_fx_program, \"aHalf\");
+    g_rgfx_fx_color_attr = glGetAttribLocation(g_rgfx_fx_program, \"aColor\");
+    g_rgfx_fx_feather_attr = glGetAttribLocation(g_rgfx_fx_program, \"aFeather\");
+    g_rgfx_fx_res_uniform = glGetUniformLocation(g_rgfx_fx_program, \"uResolution\");
+    glGenBuffers(1, &g_rgfx_fx_vbo);
+    return 1;
+}
+
+static void rgfx_fx_begin(int w, int h) {
+    g_rgfx_fx_items.clear();
+    g_rgfx_fx_fbW = w;
+    g_rgfx_fx_fbH = h;
+}
+
+static void rgfx_fx_push(float cx, float cy, float hx, float hy,
+                         int r, int g, int b, int a, float feather) {
+    if (a <= 0 || hx <= 0.f || hy <= 0.f) { return; }
+    RgfxFxItem it;
+    it.cx = cx; it.cy = cy; it.hx = hx; it.hy = hy;
+    it.r = (uint8_t) r; it.g = (uint8_t) g; it.b = (uint8_t) b; it.a = (uint8_t) a;
+    it.feather = feather;
+    g_rgfx_fx_items.push_back(it);
+}
+
+// A node glow: soft halo over the (already-expanded) node rect.
+static void rgfx_fx_push_glow(float x, float y, float w, float h,
+                              int r, int g, int b, int a) {
+    rgfx_fx_push(x + w * 0.5f, y + h * 0.5f, w * 0.5f, h * 0.5f, r, g, b, a, 0.85f);
+}
+
+// A whole-screen pulse: colour wash across the frame, brightest at centre.
+static void rgfx_fx_push_screen(int r, int g, int b, int a) {
+    if (g_rgfx_fx_fbW <= 0 || g_rgfx_fx_fbH <= 0) { return; }
+    float hw = g_rgfx_fx_fbW * 0.5f;
+    float hh = g_rgfx_fx_fbH * 0.5f;
+    rgfx_fx_push(hw, hh, hw, hh, r, g, b, a, 0.9f);
+}
+
+static void rgfx_fx_draw_overlay() {
+    if (g_rgfx_fx_items.empty() || g_rgfx_fx_fbW <= 0 || g_rgfx_fx_fbH <= 0) { return; }
+    if (!g_rgfx_gpu_mode) { g_rgfx_fx_items.clear(); return; }
+    if (!rgfx_fx_gl_init()) { g_rgfx_fx_items.clear(); return; }
+    glViewport(0, 0, g_rgfx_fb_w, g_rgfx_fb_h);
+    static const float corners[6][2] = {
+        {-1.f, -1.f}, {1.f, -1.f}, {1.f, 1.f},
+        {-1.f, -1.f}, {1.f, 1.f}, {-1.f, 1.f}
+    };
+    std::vector<float> verts;
+    verts.reserve(g_rgfx_fx_items.size() * 6u * 11u);
+    for (const RgfxFxItem& it : g_rgfx_fx_items) {
+        float cr = it.r / 255.f, cg = it.g / 255.f, cb = it.b / 255.f, ca = it.a / 255.f;
+        for (int i = 0; i < 6; ++i) {
+            verts.push_back(corners[i][0]);
+            verts.push_back(corners[i][1]);
+            verts.push_back(it.cx);
+            verts.push_back(it.cy);
+            verts.push_back(it.hx);
+            verts.push_back(it.hy);
+            verts.push_back(cr);
+            verts.push_back(cg);
+            verts.push_back(cb);
+            verts.push_back(ca);
+            verts.push_back(it.feather);
+        }
+    }
+    glUseProgram(g_rgfx_fx_program);
+    glUniform2f((GLint) g_rgfx_fx_res_uniform, (float) g_rgfx_fx_fbW, (float) g_rgfx_fx_fbH);
+    glBindBuffer(GL_ARRAY_BUFFER, g_rgfx_fx_vbo);
+    glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) (verts.size() * sizeof(float)), verts.data(), GL_DYNAMIC_DRAW);
+    const GLsizei stride = (GLsizei) (11 * sizeof(float));
+    glEnableVertexAttribArray((GLuint) g_rgfx_fx_corner_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_fx_corner_attr, 2, GL_FLOAT, GL_FALSE, stride, (void*) 0);
+    glEnableVertexAttribArray((GLuint) g_rgfx_fx_center_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_fx_center_attr, 2, GL_FLOAT, GL_FALSE, stride, (void*) (2 * sizeof(float)));
+    glEnableVertexAttribArray((GLuint) g_rgfx_fx_half_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_fx_half_attr, 2, GL_FLOAT, GL_FALSE, stride, (void*) (4 * sizeof(float)));
+    glEnableVertexAttribArray((GLuint) g_rgfx_fx_color_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_fx_color_attr, 4, GL_FLOAT, GL_FALSE, stride, (void*) (6 * sizeof(float)));
+    glEnableVertexAttribArray((GLuint) g_rgfx_fx_feather_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_fx_feather_attr, 1, GL_FLOAT, GL_FALSE, stride, (void*) (10 * sizeof(float)));
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+    glDrawArrays(GL_TRIANGLES, 0, (GLsizei) (g_rgfx_fx_items.size() * 6));
+    g_rgfx_fx_items.clear();
+}
+
+static void rgfx_gpu_sprites_begin(int w, int h, int pane) {
+    g_rgfx_active_sprite_queue = rgfx_gpu_queue_index(pane);
+    RgfxGpuSpriteQueue& q = g_rgfx_sprite_queues[g_rgfx_active_sprite_queue];
+    q.items.clear();
+    q.fbW = w;
+    q.fbH = h;
+}
+
+static void rgfx_px_to_ndc(float px, float py, int fbW, int fbH, float* nx, float* ny) {
+    *nx = (px / (float) fbW) * 2.f - 1.f;
+    *ny = 1.f - (py / (float) fbH) * 2.f;
+}
+
+static void rgfx_gpu_draw_textured_quad_corners(
+    GLuint tex, float u0, float v0, float u1, float v1,
+    float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3,
+    int fbW, int fbH) {
+    float nx0, ny0, nx1, ny1, nx2, ny2, nx3, ny3;
+    rgfx_px_to_ndc(x0, y0, fbW, fbH, &nx0, &ny0);
+    rgfx_px_to_ndc(x1, y1, fbW, fbH, &nx1, &ny1);
+    rgfx_px_to_ndc(x2, y2, fbW, fbH, &nx2, &ny2);
+    rgfx_px_to_ndc(x3, y3, fbW, fbH, &nx3, &ny3);
+    float verts[] = {
+        nx0, ny0, u0, v0,
+        nx1, ny1, u1, v0,
+        nx2, ny2, u1, v1,
+        nx0, ny0, u0, v0,
+        nx2, ny2, u1, v1,
+        nx3, ny3, u0, v1,
+    };
+    glUseProgram(g_rgfx_gl_program);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glUniform1i(g_rgfx_gl_tex_uniform, 0);
+    glBindBuffer(GL_ARRAY_BUFFER, g_rgfx_gl_vbo);
+    glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) sizeof(verts), verts, GL_DYNAMIC_DRAW);
+    glEnableVertexAttribArray((GLuint) g_rgfx_gl_pos_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_gl_pos_attr, 2, GL_FLOAT, GL_FALSE, 4 * (GLsizei) sizeof(float), (void*) 0);
+    glEnableVertexAttribArray((GLuint) g_rgfx_gl_uv_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_gl_uv_attr, 2, GL_FLOAT, GL_FALSE, 4 * (GLsizei) sizeof(float), (void*) (2 * sizeof(float)));
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+}
+
+static void rgfx_gpu_sprites_push(int texId, int atlasW, int atlasH,
+    int sx, int sy, int sw, int sh,
+    float px, float py, float dw, float dh, float angleDeg, int usePivot) {
+    if (!g_rgfx_gpu_mode || texId <= 0 || sw <= 0 || sh <= 0 || dw <= 0.f || dh <= 0.f) { return; }
+    RgfxGpuSprite s;
+    s.texId = texId;
+    s.atlasW = atlasW;
+    s.atlasH = atlasH;
+    s.sx = sx;
+    s.sy = sy;
+    s.sw = sw;
+    s.sh = sh;
+    s.px = px;
+    s.py = py;
+    s.dw = dw;
+    s.dh = dh;
+    s.angleDeg = angleDeg;
+    s.usePivot = usePivot;
+    g_rgfx_sprite_queues[g_rgfx_active_sprite_queue].items.push_back(s);
+}
+
+// Append one sprite quad (6 verts of nx,ny,u,v) to a batch buffer. Vertex
+// order and UV assignment match rgfx_gpu_draw_textured_quad_corners exactly, so
+// the batched path is pixel-identical to the per-sprite path.
+static void rgfx_gpu_sprites_append_quad(std::vector<float>& verts, const RgfxGpuSprite& s, int fbW, int fbH) {
+    float u0 = (float) s.sx / (float) s.atlasW;
+    float v0 = (float) s.sy / (float) s.atlasH;
+    float u1 = (float) (s.sx + s.sw) / (float) s.atlasW;
+    float v1 = (float) (s.sy + s.sh) / (float) s.atlasH;
+    float x[4], y[4];
+    if (s.usePivot == 0) {
+        x[0] = s.px;        y[0] = s.py;
+        x[1] = s.px + s.dw; y[1] = s.py;
+        x[2] = s.px + s.dw; y[2] = s.py + s.dh;
+        x[3] = s.px;        y[3] = s.py + s.dh;
+    } else {
+        float rad = s.angleDeg * 3.14159265f / 180.f;
+        float ca = cosf(rad), sa = sinf(rad);
+        float hw = s.dw * 0.5f, hh = s.dh * 0.5f;
+        float lx[4] = {-hw, hw, hw, -hw};
+        float ly[4] = {-hh, -hh, hh, hh};
+        for (int i = 0; i < 4; ++i) {
+            x[i] = s.px + (lx[i] * ca - ly[i] * sa);
+            y[i] = s.py + (lx[i] * sa + ly[i] * ca);
+        }
+    }
+    float nx[4], ny[4];
+    for (int i = 0; i < 4; ++i) { rgfx_px_to_ndc(x[i], y[i], fbW, fbH, &nx[i], &ny[i]); }
+    float uvx[4] = { u0, u1, u1, u0 };
+    float uvy[4] = { v0, v0, v1, v1 };
+    static const int tri[6] = { 0, 1, 2, 0, 2, 3 };
+    for (int t = 0; t < 6; ++t) {
+        int c = tri[t];
+        verts.push_back(nx[c]);
+        verts.push_back(ny[c]);
+        verts.push_back(uvx[c]);
+        verts.push_back(uvy[c]);
+    }
+}
+
+// Draw one accumulated run (all quads share a single texture) in one draw call.
+static void rgfx_gpu_sprites_flush_run(GLuint tex, std::vector<float>& verts) {
+    if (verts.empty()) { return; }
+    glUseProgram(g_rgfx_gl_program);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glUniform1i(g_rgfx_gl_tex_uniform, 0);
+    glBindBuffer(GL_ARRAY_BUFFER, g_rgfx_gl_vbo);
+    glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) (verts.size() * sizeof(float)), verts.data(), GL_DYNAMIC_DRAW);
+    const GLsizei stride = 4 * (GLsizei) sizeof(float);
+    glEnableVertexAttribArray((GLuint) g_rgfx_gl_pos_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_gl_pos_attr, 2, GL_FLOAT, GL_FALSE, stride, (void*) 0);
+    glEnableVertexAttribArray((GLuint) g_rgfx_gl_uv_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_gl_uv_attr, 2, GL_FLOAT, GL_FALSE, stride, (void*) (2 * sizeof(float)));
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glDrawArrays(GL_TRIANGLES, 0, (GLsizei) (verts.size() / 4));
+    verts.clear();
+}
+
+// --- R1b: 4x4 matrix helpers (column-major, OpenGL convention) --------------
+// Seed of the Ranger Render Core matrix path (PLAN_RANGER2D.md §6): the camera
+// path draws with gl_Position = uViewProj * vec4(pos, 0, 1). A later
+// perspective camera or per-item world matrix slots into the same contract
+// without touching the vertex format.
+static void rgfx_mat4_identity(float* m) {
+    for (int i = 0; i < 16; ++i) { m[i] = 0.f; }
+    m[0] = 1.f;
+    m[5] = 1.f;
+    m[10] = 1.f;
+    m[15] = 1.f;
+}
+
+static void rgfx_mat4_mul(float* out, const float* a, const float* b) {
+    float r[16];
+    for (int col = 0; col < 4; ++col) {
+        for (int row = 0; row < 4; ++row) {
+            float acc = 0.f;
+            for (int k = 0; k < 4; ++k) { acc += a[k * 4 + row] * b[col * 4 + k]; }
+            r[col * 4 + row] = acc;
+        }
+    }
+    for (int i = 0; i < 16; ++i) { out[i] = r[i]; }
+}
+
+// Pixel-space ortho projection: x' = 2x/fbW - 1, y' = 1 - 2y/fbH — the same
+// mapping as rgfx_px_to_ndc, evaluated on the GPU.
+static void rgfx_mat4_ortho2d(float* m, float fbW, float fbH) {
+    rgfx_mat4_identity(m);
+    m[0] = 2.f / fbW;
+    m[5] = -2.f / fbH;
+    m[12] = -1.f;
+    m[13] = 1.f;
+}
+
+// View: p' = C + zoom * R(rot) * (p - cam - C) with C = pane centre, so cam
+// pans like the existing world->screen offset and zoom/rotation pivot on the
+// centre of the pane. cam=(0,0), zoom=1, rot=0 is exactly the identity.
+static void rgfx_mat4_view2d(float* m, const RgfxGpuCamera2D& cam, float fbW, float fbH) {
+    float rad = cam.rotDeg * 3.14159265f / 180.f;
+    float ca = cosf(rad);
+    float sa = sinf(rad);
+    float l00 = cam.zoom * ca;
+    float l01 = -cam.zoom * sa;
+    float l10 = cam.zoom * sa;
+    float l11 = cam.zoom * ca;
+    float cx = fbW * 0.5f;
+    float cy = fbH * 0.5f;
+    float ox = cam.x + cx;
+    float oy = cam.y + cy;
+    rgfx_mat4_identity(m);
+    m[0] = l00;
+    m[1] = l10;
+    m[4] = l01;
+    m[5] = l11;
+    m[12] = cx - (l00 * ox + l01 * oy);
+    m[13] = cy - (l10 * ox + l11 * oy);
+}
+
+// Sprite program with a 4x4 view-projection uniform; aPos is in framebuffer
+// pixels (the pixel->NDC ortho lives inside uViewProj). Separate program from
+// the base full-frame present so the shared path stays untouched (regression
+// vector B in PLAN_RANGER2D.md §11b).
+static int rgfx_cam_gl_init() {
+    if (g_rgfx_cam_program != 0) { return 1; }
+#if (defined(__arm__) || defined(__aarch64__)) && !defined(__APPLE__)
+    const char* vs =
+        \"attribute vec2 aPos;\\n\"
+        \"attribute vec2 aUv;\\n\"
+        \"uniform mat4 uViewProj;\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"void main() { gl_Position = uViewProj * vec4(aPos, 0.0, 1.0); vUv = aUv; }\\n\";
+    const char* fs =
+        \"precision mediump float;\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"uniform sampler2D uTex;\\n\"
+        \"void main() { gl_FragColor = texture2D(uTex, vUv); }\\n\";
+#else
+    const char* vs =
+        \"#version 120\\n\"
+        \"attribute vec2 aPos;\\n\"
+        \"attribute vec2 aUv;\\n\"
+        \"uniform mat4 uViewProj;\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"void main() { gl_Position = uViewProj * vec4(aPos, 0.0, 1.0); vUv = aUv; }\\n\";
+    const char* fs =
+        \"#version 120\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"uniform sampler2D uTex;\\n\"
+        \"void main() { gl_FragColor = texture2D(uTex, vUv); }\\n\";
+#endif
+    GLuint vsId = rgfx_gl_compile(GL_VERTEX_SHADER, vs);
+    GLuint fsId = rgfx_gl_compile(GL_FRAGMENT_SHADER, fs);
+    if (vsId == 0 || fsId == 0) {
+        if (vsId != 0) { glDeleteShader(vsId); }
+        if (fsId != 0) { glDeleteShader(fsId); }
+        return 0;
+    }
+    g_rgfx_cam_program = glCreateProgram();
+    glAttachShader(g_rgfx_cam_program, vsId);
+    glAttachShader(g_rgfx_cam_program, fsId);
+    glLinkProgram(g_rgfx_cam_program);
+    GLint linked = GL_FALSE;
+    glGetProgramiv(g_rgfx_cam_program, GL_LINK_STATUS, &linked);
+    glDeleteShader(vsId);
+    glDeleteShader(fsId);
+    if (linked != GL_TRUE) {
+        char log[1024];
+        GLsizei len = 0;
+        glGetProgramInfoLog(g_rgfx_cam_program, (GLsizei) sizeof(log), &len, log);
+        SDL_Log(\"[rgfx] camera GL program link failed: %.*s\", (int) len, log);
+        glDeleteProgram(g_rgfx_cam_program);
+        g_rgfx_cam_program = 0;
+        return 0;
+    }
+    g_rgfx_cam_pos_attr = glGetAttribLocation(g_rgfx_cam_program, \"aPos\");
+    g_rgfx_cam_uv_attr = glGetAttribLocation(g_rgfx_cam_program, \"aUv\");
+    g_rgfx_cam_tex_uniform = glGetUniformLocation(g_rgfx_cam_program, \"uTex\");
+    g_rgfx_cam_vp_uniform = glGetUniformLocation(g_rgfx_cam_program, \"uViewProj\");
+    return 1;
+}
+
+// Append one sprite quad in framebuffer pixel space (6 verts of px,py,u,v) for
+// the camera path. Corner and UV math must stay in lockstep with
+// rgfx_gpu_sprites_append_quad — the only difference is that the pixel->NDC
+// mapping happens on the GPU via uViewProj.
+static void rgfx_gpu_sprites_append_quad_px(std::vector<float>& verts, const RgfxGpuSprite& s) {
+    float u0 = (float) s.sx / (float) s.atlasW;
+    float v0 = (float) s.sy / (float) s.atlasH;
+    float u1 = (float) (s.sx + s.sw) / (float) s.atlasW;
+    float v1 = (float) (s.sy + s.sh) / (float) s.atlasH;
+    float x[4], y[4];
+    if (s.usePivot == 0) {
+        x[0] = s.px;        y[0] = s.py;
+        x[1] = s.px + s.dw; y[1] = s.py;
+        x[2] = s.px + s.dw; y[2] = s.py + s.dh;
+        x[3] = s.px;        y[3] = s.py + s.dh;
+    } else {
+        float rad = s.angleDeg * 3.14159265f / 180.f;
+        float ca = cosf(rad), sa = sinf(rad);
+        float hw = s.dw * 0.5f, hh = s.dh * 0.5f;
+        float lx[4] = {-hw, hw, hw, -hw};
+        float ly[4] = {-hh, -hh, hh, hh};
+        for (int i = 0; i < 4; ++i) {
+            x[i] = s.px + (lx[i] * ca - ly[i] * sa);
+            y[i] = s.py + (lx[i] * sa + ly[i] * ca);
+        }
+    }
+    float uvx[4] = { u0, u1, u1, u0 };
+    float uvy[4] = { v0, v0, v1, v1 };
+    static const int tri[6] = { 0, 1, 2, 0, 2, 3 };
+    for (int t = 0; t < 6; ++t) {
+        int c = tri[t];
+        verts.push_back(x[c]);
+        verts.push_back(y[c]);
+        verts.push_back(uvx[c]);
+        verts.push_back(uvy[c]);
+    }
+}
+
+// Draw one accumulated pixel-space run with the camera program (one draw call).
+static void rgfx_gpu_sprites_flush_run_cam(GLuint tex, std::vector<float>& verts, const float* viewProj) {
+    if (verts.empty()) { return; }
+    glUseProgram(g_rgfx_cam_program);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glUniform1i(g_rgfx_cam_tex_uniform, 0);
+    glUniformMatrix4fv(g_rgfx_cam_vp_uniform, 1, GL_FALSE, viewProj);
+    glBindBuffer(GL_ARRAY_BUFFER, g_rgfx_gl_vbo);
+    glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) (verts.size() * sizeof(float)), verts.data(), GL_DYNAMIC_DRAW);
+    const GLsizei stride = 4 * (GLsizei) sizeof(float);
+    glEnableVertexAttribArray((GLuint) g_rgfx_cam_pos_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_cam_pos_attr, 2, GL_FLOAT, GL_FALSE, stride, (void*) 0);
+    glEnableVertexAttribArray((GLuint) g_rgfx_cam_uv_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_cam_uv_attr, 2, GL_FLOAT, GL_FALSE, stride, (void*) (2 * sizeof(float)));
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glDrawArrays(GL_TRIANGLES, 0, (GLsizei) (verts.size() / 4));
+    verts.clear();
+}
+
+static void rgfx_gpu_sprites_draw_queue_batched(int queueIndex, int viewportX, int viewportW, int viewportH);
+
+// Batched sprite draw through the 4x4 camera path: same texture-run coalescing
+// and queue order as rgfx_gpu_sprites_draw_queue_batched, but vertices stay in
+// framebuffer pixels and the ortho * view matrix is applied in the vertex
+// shader. With the default (identity) camera this renders the same frame as
+// the CPU-NDC batched path.
+static void rgfx_gpu_sprites_draw_queue_camera(int queueIndex, int viewportX, int viewportW, int viewportH) {
+    RgfxGpuSpriteQueue& q = g_rgfx_sprite_queues[queueIndex];
+    if (q.items.empty() || q.fbW <= 0 || q.fbH <= 0 || viewportW <= 0 || viewportH <= 0) { return; }
+    if (!g_rgfx_gpu_mode) { return; }
+    rgfx_gl_ensure_current();
+    if (!rgfx_gl_init()) { return; }
+    if (!rgfx_cam_gl_init()) {
+        // Camera shader unavailable: degrade to the proven CPU-NDC batch.
+        rgfx_gpu_sprites_draw_queue_batched(queueIndex, viewportX, viewportW, viewportH);
+        return;
+    }
+    glViewport(viewportX, 0, viewportW, viewportH);
+    float ortho[16];
+    float view[16];
+    float viewProj[16];
+    rgfx_mat4_ortho2d(ortho, (float) q.fbW, (float) q.fbH);
+    const RgfxGpuCamera2D& cam = g_rgfx_cameras[queueIndex];
+    if (cam.enabled) {
+        rgfx_mat4_view2d(view, cam, (float) q.fbW, (float) q.fbH);
+    } else {
+        rgfx_mat4_identity(view);
+    }
+    rgfx_mat4_mul(viewProj, ortho, view);
+    std::vector<float> verts;
+    verts.reserve(q.items.size() * 6u * 4u);
+    int runTex = -1;
+    GLuint runGlTex = 0;
+    for (const RgfxGpuSprite& s : q.items) {
+        if (s.texId <= 0 || s.texId > (int) g_rgfx_gl_textures.size()) { continue; }
+        GLuint tex = g_rgfx_gl_textures[(size_t) (s.texId - 1)];
+        if (s.texId != runTex && !verts.empty()) {
+            rgfx_gpu_sprites_flush_run_cam(runGlTex, verts, viewProj);
+        }
+        runTex = s.texId;
+        runGlTex = tex;
+        rgfx_gpu_sprites_append_quad_px(verts, s);
+    }
+    rgfx_gpu_sprites_flush_run_cam(runGlTex, verts, viewProj);
+    q.items.clear();
+}
+
+// Batched sprite draw: coalesce contiguous same-texture sprites into one draw
+// call each. Queue order is preserved (a run only flushes when the texture
+// changes), so alpha blending is identical to the per-sprite path — but an
+// atlas-based scene of N sprites collapses from N draw calls to ~one per sheet.
+static void rgfx_gpu_sprites_draw_queue_batched(int queueIndex, int viewportX, int viewportW, int viewportH) {
+    RgfxGpuSpriteQueue& q = g_rgfx_sprite_queues[queueIndex];
+    if (q.items.empty() || q.fbW <= 0 || q.fbH <= 0 || viewportW <= 0 || viewportH <= 0) { return; }
+    if (!g_rgfx_gpu_mode) { return; }
+    rgfx_gl_ensure_current();
+    if (!rgfx_gl_init()) { return; }
+    glViewport(viewportX, 0, viewportW, viewportH);
+    std::vector<float> verts;
+    verts.reserve(q.items.size() * 6u * 4u);
+    int runTex = -1;
+    GLuint runGlTex = 0;
+    for (const RgfxGpuSprite& s : q.items) {
+        if (s.texId <= 0 || s.texId > (int) g_rgfx_gl_textures.size()) { continue; }
+        GLuint tex = g_rgfx_gl_textures[(size_t) (s.texId - 1)];
+        if (s.texId != runTex && !verts.empty()) {
+            rgfx_gpu_sprites_flush_run(runGlTex, verts);
+        }
+        runTex = s.texId;
+        runGlTex = tex;
+        rgfx_gpu_sprites_append_quad(verts, s, q.fbW, q.fbH);
+    }
+    rgfx_gpu_sprites_flush_run(runGlTex, verts);
+    q.items.clear();
+}
+
+// Original one-draw-call-per-sprite path, kept as an env-selectable fallback
+// (RANGER_GFX_SPRITE_BATCH=0) so a GPU regression on real hardware can be
+// bisected without a rebuild.
+static void rgfx_gpu_sprites_draw_queue_perquad(int queueIndex, int viewportX, int viewportW, int viewportH) {
+    RgfxGpuSpriteQueue& q = g_rgfx_sprite_queues[queueIndex];
+    if (q.items.empty() || q.fbW <= 0 || q.fbH <= 0 || viewportW <= 0 || viewportH <= 0) { return; }
+    if (!g_rgfx_gpu_mode) { return; }
+    rgfx_gl_ensure_current();
+    if (!rgfx_gl_init()) { return; }
+    glViewport(viewportX, 0, viewportW, viewportH);
+    for (const RgfxGpuSprite& s : q.items) {
+        if (s.texId <= 0 || s.texId > (int) g_rgfx_gl_textures.size()) { continue; }
+        GLuint tex = g_rgfx_gl_textures[(size_t) (s.texId - 1)];
+        float u0 = (float) s.sx / (float) s.atlasW;
+        float v0 = (float) s.sy / (float) s.atlasH;
+        float u1 = (float) (s.sx + s.sw) / (float) s.atlasW;
+        float v1 = (float) (s.sy + s.sh) / (float) s.atlasH;
+        if (s.usePivot == 0) {
+            float x0 = s.px, y0 = s.py;
+            float x1 = s.px + s.dw, y1 = s.py;
+            float x2 = s.px + s.dw, y2 = s.py + s.dh;
+            float x3 = s.px, y3 = s.py + s.dh;
+            rgfx_gpu_draw_textured_quad_corners(tex, u0, v0, u1, v1,
+                x0, y0, x1, y1, x2, y2, x3, y3, q.fbW, q.fbH);
+        } else {
+            float rad = s.angleDeg * 3.14159265f / 180.f;
+            float ca = cosf(rad), sa = sinf(rad);
+            float hw = s.dw * 0.5f, hh = s.dh * 0.5f;
+            float lx[4] = {-hw, hw, hw, -hw};
+            float ly[4] = {-hh, -hh, hh, hh};
+            float wx[4], wy[4];
+            for (int i = 0; i < 4; ++i) {
+                wx[i] = s.px + (lx[i] * ca - ly[i] * sa);
+                wy[i] = s.py + (lx[i] * sa + ly[i] * ca);
+            }
+            rgfx_gpu_draw_textured_quad_corners(tex, u0, v0, u1, v1,
+                wx[0], wy[0], wx[1], wy[1], wx[2], wy[2], wx[3], wy[3], q.fbW, q.fbH);
+        }
+    }
+    q.items.clear();
+}
+
+static bool rgfx_sprite_batch_on() {
+    static int cached = -1;
+    if (cached < 0) {
+        const char* e = getenv(\"RANGER_GFX_SPRITE_BATCH\");
+        cached = (e != nullptr && e[0] == '0') ? 0 : 1;
+    }
+    return cached == 1;
+}
+
+static bool rgfx_sprite_camera_on() {
+    static int cached = -1;
+    if (cached < 0) {
+        const char* e = getenv(\"RANGER_GFX_SPRITE_CAMERA\");
+        cached = (e != nullptr && e[0] == '0') ? 0 : 1;
+    }
+    return cached == 1;
+}
+
+// Dispatcher: batched 4x4-camera path by default. RANGER_GFX_SPRITE_CAMERA=0
+// falls back to the CPU-NDC batched path and RANGER_GFX_SPRITE_BATCH=0 to the
+// original per-sprite path, so a GPU regression on real hardware can be
+// bisected without a rebuild. Both fallbacks ignore gfx_gpu_camera_set.
+static void rgfx_gpu_sprites_draw_queue(int queueIndex, int viewportX, int viewportW, int viewportH) {
+    if (!rgfx_sprite_batch_on()) {
+        rgfx_gpu_sprites_draw_queue_perquad(queueIndex, viewportX, viewportW, viewportH);
+    } else if (rgfx_sprite_camera_on()) {
+        rgfx_gpu_sprites_draw_queue_camera(queueIndex, viewportX, viewportW, viewportH);
+    } else {
+        rgfx_gpu_sprites_draw_queue_batched(queueIndex, viewportX, viewportW, viewportH);
+    }
+}
+
+static void rgfx_gpu_sprites_draw_overlay() {
+    rgfx_gpu_sprites_draw_queue(0, 0, g_rgfx_fb_w, g_rgfx_fb_h);
+}
+
+static void rgfx_gpu_draw_quad_tex(GLuint tex, float x, float y, float qw, float qh) {
+    if (g_rgfx_fb_w <= 0 || g_rgfx_fb_h <= 0) { return; }
+    float x0 = (x / (float) g_rgfx_fb_w) * 2.0f - 1.0f;
+    float y0 = 1.0f - (y / (float) g_rgfx_fb_h) * 2.0f;
+    float x1 = ((x + qw) / (float) g_rgfx_fb_w) * 2.0f - 1.0f;
+    float y1 = 1.0f - ((y + qh) / (float) g_rgfx_fb_h) * 2.0f;
+    float verts[] = {
+        x0, y0, 0.f, 0.f,
+        x1, y0, 1.f, 0.f,
+        x1, y1, 1.f, 1.f,
+        x0, y0, 0.f, 0.f,
+        x1, y1, 1.f, 1.f,
+        x0, y1, 0.f, 1.f,
+    };
+    glUseProgram(g_rgfx_gl_program);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glUniform1i(g_rgfx_gl_tex_uniform, 0);
+    glBindBuffer(GL_ARRAY_BUFFER, g_rgfx_gl_vbo);
+    glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) sizeof(verts), verts, GL_DYNAMIC_DRAW);
+    glEnableVertexAttribArray((GLuint) g_rgfx_gl_pos_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_gl_pos_attr, 2, GL_FLOAT, GL_FALSE, 4 * (GLsizei) sizeof(float), (void*) 0);
+    glEnableVertexAttribArray((GLuint) g_rgfx_gl_uv_attr);
+    glVertexAttribPointer((GLuint) g_rgfx_gl_uv_attr, 2, GL_FLOAT, GL_FALSE, 4 * (GLsizei) sizeof(float), (void*) (2 * sizeof(float)));
+    glDrawArrays(GL_TRIANGLES, 0, 6);
+}
+
+static void rgfx_gpu_start_frame(int w, int h) {
+    if (!g_rgfx_gpu_mode) { return; }
+    rgfx_gl_ensure_current();
+    int drawW = w;
+    int drawH = h;
+    if (g_rgfx_win != nullptr) {
+        SDL_GL_GetDrawableSize(g_rgfx_win, &drawW, &drawH);
+    }
+    g_rgfx_fb_w = drawW;
+    g_rgfx_fb_h = drawH;
+    glViewport(0, 0, drawW, drawH);
+    // Reset the 3D state a three_gl game (teapot/Sponza/tsx) may have left enabled,
+    // so the 2D present's quads are not back-face-culled or depth-rejected -> the
+    // menu would otherwise come back black after exiting a GL game.
+    glDisable(GL_CULL_FACE);
+    glDisable(GL_DEPTH_TEST);
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+}
+
+static void rgfx_gpu_blit_base(const uint8_t* pixels, int w, int h) {
+    if (!g_rgfx_gpu_mode || pixels == nullptr || w <= 0 || h <= 0) { return; }
+    if (g_rgfx_base_tex == 0) {
+        glGenTextures(1, &g_rgfx_base_tex);
+        g_rgfx_base_tex_w = 0;
+        g_rgfx_base_tex_h = 0;
+    }
+    rgfx_upload_frame_tex(g_rgfx_base_tex, &g_rgfx_base_tex_w, &g_rgfx_base_tex_h,
+        pixels, w, h, GL_NEAREST);
+    rgfx_gpu_draw_quad_tex(g_rgfx_base_tex, 0.f, 0.f, (float) g_rgfx_fb_w, (float) g_rgfx_fb_h);
+}
+
+static void rgfx_gpu_draw_texture(int texId, int x, int y, int tw, int th) {
+    if (!g_rgfx_gpu_mode || texId <= 0) { return; }
+    if (texId > (int) g_rgfx_gl_textures.size()) { return; }
+    GLuint tex = g_rgfx_gl_textures[(size_t) (texId - 1)];
+    rgfx_gpu_draw_quad_tex(tex, (float) x, (float) y, (float) tw, (float) th);
+}
+
+// Composite a CPU RGBA image (the rasterised RGU1 HUD) over the frame the 3D
+// path just rendered, as a full-screen alpha-blended quad. The HUD keeps its own
+// texture rather than going through rgfx_3d_upload_texture, which glGenTextures
+// on every call and would leak one texture per HUD update; here the storage is
+// reused and only its pixels are re-uploaded.
+static GLuint g_rgfx_hud_tex = 0;
+static int g_rgfx_hud_tex_w = 0;
+static int g_rgfx_hud_tex_h = 0;
+extern \"C\" void rgfx_hud_overlay_draw(const uint8_t* px, int w, int h) {
+    if (!g_rgfx_gpu_mode || px == nullptr || w <= 0 || h <= 0) { return; }
+    rgfx_gl_ensure_current();
+    if (g_rgfx_hud_tex == 0) {
+        glGenTextures(1, &g_rgfx_hud_tex);
+        g_rgfx_hud_tex_w = 0;
+        g_rgfx_hud_tex_h = 0;
+    }
+    // GL_NEAREST: the HUD is a pixel-exact raster, so keep the glyphs crisp.
+    rgfx_upload_frame_tex(g_rgfx_hud_tex, &g_rgfx_hud_tex_w, &g_rgfx_hud_tex_h, px, w, h, GL_NEAREST);
+    // The scene render already left depth testing off; blend the HUD straight
+    // over it and hand the state back as we found it.
+    glDisable(GL_DEPTH_TEST);
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    rgfx_gpu_draw_quad_tex(g_rgfx_hud_tex, 0.0f, 0.0f, (float) g_rgfx_fb_w, (float) g_rgfx_fb_h);
+    glDisable(GL_BLEND);
+}
+
+static void rgfx_gpu_prof_report() {
+    if (!rgfx_prof_on()) { return; }
+    g_rgfx_prof_frames++;
+    if (g_rgfx_prof_frames < 180) { return; }
+    double f = (double) g_rgfx_prof_frames;
+    SDL_Log(\"[rgfx-prof] frames=%d | upload=%.2fms sprites=%.2fms particles=%.2fms swap=%.2fms /frame\",
+        g_rgfx_prof_frames,
+        g_rgfx_prof_upload_ms / f,
+        g_rgfx_prof_sprite_ms / f,
+        g_rgfx_prof_particle_ms / f,
+        g_rgfx_prof_swap_ms / f);
+    g_rgfx_prof_upload_ms = 0.0;
+    g_rgfx_prof_sprite_ms = 0.0;
+    g_rgfx_prof_particle_ms = 0.0;
+    g_rgfx_prof_swap_ms = 0.0;
+    g_rgfx_prof_frames = 0;
+}
+
+static void rgfx_gpu_finish_frame() {
+    if (!g_rgfx_gpu_mode || g_rgfx_win == nullptr) { return; }
+    Uint64 t0 = rgfx_prof_now();
+    SDL_GL_SwapWindow(g_rgfx_win);
+    if (rgfx_prof_on()) { g_rgfx_prof_swap_ms += rgfx_prof_ms(t0, SDL_GetPerformanceCounter()); }
+    rgfx_gpu_prof_report();
+}
+
+// GPU split present: upload each full-res pane to its own texture and scale it
+// into a window half via a textured quad (the GPU downscale replaces the CPU
+// blit, matching rgfx_present_split's SDL_Renderer path).
+static void rgfx_gpu_present_split(const uint8_t* left, const uint8_t* right, int w, int h) {
+    if (!g_rgfx_gpu_mode || left == nullptr || right == nullptr || w <= 0 || h <= 0) { return; }
+    rgfx_gpu_start_frame(w, h);
+    const int halfW = g_rgfx_fb_w / 2;
+    Uint64 tUp0 = rgfx_prof_now();
+    if (g_rgfx_base_tex == 0) { glGenTextures(1, &g_rgfx_base_tex); g_rgfx_base_tex_w = 0; g_rgfx_base_tex_h = 0; }
+    rgfx_upload_frame_tex(g_rgfx_base_tex, &g_rgfx_base_tex_w, &g_rgfx_base_tex_h, left, w, h, GL_LINEAR);
+    rgfx_gpu_draw_quad_tex(g_rgfx_base_tex, 0.f, 0.f, (float) halfW, (float) g_rgfx_fb_h);
+    if (g_rgfx_base_tex_r == 0) { glGenTextures(1, &g_rgfx_base_tex_r); g_rgfx_base_tex_r_w = 0; g_rgfx_base_tex_r_h = 0; }
+    rgfx_upload_frame_tex(g_rgfx_base_tex_r, &g_rgfx_base_tex_r_w, &g_rgfx_base_tex_r_h, right, w, h, GL_LINEAR);
+    rgfx_gpu_draw_quad_tex(g_rgfx_base_tex_r, (float) halfW, 0.f, (float) (g_rgfx_fb_w - halfW), (float) g_rgfx_fb_h);
+    if (rgfx_prof_on()) { g_rgfx_prof_upload_ms += rgfx_prof_ms(tUp0, SDL_GetPerformanceCounter()); }
+    Uint64 tSpr0 = rgfx_prof_now();
+    rgfx_gpu_sprites_draw_queue(1, 0, halfW, g_rgfx_fb_h);
+    rgfx_gpu_sprites_draw_queue(2, halfW, g_rgfx_fb_w - halfW, g_rgfx_fb_h);
+    if (rgfx_prof_on()) { g_rgfx_prof_sprite_ms += rgfx_prof_ms(tSpr0, SDL_GetPerformanceCounter()); }
+    Uint64 tPart0 = rgfx_prof_now();
+    rgfx_particles_draw_queue(1, 0, halfW, g_rgfx_fb_h);
+    rgfx_particles_draw_queue(2, halfW, g_rgfx_fb_w - halfW, g_rgfx_fb_h);
+    if (rgfx_prof_on()) { g_rgfx_prof_particle_ms += rgfx_prof_ms(tPart0, SDL_GetPerformanceCounter()); }
+    glViewport(0, 0, g_rgfx_fb_w, g_rgfx_fb_h);
+    rgfx_gpu_finish_frame();
+}
+
+static void rgfx_gl_cleanup() {
+    for (GLuint t : g_rgfx_gl_textures) {
+        glDeleteTextures(1, &t);
+    }
+    g_rgfx_gl_textures.clear();
+    if (g_rgfx_base_tex != 0) {
+        glDeleteTextures(1, &g_rgfx_base_tex);
+        g_rgfx_base_tex = 0;
+        g_rgfx_base_tex_w = 0;
+        g_rgfx_base_tex_h = 0;
+    }
+    if (g_rgfx_base_tex_r != 0) {
+        glDeleteTextures(1, &g_rgfx_base_tex_r);
+        g_rgfx_base_tex_r = 0;
+        g_rgfx_base_tex_r_w = 0;
+        g_rgfx_base_tex_r_h = 0;
+    }
+    if (g_rgfx_gl_vbo != 0) {
+        glDeleteBuffers(1, &g_rgfx_gl_vbo);
+        g_rgfx_gl_vbo = 0;
+    }
+    if (g_rgfx_gl_program != 0) {
+        glDeleteProgram(g_rgfx_gl_program);
+        g_rgfx_gl_program = 0;
+    }
+    if (g_rgfx_part_vbo != 0) {
+        glDeleteBuffers(1, &g_rgfx_part_vbo);
+        g_rgfx_part_vbo = 0;
+    }
+    if (g_rgfx_part_program != 0) {
+        glDeleteProgram(g_rgfx_part_program);
+        g_rgfx_part_program = 0;
+    }
+    for (int i = 0; i < 3; ++i) {
+        g_rgfx_particle_queues[i].items.clear();
+        g_rgfx_sprite_queues[i].items.clear();
+    }
+    if (g_rgfx_glctx != nullptr) {
+        SDL_GL_DeleteContext(g_rgfx_glctx);
+        g_rgfx_glctx = nullptr;
+    }
+    g_rgfx_gpu_mode = 0;
+}
+
+static int rgfx_open(const std::string& title, int w, int h) {
+    rgfx_prepare_audio_env();
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK) != 0) { return 0; }
+    rgfx_scan_pads();
+    g_rgfx_win = SDL_CreateWindow(title.c_str(),
+        SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, w, h, SDL_WINDOW_SHOWN);
+    if (g_rgfx_win == nullptr) { return 0; }
+    g_rgfx_ren = SDL_CreateRenderer(g_rgfx_win, -1,
+        SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+    if (g_rgfx_ren == nullptr) { g_rgfx_ren = SDL_CreateRenderer(g_rgfx_win, -1, 0); }
+    if (g_rgfx_ren == nullptr) { return 0; }
+    g_rgfx_tex = SDL_CreateTexture(g_rgfx_ren, SDL_PIXELFORMAT_RGBA32,
+        SDL_TEXTUREACCESS_STREAMING, w, h);
+    if (g_rgfx_tex == nullptr) { return 0; }
+    return 1;
+}
+// Actual output surface size in pixels (drawable / window), so UI can be
+// rendered at native resolution instead of a low internal buffer that gets
+// upscaled (blocky text). Falls back to the logical window size.
+static int rgfx_surface_dim(int wantWidth) {
+    if (g_rgfx_win == nullptr) { return 0; }
+    int w = 0; int h = 0;
+    SDL_GL_GetDrawableSize(g_rgfx_win, &w, &h);
+    if (w <= 0 || h <= 0) { SDL_GetWindowSize(g_rgfx_win, &w, &h); }
+    return wantWidth ? w : h;
+}
+
+static void rgfx_present(const uint8_t* pixels, int w, int h) {
+    if (g_rgfx_gpu_mode) {
+        rgfx_gpu_start_frame(w, h);
+        Uint64 tUp0 = rgfx_prof_now();
+        rgfx_gpu_blit_base(pixels, w, h);
+        if (rgfx_prof_on()) { g_rgfx_prof_upload_ms += rgfx_prof_ms(tUp0, SDL_GetPerformanceCounter()); }
+        Uint64 tSpr0 = rgfx_prof_now();
+        rgfx_gpu_sprites_draw_overlay();
+        if (rgfx_prof_on()) { g_rgfx_prof_sprite_ms += rgfx_prof_ms(tSpr0, SDL_GetPerformanceCounter()); }
+        Uint64 tPart0 = rgfx_prof_now();
+        rgfx_particles_draw_overlay();
+        if (rgfx_prof_on()) { g_rgfx_prof_particle_ms += rgfx_prof_ms(tPart0, SDL_GetPerformanceCounter()); }
+        // UI effect overlay (glow/pulse) composites on top of everything else.
+        rgfx_fx_draw_overlay();
+        rgfx_gpu_finish_frame();
+        return;
+    }
+    if (g_rgfx_tex == nullptr) { return; }
+    SDL_UpdateTexture(g_rgfx_tex, nullptr, pixels, w * 4);
+    SDL_RenderClear(g_rgfx_ren);
+    SDL_RenderCopy(g_rgfx_ren, g_rgfx_tex, nullptr, nullptr);
+    SDL_RenderPresent(g_rgfx_ren);
+}
+// Split-screen present: upload each full-res pane once and let the GPU scale it
+// into its half of the window. Avoids the CPU 480→240 downscale blit entirely —
+// the scale is free on the GPU during SDL_RenderCopy.
+static void rgfx_present_split(const uint8_t* left, const uint8_t* right, int w, int h) {
+    if (g_rgfx_gpu_mode) {
+        rgfx_gpu_present_split(left, right, w, h);
+        return;
+    }
+    if (g_rgfx_tex == nullptr) { return; }
+    int outW = w;
+    int outH = h;
+    SDL_GetRendererOutputSize(g_rgfx_ren, &outW, &outH);
+    const int halfW = outW / 2;
+    SDL_Rect dstL; dstL.x = 0;     dstL.y = 0; dstL.w = halfW;        dstL.h = outH;
+    SDL_Rect dstR; dstR.x = halfW; dstR.y = 0; dstR.w = outW - halfW; dstR.h = outH;
+    SDL_RenderClear(g_rgfx_ren);
+    SDL_UpdateTexture(g_rgfx_tex, nullptr, left, w * 4);
+    SDL_RenderCopy(g_rgfx_ren, g_rgfx_tex, nullptr, &dstL);
+    SDL_UpdateTexture(g_rgfx_tex, nullptr, right, w * 4);
+    SDL_RenderCopy(g_rgfx_ren, g_rgfx_tex, nullptr, &dstR);
+    SDL_SetRenderDrawColor(g_rgfx_ren, 50, 65, 110, 255);
+    SDL_Rect divider; divider.x = halfW - 1; divider.y = 0; divider.w = 2; divider.h = outH;
+    SDL_RenderFillRect(g_rgfx_ren, &divider);
+    SDL_RenderPresent(g_rgfx_ren);
+}
+static int rgfx_poll_mask() {
+    rgfx_input_poll();
+    return g_src_mask[RGFX_SRC_KB_P1];
+}
+static int rgfx_input_source_mask(int source) {
+    rgfx_input_poll();
+    if (source < 0 || source >= RGFX_SRC_COUNT) { return 0; }
+    return g_src_mask[source];
+}
+static int rgfx_input_pad_count() {
+    rgfx_input_poll();
+    return g_pad_count;
+}
+static int rgfx_should_close() { return g_rgfx_should_close; }
+static void rgfx_clear_should_close() { g_rgfx_should_close = 0; }
+static void rgfx_delay(int ms) { SDL_Delay((Uint32) ms); }
+static uint32_t rgfx_ticks_ms() { return SDL_GetTicks(); }
+static void rgfx_set_title(const std::string& title) {
+    if (g_rgfx_win != nullptr) { SDL_SetWindowTitle(g_rgfx_win, title.c_str()); }
+}
+static void rgfx_close() {
+    rgfx_gl_cleanup();
+    if (g_rgfx_audio) { SDL_CloseAudioDevice(g_rgfx_audio); g_rgfx_audio = 0; }
+    for (int i = g_pad_count - 1; i >= 0; --i) {
+        rgfx_close_pad_slot(i);
+    }
+    g_pad_count = 0;
+    if (g_rgfx_tex) { SDL_DestroyTexture(g_rgfx_tex); g_rgfx_tex = nullptr; }
+    if (g_rgfx_ren) { SDL_DestroyRenderer(g_rgfx_ren); g_rgfx_ren = nullptr; }
+    if (g_rgfx_win) { SDL_DestroyWindow(g_rgfx_win); g_rgfx_win = nullptr; }
+    SDL_Quit();
+}
+
+// ======================= 3D mesh pipeline (render=3d) =======================
+// A minimal GLES2 forward renderer: one textured, Gouraud-ish per-pixel lit
+// program (ambient + one directional sun), depth-tested. Geometry arrives as the
+// guest's raw MESH vertex bytes (32 B/vertex fixed-point) + u16 indices; the
+// camera / model / light arrive as scalars and matrices are built here.
+struct RgfxMesh3D { GLuint vbo; GLuint ebo; int icount; };
+static std::vector<RgfxMesh3D> g_rgfx_meshes;
+static GLuint g_rgfx_3d_prog = 0;
+static GLint g_rgfx_3d_aPos = -1;
+static GLint g_rgfx_3d_aNormal = -1;
+static GLint g_rgfx_3d_aUv = -1;
+static GLint g_rgfx_3d_uMVP = -1;
+static GLint g_rgfx_3d_uNormal = -1;
+static GLint g_rgfx_3d_uTex = -1;
+static GLint g_rgfx_3d_uAmb = -1;
+static GLint g_rgfx_3d_uSunDir = -1;
+static GLint g_rgfx_3d_uSun = -1;
+static float g_rgfx_3d_vp[16];
+static float g_rgfx_3d_amb[3] = {0.f, 0.f, 0.f};
+static float g_rgfx_3d_sundir[3] = {0.f, 1.f, 0.f};
+static float g_rgfx_3d_sun[3] = {0.f, 0.f, 0.f};
+
+#define RGM4(m,r,c) (m)[(c)*4+(r)]
+#define RGM3(m,r,c) (m)[(c)*3+(r)]
+
+static void rgfx_m4_identity(float* m) { for (int i = 0; i < 16; ++i) m[i] = 0.f; m[0] = m[5] = m[10] = m[15] = 1.f; }
+static void rgfx_m4_mul(const float* a, const float* b, float* out) {
+    float t[16];
+    for (int c = 0; c < 4; ++c) for (int r = 0; r < 4; ++r) {
+        float s = 0.f; for (int k = 0; k < 4; ++k) s += RGM4(a, r, k) * RGM4(b, k, c);
+        t[c * 4 + r] = s;
+    }
+    for (int i = 0; i < 16; ++i) out[i] = t[i];
+}
+static void rgfx_m4_perspective(float fovy, float aspect, float np, float fp, float* m) {
+    for (int i = 0; i < 16; ++i) m[i] = 0.f;
+    float f = 1.f / tanf(fovy * 0.5f);
+    RGM4(m, 0, 0) = f / aspect; RGM4(m, 1, 1) = f;
+    RGM4(m, 2, 2) = (fp + np) / (np - fp);
+    RGM4(m, 2, 3) = (2.f * fp * np) / (np - fp);
+    RGM4(m, 3, 2) = -1.f;
+}
+static void rgfx_m4_lookat(float ex, float ey, float ez, float cx, float cy, float cz, float ux, float uy, float uz, float* m) {
+    float fx = cx - ex, fy = cy - ey, fz = cz - ez;
+    float fl = sqrtf(fx * fx + fy * fy + fz * fz); if (fl > 0.f) { fx /= fl; fy /= fl; fz /= fl; }
+    float sx = fy * uz - fz * uy, sy = fz * ux - fx * uz, sz = fx * uy - fy * ux;
+    float sl = sqrtf(sx * sx + sy * sy + sz * sz); if (sl > 0.f) { sx /= sl; sy /= sl; sz /= sl; }
+    float uxn = sy * fz - sz * fy, uyn = sz * fx - sx * fz, uzn = sx * fy - sy * fx;
+    for (int i = 0; i < 16; ++i) m[i] = 0.f;
+    RGM4(m, 0, 0) = sx; RGM4(m, 0, 1) = sy; RGM4(m, 0, 2) = sz; RGM4(m, 0, 3) = -(sx * ex + sy * ey + sz * ez);
+    RGM4(m, 1, 0) = uxn; RGM4(m, 1, 1) = uyn; RGM4(m, 1, 2) = uzn; RGM4(m, 1, 3) = -(uxn * ex + uyn * ey + uzn * ez);
+    RGM4(m, 2, 0) = -fx; RGM4(m, 2, 1) = -fy; RGM4(m, 2, 2) = -fz; RGM4(m, 2, 3) = (fx * ex + fy * ey + fz * ez);
+    RGM4(m, 3, 3) = 1.f;
+}
+static int rgfx_3d_gl_init() {
+    if (g_rgfx_3d_prog != 0) { return 1; }
+#if (defined(__arm__) || defined(__aarch64__)) && !defined(__APPLE__)
+    const char* vs =
+        \"attribute vec3 aPos;\\n\"
+        \"attribute vec3 aNormal;\\n\"
+        \"attribute vec2 aUv;\\n\"
+        \"uniform mat4 uMVP;\\n\"
+        \"uniform mat3 uNormal;\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"varying vec3 vN;\\n\"
+        \"void main() { gl_Position = uMVP * vec4(aPos, 1.0); vUv = aUv; vN = uNormal * aNormal; }\\n\";
+    const char* fs =
+        \"precision mediump float;\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"varying vec3 vN;\\n\"
+        \"uniform sampler2D uTex;\\n\"
+        \"uniform vec3 uAmb;\\n\"
+        \"uniform vec3 uSunDir;\\n\"
+        \"uniform vec3 uSun;\\n\"
+        \"void main() { vec3 N = normalize(vN); float ndl = max(0.0, dot(N, uSunDir)); vec3 L = uAmb + uSun * ndl; vec4 t = texture2D(uTex, vUv); gl_FragColor = vec4(t.rgb * L, t.a); }\\n\";
+#else
+    const char* vs =
+        \"#version 120\\n\"
+        \"attribute vec3 aPos;\\n\"
+        \"attribute vec3 aNormal;\\n\"
+        \"attribute vec2 aUv;\\n\"
+        \"uniform mat4 uMVP;\\n\"
+        \"uniform mat3 uNormal;\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"varying vec3 vN;\\n\"
+        \"void main() { gl_Position = uMVP * vec4(aPos, 1.0); vUv = aUv; vN = uNormal * aNormal; }\\n\";
+    const char* fs =
+        \"#version 120\\n\"
+        \"varying vec2 vUv;\\n\"
+        \"varying vec3 vN;\\n\"
+        \"uniform sampler2D uTex;\\n\"
+        \"uniform vec3 uAmb;\\n\"
+        \"uniform vec3 uSunDir;\\n\"
+        \"uniform vec3 uSun;\\n\"
+        \"void main() { vec3 N = normalize(vN); float ndl = max(0.0, dot(N, uSunDir)); vec3 L = uAmb + uSun * ndl; vec4 t = texture2D(uTex, vUv); gl_FragColor = vec4(t.rgb * L, t.a); }\\n\";
+#endif
+    GLuint vsId = rgfx_gl_compile(GL_VERTEX_SHADER, vs);
+    GLuint fsId = rgfx_gl_compile(GL_FRAGMENT_SHADER, fs);
+    if (vsId == 0 || fsId == 0) { if (vsId) glDeleteShader(vsId); if (fsId) glDeleteShader(fsId); return 0; }
+    g_rgfx_3d_prog = glCreateProgram();
+    glAttachShader(g_rgfx_3d_prog, vsId);
+    glAttachShader(g_rgfx_3d_prog, fsId);
+    glLinkProgram(g_rgfx_3d_prog);
+    glDeleteShader(vsId);
+    glDeleteShader(fsId);
+    GLint linked = GL_FALSE;
+    glGetProgramiv(g_rgfx_3d_prog, GL_LINK_STATUS, &linked);
+    if (linked != GL_TRUE) {
+        char log[1024]; GLsizei len = 0;
+        glGetProgramInfoLog(g_rgfx_3d_prog, (GLsizei) sizeof(log), &len, log);
+        SDL_Log(\"[wasm3d] 3d program LINK FAILED: %.*s\", (int) len, log);
+        glDeleteProgram(g_rgfx_3d_prog); g_rgfx_3d_prog = 0; return 0;
+    }
+    g_rgfx_3d_aPos = glGetAttribLocation(g_rgfx_3d_prog, \"aPos\");
+    g_rgfx_3d_aNormal = glGetAttribLocation(g_rgfx_3d_prog, \"aNormal\");
+    g_rgfx_3d_aUv = glGetAttribLocation(g_rgfx_3d_prog, \"aUv\");
+    g_rgfx_3d_uMVP = glGetUniformLocation(g_rgfx_3d_prog, \"uMVP\");
+    g_rgfx_3d_uNormal = glGetUniformLocation(g_rgfx_3d_prog, \"uNormal\");
+    g_rgfx_3d_uTex = glGetUniformLocation(g_rgfx_3d_prog, \"uTex\");
+    g_rgfx_3d_uAmb = glGetUniformLocation(g_rgfx_3d_prog, \"uAmb\");
+    g_rgfx_3d_uSunDir = glGetUniformLocation(g_rgfx_3d_prog, \"uSunDir\");
+    g_rgfx_3d_uSun = glGetUniformLocation(g_rgfx_3d_prog, \"uSun\");
+    SDL_Log(\"[wasm3d] 3d program ok prog=%u aPos=%d aNormal=%d aUv=%d uMVP=%d uNormal=%d uTex=%d uAmb=%d uSunDir=%d uSun=%d\", (unsigned) g_rgfx_3d_prog, g_rgfx_3d_aPos, g_rgfx_3d_aNormal, g_rgfx_3d_aUv, g_rgfx_3d_uMVP, g_rgfx_3d_uNormal, g_rgfx_3d_uTex, g_rgfx_3d_uAmb, g_rgfx_3d_uSunDir, g_rgfx_3d_uSun);
+    return 1;
+}
+static int rgfx_3d_upload_texture(const uint8_t* px, int w, int h) {
+    if (!g_rgfx_gpu_mode || px == nullptr || w <= 0 || h <= 0) { return 0; }
+    rgfx_gl_ensure_current();
+    GLuint tex = 0;
+    glGenTextures(1, &tex);
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    // GL_LINEAR (not mipmap): a mipmap min-filter without generated mipmaps makes
+    // the texture incomplete -> samples black on GL 2.1 / macOS.
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, px);
+    g_rgfx_gl_textures.push_back(tex);
+    SDL_Log(\"[wasm3d] tex upload %dx%d -> id %u glErr=%d\", w, h, (unsigned) g_rgfx_gl_textures.size(), (int) glGetError());
+    return (int) g_rgfx_gl_textures.size();
+}
+// vw holds vcount*8 int words (the guest's 32-byte vertex as 8 int32s, widened
+// to int64 by the int_buffer type); iv holds icount index values.
+static int rgfx_mesh_upload(const int64_t* vw, int vcount, const int64_t* iv, int icount) {
+    if (!g_rgfx_gpu_mode || vw == nullptr || iv == nullptr || vcount <= 0 || icount <= 0) { return 0; }
+    rgfx_gl_ensure_current();
+    std::vector<float> verts;
+    verts.reserve((size_t) vcount * 8);
+    for (int i = 0; i < vcount; ++i) {
+        const int64_t* p = vw + (size_t) i * 8;
+        int32_t xi = (int32_t) p[0], yi = (int32_t) p[1], zi = (int32_t) p[2];
+        int32_t nxi = (int32_t) p[3], nyi = (int32_t) p[4], nzi = (int32_t) p[5];
+        uint32_t uvw = (uint32_t) p[7];
+        verts.push_back((float) xi / 256.f); verts.push_back((float) yi / 256.f); verts.push_back((float) zi / 256.f);
+        verts.push_back((float) nxi / 65536.f); verts.push_back((float) nyi / 65536.f); verts.push_back((float) nzi / 65536.f);
+        verts.push_back((float) (uvw & 0xffffu) / 4096.f);
+        verts.push_back((float) ((uvw >> 16) & 0xffffu) / 4096.f);
+    }
+    // 32-bit indices: real GLB meshes routinely exceed 65535 vertices (a u16
+    // element buffer would wrap the indices and scramble the geometry).
+    std::vector<uint32_t> idx;
+    idx.reserve((size_t) icount);
+    for (int i = 0; i < icount; ++i) { idx.push_back((uint32_t) iv[i]); }
+    RgfxMesh3D m; m.vbo = 0; m.ebo = 0; m.icount = icount;
+    glGenBuffers(1, &m.vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, m.vbo);
+    glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) (verts.size() * 4), verts.data(), GL_STATIC_DRAW);
+    glGenBuffers(1, &m.ebo);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m.ebo);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr) (idx.size() * 4), idx.data(), GL_STATIC_DRAW);
+    g_rgfx_meshes.push_back(m);
+    SDL_Log(\"[wasm3d] mesh upload vbo=%u ebo=%u v=%d i=%d glErr=%d\", m.vbo, m.ebo, vcount, icount, (int) glGetError());
+    return (int) g_rgfx_meshes.size();
+}
+// High-precision variant: positions are Q16.16 (x65536) instead of the guest
+// ABI's x256, so detailed GLB models authored at unit scale (e.g. 200k+ verts
+// packed into a ~1-unit box) don't collapse nearby vertices into degenerate
+// (zero-area) triangles. Used by the model3d loader path; the guest RGMB path
+// keeps the x256 rgfx_mesh_upload above.
+static int rgfx_mesh_upload_hp(const int64_t* vw, int vcount, const int64_t* iv, int icount) {
+    if (!g_rgfx_gpu_mode || vw == nullptr || iv == nullptr || vcount <= 0 || icount <= 0) { return 0; }
+    rgfx_gl_ensure_current();
+    std::vector<float> verts;
+    verts.reserve((size_t) vcount * 8);
+    for (int i = 0; i < vcount; ++i) {
+        const int64_t* p = vw + (size_t) i * 8;
+        int32_t xi = (int32_t) p[0], yi = (int32_t) p[1], zi = (int32_t) p[2];
+        int32_t nxi = (int32_t) p[3], nyi = (int32_t) p[4], nzi = (int32_t) p[5];
+        uint32_t uvw = (uint32_t) p[7];
+        verts.push_back((float) xi / 65536.f); verts.push_back((float) yi / 65536.f); verts.push_back((float) zi / 65536.f);
+        verts.push_back((float) nxi / 65536.f); verts.push_back((float) nyi / 65536.f); verts.push_back((float) nzi / 65536.f);
+        verts.push_back((float) (uvw & 0xffffu) / 4096.f);
+        verts.push_back((float) ((uvw >> 16) & 0xffffu) / 4096.f);
+    }
+    std::vector<uint32_t> idx;
+    idx.reserve((size_t) icount);
+    for (int i = 0; i < icount; ++i) { idx.push_back((uint32_t) iv[i]); }
+    RgfxMesh3D m; m.vbo = 0; m.ebo = 0; m.icount = icount;
+    glGenBuffers(1, &m.vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, m.vbo);
+    glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) (verts.size() * 4), verts.data(), GL_STATIC_DRAW);
+    glGenBuffers(1, &m.ebo);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m.ebo);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr) (idx.size() * 4), idx.data(), GL_STATIC_DRAW);
+    g_rgfx_meshes.push_back(m);
+    SDL_Log(\"[wasm3d] mesh upload(hp) vbo=%u ebo=%u v=%d i=%d glErr=%d\", m.vbo, m.ebo, vcount, icount, (int) glGetError());
+    return (int) g_rgfx_meshes.size();
+}
+static void rgfx_3d_begin(int w, int h) {
+    if (!g_rgfx_gpu_mode) { SDL_Log(\"[wasm3d] begin: NOT gpu_mode\"); return; }
+    rgfx_gpu_start_frame(w, h);
+    if (!rgfx_3d_gl_init()) { SDL_Log(\"[wasm3d] begin: gl_init FAILED\"); return; }
+    glEnable(GL_DEPTH_TEST);
+    glDepthFunc(GL_LESS);
+    glClear(GL_DEPTH_BUFFER_BIT);
+    glUseProgram(g_rgfx_3d_prog);
+    static int begin_logged = 0;
+    if (begin_logged < 1) {
+        int ds = 0; SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, &ds);
+        SDL_Log(\"[wasm3d] begin fb=%dx%d prog=%u depthSize=%d glErr=%d\", g_rgfx_fb_w, g_rgfx_fb_h, (unsigned) g_rgfx_3d_prog, ds, (int) glGetError());
+        begin_logged = 1;
+    }
+}
+static void rgfx_3d_set_camera(float ex, float ey, float ez, float cx, float cy, float cz, float ux, float uy, float uz, float fovy, float np, float fp, float aspect) {
+    float view[16], proj[16];
+    rgfx_m4_lookat(ex, ey, ez, cx, cy, cz, ux, uy, uz, view);
+    rgfx_m4_perspective(fovy, aspect, np, fp, proj);
+    rgfx_m4_mul(proj, view, g_rgfx_3d_vp);
+}
+// Colours arrive as packed RGBA8888 ints (the guest's rgba(); the top byte is R).
+// Cast to uint32_t so a high red/alpha byte does not read as a negative int.
+static void rgfx_3d_set_light(int ambColor, float ai, float dx, float dy, float dz, int sunColor, float si) {
+    uint32_t ac = (uint32_t) ambColor;
+    float ar = (float) ((ac >> 24) & 255u) / 255.f;
+    float ag = (float) ((ac >> 16) & 255u) / 255.f;
+    float ab = (float) ((ac >> 8) & 255u) / 255.f;
+    g_rgfx_3d_amb[0] = ar * ai; g_rgfx_3d_amb[1] = ag * ai; g_rgfx_3d_amb[2] = ab * ai;
+    float dl = sqrtf(dx * dx + dy * dy + dz * dz); if (dl > 0.f) { dx /= dl; dy /= dl; dz /= dl; }
+    g_rgfx_3d_sundir[0] = dx; g_rgfx_3d_sundir[1] = dy; g_rgfx_3d_sundir[2] = dz;
+    uint32_t sc = (uint32_t) sunColor;
+    float sr = (float) ((sc >> 24) & 255u) / 255.f;
+    float sg = (float) ((sc >> 16) & 255u) / 255.f;
+    float sb = (float) ((sc >> 8) & 255u) / 255.f;
+    g_rgfx_3d_sun[0] = sr * si; g_rgfx_3d_sun[1] = sg * si; g_rgfx_3d_sun[2] = sb * si;
+}
+static void rgfx_3d_draw(int meshId, int first, int count, int texId, float rx, float ry, float rz, float px, float py, float pz) {
+    if (!g_rgfx_gpu_mode || g_rgfx_3d_prog == 0) { return; }
+    if (meshId <= 0 || meshId > (int) g_rgfx_meshes.size()) { return; }
+    RgfxMesh3D& m = g_rgfx_meshes[(size_t) (meshId - 1)];
+    float mrx[16], mry[16], rot[16], model[16];
+    { for (int i = 0; i < 16; ++i) mrx[i] = 0.f; float c = cosf(rx), s = sinf(rx); RGM4(mrx,0,0)=1.f; RGM4(mrx,1,1)=c; RGM4(mrx,1,2)=-s; RGM4(mrx,2,1)=s; RGM4(mrx,2,2)=c; RGM4(mrx,3,3)=1.f; }
+    { for (int i = 0; i < 16; ++i) mry[i] = 0.f; float c = cosf(ry), s = sinf(ry); RGM4(mry,0,0)=c; RGM4(mry,0,2)=s; RGM4(mry,1,1)=1.f; RGM4(mry,2,0)=-s; RGM4(mry,2,2)=c; RGM4(mry,3,3)=1.f; }
+    rgfx_m4_mul(mrx, mry, rot);
+    for (int i = 0; i < 16; ++i) model[i] = rot[i];
+    RGM4(model,0,3) = px; RGM4(model,1,3) = py; RGM4(model,2,3) = pz;
+    float mvp[16]; rgfx_m4_mul(g_rgfx_3d_vp, model, mvp);
+    float nrm[9];
+    RGM3(nrm,0,0)=RGM4(rot,0,0); RGM3(nrm,0,1)=RGM4(rot,0,1); RGM3(nrm,0,2)=RGM4(rot,0,2);
+    RGM3(nrm,1,0)=RGM4(rot,1,0); RGM3(nrm,1,1)=RGM4(rot,1,1); RGM3(nrm,1,2)=RGM4(rot,1,2);
+    RGM3(nrm,2,0)=RGM4(rot,2,0); RGM3(nrm,2,1)=RGM4(rot,2,1); RGM3(nrm,2,2)=RGM4(rot,2,2);
+    glUniformMatrix4fv(g_rgfx_3d_uMVP, 1, GL_FALSE, mvp);
+    glUniformMatrix3fv(g_rgfx_3d_uNormal, 1, GL_FALSE, nrm);
+    glUniform3fv(g_rgfx_3d_uAmb, 1, g_rgfx_3d_amb);
+    glUniform3fv(g_rgfx_3d_uSunDir, 1, g_rgfx_3d_sundir);
+    glUniform3fv(g_rgfx_3d_uSun, 1, g_rgfx_3d_sun);
+    glActiveTexture(GL_TEXTURE0);
+    if (texId > 0 && texId <= (int) g_rgfx_gl_textures.size()) { glBindTexture(GL_TEXTURE_2D, g_rgfx_gl_textures[(size_t) (texId - 1)]); }
+    glUniform1i(g_rgfx_3d_uTex, 0);
+    glBindBuffer(GL_ARRAY_BUFFER, m.vbo);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m.ebo);
+    if (g_rgfx_3d_aPos >= 0) { glEnableVertexAttribArray(g_rgfx_3d_aPos); glVertexAttribPointer(g_rgfx_3d_aPos, 3, GL_FLOAT, GL_FALSE, 32, (void*) 0); }
+    if (g_rgfx_3d_aNormal >= 0) { glEnableVertexAttribArray(g_rgfx_3d_aNormal); glVertexAttribPointer(g_rgfx_3d_aNormal, 3, GL_FLOAT, GL_FALSE, 32, (void*) 12); }
+    if (g_rgfx_3d_aUv >= 0) { glEnableVertexAttribArray(g_rgfx_3d_aUv); glVertexAttribPointer(g_rgfx_3d_aUv, 2, GL_FLOAT, GL_FALSE, 32, (void*) 24); }
+    glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, (void*) (size_t) (first * 4));
+    static int draw_logged = 0;
+    if (draw_logged < 2) {
+        // project a real cube corner (1,1,1,1) to check the matrix spreads
+        // vertices (the origin only exercises the translation column).
+        float kx = RGM4(mvp,0,0) + RGM4(mvp,0,1) + RGM4(mvp,0,2) + RGM4(mvp,0,3);
+        float ky = RGM4(mvp,1,0) + RGM4(mvp,1,1) + RGM4(mvp,1,2) + RGM4(mvp,1,3);
+        float kz = RGM4(mvp,2,0) + RGM4(mvp,2,1) + RGM4(mvp,2,2) + RGM4(mvp,2,3);
+        float kw = RGM4(mvp,3,0) + RGM4(mvp,3,1) + RGM4(mvp,3,2) + RGM4(mvp,3,3);
+        float nx = (kw != 0.f) ? kx / kw : 0.f;
+        float ny = (kw != 0.f) ? ky / kw : 0.f;
+        SDL_Log(\"[wasm3d] draw mesh=%d count=%d tex=%d corner(1,1,1)_clipw=%.3f ndc=(%.3f,%.3f) amb=(%.2f,%.2f,%.2f) sun=(%.2f,%.2f,%.2f) glErr=%d\", meshId, count, texId, kw, nx, ny, g_rgfx_3d_amb[0], g_rgfx_3d_amb[1], g_rgfx_3d_amb[2], g_rgfx_3d_sun[0], g_rgfx_3d_sun[1], g_rgfx_3d_sun[2], (int) glGetError());
+        draw_logged++;
+    }
+}
+static void rgfx_3d_end() {
+    if (!g_rgfx_gpu_mode) { return; }
+    glDisable(GL_DEPTH_TEST);
+}
+
+// ==================== host-managed scene (IDEAL_3D Phase H) ==================
+// The host owns the entity registry, transforms, resources, lights and camera.
+// The guest sends commands via host imports (rg_wasm_bridge.c) that call these
+// extern \"C\" functions and hold only opaque EntityIds. rgfx_scene_render walks
+// the registry and drives the same gfx_3d_* GLES2 pipeline (forward, multi-light).
+#define RGE_MESH   1
+#define RGE_CAMERA 2
+#define RGE_AMBIENT 3
+#define RGE_DIR    4
+#define RGE_POINT  5
+#define RGE_SPRITE 6
+#define RGSCENE_MAXDIR 4
+#define RGSCENE_MAXPT  8
+struct RgfxSceneEntity {
+    int type; int alive; int gen; int visible; int enabled;
+    float pos[3]; float rot[4]; float scale[3];   // rot = quaternion (x,y,z,w)
+    int meshId; int texId;                         // RGE_MESH
+    float matColor[4]; float matEmissive[3]; int matBlend; // material (from GLB)
+    int spCols, spRows, spCol, spRow; float spW, spH; // RGE_SPRITE (billboard sheet)
+    float fovy, nearp, farp; float target[3]; float up[3]; int useTarget; // RGE_CAMERA
+    float color[3]; float intensity; float range;  // lights (dir uses pos as dir-to-light)
+};
+// per-mesh material (base colour tint incl. alpha, emissive glow, blend flag),
+// applied to entities created from that mesh via rg_create_mesh_entity.
+struct RgfxMeshMat { float color[4]; float emissive[3]; int blend; };
+static std::vector<RgfxSceneEntity> g_scene;
+static int g_scene_active_cam = 0;
+static GLuint g_scene_prog = 0;
+static GLint g_scn_aPos=-1, g_scn_aNormal=-1, g_scn_aUv=-1;
+static GLint g_scn_uMVP=-1, g_scn_uModel=-1, g_scn_uNormalMat=-1, g_scn_uTex=-1;
+static GLint g_scn_uAmbient=-1, g_scn_uNumDir=-1, g_scn_uDirDir=-1, g_scn_uDirCol=-1;
+static GLint g_scn_uNumPt=-1, g_scn_uPtPos=-1, g_scn_uPtCol=-1, g_scn_uPtRange=-1;
+static GLint g_scn_uBaseColor=-1, g_scn_uEmissive=-1;
+static GLint g_scn_uUvOffset=-1, g_scn_uUvScale=-1, g_scn_uUnlit=-1, g_scn_uAlphaCut=-1;
+// 1x1 opaque-white texture bound for meshes that have no texture, so the
+// shader's texture2D(uTex)*uBaseColor yields the material's base colour instead
+// of black (an unbound sampler reads as 0 -> the mesh renders invisible).
+static GLuint g_scn_white_tex = 0;
+static GLuint rgfx_scene_ensure_white() {
+    if (g_scn_white_tex == 0) {
+        const unsigned char px[4] = {255, 255, 255, 255};
+        glGenTextures(1, &g_scn_white_tex);
+        glBindTexture(GL_TEXTURE_2D, g_scn_white_tex);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, px);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    }
+    return g_scn_white_tex;
+}
+
+static int rgfx_scene_valid(int id) { return id > 0 && id <= (int) g_scene.size() && g_scene[(size_t)(id-1)].alive; }
+
+// Named GLB-model registry: the runner preloads <game>/models/*.glb, uploads
+// each mesh + its base texture into the mesh/texture pools, and registers the
+// (meshId, default texId) here under the file's basename. The guest's
+// rg_load_model(name) import then resolves a name to a meshId.
+static std::map<std::string,int> g_scene_model_mesh;
+static std::map<int,int> g_scene_mesh_deftex;
+static std::map<int,RgfxMeshMat> g_scene_mesh_mat;
+// colorRgba/emissiveRgb are packed 0xRRGGBBAA / 0xRRGGBB00; blend != 0 => alpha blend.
+extern \"C\" void rgfx_scene_register_model(const char* name, int meshId, int texId,
+                                          int colorRgba, int emissiveRgb, int blend) {
+    if (name && name[0]) { g_scene_model_mesh[std::string(name)] = meshId; }
+    if (meshId > 0) {
+        g_scene_mesh_deftex[meshId] = texId;
+        uint32_t c = (uint32_t) colorRgba, e = (uint32_t) emissiveRgb;
+        RgfxMeshMat m;
+        m.color[0] = (float)((c>>24)&255)/255.f; m.color[1] = (float)((c>>16)&255)/255.f;
+        m.color[2] = (float)((c>>8)&255)/255.f;  m.color[3] = (float)(c&255)/255.f;
+        m.emissive[0] = (float)((e>>24)&255)/255.f; m.emissive[1] = (float)((e>>16)&255)/255.f;
+        m.emissive[2] = (float)((e>>8)&255)/255.f;
+        m.blend = blend;
+        g_scene_mesh_mat[meshId] = m;
+    }
+}
+extern \"C\" int rgfx_scene_model_mesh(const char* name) {
+    if (!name) { return 0; }
+    std::map<std::string,int>::iterator it = g_scene_model_mesh.find(std::string(name));
+    return it == g_scene_model_mesh.end() ? 0 : it->second;
+}
+// Named sprite-sheet registry: the runner preloads <game>/sprites/*.png (RGBA,
+// with alpha), uploads each to the texture pool and registers texId by basename.
+static std::map<std::string,int> g_scene_sprite_tex;
+extern \"C\" void rgfx_scene_register_sprite(const char* name, int texId) {
+    if (name && name[0]) { g_scene_sprite_tex[std::string(name)] = texId; }
+}
+extern \"C\" int rgfx_scene_sprite_tex(const char* name) {
+    if (!name) { return 0; }
+    std::map<std::string,int>::iterator it = g_scene_sprite_tex.find(std::string(name));
+    return it == g_scene_sprite_tex.end() ? 0 : it->second;
+}
+// Enumerates the basenames registered above, so a guest can discover what the
+// runner preloaded instead of hardcoding a list. Writes NUL-separated names
+// into out (map order => alphabetical) and returns the byte size the whole list
+// needs; names that do not fit whole are skipped, so out always holds complete
+// entries and a guest can retry once it sees a return value above its capacity.
+extern \"C\" int rgfx_scene_resource_names(const char* kind, char* out, int cap) {
+    std::map<std::string,int>* m = 0;
+    std::string k(kind ? kind : \"\");
+    if (k == \"models\") { m = &g_scene_model_mesh; }
+    else if (k == \"sprites\") { m = &g_scene_sprite_tex; }
+    if (!m) { return 0; }
+    int need = 0;
+    int off = 0;
+    std::map<std::string,int>::iterator it;
+    for (it = m->begin(); it != m->end(); ++it) {
+        int n = (int) it->first.size() + 1;
+        need += n;
+        if (out && cap > 0 && off + n <= cap) {
+            it->first.copy(out + off, it->first.size());
+            out[off + (int) it->first.size()] = 0;
+            off += n;
+        }
+    }
+    // Terminate the written region with an empty name, so a guest reading a
+    // truncated list stops at the last whole name instead of running on into
+    // whatever its buffer happened to hold.
+    if (out && off < cap) { out[off] = 0; }
+    return need;
+}
+
+// Free the GPU resources the previous scene owned before it is torn down.
+// setupScene() calls this on every 3D-guest load, then preloadModels/preload-
+// Sprites re-uploads fresh meshes and textures. Without freeing here, each
+// re-entry leaked every model VBO/EBO and every model/sprite texture (the
+// model_viewer alone preloads dozens of GLBs, incl. a 34 MB Chair). On a
+// memory-rich desktop the leak is invisible, but on a Raspberry Pi's small
+// shared GL memory it exhausts the GPU after a few entries; the next upload
+// then fails, the guest loads with an empty/half scene, and the runner drops
+// back to the menu — the intermittent \"works, then stops working\" seen on the
+// Pi. Only scene-owned handles are freed: the texture pool is shared with 2D
+// uploads, so we free exactly the meshes/textures recorded in the scene
+// registries and leave their now-stale slots in place (handles are 1-based
+// indices into the pools; compacting would break every other live index). The
+// billboard quad (g_scene_quad) is never registered, so it survives and stays
+// reusable across scenes.
+static void rgfx_scene_free_mesh(int meshId) {
+    if (meshId <= 0 || meshId > (int) g_rgfx_meshes.size()) { return; }
+    RgfxMesh3D& m = g_rgfx_meshes[(size_t)(meshId - 1)];
+    if (m.vbo) { glDeleteBuffers(1, &m.vbo); m.vbo = 0; }
+    if (m.ebo) { glDeleteBuffers(1, &m.ebo); m.ebo = 0; }
+    m.icount = 0;
+}
+static void rgfx_scene_free_texture(int texId) {
+    if (texId <= 0 || texId > (int) g_rgfx_gl_textures.size()) { return; }
+    GLuint& t = g_rgfx_gl_textures[(size_t)(texId - 1)];
+    if (t) { glDeleteTextures(1, &t); t = 0; }
+}
+extern \"C\" int rgfx_scene_reset() {
+    if (g_rgfx_gpu_mode) {
+        rgfx_gl_ensure_current();
+        for (std::map<int,int>::iterator it = g_scene_mesh_deftex.begin(); it != g_scene_mesh_deftex.end(); ++it) {
+            rgfx_scene_free_mesh(it->first);   // model mesh VBO/EBO
+            rgfx_scene_free_texture(it->second); // its base texture (0 = none)
+        }
+        for (std::map<std::string,int>::iterator it = g_scene_sprite_tex.begin(); it != g_scene_sprite_tex.end(); ++it) {
+            rgfx_scene_free_texture(it->second); // preloaded sprite sheet
+        }
+    }
+    g_scene_model_mesh.clear();
+    g_scene_mesh_deftex.clear();
+    g_scene_mesh_mat.clear();
+    g_scene_sprite_tex.clear();
+    g_scene.clear();
+    g_scene_active_cam = 0;
+    return 0;
+}
+
+static int rgfx_scene_alloc(int type) {
+    RgfxSceneEntity e; memset(&e, 0, sizeof(e));
+    e.type = type; e.alive = 1; e.visible = 1; e.enabled = 1;
+    e.rot[3] = 1.f; e.scale[0] = e.scale[1] = e.scale[2] = 1.f; e.up[1] = 1.f;
+    e.color[0] = e.color[1] = e.color[2] = 1.f; e.intensity = 1.f; e.range = 10.f;
+    e.matColor[0] = e.matColor[1] = e.matColor[2] = e.matColor[3] = 1.f; // opaque white default
+    g_scene.push_back(e);
+    return (int) g_scene.size();
+}
+// upload interleaved float verts (8 floats: pos3,normal3,uv2) + u16 indices -> meshId
+static int rgfx_mesh_make(const float* v8, int vcount, const uint32_t* idx, int icount) {
+    if (!g_rgfx_gpu_mode) { return 0; }
+    rgfx_gl_ensure_current();
+    RgfxMesh3D m; m.vbo = 0; m.ebo = 0; m.icount = icount;
+    glGenBuffers(1, &m.vbo); glBindBuffer(GL_ARRAY_BUFFER, m.vbo);
+    glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr) ((size_t) vcount * 8 * 4), v8, GL_STATIC_DRAW);
+    glGenBuffers(1, &m.ebo); glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m.ebo);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr) ((size_t) icount * 4), idx, GL_STATIC_DRAW);
+    g_rgfx_meshes.push_back(m);
+    return (int) g_rgfx_meshes.size();
+}
+extern \"C\" int rgfx_scene_load_texture(const char* dir, const char* name) {
+    char path[1024]; snprintf(path, sizeof(path), \"%s/%s.ppm\", dir, name);
+    FILE* f = fopen(path, \"rb\"); if (!f) { SDL_Log(\"[scene] texture not found: %s\", path); return 0; }
+    char magic[3] = {0,0,0}; int w = 0, h = 0, mx = 0;
+    if (fscanf(f, \"%2s %d %d %d\", magic, &w, &h, &mx) != 4 || magic[0] != 'P' || magic[1] != '6' || w <= 0 || h <= 0) { fclose(f); return 0; }
+    fgetc(f); // single whitespace after maxval
+    std::vector<uint8_t> rgb((size_t) w * h * 3);
+    if (fread(rgb.data(), 1, rgb.size(), f) != rgb.size()) { fclose(f); return 0; }
+    fclose(f);
+    std::vector<uint8_t> rgba((size_t) w * h * 4);
+    for (int i = 0; i < w * h; ++i) { rgba[i*4]=rgb[i*3]; rgba[i*4+1]=rgb[i*3+1]; rgba[i*4+2]=rgb[i*3+2]; rgba[i*4+3]=255; }
+    return rgfx_3d_upload_texture(rgba.data(), w, h);
+}
+// axis-aligned box, per-face normals, uv tiled by size/2; returns a mesh entity id
+extern \"C\" int rgfx_scene_create_box(float x0, float y0, float z0, float x1, float y1, float z1, int texId) {
+    float dx = (x1 - x0) * 0.5f, dy = (y1 - y0) * 0.5f, dz = (z1 - z0) * 0.5f;
+    // 6 faces * 4 verts; each vert = pos(3) normal(3) uv(2)
+    struct Q { float c[4][3]; float n[3]; float uw, uh; };
+    Q faces[6] = {
+        {{{x0,y0,z1},{x1,y0,z1},{x1,y1,z1},{x0,y1,z1}}, {0,0,1}, dx, dy},   // +Z
+        {{{x1,y0,z0},{x0,y0,z0},{x0,y1,z0},{x1,y1,z0}}, {0,0,-1}, dx, dy},  // -Z
+        {{{x1,y0,z1},{x1,y0,z0},{x1,y1,z0},{x1,y1,z1}}, {1,0,0}, dz, dy},   // +X
+        {{{x0,y0,z0},{x0,y0,z1},{x0,y1,z1},{x0,y1,z0}}, {-1,0,0}, dz, dy},  // -X
+        {{{x0,y1,z1},{x1,y1,z1},{x1,y1,z0},{x0,y1,z0}}, {0,1,0}, dx, dz},   // +Y
+        {{{x0,y0,z0},{x1,y0,z0},{x1,y0,z1},{x0,y0,z1}}, {0,-1,0}, dx, dz},  // -Y
+    };
+    float uvc[4][2] = {{0,0},{1,0},{1,1},{0,1}};
+    std::vector<float> vv; std::vector<uint32_t> ii;
+    for (int fi = 0; fi < 6; ++fi) {
+        uint32_t base = (uint32_t) (vv.size() / 8);
+        for (int k = 0; k < 4; ++k) {
+            vv.push_back(faces[fi].c[k][0]); vv.push_back(faces[fi].c[k][1]); vv.push_back(faces[fi].c[k][2]);
+            vv.push_back(faces[fi].n[0]); vv.push_back(faces[fi].n[1]); vv.push_back(faces[fi].n[2]);
+            vv.push_back(uvc[k][0] * faces[fi].uw); vv.push_back(uvc[k][1] * faces[fi].uh);
+        }
+        uint32_t tri[6] = {0,1,2,0,2,3};
+        for (int t = 0; t < 6; ++t) ii.push_back(base + tri[t]);
+    }
+    int meshId = rgfx_mesh_make(vv.data(), (int) (vv.size() / 8), ii.data(), (int) ii.size());
+    int id = rgfx_scene_alloc(RGE_MESH); g_scene[(size_t)(id-1)].meshId = meshId; g_scene[(size_t)(id-1)].texId = texId;
+    return id;
+}
+extern \"C\" int rgfx_scene_create_mesh_entity(int meshId, int texId) {
+    if (texId <= 0) { std::map<int,int>::iterator it = g_scene_mesh_deftex.find(meshId); if (it != g_scene_mesh_deftex.end()) { texId = it->second; } }
+    int id = rgfx_scene_alloc(RGE_MESH); RgfxSceneEntity& e = g_scene[(size_t)(id-1)];
+    e.meshId = meshId; e.texId = texId;
+    std::map<int,RgfxMeshMat>::iterator mit = g_scene_mesh_mat.find(meshId);
+    if (mit != g_scene_mesh_mat.end()) {
+        e.matColor[0]=mit->second.color[0]; e.matColor[1]=mit->second.color[1];
+        e.matColor[2]=mit->second.color[2]; e.matColor[3]=mit->second.color[3];
+        e.matEmissive[0]=mit->second.emissive[0]; e.matEmissive[1]=mit->second.emissive[1];
+        e.matEmissive[2]=mit->second.emissive[2]; e.matBlend=mit->second.blend;
+    }
+    return id;
+}
+// shared unit quad (XY plane, centred, UV 0..1, normal +Z) for billboards
+static int g_scene_quad = 0;
+static int rgfx_scene_ensure_quad() {
+    if (g_scene_quad > 0) { return g_scene_quad; }
+    // 4 verts: pos(3) normal(3) uv(2). +Z facing, uv y flipped so row 0 is top.
+    float v[32] = {
+        -0.5f,-0.5f,0.f, 0.f,0.f,1.f, 0.f,1.f,
+         0.5f,-0.5f,0.f, 0.f,0.f,1.f, 1.f,1.f,
+         0.5f, 0.5f,0.f, 0.f,0.f,1.f, 1.f,0.f,
+        -0.5f, 0.5f,0.f, 0.f,0.f,1.f, 0.f,0.f,
+    };
+    uint32_t idx[6] = {0,1,2,0,2,3};
+    g_scene_quad = rgfx_mesh_make(v, 4, idx, 6);
+    SDL_Log(\"[scene] billboard quad mesh=%d\", g_scene_quad);
+    return g_scene_quad;
+}
+// billboard sprite: a camera-facing quad showing cell (0,0) of a cols x rows
+// sheet; w,h are its world size. texId is the sheet (with alpha).
+extern \"C\" int rgfx_scene_create_sprite(int texId, int cols, int rows, float w, float h) {
+    int id = rgfx_scene_alloc(RGE_SPRITE); RgfxSceneEntity& e = g_scene[(size_t)(id-1)];
+    e.texId = texId; e.spCols = cols>0?cols:1; e.spRows = rows>0?rows:1;
+    e.spCol = 0; e.spRow = 0; e.spW = w>0.f?w:1.f; e.spH = h>0.f?h:1.f;
+    return id;
+}
+extern \"C\" void rgfx_scene_set_sprite_cell(int id, int col, int row) {
+    if (rgfx_scene_valid(id)) { g_scene[(size_t)(id-1)].spCol = col; g_scene[(size_t)(id-1)].spRow = row; }
+}
+extern \"C\" int rgfx_scene_create_camera(float fovy, float nearp, float farp) {
+    int id = rgfx_scene_alloc(RGE_CAMERA);
+    g_scene[(size_t)(id-1)].fovy = fovy; g_scene[(size_t)(id-1)].nearp = nearp; g_scene[(size_t)(id-1)].farp = farp;
+    if (g_scene_active_cam == 0) g_scene_active_cam = id;
+    return id;
+}
+extern \"C\" int rgfx_scene_create_light(int type, int color, float intensity) {
+    int id = rgfx_scene_alloc(type);
+    uint32_t c = (uint32_t) color;
+    g_scene[(size_t)(id-1)].color[0] = (float)((c>>24)&255)/255.f;
+    g_scene[(size_t)(id-1)].color[1] = (float)((c>>16)&255)/255.f;
+    g_scene[(size_t)(id-1)].color[2] = (float)((c>>8)&255)/255.f;
+    g_scene[(size_t)(id-1)].intensity = intensity;
+    return id;
+}
+extern \"C\" void rgfx_scene_set_position(int id, float x, float y, float z) { if (rgfx_scene_valid(id)) { g_scene[(size_t)(id-1)].pos[0]=x; g_scene[(size_t)(id-1)].pos[1]=y; g_scene[(size_t)(id-1)].pos[2]=z; } }
+extern \"C\" void rgfx_scene_set_rotation(int id, float qx, float qy, float qz, float qw) { if (rgfx_scene_valid(id)) { g_scene[(size_t)(id-1)].rot[0]=qx; g_scene[(size_t)(id-1)].rot[1]=qy; g_scene[(size_t)(id-1)].rot[2]=qz; g_scene[(size_t)(id-1)].rot[3]=qw; } }
+extern \"C\" void rgfx_scene_set_scale(int id, float sx, float sy, float sz) { if (rgfx_scene_valid(id)) { g_scene[(size_t)(id-1)].scale[0]=sx; g_scene[(size_t)(id-1)].scale[1]=sy; g_scene[(size_t)(id-1)].scale[2]=sz; } }
+extern \"C\" void rgfx_scene_set_target(int id, float x, float y, float z) { if (rgfx_scene_valid(id)) { g_scene[(size_t)(id-1)].target[0]=x; g_scene[(size_t)(id-1)].target[1]=y; g_scene[(size_t)(id-1)].target[2]=z; g_scene[(size_t)(id-1)].useTarget=1; } }
+extern \"C\" void rgfx_scene_set_range(int id, float r) { if (rgfx_scene_valid(id)) g_scene[(size_t)(id-1)].range = r; }
+extern \"C\" void rgfx_scene_set_enabled(int id, int on) { if (rgfx_scene_valid(id)) g_scene[(size_t)(id-1)].enabled = on; }
+extern \"C\" void rgfx_scene_set_visible(int id, int on) { if (rgfx_scene_valid(id)) g_scene[(size_t)(id-1)].visible = on; }
+extern \"C\" void rgfx_scene_set_active_camera(int id) { if (rgfx_scene_valid(id)) g_scene_active_cam = id; }
+extern \"C\" void rgfx_scene_destroy(int id) { if (rgfx_scene_valid(id)) { g_scene[(size_t)(id-1)].alive = 0; g_scene[(size_t)(id-1)].gen++; } }
+
+static void rgfx_quat_m3(const float* q, float* m3) { // column-major 3x3
+    float x=q[0],y=q[1],z=q[2],w=q[3];
+    float n = sqrtf(x*x+y*y+z*z+w*w); if (n>0.f){x/=n;y/=n;z/=n;w/=n;}
+    RGM3(m3,0,0)=1-2*(y*y+z*z); RGM3(m3,0,1)=2*(x*y-z*w);   RGM3(m3,0,2)=2*(x*z+y*w);
+    RGM3(m3,1,0)=2*(x*y+z*w);   RGM3(m3,1,1)=1-2*(x*x+z*z); RGM3(m3,1,2)=2*(y*z-x*w);
+    RGM3(m3,2,0)=2*(x*z-y*w);   RGM3(m3,2,1)=2*(y*z+x*w);   RGM3(m3,2,2)=1-2*(x*x+y*y);
+}
+static int rgfx_scene_gl_init() {
+    if (g_scene_prog != 0) { return 1; }
+#if (defined(__arm__) || defined(__aarch64__)) && !defined(__APPLE__)
+    const char* vs =
+        \"attribute vec3 aPos; attribute vec3 aNormal; attribute vec2 aUv;\\n\"
+        \"uniform mat4 uMVP; uniform mat4 uModel; uniform mat3 uNormalMat;\\n\"
+        \"varying vec2 vUv; varying vec3 vN; varying vec3 vWorld;\\n\"
+        \"void main(){ gl_Position=uMVP*vec4(aPos,1.0); vUv=aUv; vN=uNormalMat*aNormal; vWorld=(uModel*vec4(aPos,1.0)).xyz; }\\n\";
+    const char* fs =
+        \"precision mediump float;\\n\"
+        \"varying vec2 vUv; varying vec3 vN; varying vec3 vWorld;\\n\"
+        \"uniform sampler2D uTex; uniform vec3 uAmbient; uniform vec4 uBaseColor; uniform vec3 uEmissive;\\n\"
+        \"uniform vec2 uUvOffset; uniform vec2 uUvScale; uniform float uUnlit; uniform float uAlphaCut;\\n\"
+        \"uniform int uNumDir; uniform vec3 uDirDir[4]; uniform vec3 uDirCol[4];\\n\"
+        \"uniform int uNumPt; uniform vec3 uPtPos[8]; uniform vec3 uPtCol[8]; uniform float uPtRange[8];\\n\"
+        \"void main(){ vec3 N=normalize(vN); vec3 L=uAmbient;\\n\"
+        \"  for(int i=0;i<4;i++){ if(i>=uNumDir) break; L+=uDirCol[i]*max(0.0,dot(N,uDirDir[i])); }\\n\"
+        \"  for(int i=0;i<8;i++){ if(i>=uNumPt) break; vec3 d=uPtPos[i]-vWorld; float dist=length(d); vec3 Ld=d/max(dist,0.001); float a=max(0.0,1.0-dist/uPtRange[i]); L+=uPtCol[i]*max(0.0,dot(N,Ld))*a*a; }\\n\"
+        \"  vec2 uv=uUvOffset+vUv*uUvScale; vec4 t=texture2D(uTex,uv)*uBaseColor; if(t.a<uAlphaCut) discard;\\n\"
+        \"  vec3 lit=mix(t.rgb*L + uEmissive, t.rgb, uUnlit); gl_FragColor=vec4(lit, t.a); }\\n\";
+#else
+    const char* vs =
+        \"#version 120\\n\"
+        \"attribute vec3 aPos; attribute vec3 aNormal; attribute vec2 aUv;\\n\"
+        \"uniform mat4 uMVP; uniform mat4 uModel; uniform mat3 uNormalMat;\\n\"
+        \"varying vec2 vUv; varying vec3 vN; varying vec3 vWorld;\\n\"
+        \"void main(){ gl_Position=uMVP*vec4(aPos,1.0); vUv=aUv; vN=uNormalMat*aNormal; vWorld=(uModel*vec4(aPos,1.0)).xyz; }\\n\";
+    const char* fs =
+        \"#version 120\\n\"
+        \"varying vec2 vUv; varying vec3 vN; varying vec3 vWorld;\\n\"
+        \"uniform sampler2D uTex; uniform vec3 uAmbient; uniform vec4 uBaseColor; uniform vec3 uEmissive;\\n\"
+        \"uniform vec2 uUvOffset; uniform vec2 uUvScale; uniform float uUnlit; uniform float uAlphaCut;\\n\"
+        \"uniform int uNumDir; uniform vec3 uDirDir[4]; uniform vec3 uDirCol[4];\\n\"
+        \"uniform int uNumPt; uniform vec3 uPtPos[8]; uniform vec3 uPtCol[8]; uniform float uPtRange[8];\\n\"
+        \"void main(){ vec3 N=normalize(vN); vec3 L=uAmbient;\\n\"
+        \"  for(int i=0;i<4;i++){ if(i>=uNumDir) break; L+=uDirCol[i]*max(0.0,dot(N,uDirDir[i])); }\\n\"
+        \"  for(int i=0;i<8;i++){ if(i>=uNumPt) break; vec3 d=uPtPos[i]-vWorld; float dist=length(d); vec3 Ld=d/max(dist,0.001); float a=max(0.0,1.0-dist/uPtRange[i]); L+=uPtCol[i]*max(0.0,dot(N,Ld))*a*a; }\\n\"
+        \"  vec2 uv=uUvOffset+vUv*uUvScale; vec4 t=texture2D(uTex,uv)*uBaseColor; if(t.a<uAlphaCut) discard;\\n\"
+        \"  vec3 lit=mix(t.rgb*L + uEmissive, t.rgb, uUnlit); gl_FragColor=vec4(lit, t.a); }\\n\";
+#endif
+    GLuint vsId = rgfx_gl_compile(GL_VERTEX_SHADER, vs);
+    GLuint fsId = rgfx_gl_compile(GL_FRAGMENT_SHADER, fs);
+    if (vsId == 0 || fsId == 0) { if (vsId) glDeleteShader(vsId); if (fsId) glDeleteShader(fsId); return 0; }
+    g_scene_prog = glCreateProgram();
+    glAttachShader(g_scene_prog, vsId); glAttachShader(g_scene_prog, fsId); glLinkProgram(g_scene_prog);
+    glDeleteShader(vsId); glDeleteShader(fsId);
+    GLint linked = GL_FALSE; glGetProgramiv(g_scene_prog, GL_LINK_STATUS, &linked);
+    if (linked != GL_TRUE) { char log[1024]; GLsizei len=0; glGetProgramInfoLog(g_scene_prog,(GLsizei)sizeof(log),&len,log); SDL_Log(\"[scene] program LINK FAILED: %.*s\", (int)len, log); glDeleteProgram(g_scene_prog); g_scene_prog=0; return 0; }
+    g_scn_aPos=glGetAttribLocation(g_scene_prog,\"aPos\"); g_scn_aNormal=glGetAttribLocation(g_scene_prog,\"aNormal\"); g_scn_aUv=glGetAttribLocation(g_scene_prog,\"aUv\");
+    g_scn_uMVP=glGetUniformLocation(g_scene_prog,\"uMVP\"); g_scn_uModel=glGetUniformLocation(g_scene_prog,\"uModel\"); g_scn_uNormalMat=glGetUniformLocation(g_scene_prog,\"uNormalMat\"); g_scn_uTex=glGetUniformLocation(g_scene_prog,\"uTex\");
+    g_scn_uAmbient=glGetUniformLocation(g_scene_prog,\"uAmbient\");
+    g_scn_uBaseColor=glGetUniformLocation(g_scene_prog,\"uBaseColor\"); g_scn_uEmissive=glGetUniformLocation(g_scene_prog,\"uEmissive\");
+    g_scn_uUvOffset=glGetUniformLocation(g_scene_prog,\"uUvOffset\"); g_scn_uUvScale=glGetUniformLocation(g_scene_prog,\"uUvScale\");
+    g_scn_uUnlit=glGetUniformLocation(g_scene_prog,\"uUnlit\"); g_scn_uAlphaCut=glGetUniformLocation(g_scene_prog,\"uAlphaCut\");
+    g_scn_uNumDir=glGetUniformLocation(g_scene_prog,\"uNumDir\"); g_scn_uDirDir=glGetUniformLocation(g_scene_prog,\"uDirDir\"); g_scn_uDirCol=glGetUniformLocation(g_scene_prog,\"uDirCol\");
+    g_scn_uNumPt=glGetUniformLocation(g_scene_prog,\"uNumPt\"); g_scn_uPtPos=glGetUniformLocation(g_scene_prog,\"uPtPos\"); g_scn_uPtCol=glGetUniformLocation(g_scene_prog,\"uPtCol\"); g_scn_uPtRange=glGetUniformLocation(g_scene_prog,\"uPtRange\");
+    SDL_Log(\"[scene] program ok prog=%u\", (unsigned) g_scene_prog);
+    return 1;
+}
+extern \"C\" void rgfx_scene_render(int w, int h) {
+    if (!g_rgfx_gpu_mode) { return; }
+    rgfx_gpu_start_frame(w, h);
+    if (!rgfx_scene_gl_init()) { return; }
+    if (!rgfx_scene_valid(g_scene_active_cam)) { return; }
+    RgfxSceneEntity& cam = g_scene[(size_t)(g_scene_active_cam-1)];
+    float view[16], proj[16], vp[16];
+    float tx = cam.useTarget ? cam.target[0] : cam.pos[0];
+    float ty = cam.useTarget ? cam.target[1] : cam.pos[1];
+    float tz = cam.useTarget ? cam.target[2] : (cam.pos[2] + 1.f);
+    rgfx_m4_lookat(cam.pos[0],cam.pos[1],cam.pos[2], tx,ty,tz, cam.up[0],cam.up[1],cam.up[2], view);
+    rgfx_m4_perspective(cam.fovy, (float)w/(float)h, cam.nearp>0.f?cam.nearp:0.1f, cam.farp>0.f?cam.farp:100.f, proj);
+    rgfx_m4_mul(proj, view, vp);
+    // gather lights
+    float ambient[3] = {0,0,0};
+    float dirDir[RGSCENE_MAXDIR*3], dirCol[RGSCENE_MAXDIR*3]; int ndir=0;
+    float ptPos[RGSCENE_MAXPT*3], ptCol[RGSCENE_MAXPT*3], ptRange[RGSCENE_MAXPT]; int npt=0;
+    for (size_t i=0;i<g_scene.size();++i) {
+        RgfxSceneEntity& e = g_scene[i]; if (!e.alive || !e.enabled) continue;
+        if (e.type==RGE_AMBIENT) { ambient[0]+=e.color[0]*e.intensity; ambient[1]+=e.color[1]*e.intensity; ambient[2]+=e.color[2]*e.intensity; }
+        else if (e.type==RGE_DIR && ndir<RGSCENE_MAXDIR) { float dx=e.pos[0],dy=e.pos[1],dz=e.pos[2]; float l=sqrtf(dx*dx+dy*dy+dz*dz); if(l>0.f){dx/=l;dy/=l;dz/=l;} dirDir[ndir*3]=dx;dirDir[ndir*3+1]=dy;dirDir[ndir*3+2]=dz; dirCol[ndir*3]=e.color[0]*e.intensity;dirCol[ndir*3+1]=e.color[1]*e.intensity;dirCol[ndir*3+2]=e.color[2]*e.intensity; ndir++; }
+        else if (e.type==RGE_POINT && npt<RGSCENE_MAXPT) { ptPos[npt*3]=e.pos[0];ptPos[npt*3+1]=e.pos[1];ptPos[npt*3+2]=e.pos[2]; ptCol[npt*3]=e.color[0]*e.intensity;ptCol[npt*3+1]=e.color[1]*e.intensity;ptCol[npt*3+2]=e.color[2]*e.intensity; ptRange[npt]=e.range>0.f?e.range:10.f; npt++; }
+    }
+    glEnable(GL_DEPTH_TEST); glDepthFunc(GL_LESS); glClear(GL_DEPTH_BUFFER_BIT);
+    glUseProgram(g_scene_prog);
+    glUniform3fv(g_scn_uAmbient,1,ambient);
+    glUniform1i(g_scn_uNumDir,ndir); if(ndir>0){ glUniform3fv(g_scn_uDirDir,ndir,dirDir); glUniform3fv(g_scn_uDirCol,ndir,dirCol);}
+    glUniform1i(g_scn_uNumPt,npt); if(npt>0){ glUniform3fv(g_scn_uPtPos,npt,ptPos); glUniform3fv(g_scn_uPtCol,npt,ptCol); glUniform1fv(g_scn_uPtRange,npt,ptRange);}
+    glActiveTexture(GL_TEXTURE0); glUniform1i(g_scn_uTex,0);
+    // two passes: opaque first (depth write on), then alpha-blended materials
+    // (depth test on, depth write off) so transparent gems read correctly.
+    for (int pass=0; pass<2; ++pass) {
+      if (pass==1) { glEnable(GL_BLEND); glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA); glDepthMask(GL_FALSE); }
+      for (size_t i=0;i<g_scene.size();++i) {
+        RgfxSceneEntity& e = g_scene[i];
+        if (!e.alive || !e.enabled || !e.visible) continue;
+        if (e.type==RGE_SPRITE) {
+            if (pass!=0) continue; // sprites: opaque pass with alpha discard
+            int q = rgfx_scene_ensure_quad(); // lazily build the billboard quad (GL is current here)
+            if (q<=0 || q>(int)g_rgfx_meshes.size()) continue;
+            RgfxMesh3D& m = g_rgfx_meshes[(size_t)(q-1)];
+            // cylindrical (Y-up) billboard: face the camera horizontally
+            float fxc=cam.pos[0]-e.pos[0], fzc=cam.pos[2]-e.pos[2];
+            float fl=sqrtf(fxc*fxc+fzc*fzc); if(fl>0.f){fxc/=fl;fzc/=fl;} else {fxc=0.f;fzc=1.f;}
+            float rx=fzc, rz=-fxc; // right = up(0,1,0) x forward(fxc,0,fzc)
+            float model[16]; for(int k=0;k<16;k++) model[k]=0.f;
+            RGM4(model,0,0)=rx*e.spW; RGM4(model,2,0)=rz*e.spW;   // X = right*w
+            RGM4(model,1,1)=e.spH;                                 // Y = up*h
+            RGM4(model,0,2)=fxc; RGM4(model,2,2)=fzc;              // Z = forward
+            RGM4(model,0,3)=e.pos[0]; RGM4(model,1,3)=e.pos[1]; RGM4(model,2,3)=e.pos[2]; RGM4(model,3,3)=1.f;
+            float mvp[16]; rgfx_m4_mul(vp, model, mvp);
+            float nm[9]={1,0,0,0,1,0,0,0,1};
+            glUniformMatrix4fv(g_scn_uMVP,1,GL_FALSE,mvp); glUniformMatrix4fv(g_scn_uModel,1,GL_FALSE,model); glUniformMatrix3fv(g_scn_uNormalMat,1,GL_FALSE,nm);
+            float white[4]={1,1,1,1}, noE[3]={0,0,0};
+            glUniform4fv(g_scn_uBaseColor,1,white); glUniform3fv(g_scn_uEmissive,1,noE);
+            float us[2]={ 1.f/(float)e.spCols, 1.f/(float)e.spRows };
+            float uo[2]={ (float)e.spCol/(float)e.spCols, (float)e.spRow/(float)e.spRows };
+            // inset ~1.2% of a cell so linear filtering doesn't bleed neighbour frames
+            float insx=us[0]*0.012f, insy=us[1]*0.012f;
+            uo[0]+=insx; uo[1]+=insy; us[0]-=2.f*insx; us[1]-=2.f*insy;
+            glUniform2fv(g_scn_uUvOffset,1,uo); glUniform2fv(g_scn_uUvScale,1,us);
+            glUniform1f(g_scn_uUnlit,1.f); glUniform1f(g_scn_uAlphaCut,0.35f);
+            if (e.texId>0 && e.texId<=(int)g_rgfx_gl_textures.size()) glBindTexture(GL_TEXTURE_2D, g_rgfx_gl_textures[(size_t)(e.texId-1)]);
+            glBindBuffer(GL_ARRAY_BUFFER,m.vbo); glBindBuffer(GL_ELEMENT_ARRAY_BUFFER,m.ebo);
+            if(g_scn_aPos>=0){glEnableVertexAttribArray(g_scn_aPos); glVertexAttribPointer(g_scn_aPos,3,GL_FLOAT,GL_FALSE,32,(void*)0);}
+            if(g_scn_aNormal>=0){glEnableVertexAttribArray(g_scn_aNormal); glVertexAttribPointer(g_scn_aNormal,3,GL_FLOAT,GL_FALSE,32,(void*)12);}
+            if(g_scn_aUv>=0){glEnableVertexAttribArray(g_scn_aUv); glVertexAttribPointer(g_scn_aUv,2,GL_FLOAT,GL_FALSE,32,(void*)24);}
+            glDrawElements(GL_TRIANGLES,m.icount,GL_UNSIGNED_INT,(void*)0);
+            continue;
+        }
+        if (e.type!=RGE_MESH) continue;
+        if (e.meshId<=0 || e.meshId>(int)g_rgfx_meshes.size()) continue;
+        int wantBlend = (pass==1) ? 1 : 0; if (e.matBlend != wantBlend) continue;
+        glUniform4fv(g_scn_uBaseColor,1,e.matColor); glUniform3fv(g_scn_uEmissive,1,e.matEmissive);
+        { float z2[2]={0.f,0.f}, o2[2]={1.f,1.f}; glUniform2fv(g_scn_uUvOffset,1,z2); glUniform2fv(g_scn_uUvScale,1,o2); glUniform1f(g_scn_uUnlit,0.f); glUniform1f(g_scn_uAlphaCut,0.f); }
+        RgfxMesh3D& m = g_rgfx_meshes[(size_t)(e.meshId-1)];
+        float r3[9]; rgfx_quat_m3(e.rot, r3);
+        float model[16]; for(int k=0;k<16;k++) model[k]=0.f;
+        // model = T * R * S (column-major)
+        RGM4(model,0,0)=r3[0]*e.scale[0]; RGM4(model,1,0)=r3[1]*e.scale[0]; RGM4(model,2,0)=r3[2]*e.scale[0];
+        RGM4(model,0,1)=r3[3]*e.scale[1]; RGM4(model,1,1)=r3[4]*e.scale[1]; RGM4(model,2,1)=r3[5]*e.scale[1];
+        RGM4(model,0,2)=r3[6]*e.scale[2]; RGM4(model,1,2)=r3[7]*e.scale[2]; RGM4(model,2,2)=r3[8]*e.scale[2];
+        RGM4(model,0,3)=e.pos[0]; RGM4(model,1,3)=e.pos[1]; RGM4(model,2,3)=e.pos[2]; RGM4(model,3,3)=1.f;
+        float mvp[16]; rgfx_m4_mul(vp, model, mvp);
+        float nm[9]; nm[0]=r3[0];nm[1]=r3[1];nm[2]=r3[2];nm[3]=r3[3];nm[4]=r3[4];nm[5]=r3[5];nm[6]=r3[6];nm[7]=r3[7];nm[8]=r3[8];
+        glUniformMatrix4fv(g_scn_uMVP,1,GL_FALSE,mvp); glUniformMatrix4fv(g_scn_uModel,1,GL_FALSE,model); glUniformMatrix3fv(g_scn_uNormalMat,1,GL_FALSE,nm);
+        if (e.texId>0 && e.texId<=(int)g_rgfx_gl_textures.size()) { glBindTexture(GL_TEXTURE_2D, g_rgfx_gl_textures[(size_t)(e.texId-1)]); }
+        else { glBindTexture(GL_TEXTURE_2D, rgfx_scene_ensure_white()); }
+        glBindBuffer(GL_ARRAY_BUFFER,m.vbo); glBindBuffer(GL_ELEMENT_ARRAY_BUFFER,m.ebo);
+        if(g_scn_aPos>=0){glEnableVertexAttribArray(g_scn_aPos); glVertexAttribPointer(g_scn_aPos,3,GL_FLOAT,GL_FALSE,32,(void*)0);}
+        if(g_scn_aNormal>=0){glEnableVertexAttribArray(g_scn_aNormal); glVertexAttribPointer(g_scn_aNormal,3,GL_FLOAT,GL_FALSE,32,(void*)12);}
+        if(g_scn_aUv>=0){glEnableVertexAttribArray(g_scn_aUv); glVertexAttribPointer(g_scn_aUv,2,GL_FLOAT,GL_FALSE,32,(void*)24);}
+        glDrawElements(GL_TRIANGLES,m.icount,GL_UNSIGNED_INT,(void*)0);
+      }
+    }
+    glDepthMask(GL_TRUE); glDisable(GL_BLEND); glDisable(GL_DEPTH_TEST);
+}
+") )
+            es6 ( "true" )
+        }
+    }
+
+    ; Clear a prior window-close request (e.g. after returning to the launcher menu).
+    gfx_clear_should_close _:void () {
+        templates {
+            cpp ( "rgfx_clear_should_close()" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Sleep for `ms` milliseconds (frame pacing).
+    gfx_delay _:void (ms:int) {
+        templates {
+            cpp ( "rgfx_delay(" (e 1) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Milliseconds since SDL_Init (wall clock for FPS).
+    gfx_ticks_ms _:int () {
+        templates {
+            cpp ( "(int) rgfx_ticks_ms()" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+
+    ; Update the window title (e.g. append live FPS).
+    gfx_set_title _:void (title:string) {
+        templates {
+            cpp ( "rgfx_set_title(" (e 1) ")" (imp "<SDL2/SDL.h>") (imp "<string>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Tear down the window and quit SDL.
+    gfx_close _:void () {
+        templates {
+            cpp ( "rgfx_close()" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Set desktop fullscreen on/off (1 = fullscreen, 0 = windowed).
+    gfx_set_fullscreen _:void (on:int) {
+        templates {
+            cpp ( "rgfx_set_fullscreen(" (e 1) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Toggle desktop fullscreen (scaled). Returns 1 when fullscreen, 0 windowed.
+    gfx_toggle_fullscreen _:int () {
+        templates {
+            cpp ( "rgfx_toggle_fullscreen()" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+
+    ; True when the SDL window is in fullscreen desktop mode.
+    gfx_is_fullscreen _:boolean () {
+        templates {
+            cpp ( "(rgfx_is_fullscreen() != 0)" (imp "<SDL2/SDL.h>") )
+            es6 ( "false" )
+        }
+    }
+
+    ; Open a mono S16 audio output device (call once after gfx_open).
+    gfx_audio_open _:int (sampleRate:int) {
+        templates {
+            cpp ( "rgfx_audio_open(" (e 1) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+
+    ; Queue raw PCM bytes (mono int16 little-endian) for playback.
+    gfx_audio_queue _:void (pcm:buffer byteCount:int) {
+        templates {
+            cpp ( "rgfx_audio_queue(" (e 1) ".data(), " (e 2) ")" (imp "<SDL2/SDL.h>") (imp "<cstdint>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Drop queued PCM (e.g. when returning from a sub-game to the launcher menu).
+    gfx_audio_clear _:void () {
+        templates {
+            cpp ( "rgfx_audio_clear()" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    gfx_audio_sample_rate _:int () {
+        templates {
+            cpp ( "rgfx_audio_sample_rate()" (imp "<SDL2/SDL.h>") )
+            es6 ( "44100" )
+        }
+    }
+
+    ; Open an SDL window with an OpenGL 2.1 context for hybrid GPU sprite present.
+    ; Returns 1 on success, 0 on failure (caller may fall back to gfx_open).
+    gfx_open_gpu _:int (title:string w:int h:int) {
+        templates {
+            cpp ( "rgfx_open_gpu(" (e 1) ", " (e 2) ", " (e 3) ")"
+                  (imp "<SDL2/SDL.h>") (imp "<cstdint>") (imp "<string>") )
+            es6 ( "0" )
+        }
+    }
+
+    ; Upload an RGBA buffer as a persistent GL texture (1-based id, 0 on failure).
+    gfx_gpu_upload_texture _:int (pixels:buffer w:int h:int) {
+        templates {
+            cpp ( "rgfx_gpu_upload_texture(" (e 1) ".data(), " (e 2) ", " (e 3) ")"
+                  (imp "<SDL2/SDL.h>") (imp "<cstdint>") )
+            es6 ( "0" )
+        }
+    }
+
+    ; Begin collecting GPU particles for the next present (OpenGL path only).
+    gfx_particles_begin _:void (fbW:int fbH:int pane:int) {
+        templates {
+            cpp ( "rgfx_particles_begin(" (e 1) ", " (e 2) ", " (e 3) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Queue one soft-circle particle (screen pixels, 0..255 colour/alpha).
+    gfx_particles_push _:void (x:double y:double size:double r:int g:int b:int alpha:int) {
+        templates {
+            cpp ( "rgfx_particles_push((float)" (e 1) ", (float)" (e 2) ", (float)" (e 3) ", "
+                  (e 4) ", " (e 5) ", " (e 6) ", " (e 7) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Finish particle collection (draw happens during gfx_present on GPU path).
+    gfx_particles_end _:void () {
+        templates {
+            cpp ( "/* particles collected */" )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Begin collecting GPU UI-effect overlay quads for the next present. Clears the
+    ; queue and records the framebuffer size (needed for whole-screen pulses).
+    gfx_fx_begin _:void (fbW:int fbH:int) {
+        templates {
+            cpp ( "rgfx_fx_begin(" (e 1) ", " (e 2) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Queue a soft glow halo over a node rect (screen px, 0..255 colour/alpha).
+    gfx_fx_push_glow _:void (x:double y:double w:double h:double r:int g:int b:int alpha:int) {
+        templates {
+            cpp ( "rgfx_fx_push_glow((float)" (e 1) ", (float)" (e 2) ", (float)" (e 3) ", (float)"
+                  (e 4) ", " (e 5) ", " (e 6) ", " (e 7) ", " (e 8) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Queue a whole-screen colour pulse (0..255 colour/alpha), brightest at centre.
+    gfx_fx_push_screen _:void (r:int g:int b:int alpha:int) {
+        templates {
+            cpp ( "rgfx_fx_push_screen(" (e 1) ", " (e 2) ", " (e 3) ", " (e 4) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Begin collecting GPU sheet sprites for the next present (OpenGL path only).
+    gfx_gpu_sprites_begin _:void (fbW:int fbH:int pane:int) {
+        templates {
+            cpp ( "rgfx_gpu_sprites_begin(" (e 1) ", " (e 2) ", " (e 3) ")" (imp "<SDL2/SDL.h>") (imp "<cmath>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; Queue one spritesheet sub-rect. usePivot=0: px/py = top-left; usePivot=1: pivot + angleDeg.
+    gfx_gpu_sprites_push _:void (texId:int atlasW:int atlasH:int sx:int sy:int sw:int sh:int px:double py:double dw:double dh:double angleDeg:double usePivot:int) {
+        templates {
+            cpp ( "rgfx_gpu_sprites_push(" (e 1) ", " (e 2) ", " (e 3) ", "
+                  (e 4) ", " (e 5) ", " (e 6) ", " (e 7) ", (float)" (e 8) ", (float)" (e 9) ", "
+                  "(float)" (e 10) ", (float)" (e 11) ", (float)" (e 12) ", " (e 13) ")"
+                  (imp "<SDL2/SDL.h>") (imp "<cmath>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; R1b: set the 2D ortho camera for a pane's GPU sprite overlay. x/y pan in
+    ; framebuffer pixels (screen = world - cam, like game_camera); zoom and
+    ; angleDeg rotate/scale about the pane centre. Applied at draw time as a
+    ; 4x4 view-projection uniform. Defaults (0,0,1,0) are the identity; the
+    ; bisect fallback paths (RANGER_GFX_SPRITE_BATCH=0 / RANGER_GFX_SPRITE_CAMERA=0)
+    ; ignore the camera by design.
+    gfx_gpu_camera_set _:void (pane:int x:double y:double zoom:double angleDeg:double) {
+        templates {
+            cpp ( "rgfx_gpu_camera_set(" (e 1) ", (float)" (e 2) ", (float)" (e 3) ", "
+                  "(float)" (e 4) ", (float)" (e 5) ")"
+                  (imp "<SDL2/SDL.h>") (imp "<cmath>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; R1b: reset a pane's GPU sprite camera to the identity (no pan/zoom/rotation).
+    gfx_gpu_camera_reset _:void (pane:int) {
+        templates {
+            cpp ( "rgfx_gpu_camera_reset(" (e 1) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; ---- 3D mesh pipeline (render=3d / Wasm3dRunner) ----------------------
+    ; Upload a texture for the 3D path (GL_REPEAT + mipmaps). Returns a texId
+    ; into the shared GL texture table (same space as gfx_gpu_upload_texture).
+    gfx_3d_upload_texture _:int (pixels:buffer w:int h:int) {
+        templates {
+            cpp ( "rgfx_3d_upload_texture(" (e 1) ".data(), " (e 2) ", " (e 3) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+    ; Upload a mesh: raw guest vertex bytes (32 B/vertex fixed-point) + u16
+    ; indices. Returns a mesh handle (1-based).
+    gfx_3d_mesh_upload _:int (verts:int_buffer vcount:int idx:int_buffer icount:int) {
+        templates {
+            cpp ( "rgfx_mesh_upload(" (e 1) ".data(), " (e 2) ", " (e 3) ".data(), " (e 4) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+    ; High-precision upload: positions are Q16.16 (x65536) not x256, so dense GLB
+    ; meshes don't quantise nearby vertices into degenerate triangles.
+    gfx_3d_mesh_upload_hp _:int (verts:int_buffer vcount:int idx:int_buffer icount:int) {
+        templates {
+            cpp ( "rgfx_mesh_upload_hp(" (e 1) ".data(), " (e 2) ", " (e 3) ".data(), " (e 4) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "0" )
+        }
+    }
+    ; Begin a 3D pass: enable depth test, clear depth, bind the 3D program.
+    gfx_3d_begin _:void (w:int h:int) {
+        templates {
+            cpp ( "rgfx_3d_begin(" (e 1) ", " (e 2) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+    ; Set the camera (eye, target, up, fovy radians, near, far, aspect); the
+    ; host builds view*projection.
+    gfx_3d_set_camera _:void (ex:double ey:double ez:double tx:double ty:double tz:double ux:double uy:double uz:double fovy:double near:double far:double aspect:double) {
+        templates {
+            cpp ( "rgfx_3d_set_camera((float)" (e 1) ", (float)" (e 2) ", (float)" (e 3) ", (float)" (e 4) ", (float)" (e 5) ", (float)" (e 6) ", (float)" (e 7) ", (float)" (e 8) ", (float)" (e 9) ", (float)" (e 10) ", (float)" (e 11) ", (float)" (e 12) ", (float)" (e 13) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+    ; Set the scene light: ambient rgb+intensity, sun direction, sun rgb+intensity.
+    gfx_3d_set_light _:void (ambColor:int ambI:double dx:double dy:double dz:double sunColor:int sunI:double) {
+        templates {
+            cpp ( "rgfx_3d_set_light(" (e 1) ", (float)" (e 2) ", (float)" (e 3) ", (float)" (e 4) ", (float)" (e 5) ", " (e 6) ", (float)" (e 7) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+    ; Draw an index range of a mesh with a texture and a model (euler rot + pos).
+    gfx_3d_draw _:void (meshId:int first:int count:int texId:int rx:double ry:double rz:double px:double py:double pz:double) {
+        templates {
+            cpp ( "rgfx_3d_draw(" (e 1) ", " (e 2) ", " (e 3) ", " (e 4) ", (float)" (e 5) ", (float)" (e 6) ", (float)" (e 7) ", (float)" (e 8) ", (float)" (e 9) ", (float)" (e 10) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+    ; End the 3D pass (disable depth test so the 2D overlay draws on top).
+    gfx_3d_end _:void () {
+        templates {
+            cpp ( "rgfx_3d_end()" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+    ; Present the GL frame (swap buffers).
+    gfx_3d_present _:void () {
+        templates {
+            cpp ( "rgfx_gpu_finish_frame()" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+
+    ; ---- host-managed scene (IDEAL_3D Phase H) ---------------------------
+    ; Clear the retained scene (call when a new 3D guest loads).
+    gfx_scene_reset _:void () {
+        templates {
+            cpp ( "rgfx_scene_reset()" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+    ; Render the whole retained scene (camera + lights + mesh entities). Does NOT
+    ; swap: the caller presents with gfx_3d_present, so a HUD can be composited
+    ; in between with gfx_hud_overlay (same shape as the legacy gfx_3d_end +
+    ; gfx_3d_present path).
+    gfx_scene_render _:void (w:int h:int) {
+        templates {
+            cpp ( "rgfx_scene_render(" (e 1) ", " (e 2) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+    ; Blend a CPU RGBA image over the rendered 3D frame, stretched to the window.
+    ; Call after gfx_scene_render / gfx_3d_end and before gfx_3d_present.
+    gfx_hud_overlay _:void (pixels:buffer w:int h:int) {
+        templates {
+            cpp ( "rgfx_hud_overlay_draw(" (e 1) ".data(), " (e 2) ", " (e 3) ")" (imp "<SDL2/SDL.h>") )
+            es6 ( "undefined" )
+        }
+    }
+    ; Register a preloaded GLB mesh (+ its base texture) under a name so the
+    ; guest's rg_load_model(name) import can resolve it to this meshId.
+    gfx_scene_register_model _:void (name:string meshId:int texId:int colorRgba:int emissiveRgb:int blend:int) {
+        templates {
+            cpp ( "rgfx_scene_register_model(" (e 1) ".c_str(), " (e 2) ", " (e 3) ", " (e 4) ", " (e 5) ", " (e 6) ")" (imp "<SDL2/SDL.h>") (imp "<string>") )
+            es6 ( "undefined" )
+        }
+    }
+    ; Register a preloaded sprite sheet (uploaded RGBA texture) under a name so
+    ; the guest's rg_load_sprite(name) import can resolve it to this texId.
+    gfx_scene_register_sprite _:void (name:string texId:int) {
+        templates {
+            cpp ( "rgfx_scene_register_sprite(" (e 1) ".c_str(), " (e 2) ")" (imp "<SDL2/SDL.h>") (imp "<string>") )
+            es6 ( "undefined" )
+        }
+    }
+}

--- a/gallery/game_engine/v2/sprites/host/game_sprite.rgr
+++ b/gallery/game_engine/v2/sprites/host/game_sprite.rgr
@@ -26,7 +26,7 @@
 ; ==============================================================================
 
 Import "../framebuffer.rgr"
-Import "../gfx_sdl.rgr"
+Import "../../runtime/sdl/gfx_sdl.rgr"
 Import "./game_image_loader.rgr"
 Import "../../pdf_writer/src/jpeg/ImageBuffer.rgr"
 

--- a/gallery/game_engine/v2/tests/run.sh
+++ b/gallery/game_engine/v2/tests/run.sh
@@ -114,6 +114,9 @@ run_suite tests/sdl/sdl_host_test
 
 # ---- Phase 10 — audio / input / surface devices (fakes) ---------------------
 run_suite modules/ranger_core/tests/devices_test
+# headless music: score parse -> beat schedule -> equal-tempered PCM synth
+# (self-contained under v2/audio; the SDL gfx_audio_* sink consumes this PCM)
+run_suite audio/tests/audio_score_test
 
 # ---- BRIDGES.md steps 1–2 — schema rows + generic registry bridge ------------
 run_suite registry/schema/tests/bridge_schema_test

--- a/gallery/game_engine/v2/tests/run.sh
+++ b/gallery/game_engine/v2/tests/run.sh
@@ -108,6 +108,9 @@ run_suite render/tests/software_present2d_test
 # texture pixel store + sampling backend (real texels, sprite size/z/flip)
 run_suite modules/ranger_2d/tests/texture_store_test
 run_suite tests/render/textured_render_test
+# native SDL host — testable seams (framebuffer->RGBA pack, input map); the
+# import also compile-checks the whole native driver against the gfx_* stubs
+run_suite tests/sdl/sdl_host_test
 
 # ---- Phase 10 — audio / input / surface devices (fakes) ---------------------
 run_suite modules/ranger_core/tests/devices_test

--- a/gallery/game_engine/v2/tests/run.sh
+++ b/gallery/game_engine/v2/tests/run.sh
@@ -119,6 +119,9 @@ run_suite modules/ranger_core/tests/devices_test
 run_suite registry/schema/tests/bridge_schema_test
 run_suite tests/unit/bridge/registry_bridge_coverage_test
 
+# ---- menu / EVG launcher UI (self-contained ui/ + evg + fonts + framebuffer) -
+run_suite menu/tests/launcher_ui_test
+
 # ---- BRIDGES.md step 3 — real TSX guests on the ONE generic host -------------
 # Games are TSX-only folders (no per-game .rgr); RgGameHost is the single
 # generic host (v1 GameRunner analog). These are thin test drivers.

--- a/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
+++ b/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
@@ -1,0 +1,58 @@
+; ==============================================================================
+; sdl_host_test — the SDL host's TESTABLE seams (no window required).
+; ==============================================================================
+; The native SDL loop can't run under Node (gfx_* stub to no-ops), but its two
+; pure seams — the framebuffer -> RGBA pack and the input-mask -> logical-action
+; map — are host logic and MUST be correct. This suite exercises both, and by
+; importing RgSdlGameHost it also compile-checks the whole native driver.
+;
+; Boundary check: the map feeds bridge.input (host device) with LOGICAL actions
+; only; nothing here reaches into ranger:core or any game.
+; ==============================================================================
+
+Import "../../runtime/sdl/RgSdlGameHost.rgr"
+Import "../harness/RgTest.rgr"
+
+class SdlHostTest {
+    sfn m@(main):void () {
+        def t:RgTest (RgTest.forSuite("tests/sdl/sdl_host (framebuffer pack + input map)"))
+
+        ; ---- framebuffer 0xRRGGBB -> tightly-packed RGBA bytes --------------
+        def fb:RgFramebuffer (RgFramebuffer.create(2 1))
+        fb.plot(0 0 16744516)   ; 0xFF8044 = 255,128,68
+        fb.plot(1 0 66051)      ; 0x010203 = 1,2,3
+        def buf:buffer (fb.toRgbaBuffer())
+        t.eqInt("px0 R" (buffer_get buf 0) 255)
+        t.eqInt("px0 G" (buffer_get buf 1) 128)
+        t.eqInt("px0 B" (buffer_get buf 2) 68)
+        t.eqInt("px0 A (opaque)" (buffer_get buf 3) 255)
+        t.eqInt("px1 R" (buffer_get buf 4) 1)
+        t.eqInt("px1 G" (buffer_get buf 5) 2)
+        t.eqInt("px1 B" (buffer_get buf 6) 3)
+        t.eqInt("px1 A (opaque)" (buffer_get buf 7) 255)
+
+        ; ---- input-mask -> logical actions (host input config) --------------
+        def sdl:RgSdlGameHost (new RgSdlGameHost)
+        ; bits: 16 left · 32 right · 1 up · 2 down · 4 action
+        sdl.mapMask(0 (bit_or 16 4))   ; hold left + action
+        def inp:RgInput sdl.host.bridge.input
+        t.ok("left is down" (inp.isDown(0 "left")))
+        t.no("right is not down" (inp.isDown(0 "right")))
+        t.ok("action maps to jump" (inp.isDown(0 "jump")))
+        t.ok("action is down" (inp.isDown(0 "action")))
+        t.no("down is not down" (inp.isDown(0 "down")))
+
+        ; releasing clears (each frame re-feeds the full mask)
+        sdl.mapMask(0 32)              ; now only right
+        t.no("left released" (inp.isDown(0 "left")))
+        t.ok("right now down" (inp.isDown(0 "right")))
+        t.no("jump released" (inp.isDown(0 "jump")))
+
+        ; player 1 is independent
+        sdl.mapMask(1 1)              ; up -> jump for player 1
+        t.ok("player 1 jump (up)" (inp.isDown(1 "jump")))
+        t.no("player 0 unaffected" (inp.isDown(0 "jump")))
+
+        t.summary()
+    }
+}

--- a/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
+++ b/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
@@ -53,6 +53,36 @@ class SdlHostTest {
         t.ok("player 1 jump (up)" (inp.isDown(1 "jump")))
         t.no("player 0 unaffected" (inp.isDown(0 "jump")))
 
+        ; ---- rising-edge detection (menu nav fires once per tap) ------------
+        t.ok("right pressed this frame" (sdl.edge(0 32 32)))
+        t.no("right still held is not an edge" (sdl.edge(32 32 32)))
+        t.no("right released is not an edge" (sdl.edge(32 0 32)))
+        t.ok("left edge independent of right bit" (sdl.edge(0 16 16)))
+
+        ; ---- launcher menu driven purely by input-mask edges ---------------
+        def ui:RgLauncherUi (new RgLauncherUi)
+        ui.init(480 270)
+        ; right edge (32) moves the category selection Games -> Tests
+        def s0:int (sdl.launcherStep(0 32 ui))
+        t.eqInt("moving selection does not launch" s0 0)
+        t.eqStr("right edge selected Tests" (ui.selectedLabel()) "Tests")
+        ; left edge (16) moves back to Games
+        def s1:int (sdl.launcherStep(0 16 ui))
+        t.eqStr("left edge selected Games" (ui.selectedLabel()) "Games")
+        ; action edge (4) enters the Games category (page 1), no launch yet
+        def s2:int (sdl.launcherStep(0 4 ui))
+        t.eqInt("entering a category is not a launch" s2 0)
+        t.eqInt("now on the entries page" (ui.currentPage()) 1)
+        t.eqStr("first entry is Pomppija" (ui.selectedLabel()) "Pomppija")
+        ; action edge (4) on an entry hands off -> returns 1 with a target
+        def s3:int (sdl.launcherStep(0 4 ui))
+        t.eqInt("activating an entry hands off" s3 1)
+        t.eqStr("handoff dir is the game folder" (ui.selectedDir()) "gallery/game_engine/v2/games/ylos2")
+        ; down edge (2) goes back to the category page
+        def s4:int (sdl.launcherStep(0 2 ui))
+        t.eqInt("back is not a launch" s4 0)
+        t.eqInt("back to the category page" (ui.currentPage()) 0)
+
         t.summary()
     }
 }

--- a/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
+++ b/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
@@ -83,6 +83,29 @@ class SdlHostTest {
         t.eqInt("back is not a launch" s4 0)
         t.eqInt("back to the category page" (ui.currentPage()) 0)
 
+        ; ---- host music pump: a guest's music.play(score) is synthesised ----
+        ; The bridge records the score (rgcore_music_play); the host owns the
+        ; synth + schedule clock. Simulate the recorded state and pump frames.
+        def snd:RgSdlGameHost (new RgSdlGameHost)
+        snd.initAudio()
+        t.eqInt("no notes before any score" (snd.pumpAudio(33)) 0)
+        ; guest played a short one-bar melody (tempo 120 -> 4 beats = 2s)
+        snd.host.bridge.musicPlaying = true
+        snd.host.bridge.musicScore = "tempo 120\n@melody piano\n1:C4 1:E4 1:G4 1:C5\n"
+        ; pump ~1.9s of frames (just under the 2s loop point): all 4 notes fire
+        ; once, before the looping score would replay the bar.
+        def ms 0
+        def started 0
+        while (ms < 1900) {
+            started = (snd.pumpAudio(33))
+            ms = (ms + 33)
+        }
+        t.eqInt("all four melody notes were synthesised" started 4)
+        ; a music_stop on the bridge halts the host clock
+        snd.host.bridge.musicPlaying = false
+        def _p:int (snd.pumpAudio(33))
+        t.ok("host music stops when the guest stops" ((snd.music.isPlaying()) == false))
+
         t.summary()
     }
 }

--- a/gallery/game_engine/v2/ui/UIContext.rgr
+++ b/gallery/game_engine/v2/ui/UIContext.rgr
@@ -10,8 +10,8 @@
 
 Import "../framebuffer.rgr"
 Import "UITextRenderer.rgr"
-Import "../../evg/EVGColor.rgr"
-Import "../../pdf_writer/src/jpeg/ImageBuffer.rgr"
+Import "../evg/EVGColor.rgr"
+Import "../imaging/jpeg/ImageBuffer.rgr"
 
 ; Named colour roles. Dark, translucent-panel theme by default (reads well as an
 ; overlay on top of a bright game world). Swap fields for a light theme.

--- a/gallery/game_engine/v2/ui/UITextRenderer.rgr
+++ b/gallery/game_engine/v2/ui/UITextRenderer.rgr
@@ -18,11 +18,11 @@
 ; ==============================================================================
 
 Import "../framebuffer.rgr"
-Import "../../pdf_writer/src/raster/RasterText.rgr"
-Import "../../pdf_writer/src/raster/RasterBuffer.rgr"
-Import "../../pdf_writer/src/fonts/FontManager.rgr"
-Import "../../pdf_writer/src/jpeg/ImageBuffer.rgr"
-Import "../../evg/EVGTextMeasurer.rgr"
+Import "../imaging/raster/RasterText.rgr"
+Import "../imaging/raster/RasterBuffer.rgr"
+Import "../imaging/fonts/FontManager.rgr"
+Import "../imaging/jpeg/ImageBuffer.rgr"
+Import "../evg/EVGTextMeasurer.rgr"
 
 ; One cached, pre-rasterized line of text (color baked in).
 class UICachedLine {

--- a/gallery/game_engine/v2/web/web_teapot_sdl_runner.rgr
+++ b/gallery/game_engine/v2/web/web_teapot_sdl_runner.rgr
@@ -13,7 +13,7 @@
 ; Headless smoke (N frames, offscreen): pass a frame count as the first CLI arg.
 ; ==============================================================================
 
-Import "../gfx_sdl.rgr"
+Import "../runtime/sdl/gfx_sdl.rgr"
 Import "./web_teapot_gl_probe.rgr"
 
 class WebTeapotSdlRunner {

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "engine:game-sdl": "bash gallery/game_engine/scripts/build-game-sdl.sh",
     "engine:game-sdl:run": "bash gallery/game_engine/scripts/build-game-sdl.sh --run",
     "engine:game-sdl:launcher": "bash gallery/game_engine/scripts/build-game-sdl.sh --run",
+    "engine:game-sdl:launcher:v2": "bash gallery/game_engine/scripts/build-sdl-v2.sh --run",
     "engine:game-sdl:run:pong": "bash gallery/game_engine/scripts/build-game-sdl.sh --run gallery/game_engine/games/pong/index.tsx",
     "engine:game-sdl:run:invaders": "bash gallery/game_engine/scripts/build-game-sdl.sh --run gallery/game_engine/games/invaders/index.tsx",
     "engine:game-sdl:run:breakout": "bash gallery/game_engine/scripts/build-game-sdl.sh --run gallery/game_engine/games/breakout/index.tsx",


### PR DESCRIPTION
## Summary

Follow-up to #423 (which flagged the native SDL host, launcher, and audio synthesis as next steps). This makes the v2 engine **runnable on macOS**: a native SDL2 host opens the rich launcher screen, you navigate it, pick a game, and it hands off through the same generic host the headless tests use — with music synthesized and played. Everything the guest sees is unchanged; nothing leaks into `ranger:core`.

**Run it on macOS** (prereq `brew install sdl2`):

```sh
npm run engine:game-sdl:launcher:v2
```

That compiles `RgSdlMain.rgr` → C++ and links SDL2 + OpenGL into `tmp/sdl-v2/ranger-v2`, then launches it. A window opens on the launcher: **arrows** move, **Space/A** selects (category → game → launch), **S** back, **Q/Esc** quits. In-game, WASD+Space drives P1, arrows drive P2, and a game's `runtime.input.player(i).rumble(...)` reaches the pad.

Headless checks (no SDL2 needed): `npm run engine:v2:test` → **43/43 suites green**.

## What's in this PR

### Native SDL host (generic, no game/core leak)
- `runtime/sdl/RgSdlGameHost.rgr` — one window/present path with two loops: `runLauncher()` (present the launcher canvas via single-surface `gfx_present`, navigate on input-mask **rising edges**, hand off the chosen game) and `run(dir,file)` (poll → actions → `host.frame` → present split → forward rumble). `RgSdlMain.rgr` boots `runLauncher()`.
- Pure, unit-tested host seams: framebuffer→RGBA pack, physical-bit→logical-action map, rising-edge nav, the launcher input contract, the music pump.

### Rich EVG/UI launcher (engine chrome, TSX games untouched)
- `menu/RgLauncherUi.rgr` — a two-level launcher (categories → game entries) on the UI widget layer: title "Ranger", subtitle "valitse kategoria", cards with a moving accent highlight, footer. Rendered headlessly into a `SoftCanvas` with TrueType fonts (3×5 bitmap fallback). Logical navigation only; the SDL host maps physical keys. On select, the host reads `selectedDir()/selectedFile()` and hands off via `RgGameHost.load` — the launcher launches nothing itself.

### Self-contained v2 subtree (no imports outside `v2/`)
- Vendored the full dependency closure into `v2/`: `imaging/fonts/{FontManager,TrueTypeFont}`, `imaging/raster/{RasterText,RasterCompositing,RasterBlur}`, `framebuffer` + `rgba_fast_blit`, and the native operator boundary `runtime/sdl/gfx_sdl.rgr`. Rewired every importer (ui/, menu/, the SDL host, and the experimental web/model3d/sprites runners) to v2-local paths. The launcher → game → audio → gfx_sdl path imports nothing outside `v2/`.

### Sound
- Vendored the headless synth stack into `v2/audio` (`game_soundscore` + `game_audio`): score parser → beat schedule → equal-tempered PCM synth, no native dependency.
- Wired it end-to-end: a guest's `runtime.audio.music.play(score)` is recorded on the bridge; the host `pumpAudio()` (each game frame) picks it up, ticks the schedule, and `RgSdlAudioSink` queues each note's PCM via `gfx_audio_queue`. Schedule clock, synth, and device are all host-side.

### Build + npm
- `scripts/build-sdl-v2.sh` (SDL2 + OpenGL only — no wasm3/libcurl, since only the called operators are emitted) + `engine:game-sdl:launcher:v2`.

## Tests (`npm run engine:v2:test` → 43/43)
- `menu/tests/launcher_ui_test` (27) — categories, two-level nav + clamps, handoff targets, accent-follows-selection read back from the rendered RGBA.
- `tests/sdl/sdl_host_test` (35) — framebuffer pack, input map, rising-edge nav, the launcher input contract, and the music pump (a 4-note melody synthesizes all four notes and stops with the guest).
- `audio/tests/audio_score_test` (18) — parse/schedule/synth on ylos2's actual `SUMMIT_MUSIC`.

## Boundary note

CI has no SDL2 headers, so the `gfx_*` operators stub to no-ops under es6 (the host compiles and its pure seams run headlessly), and the Ranger→C++ codegen is validated. The live window, audible output, and final SDL link happen on a machine with SDL2 via the npm script above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wi8xneHxDrhrUpUpem17Kc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wi8xneHxDrhrUpUpem17Kc)_