### PR TITLE
game_engine/v2: strip game-specific present assumptions from core SDL host

### DIFF
--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -196,7 +196,7 @@ Also correct the stale claim in [`lpc/TODO.md`](./lpc/TODO.md) §1b that marked
 | `tests/e2e/` | 2 | yes | ylos2 + launcher — in order for current atlas/sim probes |
 | `lpc/` | 0 | no | **decoder + compose ungated** (this file, P0) |
 | `sprites/` | 0 | no | staged; runners/demos only |
-| `menu/` | 0 local | via e2e | launcher covered by `tests/e2e/launcher_e2e_test`; no folder-local unit suite |
+| `menu/` | 1 (`launcher_ui_test`) | yes | unit + `tests/e2e/launcher_e2e_test`; catalog still hardcoded in `.rgr` (see abstraction debt) |
 | `games/` | 0 | via e2e | ylos2 e2e only; chess/other ports still pending |
 | `physics/cannon/` | ~23 | no | staged Cannon class port; not wired into v2 driver |
 | `three/port/` | ~37 | no | staged; local `src/run.sh` still points at **v1** `gallery/game_engine/three/…` paths |

--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -5,8 +5,8 @@ Gaps found while reviewing coverage and **native/SDL run readiness** under
 
 | Track | What is green today | What is not |
 |-------|---------------------|-------------|
-| Headless gate | `npm run engine:v2:test` → `bash gallery/game_engine/v2/tests/run.sh` (40 suites) | — |
-| SDL / native window | — | **not runnable** (see § SDL below) |
+| Headless gate | `npm run engine:v2:test` → `bash gallery/game_engine/v2/tests/run.sh` (46 suites) | — |
+| SDL / native window | `RgSdlGameHost` + headless seam tests | full native CI smoke (see § SDL below) |
 
 Mark checklist items `[x]` when they land and stay green.
 
@@ -85,9 +85,11 @@ must move from “ES6 under Node” to “C++ binary + SDL bindings”.
 
 ### Follow-ons (after the first window opens)
 
-- [ ] Split-screen present (`gfx_present_split` or compose panes) for ylos2
-- [ ] Audio: bridge `vocalCues` / `musicScore` / one-shots → SDL audio
-      (v1: `game_audio_sdl.rgr`; v2 only records cues in the bridge today)
+- [x] Pane-aware present on `RgSdlGameHost` — follows guest `surface.paneCount()`
+      (1 → `gfx_present`, 2+ → `gfx_present_split`); neutral `clearRgb` (no
+      title-baked sky). Still wants a live native smoke of both layouts.
+- [ ] Audio: bridge `vocalCues` / one-shots → SDL audio (music path via
+      `musicScore` + `pumpAudio` already exists; vocals/SFX still record-only)
 - [ ] Real `render/backends/gl` path (GPU present) — optional once SW→SDL works
 
 ### Intentionally out of scope for “first SDL window”
@@ -95,6 +97,51 @@ must move from “ES6 under Node” to “C++ binary + SDL bindings”.
 - Full launcher/catalog parity with v1 menu
 - WASM guest profiles on the SDL binary
 - Replacing v1 `engine:game-sdl:*` (v1 stays runnable)
