### PR TITLE
fix(v2/sdl): restore macOS audio and wire ylos3d vocal SFX

### DIFF
--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -802,7 +802,7 @@ path: same host protocol compiled with `-l=cpp` + `gfx_sdl`.
 | `scripts/build-sdl-v2.sh` | live | Ranger→C++; **macOS/Homebrew-oriented today** |
 | `npm run engine:game-sdl:launcher:v2` | live | needs SDL2 on the machine |
 | `tests/sdl/sdl_host_test` | live | headless seams only (no live window in CI) |
-| Music → SDL PCM | live | `pumpAudio` |
+| Music + vocal SFX → SDL PCM | live | `pumpAudio` / `pumpVocals` |
 | `render/backends/gl/` | scaffold | after macOS+Pi SW→SDL smokes |
 
 ### Still missing (checklist)
@@ -818,7 +818,7 @@ path: same host protocol compiled with `-l=cpp` + `gfx_sdl`.
 ### Follow-ons
 
 - [x] Pane-aware present (`paneCount` → single or split; neutral `clearRgb`)
-- [ ] Audio: `vocalCues` / one-shots → SDL
+- [x] Audio: `vocalCues` → SDL (`pumpVocals` → `GameAudio.play`; one-shots still record-only)
 - [ ] Cross-platform SW screenshot hashes (Node / macOS / Pi)
 
 ### Intentionally out of scope until W+A+B are credible
@@ -882,9 +882,9 @@ Still to clean up later:
       different verbs does not fork the host.
 - [ ] **Bridge observability vs real device sinks** — `RgRegistryBridge`
       accumulates `vocalCues` / `oneShotCount` / `logLines` mainly for e2e.
-      Wire vocals/one-shots to SDL (or a real sink) and shrink test-only
-      counters to something tests can still assert without looking like a
-      parallel game API.
+      Vocals now drain to SDL via `pumpVocals`; one-shots are still
+      record-only. Shrink test-only counters to something tests can still
+      assert without looking like a parallel game API.
 - [ ] **Finish generated dispatch** — interim hand `dispatchRow` if-chain in
       `interp/engine/RgRegistryBridge.rgr` (BRIDGES.md §2.4 / step 5 →
       `registry/generated/RgDispatch.rgr`). Coverage gate already locks every

--- a/gallery/game_engine/v2/runtime/sdl/README.md
+++ b/gallery/game_engine/v2/runtime/sdl/README.md
@@ -69,17 +69,26 @@ pad through `gfx_rumble_pad`.
 
 ## Audio
 
