### PR TITLE
game_engine/v2: 16:9 SDL window + fix Metal split-present pitch

### DIFF
--- a/gallery/game_engine/v2/runtime/sdl/README.md
+++ b/gallery/game_engine/v2/runtime/sdl/README.md
@@ -22,10 +22,12 @@ knowledge** and **no additions to `ranger:core`**.
   path: `runLauncher()` (present the rich launcher canvas via `gfx_present`,
   navigate on key-press *edges*, hand off the chosen game to `run`) and `run`
   (poll input → actions → `host.frame` → present → forward rumble, honour
-  the guest launch handoff). Present follows the guest-declared pane count
-  (1 pane → `gfx_present`, 2+ → `gfx_present_split`); `clearRgb` is a neutral
-  framebuffer clear, not a scene sky. `launcherStep`/`mapMask`/`edge`/
-  `toRgbaBuffer` are pure host-input/present seams, unit-tested headlessly.
+  the guest launch handoff). The window is always one pane (`480×270`, 16:9);
+  present follows the guest-declared pane count (1 pane → `gfx_present`, 2+ →
+  `gfx_present_split` which scales each full-res pane into a window half).
+  `clearRgb` is a neutral framebuffer clear, not a scene sky.
+  `launcherStep`/`mapMask`/`edge`/`toRgbaBuffer` are pure host-input/present
+  seams, unit-tested headlessly.
 - `RgSdlMain.rgr` — native entry; calls `runLauncher()` (engine chrome, not a
   game — games remain `.tsx`-only).
 - `../../menu/RgLauncherUi.rgr` — the launcher screen itself (title, subtitle,

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
@@ -97,7 +97,8 @@ class RgSdlGameHost {
     ; Present declared panes to the window. Layout comes from the guest's
     ; runtime.surface.setLayout (paneCount on the host surface) — never from a
     ; hardcoded 1P/2P assumption. One pane → full-window present; two or more →
-    ; side-by-side of panes 0 and 1 (further panes are a future compose path).
+    ; panes 0 and 1 GPU-scaled into each window half (window stays paneW×paneH /
+    ; 16:9; further panes are a future compose path).
     fn present:void (fbL:RgFramebuffer fbR:RgFramebuffer) {
         def n:int (this.host.bridge.surface.paneCount())
         if (n <= 1) {
@@ -174,9 +175,11 @@ class RgSdlGameHost {
     ; Open a window on the rich launcher screen (engine chrome), navigate it, and
     ; hand off to the chosen game through the SAME generic run() the tests use.
     ; Single-surface present (gfx_present) of the launcher's SoftCanvas RGBA — the
-    ; launcher is not split. Native-only loop (gfx_* stub to no-ops under es6).
+    ; launcher is not split. Window is one pane (paneW×paneH, 16:9), matching the
+    ; headless launcher tests and the in-game display aspect. Native-only loop
+    ; (gfx_* stub to no-ops under es6).
     fn runLauncher:int () {
-        def lw:int (this.paneW * 2)
+        def lw:int this.paneW
         def lh:int this.paneH
         if ((gfx_open "Ranger" lw lh) == 0) { return 0 }
         def ui:RgLauncherUi (new RgLauncherUi)
@@ -212,17 +215,15 @@ class RgSdlGameHost {
     ; Open a window and run the game loop until the window closes. Generic: the
     ; game is a folder of .tsx (dir/file). Honours the guest launch(path) request
     ; generically (menu -> game) via the same RgGameHost handoff the tests use.
-    ; Window width follows the guest-declared pane count after load (1 pane =
-    ; paneW, 2+ panes = paneW*2 for side-by-side).
+    ; Display is always one pane size (paneW×paneH, 16:9). Split-screen games
+    ; still rasterise full-res panes; gfx_present_split GPU-scales each into a
+    ; window half (same as v1) — do not open a 2×-wide window.
     fn run:int (dir:string file:string) {
         if ((this.host.load(dir file)) == false) {
             return 0
         }
-        def panes:int (this.host.bridge.surface.paneCount())
-        def winW:int this.paneW
-        if (panes >= 2) { winW = (this.paneW * 2) }
         def title:string ("Ranger v2 — " + file)
-        if ((gfx_open title winW this.paneH) == 0) {
+        if ((gfx_open title this.paneW this.paneH) == 0) {
             return 0
         }
         this.initAudio()
@@ -241,15 +242,6 @@ class RgSdlGameHost {
                 this.host.loadLaunched()
                 this.lastRumble0 = 0
                 this.lastRumble1 = 0
-                ; guest may declare a different pane layout on the new load
-                def nextPanes:int (this.host.bridge.surface.paneCount())
-                def nextW:int this.paneW
-                if (nextPanes >= 2) { nextW = (this.paneW * 2) }
-                if (nextW != winW) {
-                    gfx_close
-                    winW = nextW
-                    if ((gfx_open title winW this.paneH) == 0) { return 0 }
-                }
             }
             this.present(fbL fbR)
             gfx_delay 16

--- a/gallery/game_engine/v2/runtime/sdl/gfx_sdl.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/gfx_sdl.rgr
@@ -60,7 +60,8 @@ operators {
         }
     }
 
-    ; Present two full-res panes side-by-side, GPU-scaled into each window half.
+    ; Present two full-res panes, GPU-scaled into each window half (texture =
+    ; pane size; window may be the same 16:9 pane size — not 2× wide).
     ; left/right are w*h*4 RGBA buffers; the GPU downscale replaces the CPU blit.
     gfx_present_split _:void (left:buffer right:buffer w:int h:int) {
         templates {
@@ -162,6 +163,10 @@ operators {
 static SDL_Window*   g_rgfx_win = nullptr;
 static SDL_Renderer* g_rgfx_ren = nullptr;
 static SDL_Texture*  g_rgfx_tex = nullptr;
+// Streaming texture pixel size — must match SDL_UpdateTexture pitch (w*4).
+// Mismatch vs upload width triggers AGX bytes_per_row asserts on macOS/Metal.
+static int g_rgfx_tex_w = 0;
+static int g_rgfx_tex_h = 0;
 static SDL_AudioDeviceID g_rgfx_audio = 0;
 static int g_rgfx_audio_channels = 1;
 static int g_rgfx_audio_freq = 44100;
@@ -2016,6 +2021,27 @@ static void rgfx_gl_cleanup() {
     g_rgfx_gpu_mode = 0;
 }
 
+// Ensure the streaming upload texture is exactly w×h. SDL_UpdateTexture with
+// rect=nullptr writes the whole texture; pitch must be w*4. A wider texture
+// (e.g. old 960-wide window vs 480-wide pane) fails Metal/AGX with
+// bytes_per_row >= used_bytes_per_row.
+static int rgfx_ensure_streaming_tex(int w, int h) {
+    if (g_rgfx_ren == nullptr || w <= 0 || h <= 0) { return 0; }
+    if (g_rgfx_tex != nullptr && g_rgfx_tex_w == w && g_rgfx_tex_h == h) { return 1; }
+    if (g_rgfx_tex != nullptr) {
+        SDL_DestroyTexture(g_rgfx_tex);
+        g_rgfx_tex = nullptr;
+        g_rgfx_tex_w = 0;
+        g_rgfx_tex_h = 0;
+    }
+    g_rgfx_tex = SDL_CreateTexture(g_rgfx_ren, SDL_PIXELFORMAT_RGBA32,
+        SDL_TEXTUREACCESS_STREAMING, w, h);
+    if (g_rgfx_tex == nullptr) { return 0; }
+    g_rgfx_tex_w = w;
+    g_rgfx_tex_h = h;
+    return 1;
+}
+
 static int rgfx_open(const std::string& title, int w, int h) {
     rgfx_prepare_audio_env();
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK) != 0) { return 0; }
@@ -2027,9 +2053,7 @@ static int rgfx_open(const std::string& title, int w, int h) {
         SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
     if (g_rgfx_ren == nullptr) { g_rgfx_ren = SDL_CreateRenderer(g_rgfx_win, -1, 0); }
     if (g_rgfx_ren == nullptr) { return 0; }
-    g_rgfx_tex = SDL_CreateTexture(g_rgfx_ren, SDL_PIXELFORMAT_RGBA32,
-        SDL_TEXTUREACCESS_STREAMING, w, h);
-    if (g_rgfx_tex == nullptr) { return 0; }
+    if (!rgfx_ensure_streaming_tex(w, h)) { return 0; }
     return 1;
 }
 // Actual output surface size in pixels (drawable / window), so UI can be
@@ -2060,7 +2084,7 @@ static void rgfx_present(const uint8_t* pixels, int w, int h) {
         rgfx_gpu_finish_frame();
         return;
     }
-    if (g_rgfx_tex == nullptr) { return; }
+    if (!rgfx_ensure_streaming_tex(w, h)) { return; }
     SDL_UpdateTexture(g_rgfx_tex, nullptr, pixels, w * 4);
     SDL_RenderClear(g_rgfx_ren);
     SDL_RenderCopy(g_rgfx_ren, g_rgfx_tex, nullptr, nullptr);
@@ -2068,13 +2092,14 @@ static void rgfx_present(const uint8_t* pixels, int w, int h) {
 }
 // Split-screen present: upload each full-res pane once and let the GPU scale it
 // into its half of the window. Avoids the CPU 480→240 downscale blit entirely —
-// the scale is free on the GPU during SDL_RenderCopy.
+// the scale is free on the GPU during SDL_RenderCopy. The streaming texture is
+// sized to the pane (w×h), not the window — required for correct pitch on Metal.
 static void rgfx_present_split(const uint8_t* left, const uint8_t* right, int w, int h) {
     if (g_rgfx_gpu_mode) {
         rgfx_gpu_present_split(left, right, w, h);
         return;
     }
-    if (g_rgfx_tex == nullptr) { return; }
+    if (!rgfx_ensure_streaming_tex(w, h)) { return; }
     int outW = w;
     int outH = h;
     SDL_GetRendererOutputSize(g_rgfx_ren, &outW, &outH);
@@ -2119,6 +2144,8 @@ static void rgfx_close() {
     }
     g_pad_count = 0;
     if (g_rgfx_tex) { SDL_DestroyTexture(g_rgfx_tex); g_rgfx_tex = nullptr; }
+    g_rgfx_tex_w = 0;
+    g_rgfx_tex_h = 0;
     if (g_rgfx_ren) { SDL_DestroyRenderer(g_rgfx_ren); g_rgfx_ren = nullptr; }
     if (g_rgfx_win) { SDL_DestroyWindow(g_rgfx_win); g_rgfx_win = nullptr; }
     SDL_Quit();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the ultrawide `960×270` native window and the macOS AGX log spam (`bytes_per_row >= used_bytes_per_row`).

**Aspect ratio:** `RgSdlGameHost` always opens at one pane (`480×270`, 16:9) for both the launcher and games. Split-screen still rasterises full-res panes; `gfx_present_split` GPU-scales each into a window half (same approach as v1).

**AGX assertion:** Software `SDL_UpdateTexture` was updating a window-sized streaming texture with pane-width pitch (`480×4` into a `960`-wide texture). Metal/AGX rejects that. The streaming texture is now sized to the upload dimensions via `rgfx_ensure_streaming_tex`.

## Test plan

- [x] `bash gallery/game_engine/v2/tests/run.sh` → `v2 ALL GREEN — 46/46`
- [ ] On macOS: `npm run engine:game-sdl:launcher:v2` — window is 16:9; no AGX `bytes_per_row` spam when launching a split game (e.g. ylos2 / ylos3d)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-818fc9dd-4f8c-491c-a1bd-6371d4593f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-818fc9dd-4f8c-491c-a1bd-6371d4593f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

