### PR TITLE
game_engine/v2: reorder TODO around macOS/Pi parity milestones

### DIFF
--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -10,114 +10,291 @@ driver and the roadmap below over that checklist.
 |-------|---------------------|-------------|
 | Headless gate | `npm run engine:v2:test` → 46 suites + boundary gate | — |
 | TSX guests | `games/ylos2`, `games/ylos3d` via `RgGameHost` | must-pass **chess** missing |
-| SW / textured 2D | e2e + `engine:v2:shot:ylos2` | many atlases still colour markers / incomplete art |
-| Hybrid 2D+3D (path A) | thin slice: SW 3D @2× → CPU `Texture2D` → SW 2D (`ylos3d`) | six-plane clip, top-left rule, samplers/mips, real RT, ordered pass replay — **before GPU** |
-| Native SDL | `RgSdlGameHost` + `scripts/build-sdl-v2.sh` + `engine:game-sdl:launcher:v2` | CI `SDL_VIDEODRIVER=dummy` smoke; vocals/SFX sinks |
+| SW / textured 2D | e2e + `engine:v2:shot:ylos2` | real LPC/PNG atlas pixels; vocals/SFX sinks |
+| Hybrid 2D+3D (path A) | thin slice: SW 3D @2× → CPU `Texture2D` → SW 2D (`ylos3d`) | clip/fill/alpha essentials; RT lifetime; ordered passes; **GPU later** |
+| Native SDL | `RgSdlGameHost` + `build-sdl-v2.sh` + `engine:game-sdl:launcher:v2` (macOS-oriented today) | **Pi 5 arm64** build/smoke; cross-platform `pkg-config`; live CI |
 | WASM32 published ABI | create/free/parity fixtures | IDL extract + freeze (BRIDGES steps 4–7) |
-| v1 | still **runnable legacy** | archival only at an explicit milestone (not Phase 12) |
+| v1 | still **runnable legacy** (~many titles under `games/`) | archival only at an explicit milestone (not Phase 12) |
+
+**Docs inconsistency:** README / older notes still say “no SDL window”;
+`runtime/sdl/` already has a native host (launcher, input map, split present,
+rumble, music pump). Prefer this file + `runtime/sdl/README.md` over stale
+claims. Align README when touching native work.
 
 Mark checklist items `[x]` when they land and stay green.
 
 ---
 
-## Road to v1 parity (ordered)
+## Three milestones (prove in this order)
 
-Phase 12 in the plan = **must-pass ports on v2** (chess + ylos2), not “delete v1”.
-Highest leverage is productization + must-pass games — not more staged
-Three/Cannon copies.
+“v1 parity” does **not** yet mean every v1 title. With only `ylos2` / `ylos3d`
+on disk and Chess named but missing, the first bar is:
 
-1. **[ ] Native SDL smoke that stays green** — prove
-   `npm run engine:game-sdl:launcher:v2` (or a short
-   `SDL_VIDEODRIVER=dummy` run of the built binary) for launcher → ylos2.
-   Align stale README lines that still say “no SDL window”. Optional: add
-   `engine:v2:sdl:*` aliases that call `build-sdl-v2.sh`.
-2. **[ ] Honest launcher catalog** — `menu/RgLauncherUi.rgr` hardcodes Chess /
-   Breakout paths that are **not** under `v2/games/`. Ship only existing
-   packages (`ylos2`, `ylos3d`) or data-drive the list (see abstraction debt).
-3. **[ ] Close ylos2 “must-pass” bar** — decide [`QUESTIONS.md`](./QUESTIONS.md)
-   Q4–Q7 (finish timeline / celebrate SFX / music restart / attract jump), then
-   implement that slice and extend e2e past climb + cheer + score-text.
-4. **[ ] Real atlas pixels** — `image <uri>` / PNG upload into `RgTexture2D`
-   (Q1); wire LPC decoder unit suite into `tests/run.sh` (P0 below).
-5. **[ ] Vocals / one-shots → SDL** — music already pumps via `musicScore` +
-   `pumpAudio`; wire `vocalCues` / one-shots to a real sink and shrink
-   test-only bridge counters.
-6. **[ ] Port chess** — the other named must-pass (`games/README.md`); pure TS
-   rules/AI can copy; shell on `ranger:2d` + EVG/HUD.
-7. **[ ] BRIDGES step 4+** — IDL extract; regenerate interpreter table; replace
-   hand `dispatchRow` (do not grow it); then wasm32 profile + Rust conformance
-   guest before any ABI freeze.
-8. **[ ] Shrink import allowlist** — retarget staged `lpc/` / `ui/` / `model3d/`
-   / `web/` / `sprites/` / `three/port/` escapes; decide `ts_parser` policy
-   (gallery dep vs vendor under `v2/interp/`).
-9. **[ ] Software reference + frame-pass architecture** — finish the SW path as
-   the trustworthy reference (clipping, top-left rule, samplers/mips, real
-   `RenderTarget`, ordered pass replay) **before** any GPU backend. Details in
-   § “Software reference + pass architecture” below. H1–H4 path A is only a
-   thin green slice today.
-10. **[ ] Hybrid GPU follow-ons (H5–H7)** — shared-device / surface compose
-    ([`PLAN_2D_EMBED_3D.md`](./PLAN_2D_EMBED_3D.md)) only after the software
-    reference is stable and must-pass 2D is credible. **Do not start GPU next.**
+> The selected parity games behave correctly through the v2 API and run through
+> the **same** native host on both **macOS** and **Raspberry Pi 5**.
 
