### PR TITLE
v2 evg: fix native (C++) build breaks in EVGElement (unblocks launche…

### DIFF
--- a/gallery/game_engine/v2/evg/EVGElement.rgr
+++ b/gallery/game_engine/v2/evg/EVGElement.rgr
@@ -156,9 +156,6 @@ class EVGElement {
     
     ; Clip path (for any element)
     def clipPath:string ""
-    ; SVG path data (the `d` attribute) for a <Path> element — filled with
-    ; backgroundColor, scaled to the element box (evg/ISSUES.md #3).
-    def svgPath:string ""
 
     ; CSS class (for reference)
     def className:string ""
@@ -274,7 +271,10 @@ class EVGElement {
     }
     
     fn addChild:void (child:EVGElement) {
-        child.parent = this
+        ; NOTE: no `child.parent = this` back-reference — it was write-only (never
+        ; read) and, in the C++ backend, assigning `this` to a shared_ptr field
+        ; forces enable_shared_from_this on EVGElement, which broke the native
+        ; build. Children are tracked by `children[]` (forward edges) only.
         push children child
     }
     


### PR DESCRIPTION
…r:v2)

The v2 SDL launcher (npm run engine:game-sdl:launcher:v2) failed to compile on macOS/clang because of two EVGElement issues the es6 gate can't see:

1. `svgPath` was declared twice (a stray duplicate from the SVG Path work). es6 tolerates it (last-wins); C++ emits two members -> "duplicate member 'svgPath'".

2. `addChild` did `child.parent = this`. `parent` is an @(optional) EVGElement field, and the C++ backend lowers `= this` on it to `shared_from_this()` — but for that @(optional) field it did not add the enable_shared_from_this base, so clang rejected the call (and cascaded into make_shared<EVGElement> errors). The back-reference was WRITE-ONLY (never read anywhere), so it is simply removed; children are tracked by the forward `children[]` edges alone.

Fresh C++ codegen of RgSdlMain now has a single `svgPath` member, no EVGElement shared_from_this call, and EVGElement well-formed; a minimal EVGElement driver compiles clean under g++. Headless gate stays green (104/104 + boundary).


Claude-Session: https://claude.ai/code/session_01RKwovaPGU34wAQmNcKfyeH