### PR TITLE
game_engine/v2: document remaining out-of-v2 .rgr Import escapes

### DIFF
--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -145,6 +145,61 @@ Still to clean up later:
 
 ---
 
+## Import isolation — `.rgr` files still escape `v2/`
+
+Verified by resolving every `Import "…"` under `v2/**/*.rgr` against the
+filesystem (1040 import lines). **35 still resolve outside `v2/`.**
+
+### Live stack (green gate) — 6 escapes, all to `gallery/ts_parser/`
+
+These are real and currently required by the interpreter:
+
+| File | Imports |
+|------|---------|
+| `interp/migrate/src/ComponentEngine.rgr` | `ts_parser_simple`, `ts_lexer`, `ts_ast_patch` |
+| `interp/migrate/src/EvalValue.rgr` | `ts_parser_simple` |
+| `interp/migrate/src/JSXToEVG.rgr` | `ts_parser_simple`, `ts_lexer` |
+
+- [ ] **Decide policy for `ts_parser`** — either (a) accept it as a shared
+      gallery dependency outside v2 and document the exception, or (b) vendor /
+      re-home a v2-local parser under `v2/interp/` so the live stack imports
+      only inside `v2/`.
+
+`runtime/`, `host/`, `modules/`, `render/`, `registry/`, `bridge/`, `menu/`,
+`audio/`, `imaging/`, `evg/`, `tests/` (aside from migrate→ts_parser) have
+**no** out-of-v2 `Import`s.
+
+### Staged / demo trees — 29 out-of-v2 imports (mostly broken)
+
+Paths still point at pre-v2 locations; many targets are **missing** on disk
+(pdf_writer / top-level evg / zip were folded into `v2/imaging`, `v2/evg`,
+`v2/imaging/zip`).
+
+| Area | Escapes to | Fix |
+|------|------------|-----|
+| `lpc/src/` | `../../../pdf_writer/…`, `../../../zip/…` | Retarget to `v2/imaging/…` (and `v2/imaging/zip/…`) |
+| `ui/` demos + `WasmUiSelect` / `EvgLauncherMenu` | `../../pdf_writer/…`, `../../evg/…`, `../scripting/…` | Use `../evg/…`, `../imaging/…`; drop or replace v1 `scripting/` deps (no `v2/scripting/`) |
+| `model3d/` (+ tests) | `../../pdf_writer/src/jsx/…`, JPEG decoder | Use `v2/interp/migrate/src/` + `v2/imaging/` |
+| `web/web_tsx3d_host.rgr` | `../../pdf_writer/src/jsx/…` | Same as model3d |
+| `web/web_game_host.rgr` | `../scripting/…` | Staged v1 host; rewrite onto `RgGameHost` or delete |
+
+### Wrong-depth / missing-inside-v2 (related)
+
+These resolve *under* `v2/` but to non-existent paths (copy-paste from v1
+depths). Same cleanup:
+
+- [ ] `sprites/deps/`, `sprites/host/`, `sprites/runners/` → `pdf_writer/…`
+- [ ] `three/port/src/three_gltf_textures.rgr` + `three/port/tests/**` →
+      `pdf_writer/src/jsx/…` / JPEG (should be migrate + imaging)
+- [ ] `menu/RgLauncherUi.rgr` runtime font dir string
+      `gallery/pdf_writer/assets/fonts` (not an `Import`, but a path escape)
+
+- [ ] Add a small gate (script or suite) that fails if any `v2/**/*.rgr`
+      `Import` resolves outside `v2/` (with an explicit allowlist for
+      `ts_parser` until policy (a)/(b) lands).
+
+---
+
 ## P0 — LPC PNG decoder has no unit test
 
 `lpc/src/png_decoder.rgr` decodes indexed (type 3) and RGB/RGBA sheets, and

--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -194,9 +194,12 @@ depths). Same cleanup:
 - [ ] `menu/RgLauncherUi.rgr` runtime font dir string
       `gallery/pdf_writer/assets/fonts` (not an `Import`, but a path escape)
 