-### Open decisions that block a crisp “done”
+| # | Milestone | Goal |
+|---|-----------|------|
+| **A** | **v1 gameplay / API parity** | Chess + ylos2 through v2 APIs (headless + native) |
+| **B** | **Native platform parity** | Same packages on macOS arm64 **and** Pi 5 arm64 SDL |
+| **C** | **Hybrid 2D/3D performance** | Embedded 3D without blowing the Pi frame budget; GPU without CPU readback |
+
+Software-rasterizer polish remains useful for CI / screenshots / ownership
+debugging, but it **stops being the main line** once the current image is
+visually correct. Do not deepen SW 3D (mips, fancy materials, anisotropic,
+advanced lighting) ahead of A/B.
+
+### Revised implementation sequence
+
+1. **[ ] Parity definition** — freeze executable matrices for ylos2 + Chess
+   (below).
+2. **[ ] Native smoke** — macOS **and** Pi 5: build, launch, input, split-screen,
+   audio (see § Native SDL / platform gates).
+3. **[ ] Cross-platform software screenshots** — same deterministic frame on
+   Node SW / macOS SW→SDL / Pi SW→SDL; pixel hash or tiny tolerance.
+4. **[ ] Performance instrumentation** — per-stage timings + allocation
+   counters; set Pi budgets before expanding hybrid work.
+5. **[ ] Software renderer correctness essentials only** — clipping, fill
+   rules, alpha, simple nearest/linear, configurable 1×/2× SSAA; no crashes /
+   giant triangles (see § Software reference — demoted).
+6. **[ ] Real render-target lifetime + ordered frame passes.**
+7. **[ ] 3D sprite update modes + resolution limits** — so embedded 3D cannot
+   steal the 2D frame budget.
+8. **[ ] Pi GLES backend** — GPU 3D RTT + GPU 2D composition **without**
+   readback every frame.
+9. **[ ] macOS GPU backend** — compatibility GL OK for parity; **Metal** as the
+   durable path; public API stays `Texture2D` / `RenderTarget` / `Sampler` /
+   `RenderPass` (not `GLuint`).
+10. **[ ] Broader v1 game ports** — after A+B are proven.
+
+### Practical definition of success (first platform milestone)
+
+```text
+The same v2 ylos2 package:
+- launches from the v2 launcher,
+- runs at stable speed (~60 Hz),
+- accepts two local players,
+- presents split-screen correctly,
+- plays music and effects,
+- supports controller rumble,
+- can show one animated 3D sprite (optional enhancement),
+- and works without game-specific host code
+on both macOS and Raspberry Pi 5.
+```
+
+That proves something more important than advanced AA: **the v2 API is portable
+and can replace the selected v1 runtime paths.**
+
+---
+
+## Milestone A — freeze a concrete parity matrix
+
+Before more renderer work, define exactly what must match. Must-pass titles
+(`games/README.md`): **ylos2** + **chess**.
+
+**ylos2 target capabilities** (from game policy / QUESTIONS): sprite + atlas,
+camera scroll, split-screen, 2P input, particles, rumble, vocal FX, music
+score, LPC/bitmap assets.
+
+**Chess target capabilities:** atlas pieces, text/UI, cursor actions; rules/AI
+unchanged (pure TS copy).
+
+### Executable matrix (fill as gates land)
+
+| Capability | Node/headless | macOS SDL | Pi 5 SDL |
+|------------|:-------------:|:---------:|:--------:|
+| Game loads | ✓ e2e | [ ] | [ ] |
+| Assets resolve | partial | [ ] | [ ] |
+| 1-player input | ✓ / attract | [ ] | [ ] |
+| 2-player input | ✓ e2e | [ ] | [ ] |
+| Split panes | ✓ e2e | [ ] | [ ] |
+| Music | score text / pump | [ ] | [ ] |
+| SFX / vocals | record-only | [ ] | [ ] |
+| Rumble | simulated | [ ] | [ ] |
+| Stable ~60 Hz gameplay | N/A | [ ] | [ ] |
+| Clean shutdown / relaunch | ✓ launch handoff | [ ] | [ ] |
+
+- [ ] Turn the matrix into runnable smoke scripts (headless already partly
+      covered; native = fixed-duration auto-run that exits).
+- [ ] Honest launcher catalog — only list games that exist (`ylos2`, `ylos3d`
+      today; add Chess when ported). Strip dead Chess/Breakout entries.
+- [ ] Close ylos2 bar ([`QUESTIONS.md`](./QUESTIONS.md) Q4–Q7) and extend e2e.
+- [ ] Real atlas pixels (`image` / PNG → `RgTexture2D`) + LPC decoder suite.
+- [ ] Port **chess** onto `ranger:2d` + EVG/HUD.
+- [ ] Vocals / one-shots → real audio sink (not only bridge counters).
+
+### Open decisions (still block a crisp “done”)
 
 | ID | Blocks |
 |----|--------|
-| Q1 | Atlas `image` line + pixel upload (real art / GPU) |
-| Q4–Q7 | What “must-pass ylos2” means (façades vs play-feel) |
-| BRIDGES | When to freeze wasm32 / stop growing hand dispatch |
+| Q1 | Atlas `image` line + pixel upload |
+| Q4–Q7 | ylos2 façades vs play-feel bar |
+| BRIDGES | wasm32 freeze / hand `dispatchRow` |
 | Import policy | `ts_parser` outside v2 vs vendored |
-| Plan Intent | Archival legacy only at an explicit end-of-v1 milestone |
+| Plan Intent | archival legacy only at explicit end-of-v1 milestone |
 
 ### Plan phase status (evidence vs checklist)
 
 Treat [`CODE_CLEANUP_PLAN.md`](../CODE_CLEANUP_PLAN.md) checkboxes as historical.
-From `tests/run.sh` + live code:
 
 | Phase | Evidence status |
 |-------|-----------------|
 | 0–7 | **Done** (suites green) |
-| 8–10b | **Largely done** (modules, frame, devices, D-2D core); assets/art incomplete |
-| 9 | **Slice done** (step + pose); Cannon port still staged |
+| 8–10b | **Largely done**; assets/art incomplete |
+| 9 | **Slice done**; Cannon still staged |
 | 11 | **SW + textured done**; GL scaffold |
-| 12 | **In progress** — ylos2 e2e; chess absent; no archival |
-| BRIDGES 1–3 | Schema + guests in progress; IDL/wasm freeze **not started** |
+| 12 | **In progress** — ylos2 e2e; chess absent |
+| BRIDGES 1–3 | Guests in progress; IDL/wasm freeze **not started** |
 
 ---
 
-## Software reference + pass architecture (before GPU)
+## Milestone B — native SDL as a first-class gate (macOS + Pi 5)
 
-**Best next graphics move is not the GPU backend.** First turn the current
-software path into a reliable reference implementation, then complete the
-resource / pass architecture around it. See [`PLAN_2D_EMBED_3D.md`](./PLAN_2D_EMBED_3D.md)
-(render-target lifecycle, texture views, pass retention, hazards, destinations,
-automatic producer scheduling still incomplete).
+Architecture is already right: guest sees only logical actions + `runtime.*`;
+SDL stays behind the host; same `RgGameHost` / interpreter / bridge / presenter
+in headless and native (`runtime/sdl/`).
 
-**Already landed (thin vertical slice):** SW 3D renders at 2× resolution →
-resolves into a CPU `Texture2D` → SW 2D samples that texture (`ylos3d` diamonds;
-gates `rtt_sprite` / `ylos3d_e2e`). Key files:
-`three/port/src/three_software_backend.rgr`,
-`modules/ranger_three/RgRangerThree.rgr`,
-`render/backends/software/RgTexturedRenderer2D.rgr`,
-`interp/engine/RgRegistryBridge.rgr` (pass record vs immediate RTT).
+### Platform work
 
-### Suggested PR sequence (independently reviewable)
+- [ ] **macOS arm64** build + smoke (Homebrew SDL2 path already in
+      `build-sdl-v2.sh`)
+- [ ] **Raspberry Pi OS arm64** build + smoke
+- [ ] **One build command** with platform-specific linker config
+- [ ] **`pkg-config` SDL discovery** on Linux/Pi (do not assume macOS/Homebrew
+      only)
+- [ ] **Fixed-duration automatic run** — launch ylos2, advance frames, exit 0
+- [ ] **Split-screen smoke** on both platforms
+- [ ] **Audio-device failure fallback** — headless / audio-less Pi still launches
+- [ ] **Controller connect / disconnect** testing
+- [ ] Align README (“no SDL”) with reality; optional `engine:v2:sdl:*` aliases
 
-1. Rasterizer correctness (six-plane clip + top-left + contract images)
-2. Texture sampling (sampler type, bilinear RGBA, texture alpha)
-3. Texture minification (mip chain + nearest-mip LOD)
-4. Configurable SSAA (`samples`, resolve + edge-fringe tests)
-5. Real render targets (separate identity, attachments, resize/release)
-6. Ordered frame execution (retention, exactly-once replay, multi-pass 2D)
-7. Destinations + load/store (`surface.target`, pane, offscreen)
-8. Automatic `SceneSprite3D` producer scheduling
-9. GPU 2D/3D backend parity (**last**)
+Headless suites compile-check native seams (`tests/sdl/sdl_host_test`) but do
+**not** provide a live SDL CI run (no SDL headers in current CI). Native smoke
+may stay machine-local until CI gains SDL — still required on **both** target
+machines before calling platform parity done.
 