-A guest's `runtime.audio.music.play(score)` is recorded on the bridge
-(`rgcore_music_play`); the host owns playback. `initAudio()` opens the SDL audio
-device and builds the synth; `pumpAudio(dt)` (called each game frame) picks up a
-newly-played score, ticks its beat schedule, and each due note synthesises PCM
-that `RgSdlAudioSink` queues via `gfx_audio_queue`. The synth/parser stack lives
-under `v2/audio` (`game_soundscore` + `game_audio`, self-contained). The guest
-only ever said "play" — the schedule clock, synth, and device are all host-side.
+A guest's `runtime.audio.music.play(score)` and `runtime.audio.vocal.play(id)`
+are recorded on the bridge (`rgcore_music_play` / `rgcore_vocal`); the host owns
+playback. `initAudio()` opens the SDL audio device and builds the synth;
+`pumpAudio(dt)` (called each game frame) drains new vocal cues into
+`GameAudio.play` (palette ids like `bounce`/`brick`/`wall`/`celebrate`), then
+picks up a newly-played score, ticks its beat schedule, and each due note
+synthesises PCM that `RgSdlAudioSink` queues via `gfx_audio_queue`. The
+synth/parser stack lives under `v2/audio` (`game_soundscore` + `game_audio`,
+self-contained). The guest only ever said "play" — the schedule clock, synth,
+and device are all host-side.
+
+Device open notes (macOS): empty `SDL_GetNumAudioDevices` is not treated as
+fatal — CoreAudio still opens the system default via `NULL`. Frequency/channel
+negotiation is allowed so a 48 kHz device is accepted; the host adopts
+`gfx_audio_sample_rate()` after open.
 
 > The final SDL2 **link** needs SDL2 headers, which are absent in CI — so the
 > headless suite compile-checks the host, validates the Ranger→C++ codegen, and
 > tests its pure seams (`tests/sdl/sdl_host_test`: framebuffer→RGBA pack, input
-> map, launcher-nav edges, the music pump; `menu/tests/launcher_ui_test`: the
-> rendered launcher screen; `audio/tests/audio_score_test`: parse→schedule→PCM).
-> The live window + audible output happen on a machine with SDL2.
+> map, launcher-nav edges, the music + vocal pumps; `menu/tests/launcher_ui_test`:
+> the rendered launcher screen; `audio/tests/audio_score_test`:
+> parse→schedule→PCM). The live window + audible output happen on a machine with
+> SDL2.

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
@@ -56,13 +56,17 @@ class RgSdlGameHost {
     ; last observed haptic counts, to forward only NEW rumble commands to SDL
     def lastRumble0:int 0
     def lastRumble1:int 0
-    ; host-side music playback: the guest's runtime.audio.music.play(score) is
-    ; recorded on the bridge; the host owns the synth + schedule clock and pushes
-    ; PCM to SDL. (Nothing here is game logic; the guest only ever said "play".)
+    ; host-side music + SFX playback: the guest's runtime.audio.music.play(score)
+    ; and runtime.audio.vocal.play(id) are recorded on the bridge; the host owns
+    ; the synth + schedule clock and pushes PCM to SDL. (Nothing here is game
+    ; logic; the guest only ever said "play".)
     def musicAudio:GameAudio (new GameAudio)
     def music:SoundScorePlayer (new SoundScorePlayer)
     def audioReady:boolean false
     def lastScore:string ""
+    ; Index into bridge.vocalCues already synthesised (same rising-edge pattern
+    ; as rumble — leave the cue list intact for e2e observability).
+    def lastVocal:int 0
 
     ; Map a raw input source bitmask to logical actions for one player and feed
     ; the host input device. PURE host-input config (no gfx, no game): bits are
@@ -117,7 +121,8 @@ class RgSdlGameHost {
 
     ; Bring up the host synth once: build its frequency tables, open the SDL audio
     ; device, and route synthesised PCM to it. Idempotent; native device is a
-    ; no-op under es6.
+    ; no-op under es6. After open, adopt the device's negotiated sample rate
+    ; (CoreAudio often hands back 48 kHz).
     fn initAudio:void () {
         if (this.audioReady) { return }
         this.musicAudio.init()
@@ -125,15 +130,36 @@ class RgSdlGameHost {
         this.musicAudio.sink = sink
         this.music.audio = this.musicAudio
         def _o:int (gfx_audio_open 44100)
+        def rate:int (gfx_audio_sample_rate)
+        if (rate > 0) {
+            this.musicAudio.sampleRate = rate
+        }
         this.audioReady = true
     }
 
-    ; Advance host music one frame: pick up a newly play()'d score recorded on the
-    ; bridge (the guest called runtime.audio.music.play), then tick the schedule —
-    ; each due note synthesises and queues PCM through the sink. Returns the
-    ; running note-start count so the wiring is testable without an audio device.
+    ; Drain newly-recorded vocal cues (runtime.audio.vocal.play) into the synth.
+    ; Returns how many cues were synthesised this call (testable headlessly).
+    fn pumpVocals:int () {
+        def b:RgRegistryBridge this.host.bridge
+        def n:int (array_length b.vocalCues)
+        def started:int 0
+        while (this.lastVocal < n) {
+            def id:string (itemAt b.vocalCues this.lastVocal)
+            this.musicAudio.play(id)
+            this.lastVocal = (this.lastVocal + 1)
+            started = (started + 1)
+        }
+        return started
+    }
+
+    ; Advance host audio one frame: synthesise any new vocal cues, then pick up a
+    ; newly play()'d score recorded on the bridge (the guest called
+    ; runtime.audio.music.play) and tick its schedule — each due note synthesises
+    ; and queues PCM through the sink. Returns the running note-start count so
+    ; the music wiring is testable without an audio device.
     fn pumpAudio:int (dtMs:int) {
         def b:RgRegistryBridge this.host.bridge
+        def _v:int (this.pumpVocals())
         if (b.musicPlaying) {
             if (b.musicScore != this.lastScore) {
                 this.music.load(b.musicScore)
@@ -242,6 +268,8 @@ class RgSdlGameHost {
                 this.host.loadLaunched()
                 this.lastRumble0 = 0
                 this.lastRumble1 = 0
+                this.lastVocal = 0
+                this.lastScore = ""
             }
             this.present(fbL fbR)
             gfx_delay 16

--- a/gallery/game_engine/v2/runtime/sdl/gfx_sdl.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/gfx_sdl.rgr
@@ -586,7 +586,10 @@ static int rgfx_try_open_audio_device(int sampleRate, const char* dev, int chann
     want.samples = 512;
     want.callback = nullptr;
     want.userdata = nullptr;
-    SDL_AudioDeviceID id = SDL_OpenAudioDevice(dev, 0, &want, &have, 0);
+    // Allow freq/channel negotiation: CoreAudio (macOS) often prefers 48 kHz,
+    // and some devices only expose stereo. Exact-match (0) silently fails there.
+    const int allow = SDL_AUDIO_ALLOW_FREQUENCY_CHANGE | SDL_AUDIO_ALLOW_CHANNELS_CHANGE;
+    SDL_AudioDeviceID id = SDL_OpenAudioDevice(dev, 0, &want, &have, allow);
     if (id == 0) {
         fprintf(stderr, \"[rgfx] audio open failed (%s, %d ch): %s\\n\",
             dev != nullptr ? dev : \"default\", channels, SDL_GetError());
@@ -642,7 +645,12 @@ static int rgfx_audio_open(int sampleRate) {
 
     rgfx_log_audio_devices();
 
-    if (rgfx_audio_dummy_only()) {
+    // SDL may report 0 / -1 devices and still open the system default via NULL
+    // (documented for CoreAudio on macOS and remote drivers). Only refuse when
+    // the driver *did* enumerate devices and every one is Dummy — the typical
+    // Linux Pulse/PipeWire-over-SSH fallback.
+    const int nDev = SDL_GetNumAudioDevices(0);
+    if (nDev > 0 && rgfx_audio_dummy_only()) {
         fprintf(stderr, \"[rgfx] Pulse/PipeWire unavailable (Dummy Output)\\n\");
         fprintf(stderr, \"[rgfx] set RANGER_AUDIO_DEVICE=plughw:N,0 (see: aplay -l)\\n\");
         return 0;
@@ -656,7 +664,7 @@ static int rgfx_audio_open(int sampleRate) {
         if (rgfx_try_open_audio_device(sampleRate, nullptr, 1)) { return 1; }
     }
 
-    fprintf(stderr, \"[rgfx] audio: no device — set RANGER_AUDIO_DEVICE=plughw:N,0 (aplay -l)\\n\");
+    fprintf(stderr, \"[rgfx] audio: no device — try default CoreAudio (macOS) or RANGER_AUDIO_DEVICE=plughw:N,0 (Linux)\\n\");
     return 0;
 }
 #include <vector>

--- a/gallery/game_engine/v2/tests/e2e/launcher_e2e_test.rgr
+++ b/gallery/game_engine/v2/tests/e2e/launcher_e2e_test.rgr
@@ -59,8 +59,9 @@ class LauncherE2ETest {
 
         t.ok("host honoured the launch request (fresh realm)" (host.loadLaunched()))
         host.loadFixture("gallery/game_engine/v2/games/ylos2/tests" "probe.tsx")
-        t.eqInt("launched game built its scene (2 players + 12 enemies)"
-            (host.bridge.d2.liveOfType((Rg2DType.sprite()))) 14)
+        ; Match ylos2_e2e: walk + super per player, twelve skeleton enemies.
+        t.eqInt("launched game built its scene (2+2 players + 12 enemies)"
+            (host.bridge.d2.liveOfType((Rg2DType.sprite()))) 16)
         def y0:double (host.callSlot("playerY" 0))
         def f 0
         while (f < 90) {

--- a/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
+++ b/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
@@ -104,6 +104,26 @@ class SdlHostTest {
         def _p:int (snd.pumpAudio(33))
         t.ok("host music stops when the guest stops" ((snd.music.isPlaying()) == false))
 
+        ; ---- host vocal/SFX pump: vocal.play(id) → GameAudio.play ------------
+        ; The bridge accumulates cue strings (rgcore_vocal); the host drains
+        ; them into the shared synth (palette ids: bounce/brick/wall/…).
+        def sfx:RgSdlGameHost (new RgSdlGameHost)
+        sfx.initAudio()
+        t.eqInt("no vocals before any cue" (sfx.pumpVocals()) 0)
+        push sfx.host.bridge.vocalCues "bounce"
+        push sfx.host.bridge.vocalCues "brick"
+        push sfx.host.bridge.vocalCues "cheer"
+        t.eqInt("three vocal cues synthesised" (sfx.pumpVocals()) 3)
+        t.eqStr("last synthesised id retained" sfx.musicAudio.lastId "cheer")
+        t.eqInt("playCount advanced for each cue" sfx.musicAudio.playCount 3)
+        ; a second pump must not re-fire already-drained cues
+        t.eqInt("drained cues are not replayed" (sfx.pumpVocals()) 0)
+        ; a new cue after drain is still picked up (rising-edge index)
+        push sfx.host.bridge.vocalCues "wall"
+        def _n:int (sfx.pumpAudio(33))
+        t.eqInt("pumpAudio drains a new vocal too" sfx.musicAudio.playCount 4)
+        t.eqStr("newest vocal id is wall" sfx.musicAudio.lastId "wall")
+
         t.summary()
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On macOS, `gallery/game_engine/v2` native SDL games (including **ylos3d**) had no audible effects — and often no audio at all.

Two independent gaps:

1. **Device open treated empty enumeration as fatal.** `rgfx_audio_open` returned early when `SDL_GetNumAudioDevices` was ≤ 0 / only Dummy. SDL documents that an empty list is *not* fatal — CoreAudio still opens the system default via `NULL`. Exact-match open (`allowed_changes = 0`) also fails on many macOS devices that prefer 48 kHz / stereo.
2. **Vocal/SFX cues were record-only.** ylos3d calls `runtime.audio.vocal.play("bounce"|"brick"|…)` → bridge `vocalCues`, but `RgSdlGameHost.pumpAudio` only drove music scores. Documented as TODO (`vocalCues` → SDL).

## Fix

- Allow frequency/channel negotiation; only refuse when devices *were* enumerated and all are Dummy (Linux Pulse/SSH case).
- Adopt `gfx_audio_sample_rate()` after open.
- Drain new `vocalCues` each frame via `pumpVocals` → `GameAudio.play` (palette ids: bounce/brick/wall/lose/win/celebrate; unknown names get the default tone).
- Headless coverage in `tests/sdl/sdl_host_test`.
- Align stale launcher e2e sprite count (14 → 16) with ylos2 supers so the v2 gate stays green.

## Test plan

- [x] `bash gallery/game_engine/v2/tests/run.sh` → **v2 ALL GREEN**
- [ ] On macOS with SDL2: `npm run engine:game-sdl:launcher:v2` → ylos3d — jump/stomp/wall/celebrate should be audible; summit music after goal still works
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a925328-7f27-442a-aff2-a2953bea4043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a925328-7f27-442a-aff2-a2953bea4043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

