### PR TITLE
fix(v2/sdl): v1-parity audio — GameVocalFx + CoreAudio reopen

### DIFF
--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -818,7 +818,7 @@ path: same host protocol compiled with `-l=cpp` + `gfx_sdl`.
 ### Follow-ons
 
 - [x] Pane-aware present (`paneCount` → single or split; neutral `clearRgb`)
-- [x] Audio: `vocalCues` → SDL (`pumpVocals` → `GameAudio.play`; one-shots still record-only)
+- [x] Audio: `vocalCues` → SDL (`pumpVocals` → `GameAudio` palette + `GameVocalFx`; one-shots still record-only)
 - [ ] Cross-platform SW screenshot hashes (Node / macOS / Pi)
 
 ### Intentionally out of scope until W+A+B are credible

--- a/gallery/game_engine/v2/audio/game_vocal_fx.rgr
+++ b/gallery/game_engine/v2/audio/game_vocal_fx.rgr
@@ -1,0 +1,666 @@
+; ==============================================================================
+; game_vocal_fx - predefined vocal sound effects for the game engine.
+; ==============================================================================
+; Vendored into v2/audio from scripting/game_vocal_fx.rgr so the native SDL host
+; can play cheer/chuckle/gasp (and the rest of the catalogue) without importing
+; outside v2/. Keep in sync with the scripting copy when the synth changes.
+;
+; Inspired by Voicebox (https://github.com/jamiepine/voicebox), whose
+; "Chatterbox Turbo" TTS interprets paralinguistic tags such as [laugh],
+; [sigh], [gasp] and [cough]. This module gives the Ranger game engine a small
+; catalogue of *named* vocal effects that a game reaches through the engine ABI:
+;
+;   * event route   : update() emits { kind: "playVoice", id: "laugh" }
+;   * native route  : a script calls laugh() / voice("sigh") (see the bridge)
+;
+; Each effect maps to a Voicebox paralinguistic tag when one exists (laugh,
+; sigh, gasp, cough) and otherwise to an engine-only extension (cheer, boo,
+; hmm, huh, yawn, giggle, chuckle). So the same catalogue can drive:
+;
+;   * a built-in procedural VOICE SYNTH (works headless / SDL, no desktop app),
+;   * or a real Voicebox render dropped in as a 16-bit mono WAV asset, which
+;     overrides the synth when registered (registerAssetWav).
+;
+; The synth is deliberately small: a glottal pitch glide + a few vowel formant
+; harmonics + breath noise, gated into bursts. It is not speech, but "ha-ha",
+; a breathy sigh, a sharp gasp and a cough are all clearly recognisable.
+; ==============================================================================
+
+Import "./game_audio.rgr"
+
+; One predefined vocal expression.
+class VoiceSpec {
+    def name:string ""
+    def tag:string ""          ; Voicebox paralinguistic tag, e.g. "[laugh]"
+    def native:boolean false   ; true = real Voicebox tag; false = engine extension
+    def vowel:string "ah"      ; formant colour: ah | oo | ee | uh | mm
+    def envShape:string "pluck" ; pluck | swell | rise | fall
+    def basePitchHz:double 300.0
+    def endPitchHz:double 300.0 ; linear pitch glide target across the effect
+    def bursts:int 1           ; repeated syllables ("ha-ha-ha")
+    def burstMs:int 200        ; voiced length of one burst
+    def gapMs:int 0            ; silence between bursts
+    def breath:double 0.3      ; 0..1 mix of breath noise over the voiced tone
+    def vibrato:double 0.0     ; pitch wobble depth
+    def volume:double 0.32
+}
+
+class GameVocalFx {
+    ; Own a private GameAudio purely for its stateless synth helpers
+    ; (sine table + noise). Playback uses the shared sink passed to play().
+    def synth:GameAudio (new GameAudio)
+    def playCount:int 0
+    def lastId:string ""
+    def verbose:boolean false
+
+    ; Pre-rendered Voicebox WAV overrides (16-bit mono PCM), keyed by effect name.
+    def assetPcm:[string:buffer]
+    def assetFrames:[string:int]
+    ; Registered override ids. A string-list membership test is reliable on every
+    ; target; probing an int/buffer map for a MISSING key returns has_value=true
+    ; under the C++ backend (empty map), which wrongly sent every effect down the
+    ; empty-asset path -> 0 bytes -> silent voices in the SDL host.
+    def assetIds:[string]
+    ; Optional per-asset metadata from a sibling <id>.info file (key=value):
+    ; text = what the clip says (subtitles / accessibility), lang = fi | en | ...
+    def assetText:[string:string]
+    def assetLang:[string:string]
+
+    fn init:void () {
+        synth.init()
+    }
+
+    fn sampleRate:int () {
+        return synth.sampleRate
+    }
+
+    ; --- catalogue -----------------------------------------------------------
+
+    fn names:[string] () {
+        def out:[string]
+        push out "laugh"
+        push out "giggle"
+        push out "chuckle"
+        push out "sigh"
+        push out "gasp"
+        push out "cough"
+        push out "cheer"
+        push out "boo"
+        push out "hmm"
+        push out "huh"
+        push out "yawn"
+        return out
+    }
+
+    fn has:boolean (id:string) {
+        def all:[string] (this.names())
+        def i 0
+        while (i < (array_length all)) {
+            if ((itemAt all i) == id) {
+                return true
+            }
+            i = (i + 1)
+        }
+        return false
+    }
+
+    fn tagFor:string (id:string) {
+        def spec:VoiceSpec (this.lookupSpec(id))
+        return spec.tag
+    }
+
+    fn isNative:boolean (id:string) {
+        def spec:VoiceSpec (this.lookupSpec(id))
+        return spec.native
+    }
+
+    ; Named expression -> synth + tag parameters. Mirrors GameAudio.lookupSpec.
+    fn lookupSpec:VoiceSpec (id:string) {
+        def s:VoiceSpec (new VoiceSpec)
+        s.name = id
+        if (id == "laugh") {
+            s.tag = "[laugh]"
+            s.native = true
+            s.vowel = "ah"
+            s.envShape = "pluck"
+            s.basePitchHz = 320.0
+            s.endPitchHz = 250.0
+            s.bursts = 4
+            s.burstMs = 120
+            s.gapMs = 70
+            s.breath = 0.25
+            s.vibrato = 0.02
+            s.volume = 0.34
+            return s
+        }
+        if (id == "giggle") {
+            s.tag = "[laugh]"
+            s.native = true
+            s.vowel = "ee"
+            s.envShape = "pluck"
+            s.basePitchHz = 500.0
+            s.endPitchHz = 440.0
+            s.bursts = 5
+            s.burstMs = 80
+            s.gapMs = 55
+            s.breath = 0.2
+            s.vibrato = 0.03
+            s.volume = 0.30
+            return s
+        }
+        if (id == "chuckle") {
+            s.tag = "[laugh]"
+            s.native = true
+            s.vowel = "uh"
+            s.envShape = "pluck"
+            s.basePitchHz = 250.0
+            s.endPitchHz = 210.0
+            s.bursts = 3
+            s.burstMs = 135
+            s.gapMs = 95
+            s.breath = 0.3
+            s.vibrato = 0.015
+            s.volume = 0.30
+            return s
+        }
+        if (id == "sigh") {
+            s.tag = "[sigh]"
+            s.native = true
+            s.vowel = "ah"
+            s.envShape = "swell"
+            s.basePitchHz = 300.0
+            s.endPitchHz = 185.0
+            s.bursts = 1
+            s.burstMs = 750
+            s.gapMs = 0
+            s.breath = 0.55
+            s.vibrato = 0.01
+            s.volume = 0.30
+            return s
+        }
+        if (id == "gasp") {
+            s.tag = "[gasp]"
+            s.native = true
+            s.vowel = "ah"
+            s.envShape = "rise"
+            s.basePitchHz = 340.0
+            s.endPitchHz = 620.0
+            s.bursts = 1
+            s.burstMs = 260
+            s.gapMs = 0
+            s.breath = 0.6
+            s.vibrato = 0.0
+            s.volume = 0.34
+            return s
+        }
+        if (id == "cough") {
+            s.tag = "[cough]"
+            s.native = true
+            s.vowel = "uh"
+            s.envShape = "pluck"
+            s.basePitchHz = 180.0
+            s.endPitchHz = 150.0
+            s.bursts = 2
+            s.burstMs = 110
+            s.gapMs = 95
+            s.breath = 0.5
+            s.vibrato = 0.0
+            s.volume = 0.40
+            return s
+        }
+        if (id == "cheer") {
+            s.tag = "[cheer]"
+            s.native = false
+            s.vowel = "ah"
+            s.envShape = "rise"
+            s.basePitchHz = 400.0
+            s.endPitchHz = 700.0
+            s.bursts = 1
+            s.burstMs = 620
+            s.gapMs = 0
+            s.breath = 0.3
+            s.vibrato = 0.04
+            s.volume = 0.32
+            return s
+        }
+        if (id == "boo") {
+            s.tag = "[boo]"
+            s.native = false
+            s.vowel = "oo"
+            s.envShape = "fall"
+            s.basePitchHz = 260.0
+            s.endPitchHz = 150.0
+            s.bursts = 1
+            s.burstMs = 520
+            s.gapMs = 0
+            s.breath = 0.25
+            s.vibrato = 0.02
+            s.volume = 0.32
+            return s
+        }
+        if (id == "hmm") {
+            s.tag = "[hmm]"
+            s.native = false
+            s.vowel = "mm"
+            s.envShape = "swell"
+            s.basePitchHz = 210.0
+            s.endPitchHz = 190.0
+            s.bursts = 1
+            s.burstMs = 430
+            s.gapMs = 0
+            s.breath = 0.15
+            s.vibrato = 0.01
+            s.volume = 0.26
+            return s
+        }
+        if (id == "huh") {
+            s.tag = "[huh]"
+            s.native = false
+            s.vowel = "uh"
+            s.envShape = "rise"
+            s.basePitchHz = 240.0
+            s.endPitchHz = 300.0
+            s.bursts = 1
+            s.burstMs = 300
+            s.gapMs = 0
+            s.breath = 0.35
+            s.vibrato = 0.0
+            s.volume = 0.30
+            return s
+        }
+        if (id == "yawn") {
+            s.tag = "[yawn]"
+            s.native = false
+            s.vowel = "ah"
+            s.envShape = "swell"
+            s.basePitchHz = 240.0
+            s.endPitchHz = 200.0
+            s.bursts = 1
+            s.burstMs = 850
+            s.gapMs = 0
+            s.breath = 0.4
+            s.vibrato = 0.02
+            s.volume = 0.30
+            return s
+        }
+        ; Unknown id -> neutral short "uh".
+        s.tag = "[speak]"
+        s.native = false
+        s.vowel = "uh"
+        s.envShape = "pluck"
+        s.basePitchHz = 240.0
+        s.endPitchHz = 220.0
+        s.bursts = 1
+        s.burstMs = 200
+        s.gapMs = 0
+        s.breath = 0.3
+        s.vibrato = 0.0
+        s.volume = 0.30
+        return s
+    }
+
+    ; --- vocal synthesis -----------------------------------------------------
+
+    ; Weighted formant harmonics approximate a vowel colour.
+    fn vowelSample:double (vowel:string phase:double) {
+        def s:double (synth.sampleSine(phase))
+        def p2:double (synth.harmPhase(phase 2))
+        def p3:double (synth.harmPhase(phase 3))
+        def p4:double (synth.harmPhase(phase 4))
+        def p5:double (synth.harmPhase(phase 5))
+        if (vowel == "ah") {
+            s = (s + (0.60 * (synth.sampleSine(p2))))
+            s = (s + (0.40 * (synth.sampleSine(p3))))
+            s = (s + (0.24 * (synth.sampleSine(p4))))
+            s = (s + (0.14 * (synth.sampleSine(p5))))
+            return (s * 0.42)
+        }
+        if (vowel == "ee") {
+            s = (s * 0.7)
+            s = (s + (0.50 * (synth.sampleSine(p2))))
+            s = (s + (0.62 * (synth.sampleSine(p3))))
+            s = (s + (0.34 * (synth.sampleSine(p4))))
+            return (s * 0.40)
+        }
+        if (vowel == "oo") {
+            s = (s + (0.30 * (synth.sampleSine(p2))))
+            s = (s + (0.10 * (synth.sampleSine(p3))))
+            return (s * 0.58)
+        }
+        if (vowel == "mm") {
+            s = (s + (0.20 * (synth.sampleSine(p2))))
+            return (s * 0.62)
+        }
+        ; "uh" — mid, slightly darker than ah.
+        s = (s + (0.45 * (synth.sampleSine(p2))))
+        s = (s + (0.22 * (synth.sampleSine(p3))))
+        s = (s + (0.10 * (synth.sampleSine(p4))))
+        return (s * 0.46)
+    }
+
+    ; Burst amplitude envelope in [0,1] for local burst time bt in [0,1].
+    fn burstEnv:double (shape:string bt:double) {
+        if (shape == "swell") {
+            ; smooth hump: 0 -> 1 -> 0
+            def x:double (bt * 3.14159265)
+            return (synth.sampleSine((x / 6.283185307)))
+        }
+        if (shape == "rise") {
+            def atk:double 0.75
+            if (bt < atk) {
+                def u:double (bt / atk)
+                return (u * u)
+            }
+            def d:double ((bt - atk) / (1.0 - atk))
+            return (1.0 - d)
+        }
+        if (shape == "fall") {
+            def atk:double 0.12
+            if (bt < atk) {
+                return (bt / atk)
+            }
+            def d:double ((bt - atk) / (1.0 - atk))
+            return (1.0 - (d * d))
+        }
+        ; "pluck" — fast attack, quadratic decay.
+        def atk:double 0.10
+        if (bt < atk) {
+            return (bt / atk)
+        }
+        def d:double ((bt - atk) / (1.0 - atk))
+        def env:double (1.0 - d)
+        return (env * env)
+    }
+
+    ; Render one expression to mono 16-bit PCM.
+    fn render:ScoreVoiceRender (id:string) {
+        def out:ScoreVoiceRender (new ScoreVoiceRender)
+        def spec:VoiceSpec (this.lookupSpec(id))
+        def sr:int synth.sampleRate
+        def periodMs:int (spec.burstMs + spec.gapMs)
+        def totalMs:int (periodMs * spec.bursts)
+        if (totalMs < 40) {
+            totalMs = 40
+        }
+        def frames:int (to_int (((to_double totalMs) * (to_double sr)) / 1000.0))
+        if (frames < 1) {
+            frames = 1
+        }
+        def burstFrames:int (to_int (((to_double spec.burstMs) * (to_double sr)) / 1000.0))
+        if (burstFrames < 1) {
+            burstFrames = 1
+        }
+        def periodFrames:int (to_int (((to_double periodMs) * (to_double sr)) / 1000.0))
+        if (periodFrames < 1) {
+            periodFrames = 1
+        }
+        def pcm:buffer (buffer_alloc (frames * 2))
+        def phase:double 0.0
+        def pluck:boolean (spec.envShape == "pluck")
+        def i 0
+        while (i < frames) {
+            def t:double ((to_double i) / (to_double frames))
+            def pitch:double (spec.basePitchHz + ((spec.endPitchHz - spec.basePitchHz) * t))
+            ; Jitter: slow incommensurate wobble = vocal-fold micro-variation.
+            ; Without it a steady tone reads as a synth/harmonica, not a voice.
+            def jit:double (1.0 + (0.014 * (synth.sampleSine((to_double i) / 301.0))) + (0.008 * (synth.sampleSine((to_double i) / 173.0))))
+            pitch = (pitch * jit)
+            if (spec.vibrato > 0.0) {
+                def vib:double (1.0 + (spec.vibrato * (synth.sampleSine((to_double i) / 210.0))))
+                pitch = (pitch * vib)
+            }
+            def burstIdx:int (to_int (i / periodFrames))
+            def localFrame:int (i - (burstIdx * periodFrames))
+            def env:double 0.0
+            def breathNow:double spec.breath
+            if (localFrame < burstFrames) {
+                def bt:double ((to_double localFrame) / (to_double burstFrames))
+                env = (this.burstEnv(spec.envShape bt))
+                ; later syllables of a laugh sag a little
+                def sag:double (1.0 - (0.12 * (to_double burstIdx)))
+                if (sag < 0.4) { sag = 0.4 }
+                env = (env * sag)
+                if (pluck) {
+                    ; Each syllable ("ha") starts high and falls — natural contour.
+                    def arc:double (1.0 + (0.22 * (1.0 - bt) * (1.0 - bt)))
+                    pitch = (pitch * arc)
+                    ; Breathy [h] aspiration at the onset, easing into the vowel.
+                    if (bt < 0.20) {
+                        def hmix:double (1.0 - (bt / 0.20))
+                        breathNow = (spec.breath + ((1.0 - spec.breath) * hmix))
+                    }
+                }
+            }
+            def voiced:double (this.vowelSample(spec.vowel phase))
+            def noise:double (synth.sampleInstrument("drums" phase i))
+            def sample:double ((voiced * (1.0 - breathNow)) + (noise * breathNow))
+            ; Clamp to unity: summed formants (and the shared sine table's Taylor
+            ; overshoot near wrap) can exceed 1.0, which would hit the rail.
+            if (sample > 1.0) { sample = 1.0 }
+            if (sample < -1.0) { sample = -1.0 }
+            ; Shimmer: small amplitude wobble (also anti-synthetic).
+            def shim:double (1.0 + (0.06 * (synth.sampleSine((to_double i) / 97.0))))
+            def amp:double (sample * spec.volume * env * shim * 0.92 * 32767.0)
+            ; short fade at the very end to avoid a click
+            if (i >= (frames - 12)) {
+                def tail:int (frames - i)
+                amp = (amp * ((to_double tail) / 12.0))
+            }
+            def iv:int (to_int amp)
+            if (iv > 32767) { iv = 32767 }
+            if (iv < -32768) { iv = -32768 }
+            def v:int iv
+            if (v < 0) {
+                v = (65536 + v)
+            }
+            def lo:int (bit_and v 255)
+            def hi:int (bit_and (to_int (v / 256)) 255)
+            def off:int (i * 2)
+            buffer_set pcm off lo
+            buffer_set pcm (off + 1) hi
+            phase = (phase + (pitch / (to_double sr)))
+            phase = (synth.wrapPhase(phase))
+            i = (i + 1)
+        }
+        out.pcm = pcm
+        out.frames = frames
+        return out
+    }
+
+    ; --- Voicebox WAV asset overrides ---------------------------------------
+
+    ; Register pre-rendered PCM (e.g. exported from the Voicebox desktop app).
+    fn registerAsset:void (id:string pcm:buffer frames:int) {
+        set assetPcm id pcm
+        set assetFrames id frames
+        if (false == (this.hasAsset(id))) {
+            push assetIds id
+        }
+    }
+
+    fn hasAsset:boolean (id:string) {
+        ; Explicit membership test — reliable on every target (see assetIds note).
+        def i 0
+        while (i < (array_length assetIds)) {
+            if ((itemAt assetIds i) == id) {
+                return true
+            }
+            i = (i + 1)
+        }
+        return false
+    }
+
+    ; Little-endian readers over a raw file buffer.
+    fn rdU16:int (b:buffer off:int) {
+        return ((buffer_get b off) + ((buffer_get b (off + 1)) * 256))
+    }
+
+    fn rdU32:int (b:buffer off:int) {
+        def v0:int (buffer_get b off)
+        def v1:int (buffer_get b (off + 1))
+        def v2:int (buffer_get b (off + 2))
+        def v3:int (buffer_get b (off + 3))
+        return (v0 + (v1 * 256) + (v2 * 65536) + (v3 * 16777216))
+    }
+
+    ; True when the 4 bytes at off equal the given ASCII codes (chunk tag).
+    fn tag4:boolean (b:buffer off:int a:int c:int d:int e:int) {
+        if ((buffer_get b off) != a) { return false }
+        if ((buffer_get b (off + 1)) != c) { return false }
+        if ((buffer_get b (off + 2)) != d) { return false }
+        if ((buffer_get b (off + 3)) != e) { return false }
+        return true
+    }
+
+    ; Load a 16-bit PCM WAV as an override for `id`. Walks the RIFF chunks (so a
+    ; real file with LIST/fact/etc. before `data` still works), downmixes stereo
+    ; to mono. Best at the audio device rate (44100 Hz) — a different rate plays
+    ; back at the wrong speed because the SDL device rate is fixed.
+    fn registerAssetWav:boolean (id:string dir:string file:string) {
+        def raw:buffer (buffer_read_file dir file)
+        def total:int (buffer_length raw)
+        if (total < 44) { return false }
+        if (false == (this.tag4(raw 0 82 73 70 70))) { return false }   ; "RIFF"
+        if (false == (this.tag4(raw 8 87 65 86 69))) { return false }   ; "WAVE"
+        def channels:int 1
+        def bits:int 16
+        def dataOff:int -1
+        def dataLen:int 0
+        def p:int 12
+        while ((p + 8) <= total) {
+            def csize:int (this.rdU32(raw (p + 4)))
+            def body:int (p + 8)
+            if (this.tag4(raw p 102 109 116 32)) {    ; "fmt "
+                channels = (this.rdU16(raw (body + 2)))
+                bits = (this.rdU16(raw (body + 14)))
+            }
+            if (this.tag4(raw p 100 97 116 97)) {      ; "data"
+                dataOff = body
+                dataLen = csize
+            }
+            def adv:int csize
+            if ((bit_and adv 1) == 1) { adv = (adv + 1) }
+            p = (body + adv)
+        }
+        if (dataOff < 0) { return false }
+        if (bits != 16) { return false }
+        if (channels < 1) { channels = 1 }
+        if ((dataOff + dataLen) > total) { dataLen = (total - dataOff) }
+        def frameBytes:int (2 * channels)
+        def frames:int (to_int (dataLen / frameBytes))
+        if (frames < 1) { return false }
+        def pcm:buffer (buffer_alloc (frames * 2))
+        def fi 0
+        while (fi < frames) {
+            def base:int (dataOff + (fi * frameBytes))
+            def sum:int 0
+            def ch 0
+            while (ch < channels) {
+                def o:int (base + (ch * 2))
+                def sv:int ((buffer_get raw o) + ((buffer_get raw (o + 1)) * 256))
+                if (sv >= 32768) { sv = (sv - 65536) }
+                sum = (sum + sv)
+                ch = (ch + 1)
+            }
+            def m:int (to_int (sum / channels))
+            if (m > 32767) { m = 32767 }
+            if (m < -32768) { m = -32768 }
+            def uv:int m
+            if (uv < 0) { uv = (65536 + uv) }
+            def outOff:int (fi * 2)
+            buffer_set pcm outOff (bit_and uv 255)
+            buffer_set pcm (outOff + 1) (bit_and (to_int (uv / 256)) 255)
+            fi = (fi + 1)
+        }
+        this.registerAsset(id pcm frames)
+        return true
+    }
+
+    ; --- .info metadata (subtitles / language / accessibility) ---------------
+
+    fn registerAssetInfo:void (id:string lang:string text:string) {
+        set assetLang id lang
+        set assetText id text
+    }
+
+    fn textFor:string (id:string) {
+        def v@(optional):string (get assetText id)
+        if (!null? v) {
+            return (unwrap v)
+        }
+        return ""
+    }
+
+    fn langFor:string (id:string) {
+        def v@(optional):string (get assetLang id)
+        if (!null? v) {
+            return (unwrap v)
+        }
+        return ""
+    }
+
+    ; Parse a sibling `<id>.info` file: key=value lines, `lang=` and `text=`.
+    ; A line without `=` is ignored; everything after the first `=` is the value.
+    fn loadAssetInfo:boolean (id:string dir:string file:string) {
+        def raw:buffer (buffer_read_file dir file)
+        def txt:string (buffer_to_string raw)
+        def lang:string ""
+        def text:string ""
+        def line:string ""
+        def i 0
+        def n:int (strlen txt)
+        while (i <= n) {
+            def atEnd:boolean (i == n)
+            def ch:string ""
+            if (false == atEnd) {
+                ch = (substring txt i (i + 1))
+            }
+            if (atEnd || (ch == "\n")) {
+                def eq:int (indexOf line "=")
+                if (eq > 0) {
+                    def key:string (substring line 0 eq)
+                    def val:string (substring line (eq + 1) (strlen line))
+                    if (key == "lang") { lang = val }
+                    if (key == "text") { text = val }
+                }
+                line = ""
+            } {
+                if (ch != "\r") {
+                    line = (line + ch)
+                }
+            }
+            i = (i + 1)
+        }
+        this.registerAssetInfo(id lang text)
+        return true
+    }
+
+    ; --- playback ------------------------------------------------------------
+
+    ; Render (or fetch the WAV override) and hand the PCM to a shared sink.
+    fn play:void (id:string sink:GameAudioSink) {
+        playCount = (playCount + 1)
+        lastId = id
+        if verbose {
+            print ("[vocalfx] play " + id + " " + (this.tagFor(id)))
+        }
+        if (this.hasAsset(id)) {
+            def pcm@(optional):buffer (get assetPcm id)
+            def fr@(optional):int (get assetFrames id)
+            def frames:int 0
+            if (!null? fr) {
+                frames = (unwrap fr)
+            }
+            ; Only use the override when it truly has audio; otherwise synthesize.
+            if (frames > 0) {
+                sink.onSynthPlay(("voice:" + id) synth.sampleRate frames (unwrap pcm))
+                return
+            }
+        }
+        def rendered:ScoreVoiceRender (this.render(id))
+        if (rendered.frames <= 0) {
+            return
+        }
+        sink.onSynthPlay(("voice:" + id) synth.sampleRate rendered.frames rendered.pcm)
+    }
+}

--- a/gallery/game_engine/v2/runtime/sdl/README.md
+++ b/gallery/game_engine/v2/runtime/sdl/README.md
@@ -71,19 +71,19 @@ pad through `gfx_rumble_pad`.
 
 A guest's `runtime.audio.music.play(score)` and `runtime.audio.vocal.play(id)`
 are recorded on the bridge (`rgcore_music_play` / `rgcore_vocal`); the host owns
-playback. `initAudio()` opens the SDL audio device and builds the synth;
-`pumpAudio(dt)` (called each game frame) drains new vocal cues into
-`GameAudio.play` (palette ids like `bounce`/`brick`/`wall`/`celebrate`), then
-picks up a newly-played score, ticks its beat schedule, and each due note
-synthesises PCM that `RgSdlAudioSink` queues via `gfx_audio_queue`. The
-synth/parser stack lives under `v2/audio` (`game_soundscore` + `game_audio`,
-self-contained). The guest only ever said "play" — the schedule clock, synth,
-and device are all host-side.
+playback — same split as v1 (`playSound` → `GameAudio`, `playVoice` →
+`GameVocalFx`, music → score player). `initAudio()` opens the SDL audio device
+and builds the synth; `pumpAudio(dt)` (called each game frame) drains new vocal
+cues: catalogue voices (`cheer`/`chuckle`/`gasp`/…) through `GameVocalFx`,
+palette SFX (`bounce`/`brick`/`wall`/`celebrate`/…) through `GameAudio.play`,
+then ticks any playing score. PCM goes to `RgSdlAudioSink` → `gfx_audio_queue`.
+Stack under `v2/audio` (`game_soundscore` + `game_audio` + `game_vocal_fx`).
 
-Device open notes (macOS): empty `SDL_GetNumAudioDevices` is not treated as
-fatal — CoreAudio still opens the system default via `NULL`. Frequency/channel
-negotiation is allowed so a 48 kHz device is accepted; the host adopts
-`gfx_audio_sample_rate()` after open.
+Device open notes (macOS): default `SDL_AUDIODRIVER=coreaudio`; empty
+`SDL_GetNumAudioDevices` is not fatal (open system default via `NULL`);
+frequency/channel negotiation is allowed; host adopts `gfx_audio_sample_rate()`
+and retunes `GameVocalFx` to match. `gfx_close` clears `audioReady` so a
+launcher → game → launcher relaunch reopens the device.
 
 > The final SDL2 **link** needs SDL2 headers, which are absent in CI — so the
 > headless suite compile-checks the host, validates the Ranger→C++ codegen, and

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
@@ -28,6 +28,7 @@ Import "../game_host/RgGameHost.rgr"
 Import "../game_host/Rg2DPresenter.rgr"
 Import "../../menu/RgLauncherUi.rgr"
 Import "../../audio/game_soundscore.rgr"
+Import "../../audio/game_vocal_fx.rgr"
 Import "./gfx_sdl.rgr"
 
 ; The SDL audio sink: the score synth calls onSynthPlay with a PCM buffer as each
@@ -56,12 +57,19 @@ class RgSdlGameHost {
     ; last observed haptic counts, to forward only NEW rumble commands to SDL
     def lastRumble0:int 0
     def lastRumble1:int 0
-    ; host-side music + SFX playback: the guest's runtime.audio.music.play(score)
-    ; and runtime.audio.vocal.play(id) are recorded on the bridge; the host owns
-    ; the synth + schedule clock and pushes PCM to SDL. (Nothing here is game
-    ; logic; the guest only ever said "play".)
+    ; host-side music + SFX + voice playback (v1 parity):
+    ;   runtime.audio.music.play(score)  → SoundScorePlayer → GameAudio synth
+    ;   runtime.audio.vocal.play(id)     → GameAudio palette (bounce/brick/…)
+    ;                                    OR GameVocalFx (cheer/chuckle/gasp/…)
+    ; Both are recorded on the bridge; the host owns the synth clock and pushes
+    ; PCM to SDL. (Nothing here is game logic; the guest only ever said "play".)
     def musicAudio:GameAudio (new GameAudio)
     def music:SoundScorePlayer (new SoundScorePlayer)
+    def vocalFx:GameVocalFx (new GameVocalFx)
+    def audioSink:RgSdlAudioSink (new RgSdlAudioSink)
+    ; synth tables / sink wired (independent of whether the device opened)
+    def audioInited:boolean false
+    ; native device currently open (false under es6 stubs; false after gfx_close)
     def audioReady:boolean false
     def lastScore:string ""
     ; Index into bridge.vocalCues already synthesised (same rising-edge pattern
@@ -119,33 +127,54 @@ class RgSdlGameHost {
         gfx_present_split (fbL.toRgbaBuffer()) (fbR.toRgbaBuffer()) this.paneW this.paneH
     }
 
-    ; Bring up the host synth once: build its frequency tables, open the SDL audio
-    ; device, and route synthesised PCM to it. Idempotent; native device is a
-    ; no-op under es6. After open, adopt the device's negotiated sample rate
-    ; (CoreAudio often hands back 48 kHz).
+    ; Mark the native device closed. gfx_close / SDL_Quit tear the device down;
+    ; the next initAudio must reopen it (do NOT leave audioReady stuck true).
+    fn resetAudioDevice:void () {
+        this.audioReady = false
+        this.lastVocal = 0
+        this.lastScore = ""
+    }
+
+    ; Bring up the host synth (once) and (re)open the SDL audio device.
+    ; Mirrors v1 game_sdl_runner: open after the window, adopt the negotiated
+    ; sample rate, and retune GameVocalFx to match. Safe to call every run() —
+    ; gfx_close clears the device, so relaunch must reopen.
     fn initAudio:void () {
-        if (this.audioReady) { return }
-        this.musicAudio.init()
-        def sink:RgSdlAudioSink (new RgSdlAudioSink)
-        this.musicAudio.sink = sink
-        this.music.audio = this.musicAudio
-        def _o:int (gfx_audio_open 44100)
+        if (this.audioInited == false) {
+            this.musicAudio.init()
+            this.vocalFx.init()
+            this.musicAudio.sink = this.audioSink
+            this.music.audio = this.musicAudio
+            this.audioInited = true
+        }
+        def opened:int (gfx_audio_open 44100)
         def rate:int (gfx_audio_sample_rate)
         if (rate > 0) {
             this.musicAudio.sampleRate = rate
+            this.vocalFx.synth.sampleRate = rate
         }
-        this.audioReady = true
+        if (opened != 0) {
+            this.audioReady = true
+        } {
+            this.audioReady = false
+        }
     }
 
-    ; Drain newly-recorded vocal cues (runtime.audio.vocal.play) into the synth.
-    ; Returns how many cues were synthesised this call (testable headlessly).
+    ; Drain newly-recorded vocal cues (runtime.audio.vocal.play).
+    ; Voice catalogue ids (cheer/chuckle/gasp/…) → GameVocalFx (v1 path);
+    ; palette SFX (bounce/brick/wall/…) → GameAudio.play. Returns how many
+    ; cues were synthesised this call (testable headlessly).
     fn pumpVocals:int () {
         def b:RgRegistryBridge this.host.bridge
         def n:int (array_length b.vocalCues)
         def started:int 0
         while (this.lastVocal < n) {
             def id:string (itemAt b.vocalCues this.lastVocal)
-            this.musicAudio.play(id)
+            if (this.vocalFx.has(id)) {
+                this.vocalFx.play(id this.audioSink)
+            } {
+                this.musicAudio.play(id)
+            }
             this.lastVocal = (this.lastVocal + 1)
             started = (started + 1)
         }
@@ -221,9 +250,11 @@ class RgSdlGameHost {
                 def d:string (ui.selectedDir())
                 def f:string (ui.selectedFile())
                 gfx_close
+                this.resetAudioDevice()
                 def _g:int (this.run(d f))
                 ; back from the game: reopen the launcher and resume on categories
                 gfx_clear_should_close
+                this.resetAudioDevice()
                 if ((gfx_open "Ranger" lw lh) == 0) { return 1 }
                 ui.back()
                 prev = 0
@@ -235,6 +266,7 @@ class RgSdlGameHost {
             }
         }
         gfx_close
+        this.resetAudioDevice()
         return 1
     }
 
@@ -276,6 +308,7 @@ class RgSdlGameHost {
             if (gfx_should_close) { go = false }
         }
         gfx_close
+        this.resetAudioDevice()
         return 1
     }
 }

--- a/gallery/game_engine/v2/runtime/sdl/gfx_sdl.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/gfx_sdl.rgr
@@ -496,15 +496,22 @@ static void rgfx_prepare_audio_env() {
         fprintf(stderr, \"[rgfx] RANGER_AUDIO_DEVICE=%s → SDL_AUDIODRIVER=alsa\\n\", dev);
         return;
     }
-    const char* existing = getenv(\"SDL_AUDIODRIVER\");
-    if (existing != nullptr && existing[0] != '\\0') {
-        fprintf(stderr, \"[rgfx] SDL_AUDIODRIVER=%s (from env)\\n\", existing);
-        return;
-    }
     const char* ranger = getenv(\"RANGER_SDL_AUDIO_DRIVER\");
     if (ranger != nullptr && ranger[0] != '\\0') {
         SDL_setenv(\"SDL_AUDIODRIVER\", ranger, 1);
         fprintf(stderr, \"[rgfx] SDL_AUDIODRIVER=%s (RANGER_SDL_AUDIO_DRIVER)\\n\", ranger);
+        return;
+    }
+#if defined(__APPLE__)
+    // macOS: always pin CoreAudio. A stale SDL_AUDIODRIVER=pulse/alsa from a
+    // shared shell profile otherwise selects a missing driver → silent output.
+    SDL_setenv(\"SDL_AUDIODRIVER\", \"coreaudio\", 1);
+    fprintf(stderr, \"[rgfx] SDL_AUDIODRIVER=coreaudio (macOS default)\\n\");
+    return;
+#endif
+    const char* existing = getenv(\"SDL_AUDIODRIVER\");
+    if (existing != nullptr && existing[0] != '\\0') {
+        fprintf(stderr, \"[rgfx] SDL_AUDIODRIVER=%s (from env)\\n\", existing);
         return;
     }
 #if defined(__linux__)

--- a/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
+++ b/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
@@ -104,9 +104,9 @@ class SdlHostTest {
         def _p:int (snd.pumpAudio(33))
         t.ok("host music stops when the guest stops" ((snd.music.isPlaying()) == false))
 
-        ; ---- host vocal/SFX pump: vocal.play(id) → GameAudio.play ------------
+        ; ---- host vocal/SFX pump (v1 parity: palette + GameVocalFx) ----------
         ; The bridge accumulates cue strings (rgcore_vocal); the host drains
-        ; them into the shared synth (palette ids: bounce/brick/wall/…).
+        ; palette ids through GameAudio and voice ids through GameVocalFx.
         def sfx:RgSdlGameHost (new RgSdlGameHost)
         sfx.initAudio()
         t.eqInt("no vocals before any cue" (sfx.pumpVocals()) 0)
@@ -114,15 +114,29 @@ class SdlHostTest {
         push sfx.host.bridge.vocalCues "brick"
         push sfx.host.bridge.vocalCues "cheer"
         t.eqInt("three vocal cues synthesised" (sfx.pumpVocals()) 3)
-        t.eqStr("last synthesised id retained" sfx.musicAudio.lastId "cheer")
-        t.eqInt("playCount advanced for each cue" sfx.musicAudio.playCount 3)
+        ; bounce/brick hit GameAudio; cheer is a GameVocalFx catalogue id
+        t.eqStr("last palette id is brick" sfx.musicAudio.lastId "brick")
+        t.eqInt("two palette SFX synthesised" sfx.musicAudio.playCount 2)
+        t.eqStr("cheer went through GameVocalFx" sfx.vocalFx.lastId "cheer")
+        t.eqInt("one voice effect synthesised" sfx.vocalFx.playCount 1)
         ; a second pump must not re-fire already-drained cues
         t.eqInt("drained cues are not replayed" (sfx.pumpVocals()) 0)
         ; a new cue after drain is still picked up (rising-edge index)
         push sfx.host.bridge.vocalCues "wall"
         def _n:int (sfx.pumpAudio(33))
-        t.eqInt("pumpAudio drains a new vocal too" sfx.musicAudio.playCount 4)
-        t.eqStr("newest vocal id is wall" sfx.musicAudio.lastId "wall")
+        t.eqInt("pumpAudio drains a new palette vocal too" sfx.musicAudio.playCount 3)
+        t.eqStr("newest palette id is wall" sfx.musicAudio.lastId "wall")
+        ; chuckle (voice) vs bounce (palette) in one pump
+        push sfx.host.bridge.vocalCues "chuckle"
+        push sfx.host.bridge.vocalCues "bounce"
+        t.eqInt("mixed voice+sfx pump" (sfx.pumpVocals()) 2)
+        t.eqStr("chuckle via GameVocalFx" sfx.vocalFx.lastId "chuckle")
+        t.eqInt("voice playCount is 2" sfx.vocalFx.playCount 2)
+        t.eqInt("palette playCount is 4" sfx.musicAudio.playCount 4)
+        ; relaunch must reopen the device flag (gfx_close clears it)
+        sfx.audioReady = true
+        sfx.resetAudioDevice()
+        t.no("resetAudioDevice clears audioReady" sfx.audioReady)
 
         t.summary()
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Follow-up to merged #438. macOS was still silent: palette SFX wiring alone was not enough, and v2 was missing v1’s voice path.

## Answers to the investigation

**Do ylos2 / ylos3d use audio effects on v2?** Yes. Both call `runtime.audio.vocal.play` for `bounce`/`brick`/`wall`/`lose`/`win`/`celebrate`/`cheer`/`chuckle`/`gasp`, plus `music.play` at the goal.

**How does v1 do it?** Guest events → `GameHost.handleEvent`:
- `playSound` → `GameAudio.play` (palette)
- `playVoice` → `GameVocalFx.play` (formant synth)
- music → `SoundScorePlayer` → same SDL sink

## This fix

- Vendor `game_vocal_fx.rgr` into `v2/audio`
- `pumpVocals`: voice catalogue → `GameVocalFx`, palette ids → `GameAudio`
- Force `SDL_AUDIODRIVER=coreaudio` on macOS
- Reset/reopen audio after every `gfx_close` (launcher ↔ game)
- Retune both synths to the device sample rate (v1 did this for voices)

## Test plan

- [x] `bash gallery/game_engine/v2/tests/run.sh` → v2 ALL GREEN
- [ ] macOS: **rebuild** `npm run engine:game-sdl:launcher:v2` (old binary will still be silent)
- [ ] stderr should show `[rgfx] SDL_AUDIODRIVER=coreaudio` and `[rgfx] audio opened: …`
- [ ] ylos3d jump/land/stomp/goal should be audible
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a925328-7f27-442a-aff2-a2953bea4043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a925328-7f27-442a-aff2-a2953bea4043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