-Highest-value immediate work: **PR 1**, then **samplers + mipmaps**.
+### Cross-platform SW screenshot gate
+
+- [ ] Render the same deterministic frame via:
+      ```text
+      Node software
+      macOS software → SDL
+      Pi software → SDL
+      ```
+- [ ] Compare pixel hashes (or tiny tolerance) so host/platform work cannot
+      silently change gameplay rendering
+
+### Pi performance budgets (before expanding hybrid)
+
+Pi 5 = quad Cortex-A76 + VideoCore VII (GLES 3.1 / Vulkan 1.3) — capable, but
+CPU render cost scales as:
+
+```text
+3D target pixels × SSAA × triangles × embedded views × update frequency
+```
+
+- [ ] Instrument per stage: guest update · 3D SW raster · SSAA resolve · 2D
+      compose · RGBA pack · SDL upload/present · audio pump
+- [ ] Provisional **60 Hz** budgets (~16.7 ms/frame) — adjust after measurement:
+      ```text
+      Game / interpreter update     ≤ 3 ms
+      2D render + composition       ≤ 4 ms
+      Small embedded 3D work        ≤ 4 ms
+      SDL packing / presentation    ≤ 3 ms
+      Remaining margin              ≥ 2 ms
+      ```
+- [ ] Soak test several minutes (thermals / sustained), not only first frames
+
+---
+
+## Milestone C — hybrid performance + GPU strategy
+
+### 3D sprite update modes (use aggressively on Pi)
+
+Embedded 3D must not rerender every game frame by default
+([`PLAN_2D_EMBED_3D.md`](./PLAN_2D_EMBED_3D.md)):
+
+```ts
+update: "manual" | "whenDirty" | { fps: 15 } | "everyFrame"
+```
+
+| Use | Mode |
+|-----|------|
+| Inventory item | `manual` / `whenDirty` |
+| Character portrait | 10–15 fps |
+| Celebration diamond | `everyFrame` briefly |
+| Static decorative mesh | render once |
+| Full 3D world / background | `everyFrame`, **GPU required** |
+
+For v1 parity, a 3D sprite is an **enhancement** — it must not make the 2D game
+miss its frame budget.
+
+### Do not require one identical GPU API on macOS and Pi
+
+Shared layer = Ranger renderer contract, not one native GPU API:
+
+```text
+Renderer2D / Renderer3D
+        ↓
+RgGraphicsDevice
+        ├── Software   (CI, screenshots, fallback)
+        ├── GL / GLES  (Pi production; macOS parity OK)
+        └── Metal      (durable macOS)
+```
+
+Public guest API stays `Texture2D` / `RenderTarget` / `Sampler` / `RenderPass`
+— never `GLuint` / FBO types.
+
+| Platform | Parity milestone | Production direction |
+|----------|------------------|----------------------|
+| **Pi 5** | SW→SDL first | **OpenGL ES 3.1** (smaller step) or Vulkan; FBO RTT stays **GPU-resident** when sampled by 2D — **no** GPU→CPU readback→SW 2D every frame |
+| **macOS** | SDL + OpenGL OK to prove parity | Apple deprecated OpenGL (10.14+); durable path = **Metal** (direct or via abstraction) |
+
+- [ ] Pi GLES: textures, FBO RT + depth, sprite batching, basic mesh shaders,
+      RT→sprite with **no readback**
+- [ ] macOS: keep GL only as compatibility; design APIs for Metal later
+- [ ] Shader-source variants for desktop GL vs GLES where they share code
+
+---
+
+## Software reference — correctness essentials (demoted main line)
+
+SW path stays valuable for: deterministic screenshots, CI, ownership/pass
+debugging, macOS↔Pi visual compare, GPU-init fallback. It does **not** need to
+become a fully optimized production 3D renderer.
+
+**Already landed (thin slice):** SW 3D @2× → CPU `Texture2D` → SW 2D
+(`ylos3d`; `rtt_sprite` / `ylos3d_e2e`).
+
+**Finish only these essentials**, then stop deepening SW 3D ahead of milestones
+A/B:
+
+- [ ] Complete frustum clipping (six homogeneous planes)
+- [ ] Consistent triangle fill (top-left rule)
+- [ ] Correct alpha (texture α + material; no dark fringes)
+- [ ] Configurable 1× / 2× SSAA (`samples` API)
+- [ ] Nearest + linear sampling (shared `sampleLinear` at texture store)
+- [ ] No crashes / giant triangles (remove 8× span guard once clip works)
+
+**Defer** (after A/B, or never as SW mainline): mip chains / anisotropic /
+sophisticated transparent materials / advanced lighting / trilinear.
+
+### Suggested PR sequence (graphics — after native smoke is moving)
+
+1. Rasterizer correctness essentials (clip + top-left + contract images)
+2. Nearest/linear sampling + texture alpha
+3. Configurable SSAA (`samples`) + edge-fringe tests
+4. Real render targets (identity, resize/release)
+5. Ordered frame execution (retention, exactly-once replay, multi-pass 2D)
+6. Destinations + load/store
+7. `SceneSprite3D` update modes / producer scheduling
+8. Pi GLES → macOS Metal/GL parity (**Milestone C**)
+
+Detail checklists below remain the implementation notes for items 1–7.
 
 ### 1. Finish software rasterizer correctness
 
-Make this the next small graphics PR.
+Do after Milestone B smoke is moving — not ahead of native macOS/Pi gates.
 (`three/port/src/three_software_backend.rgr`)
 
 - [ ] **Six homogeneous clipping planes** — today only near-plane clip; large
@@ -174,18 +351,13 @@ Nearest-neighbour in both SW 3D and SW 2D makes upper facets noisy
 - [ ] **Wire nearest/linear into both** SW 3D rasterizer and SW 2D compositor
       (no duplicated filter math).
 
-### 3. Mipmaps (after bilinear)
+### 3. Mipmaps — **deferred** (not SW mainline)
 
-Bilinear helps magnification; diamond top facets are a **minification** problem.
+Useful later for patterned minification (e.g. diamond tops), but **do not**
+prioritize ahead of milestones A/B or Pi GLES. When revisited:
 
 - [ ] Generate mip chain on image load (`W×H`, `W/2×H/2`, …)
-- [ ] LOD from perspective-correct UV derivatives (finite differences OK for SW):
-      ```
-      rho = max(texW * |dUV/dx|, texH * |dUV/dy|)
-      lod = log2(rho)
-      ```
-- [ ] Start with **nearest mip** selection; trilinear later
-- [ ] Expect mipmapping to beat 2×→4× geometry SSAA for patterned diamond tops
+- [ ] LOD from UV derivatives; start with nearest-mip (trilinear later)
 
 ### 4. Configurable antialiasing (not hardcoded 2×)
 
@@ -273,25 +445,19 @@ samples `gem.sprite`.
 - [ ] **Do not** implement `whenDirty` until scene/camera/material/light/texture
       revision counters exist (PLAN defers this)
 
-### 9. GPU parity (explicitly last)
+### 9. GPU parity (Milestone C — last)
 
-- [ ] GPU 2D/3D backend parity tests against the SW reference images / contracts
-      above — only after PRs 1–8 make the software path trustworthy
+- [ ] Parity tests vs SW reference images — only after A/B + essentials above
+- [ ] Prefer Pi GLES / macOS Metal strategy in § Milestone C (no single forced
+      low-level API; no GPU→CPU readback loops)
 
 ---
 
-## P0 — SDL / native: productize what already exists
+## P0 — SDL / native building blocks (see Milestone B)
 