+
+---
+
+## Abstraction boundary debt (core must stay game/test-neutral)
+
+From the master audit of `v2/` core `.rgr` (tests/e2e may stay game-aware;
+`games/` must not grow host shells). Fixed already: ylos2 sky clear + forced
+2P split baked into `RgSdlGameHost` → pane-aware present + neutral `clearRgb`
+(see PR history / `runtime/sdl/RgSdlGameHost.rgr`).
+
+Still to clean up later:
+
+- [ ] **Launcher catalog is hardcoded in Ranger** — `menu/RgLauncherUi.rgr`
+      `init()` embeds Pomppija / Chess / Breakout / Sprites paths. Boundary map
+      wants menus as **TSX guests**; at minimum drive the catalog from data
+      (JSON / guest list) so adding a game does not edit core `.rgr`. Update
+      `menu/tests/launcher_ui_test` + `tests/e2e/launcher_e2e_test` with it.
+- [ ] **Default action-map conventions live in the SDL host** —
+      `mapMask` hardwires `jump = up | action` and fixed bit→action names;
+      `RgAttractDriver` hardwires left/right/jump bit packing. Document as the
+      default host profile, or make the map data-driven so a second title with
+      different verbs does not fork the host.
+- [ ] **Bridge observability vs real device sinks** — `RgRegistryBridge`
+      accumulates `vocalCues` / `oneShotCount` / `logLines` mainly for e2e.
+      Wire vocals/one-shots to SDL (or a real sink) and shrink test-only
+      counters to something tests can still assert without looking like a
+      parallel game API.
+- [ ] **Finish generated dispatch** — interim hand `dispatchRow` if-chain in
+      `interp/engine/RgRegistryBridge.rgr` (BRIDGES.md §2.4 / step 5 →
+      `registry/generated/RgDispatch.rgr`). Coverage gate already locks every
+      row; replace the hand section, do not grow it.
+- [ ] **Relocate `interp/engine/engine_probe.rgr`** — local smoke probe under
+      the engine path; belongs under `tests/` (or delete once e2e covers the
+      same thread).
+- [ ] **`RgInput.create(2)` default capacity** — fine as a host default, but
+      if a title ever needs >2 logical players, construct/install a larger
+      `RgInput` (or raise the default) without a game-named branch.
+
+**Keep green / do not regress**
+
+- No game name (`ylos*`, `chess`, …) in generic core `.rgr` (comments in
+  modules/runtime/host/render/bridge — docs/TODO/e2e excepted).
+- No `.rgr` runners inside `games/<name>/` (see `games/AGENTS.md`).
+- Scene clear / sky colours stay in guest paint or test tools — never baked
+  into `RgSdlGameHost` / presenters as a title palette.
 
 ---
 