-- [ ] Add a small gate (script or suite) that fails if any `v2/**/*.rgr`
-      `Import` resolves outside `v2/` (with an explicit allowlist for
-      `ts_parser` until policy (a)/(b) lands).
+- [x] **Boundary gate in `tests/run.sh`** — after all suites,
+      `tests/check_boundaries.py` fails the run on (1) any `.rgr` under
+      `games/`, (2) any out-of-v2 `Import` not listed in
+      `tests/boundary_import_allowlist.txt`, (3) game-title identifiers in
+      live-core `.rgr`. Known staged escapes stay allowlisted until retargeted
+      — **do not grow the allowlist**.
 
 ---
 

--- a/gallery/game_engine/v2/tests/.gitignore
+++ b/gallery/game_engine/v2/tests/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/gallery/game_engine/v2/tests/boundary_import_allowlist.txt
+++ b/gallery/game_engine/v2/tests/boundary_import_allowlist.txt
@@ -1,0 +1,50 @@
+# Known out-of-v2 Import escapes (file:import-path).
+# NEW escapes must NOT be added here — fix the Import instead.
+# Shrink this list as staged trees retarget to v2/imaging, v2/evg, etc.
+# See TODO.md § "Import isolation".
+#
+# Format: one entry per line, relative to v2/, no spaces around ':'.
+# Lines starting with # are comments.
+
+# ---- live interpreter: shared gallery parser (policy TBD: vendor or keep) ----
+interp/migrate/src/ComponentEngine.rgr:../../../../../ts_parser/ts_ast_patch.rgr
+interp/migrate/src/ComponentEngine.rgr:../../../../../ts_parser/ts_lexer.rgr
+interp/migrate/src/ComponentEngine.rgr:../../../../../ts_parser/ts_parser_simple.rgr
+interp/migrate/src/EvalValue.rgr:../../../../../ts_parser/ts_parser_simple.rgr
+interp/migrate/src/JSXToEVG.rgr:../../../../../ts_parser/ts_lexer.rgr
+interp/migrate/src/JSXToEVG.rgr:../../../../../ts_parser/ts_parser_simple.rgr
+
+# ---- staged LPC (retarget to v2/imaging + v2/imaging/zip) ----
+lpc/src/lpc_blit.rgr:../../../pdf_writer/src/jpeg/ImageBuffer.rgr
+lpc/src/lpc_blit.rgr:../../../pdf_writer/src/raster/RasterBuffer.rgr
+lpc/src/lpc_catalog.rgr:../../../zip/ZipReader.rgr
+lpc/src/lpc_compose.rgr:../../../pdf_writer/src/jpeg/ImageBuffer.rgr
+lpc/src/lpc_compose.rgr:../../../pdf_writer/src/raster/RasterBuffer.rgr
+lpc/src/lpc_compose_runner.rgr:../../../pdf_writer/src/raster/PNGEncoder.rgr
+lpc/src/lpc_pack_builder.rgr:../../../zip/ZipWriter.rgr
+lpc/src/lpc_palette.rgr:../../../pdf_writer/src/jpeg/ImageBuffer.rgr
+lpc/src/png_decoder.rgr:../../../pdf_writer/src/core/Buffer.rgr
+lpc/src/png_decoder.rgr:../../../pdf_writer/src/jpeg/ImageBuffer.rgr
+lpc/src/png_decoder.rgr:../../../zip/Inflate.rgr
+
+# ---- staged model3d / web (retarget to migrate + imaging) ----
+model3d/Model3dScriptBridge.rgr:../../pdf_writer/src/jsx/ComponentEngine.rgr
+model3d/Model3dScriptBridge.rgr:../../pdf_writer/src/jsx/EvalValue.rgr
+model3d/TextureDecode.rgr:../../pdf_writer/src/jpeg/JPEGDecoder.rgr
+model3d/tests/Model3dScriptBridgeTest.rgr:../../../pdf_writer/src/jsx/ComponentEngine.rgr
+model3d/tests/Model3dScriptBridgeTest.rgr:../../../pdf_writer/src/jsx/EvalValue.rgr
+model3d/tests/Scene3dBridgeTest.rgr:../../../pdf_writer/src/jsx/ComponentEngine.rgr
+model3d/tests/Scene3dBridgeTest.rgr:../../../pdf_writer/src/jsx/EvalValue.rgr
+web/web_tsx3d_host.rgr:../../pdf_writer/src/jsx/ComponentEngine.rgr
+web/web_tsx3d_host.rgr:../../pdf_writer/src/jsx/EvalValue.rgr
+
+# ---- staged ui demos (use ../evg, ../imaging; drop v1 scripting) ----
+ui/EvgLauncherMenu.rgr:../../evg/EVGColor.rgr
+ui/WasmUiSelect.rgr:../../evg/EVGElement.rgr
+ui/WasmUiSelect.rgr:../../evg/EVGLayout.rgr
+ui/evg_launcher_demo.rgr:../../pdf_writer/src/raster/PNGEncoder.rgr
+ui/ui_anim_visual_demo.rgr:../../pdf_writer/src/raster/PNGEncoder.rgr
+ui/ui_bgimage_demo.rgr:../../evg/EVGColor.rgr
+ui/ui_bgimage_demo.rgr:../../pdf_writer/src/raster/PNGEncoder.rgr
+ui/ui_editor_demo.rgr:../../pdf_writer/src/raster/PNGEncoder.rgr
+ui/wasm_ui_select_demo.rgr:../../pdf_writer/src/raster/PNGEncoder.rgr