-### How headless works today (for contrast)
-
-v2 games **do** run through the TSX interpreter under Node (`-es6`):
-
-1. Compile a Ranger host/driver (e.g. `tests/e2e/ylos2_e2e_test.rgr`).
-2. **Node.js** executes that ES6 host.
-3. `RgGameHost` → `ComponentEngine` evaluates guest `index.tsx`.
-4. Software/textured present → in-memory `RgFramebuffer` (shots → PNG).
-
-See [`README.md`](./README.md) “How v2 runs today”.
+Detail for Milestone B. Headless path (contrast): Ranger `-es6` → Node →
+`RgGameHost` → `ComponentEngine` evaluates guest TSX → SW framebuffer. Native
+path: same host protocol compiled with `-l=cpp` + `gfx_sdl`.
 
 ### What already exists (do not rebuild from scratch)
 
@@ -299,38 +465,34 @@ See [`README.md`](./README.md) “How v2 runs today”.
 |-------|--------|-------|
 | `RgGameHost` + `Rg2DPresenter` | live | TSX → frame; SW/textured present |
 | `runtime/sdl/RgSdlGameHost.rgr` + `RgSdlMain.rgr` | live | launcher + game loop; pane-aware present; `clearRgb` |
-| `scripts/build-sdl-v2.sh` | live | Ranger→C++→link SDL2 |
-| `npm run engine:game-sdl:launcher:v2` | live | build + launch (needs SDL2 on the machine) |
-| `tests/sdl/sdl_host_test` | live | headless seams (RGBA pack, `mapMask`, music pump) |
-| Music → SDL PCM | live | `pumpAudio` + `audio/tests/audio_score_test` |
-| `render/backends/gl/` | scaffold | after SW→SDL is smoke-green |
+| `scripts/build-sdl-v2.sh` | live | Ranger→C++; **macOS/Homebrew-oriented today** |
+| `npm run engine:game-sdl:launcher:v2` | live | needs SDL2 on the machine |
+| `tests/sdl/sdl_host_test` | live | headless seams only (no live window in CI) |
+| Music → SDL PCM | live | `pumpAudio` |
+| `render/backends/gl/` | scaffold | after macOS+Pi SW→SDL smokes |
 
 ### Still missing (checklist)
 
-- [ ] **CI / dummy smoke** — short `SDL_VIDEODRIVER=dummy` run of the v2 binary
-      (parity with `engine:game-sdl:smoke:*`); prove launcher → ylos2 without a
-      display
-- [ ] **npm naming clarity** — either document `engine:game-sdl:launcher:v2` as
-      the v2 entry, or add `engine:v2:sdl` / `:run` aliases → `build-sdl-v2.sh`
-- [ ] **Direct game run script** — `build-sdl-v2.sh` path that skips the
-      launcher and loads a given `v2/games/<name>/index.tsx` (v1 has
-      `engine:game-sdl:run -- <path>`)
-- [ ] **Refresh docs** — README still claims “no SDL window” in places; keep
-      them aligned with `build-sdl-v2.sh`
-- [ ] **Do not** reuse v1 `game_sdl_runner.rgr` as the v2 host (`GameRunner` ≠
-      `RgGameHost`)
+- [ ] Pi 5 arm64 build (`pkg-config` SDL) — see Milestone B
+- [ ] Fixed-duration auto-run smoke on macOS **and** Pi
+- [ ] `SDL_VIDEODRIVER=dummy` / CI smoke when headers available
+- [ ] Direct game run (skip launcher) like v1 `engine:game-sdl:run -- <path>`
+- [ ] Audio-device failure fallback; controller hotplug
+- [ ] README alignment; optional `engine:v2:sdl:*` aliases
+- [ ] **Do not** reuse v1 `game_sdl_runner.rgr` (`GameRunner` ≠ `RgGameHost`)
 
-### Follow-ons (after smoke is green)
+### Follow-ons
 
 - [x] Pane-aware present (`paneCount` → single or split; neutral `clearRgb`)
-- [ ] Audio: `vocalCues` / one-shots → SDL (music path already exists)
-- [ ] Real `render/backends/gl` path (optional once SW→SDL smokes)
+- [ ] Audio: `vocalCues` / one-shots → SDL
+- [ ] Cross-platform SW screenshot hashes (Node / macOS / Pi)
 
-### Intentionally out of scope until must-pass 2D is credible
+### Intentionally out of scope until A+B are credible
 
-- Full v1 menu/catalog parity
-- WASM guest profiles on the SDL binary
+- Full v1 catalog port
+- WASM guests on the SDL binary
 - Replacing v1 `engine:game-sdl:*` (v1 stays runnable)
+- Deep SW 3D / GPU backends as the mainline
 
 ---
 

--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -388,29 +388,34 @@ Contract: [`BRIDGES.md`](./BRIDGES.md) rev 2. Today steps 1–2 are done
 - Proves D-IDENTITY / D-OWN / D-SYNC across a second guest language.
 - Keeps content scope fixed while the **transport** is the variable under test.
 
-### Checklist
+### Checklist (aligns with “Validate the approach” sequence)
 
-- [ ] Author semantic IDL; stop growing the hand `dispatchRow` if-chain
-      (`RgRegistryBridge` — BRIDGES §2.4 / step 5 emitter replaces it)
-- [ ] Regenerate interpreter-profile command table from IDL; coverage gate red
-      on drift
-- [ ] wasm32 ABI profile + import surface under `bridge/` (or
-      `registry/generated/`)
+- [ ] Stabilize registry / IDL for current 2D + render-target / hybrid slice
+      (Texture2D, TextureView2D, RenderTarget, destinations, samplers — not
+      TSX-only)
+- [ ] Stop growing the hand `dispatchRow` if-chain; emitter replaces it
+      (`RgRegistryBridge` — BRIDGES §2.4)
+- [ ] Generate raw Rust `sys` imports from schema (no policy in that layer)
+- [ ] Safe `ranger_wasm`: `OwnedHandle<T>` (retain/release), errors, strings,
+      spans, `Game` + `export_game!`, typed descriptors
 - [ ] Golden wire vectors: handles, strings, spans, enums/results, typed errors
-- [ ] **Rust crate**: `ylos3d`-equivalent guest issuing the same registry
-      commands (split, sprites/atlases, 3D RTT gems, frame loop)
-- [ ] Host loads Rust wasm module through the generic path (no
-      game-specific `.rgr` shell — same rule as TSX packages)
-- [ ] Parity assertions: TSX ylos3d vs Rust ylos3d on host state / present
-      smoke (pixel or command-trace level)
-- [ ] old-guest / new-host compatibility runs before freeze
-- [ ] **Do not freeze** a published wasm32 ABI until step 7 criteria pass
+- [ ] **First E2E gate:** dual-source `wasm_parity` (TSX + Rust) — sprite move,
+      input, sound, small 3D RT→2D sprite, clean shutdown + trap cleanup;
+      compare command traces (see approach section)
+- [ ] TSX↔Rust command-trace parity gate in `tests/run.sh`
+- [ ] `GuestInstance` / `WasmGuestInstance` on host; WASM profile on SDL host
+- [ ] Same `.wasm` on macOS + Pi 5 (software present first)
+- [ ] Scale to **Rust `ylos3d`** reference (full hybrid slice)
+- [ ] old-guest / new-host compatibility runs
+- [ ] **Do not freeze** a published wasm32 ABI until TSX + Rust both pass on
+      one host (BRIDGES step 7)
 
 ### Explicit non-goals until W is green
 
 - [ ] Porting Chess or other v1 titles “to show progress”
 - [ ] Growing the launcher catalog with missing folders
 - [ ] Treating bridge fixture suites as sufficient WASM validation
+- [ ] Publishing ABI before the dual-source parity gate is green
 
 ---
 

--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -687,9 +687,10 @@ python3 gallery/game_engine/v2/tests/check_boundaries.py
 # Optional: offline PNG of ylos2 via textured software present
 npm run engine:v2:shot:ylos2
 