--- a/gallery/game_engine/v2/interp/engine/RgRegistryBridge.rgr
+++ b/gallery/game_engine/v2/interp/engine/RgRegistryBridge.rgr
@@ -83,6 +83,9 @@ class RgRegistryBridge extends EvalNativeBridge {
     def d2:RgRanger2D (new RgRanger2D)
     def d3:RgRangerThree (new RgRangerThree)
     def audio:RgAudio (new RgAudio)
+    ; Default host capacity for logical players (not a title-specific count).
+    ; Guests that need fewer simply leave slots unused; hosts that need more
+    ; construct the bridge with a larger RgInput before install.
     def input:RgInput (RgInput.create(2))
     def surface:RgSurface (new RgSurface)
     def clock:RgClock (new RgClock)

--- a/gallery/game_engine/v2/modules/ranger_core/RgInputSurface.rgr
+++ b/gallery/game_engine/v2/modules/ranger_core/RgInputSurface.rgr
@@ -7,8 +7,9 @@
 ;   Action            jump / rotate / … (logical, with edge states)
 ;
 ; Surface owns runtime panes (viewports) on the single surface for split-screen
-; — required for 2-player titles (ylos2). Cameras render into panes; the same
-; Camera2D math applies (D-2D-4).
+; and multi-viewport layouts. Cameras render into panes; the same Camera2D math
+; applies (D-2D-4). Layout is guest-declared via setLayout — the host never
+; assumes a player count or title.
 ; ==============================================================================
 
 Import "../../host/RgRegistry.rgr"

--- a/gallery/game_engine/v2/modules/ranger_core/audio/README.md
+++ b/gallery/game_engine/v2/modules/ranger_core/audio/README.md
@@ -1,7 +1,7 @@
 # ranger_core/audio
 
 Clip / source / voice primitives, plus higher-level **vocal FX** and **music
-score** facades required by ylos2-class ports (CODE_CLEANUP D-MODULES).
+score** facades (CODE_CLEANUP D-MODULES).
 
 **Plan phase:** 8,10 — see [`CODE_CLEANUP_PLAN.md`](../../../../CODE_CLEANUP_PLAN.md).
 
@@ -21,7 +21,7 @@ score** facades required by ylos2-class ports (CODE_CLEANUP D-MODULES).
 - audio_api_smoke_headless
 - vocal_cue_playOneShot_no_leak
 - music_start_stop_releases_or_stops_voices
-- ylos2_port_not_blocked_on_missing_facade (contract presence)
+- vocal_and_music_facade_contract_presence
 
 ---
 

--- a/gallery/game_engine/v2/modules/ranger_core/surface/README.md
+++ b/gallery/game_engine/v2/modules/ranger_core/surface/README.md
@@ -3,8 +3,8 @@
 Size, title, cursor, fullscreen — runtime-owned; guest cannot `new Surface`.
 
 **Split-screen / panes** are first-class: layout + `pane(i)` rectangles that
-`Camera2D` / renderers target (CODE_CLEANUP D-MODULES — required for ylos2 /
-pyorretris2p).
+`Camera2D` / renderers target (CODE_CLEANUP D-MODULES — required for any
+multi-viewport / 2P title).
 
 **Plan phase:** 8,10 — see [`CODE_CLEANUP_PLAN.md`](../../../../CODE_CLEANUP_PLAN.md).
 

--- a/gallery/game_engine/v2/runtime/sdl/README.md
+++ b/gallery/game_engine/v2/runtime/sdl/README.md
@@ -21,9 +21,11 @@ knowledge** and **no additions to `ranger:core`**.
 - `RgSdlGameHost.rgr` — the driver. Two entry loops share one window/present
   path: `runLauncher()` (present the rich launcher canvas via `gfx_present`,
   navigate on key-press *edges*, hand off the chosen game to `run`) and `run`
-  (poll input → actions → `host.frame` → present split → forward rumble, honour
-  the guest launch handoff). `launcherStep`/`mapMask`/`edge`/`toRgbaBuffer` are
-  pure host-input/present seams, unit-tested headlessly.
+  (poll input → actions → `host.frame` → present → forward rumble, honour
+  the guest launch handoff). Present follows the guest-declared pane count
+  (1 pane → `gfx_present`, 2+ → `gfx_present_split`); `clearRgb` is a neutral
+  framebuffer clear, not a scene sky. `launcherStep`/`mapMask`/`edge`/
+  `toRgbaBuffer` are pure host-input/present seams, unit-tested headlessly.
 - `RgSdlMain.rgr` — native entry; calls `runLauncher()` (engine chrome, not a
   game — games remain `.tsx`-only).
 - `../../menu/RgLauncherUi.rgr` — the launcher screen itself (title, subtitle,

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
@@ -48,8 +48,11 @@ class RgSdlGameHost {
     def host:RgGameHost (new RgGameHost)
     def paneW:int 480
     def paneH:int 270
-    ; base sky colour behind the world-space gradient bands
-    def sky:int 5215951      ; 0x4f96cf
+    ; Neutral framebuffer clear before the guest's own world-space background
+    ; paint (rg2d_bg_*). NOT a scene/sky colour — games own their art via
+    ; beginBackground/fillRect. Presenters take this as bgRGB; hosts that want a
+    ; different clear set the field, they do not bake a title's palette here.
+    def clearRgb:int 0
     ; last observed haptic counts, to forward only NEW rumble commands to SDL
     def lastRumble0:int 0
     def lastRumble1:int 0
@@ -91,11 +94,23 @@ class RgSdlGameHost {
         }
     }
 
-    ; Present both panes to the window: each pane rasterises through the generic
-    ; presenter into an RgFramebuffer, packs to RGBA, and blits side-by-side.
+    ; Present declared panes to the window. Layout comes from the guest's
+    ; runtime.surface.setLayout (paneCount on the host surface) — never from a
+    ; hardcoded 1P/2P assumption. One pane → full-window present; two or more →
+    ; side-by-side of panes 0 and 1 (further panes are a future compose path).
     fn present:void (fbL:RgFramebuffer fbR:RgFramebuffer) {
-        def dL:int (Rg2DPresenter.presentTextured(this.host.bridge 0 fbL this.sky))
-        def dR:int (Rg2DPresenter.presentTextured(this.host.bridge 1 fbR this.sky))
+        def n:int (this.host.bridge.surface.paneCount())
+        if (n <= 1) {
+            if (n == 1) {
+                def d0:int (Rg2DPresenter.presentTextured(this.host.bridge 0 fbL this.clearRgb))
+            } {
+                fbL.fill(this.clearRgb)
+            }
+            gfx_present (fbL.toRgbaBuffer()) this.paneW this.paneH
+            return
+        }
+        def dL:int (Rg2DPresenter.presentTextured(this.host.bridge 0 fbL this.clearRgb))
+        def dR:int (Rg2DPresenter.presentTextured(this.host.bridge 1 fbR this.clearRgb))
         gfx_present_split (fbL.toRgbaBuffer()) (fbR.toRgbaBuffer()) this.paneW this.paneH
     }
 
@@ -197,13 +212,17 @@ class RgSdlGameHost {
     ; Open a window and run the game loop until the window closes. Generic: the
     ; game is a folder of .tsx (dir/file). Honours the guest launch(path) request
     ; generically (menu -> game) via the same RgGameHost handoff the tests use.
+    ; Window width follows the guest-declared pane count after load (1 pane =
+    ; paneW, 2+ panes = paneW*2 for side-by-side).
     fn run:int (dir:string file:string) {
-        def title:string ("Ranger v2 — " + file)
-        if ((gfx_open title (this.paneW * 2) this.paneH) == 0) {
+        if ((this.host.load(dir file)) == false) {
             return 0
         }
-        if ((this.host.load(dir file)) == false) {
-            gfx_close
+        def panes:int (this.host.bridge.surface.paneCount())
+        def winW:int this.paneW
+        if (panes >= 2) { winW = (this.paneW * 2) }
+        def title:string ("Ranger v2 — " + file)
+        if ((gfx_open title winW this.paneH) == 0) {
             return 0
         }
         this.initAudio()
@@ -222,6 +241,15 @@ class RgSdlGameHost {
                 this.host.loadLaunched()
                 this.lastRumble0 = 0
                 this.lastRumble1 = 0
+                ; guest may declare a different pane layout on the new load
+                def nextPanes:int (this.host.bridge.surface.paneCount())
+                def nextW:int this.paneW
+                if (nextPanes >= 2) { nextW = (this.paneW * 2) }
+                if (nextW != winW) {
+                    gfx_close
+                    winW = nextW
+                    if ((gfx_open title winW this.paneH) == 0) { return 0 }
+                }
             }
             this.present(fbL fbR)
             gfx_delay 16


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audit of `gallery/game_engine/v2/` core `.rgr` for game/test-specific leaks into rendering, controller, and bridge layers (tests/e2e remain game-aware by design).

### Fixed

- **`RgSdlGameHost`**: removed baked-in ylos2 sky clear (`0x4f96cf`); replaced with neutral `clearRgb` (default black). Present now follows guest-declared `surface.paneCount()` (1 pane → `gfx_present`, 2+ → split) instead of always forcing side-by-side 2P.
- **`run()`**: opens the window after load sized from pane count; reopens on launch handoff if layout changes.
- Core comments/docs that named ylos2 as the reason for surface/audio features reworded to stay title-neutral.
- **`TODO.md`**: new **Abstraction boundary debt** section for leftovers (launcher catalog, action-map conventions, bridge observability, generated dispatch, `engine_probe` placement); marked pane-aware SDL present done; suite count 46.

### Deferred (tracked in TODO.md)

| Finding | Where |
|---|---|
| Hardcoded launcher catalog | `menu/RgLauncherUi.rgr` |
| Default action map / attract bit packing | `RgSdlGameHost.mapMask`, `RgAttractDriver` |
| Bridge test observability (`vocalCues`, etc.) | `RgRegistryBridge` |
| Interim hand `dispatchRow` if-chain | BRIDGES.md §2.4 |
| `engine_probe.rgr` under `interp/engine/` | move to `tests/` |
| `RgInput.create(2)` default capacity | document / raise when needed |

## Test plan

- [x] `npm run engine:v2:test` → **v2 ALL GREEN — 46/46 suites passed**
- [x] `tests/sdl/sdl_host_test` still covers mapMask / launcher edges / music pump
- [x] ylos2 e2e / screenshot tools unchanged (sky colour stays in test tools, not core)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fadf32c-22ac-48e8-a620-b1c18c16349d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fadf32c-22ac-48e8-a620-b1c18c16349d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