--- a/gallery/game_engine/v2/tests/check_boundaries.py
+++ b/gallery/game_engine/v2/tests/check_boundaries.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# check_boundaries.py — static gate for v2 abstraction / import isolation.
+# ==============================================================================
+# Run after the unit/contract suites (from tests/run.sh). Cheap filesystem
+# scan — does not compile Ranger. Exit 0 only when:
+#
+#   1. No .rgr files live under games/ (games are TSX-only).
+#   2. Every Import "…" that resolves OUTSIDE v2/ is listed in
+#      boundary_import_allowlist.txt (shrink the list; do not grow it).
+#   3. Live-core .rgr files contain no game-title identifiers (ylos*, autopeli,
+#      pong, pacman, invaders, breakout, chess as whole words).
+#
+# Live core = runtime host modules render registry bridge interp imaging audio
+# evg + top-level framebuffer/rgba — excluding **/tests/** and *_test.rgr.
+# menu/ is excluded from (3) until the hardcoded catalog is data-driven.
+# ==============================================================================
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+V2_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+# v2/ → game_engine/ → gallery/ → repo root
+REPO_ROOT = os.path.abspath(os.path.join(V2_ROOT, "..", "..", ".."))
+ALLOWLIST_PATH = os.path.join(os.path.dirname(__file__), "boundary_import_allowlist.txt")
+
+IMPORT_RE = re.compile(r'Import\s+"([^"]+)"')
+# Title names that must not appear in generic core .rgr (AGENTS.md).
+GAME_NAME_RE = re.compile(
+    r"(?i)(?<![A-Za-z0-9_])(ylos\d*|autopeli|\bpong\b|pacman|invaders|breakout|\bchess\b)(?![A-Za-z0-9_])"
+)
+
+LIVE_PREFIXES = (
+    "runtime/",
+    "host/",
+    "modules/",
+    "render/",
+    "registry/",
+    "bridge/",
+    "interp/",
+    "imaging/",
+    "audio/",
+    "evg/",
+    "framebuffer.rgr",
+    "rgba_fast_blit.rgr",
+)
+
+# Paths under live prefixes that are allowed to mention game names (none today).
+GAME_NAME_EXCLUDE_SUFFIXES = (
+    "/tests/",
+    "_test.rgr",
+)
+
+
+def rel_v2(path: str) -> str:
+    return os.path.relpath(path, V2_ROOT).replace("\\", "/")
+
+
+def load_allowlist() -> set[str]:
+    entries: set[str] = set()
+    if not os.path.isfile(ALLOWLIST_PATH):
+        return entries
+    with open(ALLOWLIST_PATH, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            entries.add(line)
+    return entries
+
+
+def resolve_import(from_file: str, import_path: str) -> str:
+    if import_path.startswith("gallery/"):
+        return os.path.normpath(os.path.join(REPO_ROOT, import_path))
+    return os.path.normpath(os.path.join(os.path.dirname(from_file), import_path))
+
+
+def is_inside_v2(abs_path: str) -> bool:
+    return abs_path == V2_ROOT or abs_path.startswith(V2_ROOT + os.sep)
+
+
+def is_live_core(rel: str) -> bool:
+    if any(rel.startswith(p) or rel == p for p in LIVE_PREFIXES):
+        if any(s in rel for s in GAME_NAME_EXCLUDE_SUFFIXES):
+            return False
+        return True
+    return False
+
+
+def iter_rgr_files():
+    for dirpath, _, files in os.walk(V2_ROOT):
+        for name in files:
+            if name.endswith(".rgr"):
+                yield os.path.join(dirpath, name)
+
+
+def check_no_rgr_in_games() -> list[str]:
+    games = os.path.join(V2_ROOT, "games")
+    bad: list[str] = []
+    if not os.path.isdir(games):
+        return bad
+    for dirpath, _, files in os.walk(games):
+        for name in files:
+            if name.endswith(".rgr"):
+                bad.append(rel_v2(os.path.join(dirpath, name)))
+    return bad
+
+
+def check_out_of_v2_imports(allowlist: set[str]) -> tuple[list[str], list[str]]:
+    """Returns (new_violations, stale_allowlist_entries)."""
+    found: set[str] = set()
+    for fp in iter_rgr_files():
+        rel = rel_v2(fp)
+        with open(fp, encoding="utf-8", errors="replace") as fh:
+            for lineno, line in enumerate(fh, 1):
+                m = IMPORT_RE.search(line)
+                if not m:
+                    continue
+                imp = m.group(1)
+                abs_p = resolve_import(fp, imp)
+                if is_inside_v2(abs_p):
+                    continue
+                key = f"{rel}:{imp}"
+                found.add(key)
+    new_violations = sorted(found - allowlist)
+    stale = sorted(allowlist - found)
+    # Format new with a hint path for the banner
+    detailed = []
+    for key in new_violations:
+        detailed.append(key)
+    return detailed, stale
+
+
+def check_game_names_in_live_core() -> list[str]:
+    hits: list[str] = []
+    for fp in iter_rgr_files():
+        rel = rel_v2(fp)
+        if not is_live_core(rel):
+            continue
+        with open(fp, encoding="utf-8", errors="replace") as fh:
+            for lineno, line in enumerate(fh, 1):
+                # skip pure comment noise? still flag — comments naming a title
+                # in core are the smell we want. Allow "game" as generic word.
+                if GAME_NAME_RE.search(line):
+                    hits.append(f"{rel}:{lineno}: {line.rstrip()}")
+    return hits
+
+
+def main() -> int:
+    allowlist = load_allowlist()
+    failed = 0
+
+    print("### boundary gate (static)")
+    print("  v2 root: gallery/game_engine/v2")
+
+    games_rgr = check_no_rgr_in_games()
+    if games_rgr:
+        failed += 1
+        print("  FAIL games/ must not contain .rgr (TSX-only packages):")
+        for p in games_rgr:
+            print(f"    - {p}")
+    else:
+        print("  PASS no .rgr under games/")
+
+    new_imps, stale = check_out_of_v2_imports(allowlist)
+    if new_imps:
+        failed += 1
+        print("  FAIL Import resolves outside v2/ (not in allowlist):")
+        for p in new_imps:
+            print(f"    - {p}")
+        print("    fix the Import, or (staged debt only) add to")
+        print("    tests/boundary_import_allowlist.txt and shrink later")
+    else:
+        print(f"  PASS out-of-v2 Imports ({len(allowlist)} allowlisted, 0 new)")
+
+    if stale:
+        # Soft: allowlist entries that disappeared are OK (progress) but print
+        # so authors remove them from the file.
+        print(f"  NOTE {len(stale)} allowlist entr(y/ies) no longer present — remove from allowlist:")
+        for p in stale[:12]:
+            print(f"    - {p}")
+        if len(stale) > 12:
+            print(f"    … and {len(stale) - 12} more")
+
+    name_hits = check_game_names_in_live_core()
+    if name_hits:
+        failed += 1
+        print("  FAIL game title identifier in live-core .rgr:")
+        for h in name_hits[:20]:
+            print(f"    - {h}")
+        if len(name_hits) > 20:
+            print(f"    … and {len(name_hits) - 20} more")
+    else:
+        print("  PASS no game-title identifiers in live-core .rgr")
+
+    if failed:
+        print("  SOME FAILED — boundary gate")
+        return 1
+    print("  ALL PASS — boundary gate")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/gallery/game_engine/v2/tests/run.sh
+++ b/gallery/game_engine/v2/tests/run.sh
@@ -9,7 +9,8 @@
 #
 #   bash gallery/game_engine/v2/tests/run.sh
 #
-# Exit code is non-zero if any suite fails to compile or reports SOME FAILED.
+# Exit code is non-zero if any suite fails to compile or reports SOME FAILED,
+# or if the post-suite boundary gate fails (out-of-v2 Imports / game-name leaks).
 # ==============================================================================
 set -u
 
@@ -23,6 +24,7 @@ V2="gallery/game_engine/v2"
 
 TOTAL_SUITES=0
 FAILED_SUITES=0
+BOUNDARY_FAIL=0
 
 # run_suite <relative-path-under-v2 without .rgr>
 run_suite() {
@@ -136,11 +138,25 @@ run_suite tests/e2e/ylos2_e2e_test
 run_suite tests/e2e/ylos3d_e2e_test
 run_suite tests/e2e/launcher_e2e_test
 
-echo "=============================================================="
-if [ "$FAILED_SUITES" -eq 0 ]; then
-  echo "v2 ALL GREEN — ${TOTAL_SUITES}/${TOTAL_SUITES} suites passed"
-  exit 0
-else
-  echo "v2 FAILURES — ${FAILED_SUITES}/${TOTAL_SUITES} suites failed"
-  exit 1
+# ---- Boundary gate (static) — after suites; cheap Import / title scan --------
+# Unit/contract suites prove behaviour; this proves the *tree* did not grow
+# game-specific core or new out-of-v2 Imports. Known staged debt is allowlisted
+# in tests/boundary_import_allowlist.txt (shrink only). See TODO.md.
+echo
+if ! python3 "${V2}/tests/check_boundaries.py"; then
+  BOUNDARY_FAIL=1
 fi
+echo
+
+echo "=============================================================="
+if [ "$FAILED_SUITES" -eq 0 ] && [ "$BOUNDARY_FAIL" -eq 0 ]; then
+  echo "v2 ALL GREEN — ${TOTAL_SUITES}/${TOTAL_SUITES} suites passed (+ boundary gate)"
+  exit 0
+fi
+if [ "$FAILED_SUITES" -ne 0 ]; then
+  echo "v2 FAILURES — ${FAILED_SUITES}/${TOTAL_SUITES} suites failed"
+fi
+if [ "$BOUNDARY_FAIL" -ne 0 ]; then
+  echo "v2 BOUNDARY FAIL — see check_boundaries.py output above"
+fi
+exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Yes — this is a good idea: keep the unit/contract suites for behaviour, then add a **cheap static gate** after they finish so “ALL GREEN” also means the tree did not grow abstraction leaks.

### What landed

1. **`tests/check_boundaries.py`** — post-suite gate that fails on:
   - any `.rgr` under `games/` (TSX-only packages)
   - any `Import` resolving **outside** `v2/` that is not in `tests/boundary_import_allowlist.txt`
   - game-title identifiers (`ylos*`, `autopeli`, `pong`, …) in **live-core** `.rgr` (`runtime/`, `host/`, `modules/`, …)

2. **`tests/boundary_import_allowlist.txt`** — the current 35 known escapes (6 live `ts_parser` + 29 staged). **Shrink only; do not grow.**

3. **`tests/run.sh`** — runs the gate after all suites; banner becomes  
   `v2 ALL GREEN — 46/46 suites passed (+ boundary gate)`.

4. **`TODO.md`** — documents the import-isolation audit + marks the gate done.

### Why not Ranger unit tests alone?

Suites prove APIs work; they do not notice a new `Import "../../pdf_writer/…"` or a game name in `RgGameHost`. A filesystem scan is the right tool for that, and it stays fast (~0.2s).

## Test plan

- [x] `python3 gallery/game_engine/v2/tests/check_boundaries.py` → ALL PASS
- [x] `npm run engine:v2:test` → `v2 ALL GREEN — 46/46 suites passed (+ boundary gate)`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fadf32c-22ac-48e8-a620-b1c18c16349d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fadf32c-22ac-48e8-a620-b1c18c16349d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