-# Native SDL launcher (needs SDL2 headers/libs on the machine)
+# Native SDL launcher (macOS today; Pi 5 arm64 is Milestone B)
 npm run engine:game-sdl:launcher:v2
 # build only: bash gallery/game_engine/scripts/build-sdl-v2.sh
+# Target: same binary path on Raspberry Pi OS arm64 via pkg-config SDL2
 
 # Inventory: local tests vs central driver
 # (suites listed in tests/run.sh vs find v2 -name '*_test.rgr')

--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -25,30 +25,272 @@ Mark checklist items `[x]` when they land and stay green.
 
 ---
 
+## Validate the approach — WASM as a first-class parity target **now**
+
+**Yes — treat WASM as a first-class parity target now**, not after the TSX API
+is “finished.” Otherwise the 2D/3D API may accumulate conveniences that cannot
+be lowered cleanly to a stable binary boundary.
+
+Architectural intent is already right
+([`CODE_CLEANUP.md`](../CODE_CLEANUP.md), [`BRIDGES.md`](./BRIDGES.md)):
+TSX and WASM guests issue the **same registry commands** against the same
+host-owned resources. One schema should generate host dispatch, interpreter
+bindings, WASM imports, TypeScript declarations, Rust wrappers, and parity
+tests.
+
+**Implementation is uneven today:**
+
+| Piece | Status |
+|-------|--------|
+| Low-level WASM bridge (handle, retain/release, span, async poll, TSX↔WASM command-trace fixtures) | green under `bridge/wasm/tests/` |
+| Ergonomic `ranger_wasm` Rust package | still a **scaffold** |
+| WASM guest through macOS/Pi SDL host | **not** in the first SDL-window milestone — no Rust game E2E on native yet |
+
+### Desired layering
+
+```text
+TSX game                           Rust game
+   │                                  │
+ranger:core / ranger:2d          ranger_wasm::core / ::two_d
+   │                                  │
+interpreter adapter              generated safe Rust wrappers
+   │                                  │
+   └──────── same registry commands ──┘
+                       │
+                 RgGameHost
+                       │
+       software / GLES / Metal renderer
+```
+
+Public programming experience should be **similar**; the binary ABI stays
+deliberately **primitive**.
+
+### Similar source APIs, not identical syntax
+
+TSX:
+
+```ts
+import { runtime } from "ranger:core";
+import * as TWO from "ranger:2d";
+
+class JumperGame {
+  layer = new TWO.Layer2D();
+  camera = new TWO.Camera2D();
+  renderer = new TWO.Renderer2D();
+  update(frame) {
+    this.renderer.render(this.layer, this.camera, 0);
+  }
+}
+runtime.start(new JumperGame());
+```
+
+Rust should preserve the same concepts and lifecycle, with Rust conventions
+(`snake_case`, `Result`, RAII, borrowing, typed options, `Clone`/`Drop`) —
+not JS property proxies:
+
+```rust
+use ranger_wasm::{
+    core::{FrameInfo, Game, GameContext, InitContext, Result},
+    two_d,
+};
+
+struct JumperGame {
+    layer: two_d::Layer2D,
+    camera: two_d::Camera2D,
+    renderer: two_d::Renderer2D,
+}
+
+impl Game for JumperGame {
+    async fn init(_ctx: &mut InitContext) -> Result<Self> {
+        Ok(Self {
+            layer: two_d::Layer2D::new()?,
+            camera: two_d::Camera2D::new()?,
+            renderer: two_d::Renderer2D::new()?,
+        })
+    }
+    fn update(
+        &mut self,
+        _ctx: &mut GameContext,
+        _frame: FrameInfo,
+    ) -> Result<()> {
+        self.renderer.render(&self.layer, &self.camera, 0)?;
+        Ok(())
+    }
+}
+
+ranger_wasm::export_game!(JumperGame);
+```
+
+`Game` trait + `export_game!` → lifecycle exports (create, async-init poll,
+update, resize, shutdown) per CODE_CLEANUP / BRIDGES.
+
+### ABI smaller than either source API
+
+Raw ABI must **not** expose classes, Rust references, TS objects, or renderer
+impl details. Reasonable core lowering (already the documented direction):
+
+```text
+handles        two u32 words: low, high
+bool/enums     i32/u32
+numbers        i32/u32/f32/f64
+strings        UTF-8 offset + byte length
+arrays         memory offset + element count + element type
+results        status code + out parameters
+async          begin / poll / cancel / release
+```
+
+Friendly call → ugly raw import (by design; only generated bindings call it):
+
+```text
+Sprite2D::from_texture(&view)
+  → rg_sprite2d_create_from_texture_view(view_lo, view_hi, out_lo, out_hi) -> status
+```
+
+### Generate two Rust layers in `ranger_wasm`
+
+**1. Generated raw `sys` layer** — no policy; regenerated entirely from the
+registry:
+
+```rust
+mod sys {
+    extern "C" {
+        pub fn rg_sprite2d_set_position(lo: u32, hi: u32, x: f32, y: f32) -> i32;
+    }
+}
+```
+
+**2. Safe ergonomic layer** — `OwnedHandle<T>` with `Clone → rg_retain`,
+`Drop → rg_release`; host still validates realm/generation/slot/type (hostile
+modules can bypass wrappers). Also: `BorrowedHandle`, `Error`/`Result`, UTF-8
++ checked span lowering, async `Future` wrappers, `Game` contexts,
+`export_game!`, typed descriptors.
+
+### Put 2D/3D composition into the schema **now**
+
+Do not leave these TSX-only — they must lower to both guests:
+
+```text
+Texture2D · TextureView2D · RenderTarget
+SceneSprite3D (or helper)
+render-to-target · pane/surface destination
+sampler/filter · pass clear/load
+```
+
+If an API cannot be expressed naturally in **both** TSX and Rust, the public
+abstraction is probably over-fit to TS object behaviour. That is a design test
+for the hybrid slice (`ylos3d`).
+
+### Versioned descriptors for complex options
+
+- Hot ops: direct versioned imports (`rg_sprite2d_set_position_v1`)
+- Option-rich constructors: versioned **memory descriptors**
+  (`rg_render_target_create_v1(desc_off, desc_size, out_lo, out_hi)`) with
+  `struct_size` first field
+- **Never** silently add args to an existing import (Wasm validates types at
+  instantiate — “defaulted” params still break old guests)
+- Prefer direct versioned imports for common ops; descriptors for rich create;
+  generic dispatcher only for experiments / rare extensions
+
+### Native macOS and Pi — WASM is a guest format, not a browser mode
+
+```text
+Raspberry Pi SDL host          macOS SDL host
+  + embedded WASM runtime        + embedded WASM runtime
+  + Ranger imports               + identical Ranger imports
+  + game.wasm                    + same game.wasm
+```
+
+Renderer stays native. WASM only sends commands + handles. Same `.wasm` must
+drive software / Pi GLES / macOS Metal (or compat GL). **No** GPU pointers,
+SDL handles, native paths, or GL IDs cross the ABI.
+
+Host common guest interface (so `RgGameHost` does not care which it ticks):
+
+```text
+GuestInstance
+├── TsxGuestInstance
+└── WasmGuestInstance
+    create() · pollInit() · update(frame) · resize() · shutdown()
+```
+
+### WASM-specific Pi constraints
+
+(see also [`docs/WASM_MEMORY_ABI.md`](../docs/WASM_MEMORY_ABI.md))
+
+- Prefer **host-side** asset decoding (large models must not occupy linear
+  memory first)
+- Chunk large guest geometry uploads
+- Do not cache host views across `memory.grow`
+- Avoid per-vertex ABI calls
+- Realm teardown must release handles after a trap
+- Limits: memory, handles, pending requests, commands/frame
+
+### First end-to-end parity gate (before full ylos3d Rust port)
+
+Do **not** start with the full 3D game. One small dual-source package:
+
+```text
+games/wasm_parity/          (or tests/fixtures/wasm_parity/)
+├── index.tsx
+└── rust/
+    ├── Cargo.toml
+    └── src/lib.rs
+```
+
+Both versions must:
+
+1. Create layer, camera, renderer, atlas, sprite  
+2. Read a typed input action  
+3. Move the sprite  
+4. Render one pane  
+5. Play one sound  
+6. Create a small 3D render target  
+7. Show its texture through a 2D sprite  
+8. Shut down cleanly  
+
+Compare: registry command IDs + order · handle types · retain/release ·
+render-pass · framebuffer · input edges · audio events · cleanup after normal
+shutdown **and** after a WASM trap.
+
+Then scale that package up to a full **Rust `ylos3d`** reference (Milestone W).
+
+### Approach-validation priority (tight sequence)
+
+1. Stabilize registry defs for the current 2D + render-target slice  
+2. Generate raw Rust `sys` imports from that schema  
+3. Implement `OwnedHandle<T>`, errors, strings, spans, lifecycle exports  
+4. Run one minimal Rust/WASM game in the **headless** host  
+5. TSX-versus-Rust **command-trace** parity  
+6. Add WASM guest profile to the **SDL** host  
+7. Run the same `.wasm` on macOS and Pi 5  
+8. Add 3D-RT→2D-sprite parity case  
+9. **Only then** publish the first stable ABI version  
+10. Continue GPU backends behind that **unchanged** ABI  
+
+**Most important point:**
+
+> TSX and Rust share the same conceptual API and exactly the same host command
+> semantics; the WASM ABI remains a small, stable, generated implementation
+> detail.
+
+That gives Rust a native-feeling API without a second engine architecture.
+**Adding more games is lower priority than proving this path.**
+
+---
+
 ## PoC priority — full path over more games
 
-**WASM is a first-class part of the v2 PoC**, not a follow-on after “all the
-TSX games.” The interpreter profile (TSX → `RgRegistryBridge`) is necessary
-but not sufficient: the same semantic commands must also run from a
-**Rust→wasm32** guest against the same host ([`BRIDGES.md`](./BRIDGES.md)
-rev 2).
-
-**Adding more games right now is not the priority.** Chess and a wider catalog
-stay on the long-term must-pass list, but they wait until the **end-to-end
-path** is validated:
+See **Validate the approach** above. Summary: WASM is first-class for the v2
+PoC; the interpreter profile alone is not enough. Wait on Chess / catalog
+growth until TSX + Rust share one host command stream.
 
 ```text
 TSX ylos2 / ylos3d  (interpreter profile)     ✓ partly green
         +
-Rust ylos3d         (wasm32 profile)          ← elevate this
+minimal wasm_parity  →  Rust ylos3d           ← elevate (Milestone W)
         ↓
 same host arenas / present / (later) native SDL on macOS + Pi 5
 ```
-
-`ylos3d` is the right WASM reference: it already exercises **2D + embedded 3D
-RTT + split panes + input + audio façades** — more of the registry surface
-than Chess would. Porting Chess early would expand content without proving
-the second guest language / ABI.
 
 ---
 

--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -9,11 +9,11 @@ driver and the roadmap below over that checklist.
 | Track | What is green today | What is not |
 |-------|---------------------|-------------|
 | Headless gate | `npm run engine:v2:test` → 46 suites + boundary gate | — |
-| TSX guests | `games/ylos2`, `games/ylos3d` via `RgGameHost` | must-pass **chess** missing |
+| TSX guests | `games/ylos2`, `games/ylos3d` via `RgGameHost` | Chess / broader catalog **deprioritized** vs E2E path validation |
 | SW / textured 2D | e2e + `engine:v2:shot:ylos2` | real LPC/PNG atlas pixels; vocals/SFX sinks |
-| Hybrid 2D+3D (path A) | thin slice: SW 3D @2× → CPU `Texture2D` → SW 2D (`ylos3d`) | clip/fill/alpha essentials; RT lifetime; ordered passes; **GPU later** |
+| Hybrid 2D+3D (path A) | thin TSX slice: SW 3D @2× → CPU `Texture2D` → SW 2D (`ylos3d`) | same slice as **Rust→wasm32** guest; RT/pass architecture |
 | Native SDL | `RgSdlGameHost` + `build-sdl-v2.sh` + `engine:game-sdl:launcher:v2` (macOS-oriented today) | **Pi 5 arm64** build/smoke; cross-platform `pkg-config`; live CI |
-| WASM32 published ABI | create/free/parity fixtures | IDL extract + freeze (BRIDGES steps 4–7) |
+| WASM32 / Rust | create/free/parity **fixtures** only | IDL + wasm32 profile + **Rust ylos3d** conformance guest + wire vectors |
 | v1 | still **runnable legacy** (~many titles under `games/`) | archival only at an explicit milestone (not Phase 12) |
 
 **Docs inconsistency:** README / older notes still say “no SDL window”;
@@ -25,103 +25,190 @@ Mark checklist items `[x]` when they land and stay green.
 
 ---
 
-## Three milestones (prove in this order)
+## PoC priority — full path over more games
 
-“v1 parity” does **not** yet mean every v1 title. With only `ylos2` / `ylos3d`
-on disk and Chess named but missing, the first bar is:
+**WASM is a first-class part of the v2 PoC**, not a follow-on after “all the
+TSX games.” The interpreter profile (TSX → `RgRegistryBridge`) is necessary
+but not sufficient: the same semantic commands must also run from a
+**Rust→wasm32** guest against the same host ([`BRIDGES.md`](./BRIDGES.md)
+rev 2).
 
-> The selected parity games behave correctly through the v2 API and run through
-> the **same** native host on both **macOS** and **Raspberry Pi 5**.
+**Adding more games right now is not the priority.** Chess and a wider catalog
+stay on the long-term must-pass list, but they wait until the **end-to-end
+path** is validated:
+
+```text
+TSX ylos2 / ylos3d  (interpreter profile)     ✓ partly green
+        +
+Rust ylos3d         (wasm32 profile)          ← elevate this
+        ↓
+same host arenas / present / (later) native SDL on macOS + Pi 5
+```
+
+`ylos3d` is the right WASM reference: it already exercises **2D + embedded 3D
+RTT + split panes + input + audio façades** — more of the registry surface
+than Chess would. Porting Chess early would expand content without proving
+the second guest language / ABI.
+
+---
+
+## Four milestones (prove in this order)
+
+“v1 parity” does **not** yet mean every v1 title. The PoC bar is:
+
+> Selected packages (`ylos2`, `ylos3d`) behave correctly through the v2 API
+> from **both** the TSX interpreter profile **and** a Rust wasm32 guest, and
+> the TSX packages also run through the same native host on **macOS** and
+> **Raspberry Pi 5**.
 
 | # | Milestone | Goal |
 |---|-----------|------|
-| **A** | **v1 gameplay / API parity** | Chess + ylos2 through v2 APIs (headless + native) |
+| **W** | **WASM / Rust path (PoC)** | IDL + wasm32 profile + **Rust `ylos3d`** conformance guest + wire vectors; same host as TSX |
+| **A** | **Selected gameplay / API parity** | Deepen `ylos2` / `ylos3d` (not new titles); matrices below |
 | **B** | **Native platform parity** | Same packages on macOS arm64 **and** Pi 5 arm64 SDL |
-| **C** | **Hybrid 2D/3D performance** | Embedded 3D without blowing the Pi frame budget; GPU without CPU readback |
+| **C** | **Hybrid 2D/3D performance** | Embedded 3D within Pi budgets; GPU without CPU readback |
 
 Software-rasterizer polish remains useful for CI / screenshots / ownership
 debugging, but it **stops being the main line** once the current image is
 visually correct. Do not deepen SW 3D (mips, fancy materials, anisotropic,
-advanced lighting) ahead of A/B.
+advanced lighting) ahead of W/A/B. **Do not** expand the game catalog ahead of W.
 
 ### Revised implementation sequence
 
-1. **[ ] Parity definition** — freeze executable matrices for ylos2 + Chess
-   (below).
-2. **[ ] Native smoke** — macOS **and** Pi 5: build, launch, input, split-screen,
-   audio (see § Native SDL / platform gates).
-3. **[ ] Cross-platform software screenshots** — same deterministic frame on
-   Node SW / macOS SW→SDL / Pi SW→SDL; pixel hash or tiny tolerance.
-4. **[ ] Performance instrumentation** — per-stage timings + allocation
-   counters; set Pi budgets before expanding hybrid work.
-5. **[ ] Software renderer correctness essentials only** — clipping, fill
-   rules, alpha, simple nearest/linear, configurable 1×/2× SSAA; no crashes /
-   giant triangles (see § Software reference — demoted).
-6. **[ ] Real render-target lifetime + ordered frame passes.**
-7. **[ ] 3D sprite update modes + resolution limits** — so embedded 3D cannot
-   steal the 2D frame budget.
-8. **[ ] Pi GLES backend** — GPU 3D RTT + GPU 2D composition **without**
-   readback every frame.
-9. **[ ] macOS GPU backend** — compatibility GL OK for parity; **Metal** as the
-   durable path; public API stays `Texture2D` / `RenderTarget` / `Sampler` /
-   `RenderPass` (not `GLuint`).
-10. **[ ] Broader v1 game ports** — after A+B are proven.
+1. **[ ] BRIDGES IDL extract** — semantic IDL; regenerate interpreter table
+   (coverage gate stays green). See § Milestone W.
+2. **[ ] wasm32 profile + wire vectors** — unsigned/token lowering, golden
+   vectors (handles, strings, spans, errors).
+3. **[ ] Rust `ylos3d` reference guest** — real game (not a toy fixture) on
+   wasm32 against the **same** host arenas/present path as TSX `ylos3d`.
+4. **[ ] Freeze gate** — TSX interpreter + Rust wasm32 both green on one host
+   before any published ABI freeze.
+5. **[ ] Parity matrices** — executable Node / macOS / Pi checks for ylos2 +
+   ylos3d (Chess later).
+6. **[ ] Native smoke** — macOS **and** Pi 5: build, launch, input, split,
+   audio.
+7. **[ ] Cross-platform software screenshots** — Node / macOS / Pi hashes.
+8. **[ ] Performance instrumentation** — Pi budgets before hybrid expansion.
+9. **[ ] SW correctness essentials** — clip, fill rule, alpha, nearest/linear,
+   1×/2× SSAA (demoted detail section below).
+10. **[ ] RT lifetime + ordered frame passes** · 3D sprite update modes.
+11. **[ ] Pi GLES / macOS Metal** — Milestone C; public API stays
+    `Texture2D` / `RenderTarget` / `Sampler` / `RenderPass`.
+12. **[ ] Broader v1 ports (Chess, …)** — **only after** W + A + B prove the
+    full path.
 
-### Practical definition of success (first platform milestone)
+### Practical definition of success (PoC + first platform milestone)
 
 ```text
-The same v2 ylos2 package:
-- launches from the v2 launcher,
-- runs at stable speed (~60 Hz),
-- accepts two local players,
-- presents split-screen correctly,
-- plays music and effects,
-- supports controller rumble,
-- can show one animated 3D sprite (optional enhancement),
-- and works without game-specific host code
-on both macOS and Raspberry Pi 5.
+PoC (WASM):
+- TSX ylos3d and Rust→wasm32 ylos3d drive the same host commands
+- wire vectors pinned; no published ABI until both guests pass
+- hybrid 2D+3D slice works from both guest languages
+
+Platform:
+- the same v2 ylos2 (and ylos3d) packages:
+  - launch from the v2 launcher,
+  - run at stable speed (~60 Hz),
+  - accept two local players / split-screen,
+  - play music and effects, rumble where available,
+  - show the embedded 3D sprite path,
+  - with no game-specific host code
+  on both macOS and Raspberry Pi 5.
 ```
 
-That proves something more important than advanced AA: **the v2 API is portable
-and can replace the selected v1 runtime paths.**
+That proves: **one API, two guest languages (TSX + Rust/WASM), two native
+machines** — more important than shipping additional titles.
 
 ---
 
-## Milestone A — freeze a concrete parity matrix
+## Milestone W — WASM / Rust / BRIDGES (elevate for PoC)
 
-Before more renderer work, define exactly what must match. Must-pass titles
-(`games/README.md`): **ylos2** + **chess**.
+Contract: [`BRIDGES.md`](./BRIDGES.md) rev 2. Today steps 1–2 are done
+(interpreter table + coverage); step 3 (real TSX guests) is in progress;
+**steps 4–7 are the PoC spine**.
 
-**ylos2 target capabilities** (from game policy / QUESTIONS): sprite + atlas,
-camera scroll, split-screen, 2P input, particles, rumble, vocal FX, music
-score, LPC/bitmap assets.
+| Step | Work | Status |
+|------|------|--------|
+| 1–2 | Interpreter profile table + generic bridge + coverage | done (not a published ABI) |
+| 3 | Real TSX guests (ylos2 / ylos3d / launcher) | in progress |
+| **4** | **IDL extraction** — full types, identities, capabilities; regen interpreter table from IDL × profile | **not started — next** |
+| **5** | **wasm32 profile** — token/epoch lowering; golden **wire vectors** | not started |
+| **5b** | **Rust→wasm32 `ylos3d` conformance guest** — reference implementation covering hybrid use cases | **elevate** |
+| 6 | Extend IDL to three + cannon; dispatcher emitter; generated façades | after 5 |
+| 7 | **Golden freeze** only when TSX + Rust guests both pass on one host | gated |
 
-**Chess target capabilities:** atlas pieces, text/UI, cursor actions; rules/AI
-unchanged (pure TS copy).
+### Why Rust `ylos3d` (not a toy, not Chess first)
+
+- Covers **ranger:2d + ranger:three RTT + surface panes + input + audio** in one
+  package — the interesting v2 surface.
+- Forces the wasm32 lowering to be real (handles, strings/assets, errors), not
+  just `create`/`free` fixtures under `bridge/wasm/tests/`.
+- Proves D-IDENTITY / D-OWN / D-SYNC across a second guest language.
+- Keeps content scope fixed while the **transport** is the variable under test.
+
+### Checklist
+
+- [ ] Author semantic IDL; stop growing the hand `dispatchRow` if-chain
+      (`RgRegistryBridge` — BRIDGES §2.4 / step 5 emitter replaces it)
+- [ ] Regenerate interpreter-profile command table from IDL; coverage gate red
+      on drift
+- [ ] wasm32 ABI profile + import surface under `bridge/` (or
+      `registry/generated/`)
+- [ ] Golden wire vectors: handles, strings, spans, enums/results, typed errors
+- [ ] **Rust crate**: `ylos3d`-equivalent guest issuing the same registry
+      commands (split, sprites/atlases, 3D RTT gems, frame loop)
+- [ ] Host loads Rust wasm module through the generic path (no
+      game-specific `.rgr` shell — same rule as TSX packages)
+- [ ] Parity assertions: TSX ylos3d vs Rust ylos3d on host state / present
+      smoke (pixel or command-trace level)
+- [ ] old-guest / new-host compatibility runs before freeze
+- [ ] **Do not freeze** a published wasm32 ABI until step 7 criteria pass
+
+### Explicit non-goals until W is green
+
+- [ ] Porting Chess or other v1 titles “to show progress”
+- [ ] Growing the launcher catalog with missing folders
+- [ ] Treating bridge fixture suites as sufficient WASM validation
+
+---
+
+## Milestone A — selected gameplay matrix (ylos2 / ylos3d first)
+
+Deepen the **existing** packages before new ones. Long-term must-pass names
+remain ylos2 + Chess (`games/README.md`), but **Chess is queued after
+Milestone W**.
+
+**ylos2:** sprite + atlas, camera scroll, split-screen, 2P input, particles,
+rumble, vocal FX, music score, LPC/bitmap assets.
+
+**ylos3d:** above + embedded 3D RTT sprites (the WASM reference target).
+
+**Chess (later):** atlas pieces, text/UI, cursor; rules/AI unchanged.
 
 ### Executable matrix (fill as gates land)
 
-| Capability | Node/headless | macOS SDL | Pi 5 SDL |
-|------------|:-------------:|:---------:|:--------:|
-| Game loads | ✓ e2e | [ ] | [ ] |
-| Assets resolve | partial | [ ] | [ ] |
-| 1-player input | ✓ / attract | [ ] | [ ] |
-| 2-player input | ✓ e2e | [ ] | [ ] |
-| Split panes | ✓ e2e | [ ] | [ ] |
-| Music | score text / pump | [ ] | [ ] |
-| SFX / vocals | record-only | [ ] | [ ] |
-| Rumble | simulated | [ ] | [ ] |
-| Stable ~60 Hz gameplay | N/A | [ ] | [ ] |
-| Clean shutdown / relaunch | ✓ launch handoff | [ ] | [ ] |
+| Capability | Node/headless | macOS SDL | Pi 5 SDL | Rust wasm32 |
+|------------|:-------------:|:---------:|:--------:|:-----------:|
+| ylos2 loads | ✓ e2e | [ ] | [ ] | N/A (2D-only TSX first) |
+| ylos3d loads | ✓ e2e | [ ] | [ ] | [ ] **PoC** |
+| Assets resolve | partial | [ ] | [ ] | [ ] |
+| 1-player input | ✓ / attract | [ ] | [ ] | [ ] |
+| 2-player input | ✓ e2e | [ ] | [ ] | [ ] |
+| Split panes | ✓ e2e | [ ] | [ ] | [ ] |
+| Embedded 3D RTT | ✓ ylos3d | [ ] | [ ] | [ ] |
+| Music | score / pump | [ ] | [ ] | [ ] |
+| SFX / vocals | record-only | [ ] | [ ] | [ ] |
+| Rumble | simulated | [ ] | [ ] | [ ] |
+| Stable ~60 Hz | N/A | [ ] | [ ] | N/A |
+| Clean shutdown / relaunch | ✓ launch | [ ] | [ ] | [ ] |
 
-- [ ] Turn the matrix into runnable smoke scripts (headless already partly
-      covered; native = fixed-duration auto-run that exits).
-- [ ] Honest launcher catalog — only list games that exist (`ylos2`, `ylos3d`
-      today; add Chess when ported). Strip dead Chess/Breakout entries.
-- [ ] Close ylos2 bar ([`QUESTIONS.md`](./QUESTIONS.md) Q4–Q7) and extend e2e.
-- [ ] Real atlas pixels (`image` / PNG → `RgTexture2D`) + LPC decoder suite.
-- [ ] Port **chess** onto `ranger:2d` + EVG/HUD.
-- [ ] Vocals / one-shots → real audio sink (not only bridge counters).
+- [ ] Runnable smoke scripts for the matrix (native = fixed-duration exit).
+- [ ] Honest launcher catalog — only existing packages; no fake Chess/Breakout
+      entries.
+- [ ] Close ylos2 bar ([`QUESTIONS.md`](./QUESTIONS.md) Q4–Q7); extend e2e.
+- [ ] Real atlas pixels + LPC decoder suite.
+- [ ] Vocals / one-shots → real audio sink.
+- [ ] **Chess port** — after W is green (not the current critical path).
 
 ### Open decisions (still block a crisp “done”)
 
@@ -129,7 +216,7 @@ unchanged (pure TS copy).
 |----|--------|
 | Q1 | Atlas `image` line + pixel upload |
 | Q4–Q7 | ylos2 façades vs play-feel bar |
-| BRIDGES | wasm32 freeze / hand `dispatchRow` |
+| BRIDGES | IDL / wasm32 freeze / hand `dispatchRow` |
 | Import policy | `ts_parser` outside v2 vs vendored |
 | Plan Intent | archival legacy only at explicit end-of-v1 milestone |
 
@@ -143,8 +230,8 @@ Treat [`CODE_CLEANUP_PLAN.md`](../CODE_CLEANUP_PLAN.md) checkboxes as historical
 | 8–10b | **Largely done**; assets/art incomplete |
 | 9 | **Slice done**; Cannon still staged |
 | 11 | **SW + textured done**; GL scaffold |
-| 12 | **In progress** — ylos2 e2e; chess absent |
-| BRIDGES 1–3 | Guests in progress; IDL/wasm freeze **not started** |
+| 12 | **PoC in progress** — ylos2/ylos3d e2e; Chess deferred; WASM path open |
+| BRIDGES 1–3 | TSX guests in progress; **IDL/wasm/Rust not started** |
 
 ---
 

--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -574,12 +574,13 @@ path: same host protocol compiled with `-l=cpp` + `gfx_sdl`.
 - [ ] Audio: `vocalCues` / one-shots → SDL
 - [ ] Cross-platform SW screenshot hashes (Node / macOS / Pi)
 
-### Intentionally out of scope until A+B are credible
+### Intentionally out of scope until W+A+B are credible
 
-- Full v1 catalog port
-- WASM guests on the SDL binary
+- Full v1 catalog port (Chess and friends — after WASM PoC)
 - Replacing v1 `engine:game-sdl:*` (v1 stays runnable)
 - Deep SW 3D / GPU backends as the mainline
+- Native SDL hosting of the Rust wasm guest can follow headless
+  TSX↔Rust parity; do not block Milestone W on Pi GLES
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorders and expands `v2/TODO.md` so WASM is a **first-class PoC parity target now**.

### Lead section: Validate the approach
- Desired TSX ↔ Rust layering over one registry / `RgGameHost`
- Similar APIs, not identical syntax (`Game` + `export_game!`)
- Primitive ABI (handles as two u32s, spans, poll-async)
- Two `ranger_wasm` layers: generated `sys` + safe `OwnedHandle`
- Put hybrid 2D/3D composition into the schema now (not TSX-only)
- Versioned imports / descriptors; never silent arity changes
- WASM as guest format on macOS + Pi SDL (same `.wasm`)
- Pi memory constraints; dual-source `wasm_parity` as first E2E gate
- Freeze ABI only after TSX↔Rust command-trace parity

### Milestone W elevated
Rust `ylos3d` / `wasm_parity` before Chess or catalog growth.

### Then A → B → C
Selected gameplay deepen → macOS/Pi native → hybrid GPU performance.

Docs only.

## Test plan

- [x] Structure review of `TODO.md`
- [ ] N/A for `engine:v2:test` (docs-only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fadf32c-22ac-48e8-a620-b1c18c16349d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fadf32c-22ac-48e8-a620-b1c18c16349d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

