### PR TITLE
Fix v2 launcher layout, Q-to-quit, and Tests category

### DIFF
--- a/gallery/game_engine/v2/games/cannon3d/game.info
+++ b/gallery/game_engine/v2/games/cannon3d/game.info
@@ -1,4 +1,4 @@
 name=Cannon 3D
-category=Games
+category=Tests
 index=3
 splitScreen=never

--- a/gallery/game_engine/v2/games/pinball/game.info
+++ b/gallery/game_engine/v2/games/pinball/game.info
@@ -1,4 +1,4 @@
 name=Pinball
-category=Games
+category=Tests
 index=4
 splitScreen=never

--- a/gallery/game_engine/v2/menu/RgLauncherUi.rgr
+++ b/gallery/game_engine/v2/menu/RgLauncherUi.rgr
@@ -55,8 +55,14 @@ class RgLauncherUi {
     def categoryNames:[string]
     def catCards:[UIBox]
     def games:[RgLauncherGame]
+    def title:UILabel (new UILabel)
     def sub:UILabel (new UILabel)
     def footer:UILabel (new UILabel)
+    ; fixed vertical band for chrome so title/subtitle never overlap cards
+    def titleY:int 14
+    def subY:int 0
+    def footerY:int 0
+    def cardY:int 0
 
     ; override the scan root before init() (tests / alternate game trees)
     fn setGamesDir:void (dir:string) { this.gamesDir = dir }
@@ -66,6 +72,18 @@ class RgLauncherUi {
         def cx:int (idiv this.w 2)
         def totalW:int ((cardW * n) + (gap * (n - 1)))
         return (cx - (idiv totalW 2))
+    }
+
+    ; Place a label centred on x=cx at top y, sized to its measured text so
+    ; left-aligned UILabel drawing still reads as centred (v1 flex parity).
+    fn layoutCenteredLabel:void (lbl:UILabel cx:int y:int) {
+        def tw:int (to_int (this.layer.ctx.measureWidth(lbl.text lbl.fontSize)))
+        def lh:int (to_int (this.layer.ctx.lineHeight(lbl.fontSize)))
+        if (tw < 20) { tw = 20 }
+        if (lh < 12) { lh = 12 }
+        ; pad the box slightly so TTF glyphs aren't clipped at the edges
+        def pad:int 8
+        lbl.setBounds(((cx - (idiv tw 2)) - pad) y (tw + (pad * 2)) lh)
     }
 
     ; decode a game's game.info icon (relative to its folder) to an RGBA image
@@ -145,26 +163,43 @@ class RgLauncherUi {
 
         def cx:int (idiv width 2)
 
-        def title:UILabel (new UILabel)
-        title.text = "Ranger"
-        title.fontSize = 40.0
-        title.setBounds((cx - 90) (idiv height 12) 180 48)
-        this.layer.add(title)
+        ; Title + subtitle stacked with measured line heights (at 480×270 the old
+        ; h/12 + h/5 boxes overlapped: title glyphs ran past the subtitle baseline).
+        this.title.text = "Ranger"
+        this.title.fontSize = 34.0
+        this.layoutCenteredLabel(this.title cx this.titleY)
+        this.layer.add(this.title)
 
+        def titleLh:int (to_int (this.layer.ctx.lineHeight(this.title.fontSize)))
+        this.subY = ((this.titleY + titleLh) + 6)
         this.sub.text = "valitse kategoria"
-        this.sub.fontSize = 16.0
-        this.sub.setBounds((cx - 100) (idiv height 5) 200 20)
+        this.sub.fontSize = 15.0
+        this.layoutCenteredLabel(this.sub cx this.subY)
         this.layer.add(this.sub)
+
+        def subLh:int (to_int (this.layer.ctx.lineHeight(this.sub.fontSize)))
+        this.footer.fontSize = 13.0
+        def footLh:int (to_int (this.layer.ctx.lineHeight(this.footer.fontSize)))
+        this.footerY = ((height - footLh) - 12)
+        this.footer.text = "A avaa, nuolet liikkuvat"
+        this.layoutCenteredLabel(this.footer cx this.footerY)
+        this.layer.add(this.footer)
+
+        ; Cards sit below the subtitle band and above the footer.
+        this.cardY = ((this.subY + subLh) + 14)
+        def cardBottom:int (this.footerY - 10)
+        def cardMaxH:int (cardBottom - this.cardY)
+        def cardW:int (idiv width 4)
+        def cardH:int cardW
+        if (cardH > cardMaxH) { cardH = cardMaxH }
+        if (cardH < 64) { cardH = 64 }
 
         ; ---- DISCOVER the catalog from the filesystem (v1 model) -------------
         this.catalog.setGamesDir(this.gamesDir)
         this.catalog.scan()
         this.categoryNames = (this.catalog.categories())
 
-        def cardW:int (idiv width 4)
-        def cardH:int cardW
         def gap:int 24
-        def cardY:int (idiv height 3)
         def nCats:int (array_length this.categoryNames)
         def startX:int (this.rowStartX(nCats cardW gap))
         def ci:int 0
@@ -174,7 +209,7 @@ class RgLauncherUi {
             def ccard:UIBox (new UIBox)
             ccard.text = cname
             ccard.fontSize = 20.0
-            ccard.setBounds(cxi cardY cardW cardH)
+            ccard.setBounds(cxi this.cardY cardW cardH)
             this.layer.add(ccard)
             push this.catCards ccard
 
@@ -200,7 +235,7 @@ class RgLauncherUi {
                 ; one without falls back to a centered title on the plain card.
                 if (g.hasImg) { g.card.text = "" } { g.card.text = e.title }
                 def exj:int (eStartX + (ei * (eCardW + eGap)))
-                g.card.setBounds(exj cardY eCardW cardH)
+                g.card.setBounds(exj this.cardY eCardW cardH)
                 g.card.visible = false
                 this.layer.add(g.card)
                 push this.games g
@@ -211,11 +246,6 @@ class RgLauncherUi {
             if ((this.catFirstImageIndex(ci)) >= 0) { ccard.text = "" }
             ci = (ci + 1)
         }
-
-        this.footer.text = "A avaa, nuolet liikkuvat"
-        this.footer.fontSize = 13.0
-        this.footer.setBounds((cx - 110) (height - (idiv height 10)) 220 16)
-        this.layer.add(this.footer)
 
         this.selected = 0
         this.applyPage()
@@ -276,8 +306,14 @@ class RgLauncherUi {
             this.footer.text = "A avaa, nuolet liikkuvat"
         } {
             this.sub.text = (itemAt this.categoryNames this.activeCat)
-            this.footer.text = "A pelaa, B takaisin"
+            this.footer.text = "A pelaa, Q/B takaisin"
         }
+        ; Re-centre chrome labels whenever the copy changes (category name lengths
+        ; differ; a fixed 200px box left the shorter Finnish strings off-centre).
+        def cx:int (idiv this.w 2)
+        this.layoutCenteredLabel(this.title cx this.titleY)
+        this.layoutCenteredLabel(this.sub cx this.subY)
+        this.layoutCenteredLabel(this.footer cx this.footerY)
         this.highlight()
     }
 

--- a/gallery/game_engine/v2/menu/tests/launcher_ui_test.rgr
+++ b/gallery/game_engine/v2/menu/tests/launcher_ui_test.rgr
@@ -66,22 +66,35 @@ class LauncherUiTest {
         ui.init(480 270)
 
         ; ---- catalog DISCOVERED from the real v2 games folder ---------------
-        ; Only ylos2 (Pomppija) is a ported v2 game today, so the scan finds one
-        ; "Games" category with Pomppija in it. (Adding a game folder with a
-        ; game.info would extend this automatically — the test is intentionally
-        ; tied to the real filesystem, like v1's launcher.)
+        ; Games: Pomppija + Ylos3D (WASM). Tests: Cannon 3D + Pinball prototypes.
+        ; Categories appear in first-seen order (Games, then Tests).
         t.ok("at least one category discovered" ((ui.categoryCount()) >= 1))
+        t.ok("at least two categories (Games + Tests)" ((ui.categoryCount()) >= 2))
         t.ok("at least one game discovered" ((ui.gameCount()) >= 1))
         t.eqStr("first category is Games" (ui.selectedLabel()) "Games")
         t.eqStr("selected category name" (ui.selectedCategory()) "Games")
         ui.moveSelection(0 - 5)
         t.eqStr("left clamps to the first category" (ui.selectedLabel()) "Games")
+        ui.moveSelection(1)
+        t.eqStr("right moves to Tests" (ui.selectedLabel()) "Tests")
+        ui.moveSelection(0 - 1)
+        t.eqStr("back on Games" (ui.selectedLabel()) "Games")
 
         ; ---- it actually renders pixels + an accent card -------------------
         ui.render()
         t.ok("something was drawn into the canvas" ((LauncherUiTest.nonBackground(ui)) > 0))
         def catAccent:int (LauncherUiTest.countColor(ui 0 0 480 270 255 190 70))
         t.ok("the selected category card is accent-filled" (catAccent > 0))
+
+        ; title ("Ranger") and subtitle must not share the same vertical band —
+        ; previously both boxes overlapped at 480×270 (h/12 vs h/5).
+        t.ok("title sits above the subtitle" (ui.title.y < ui.sub.y))
+        t.ok("title and subtitle do not overlap vertically" ((ui.title.y + ui.title.h) <= ui.sub.y))
+        ; measured centering: label box straddles the canvas midline
+        def midX:int 240
+        t.ok("title box covers the horizontal center" ((ui.title.x < midX) && ((ui.title.x + ui.title.w) > midX)))
+        t.ok("subtitle box covers the horizontal center" ((ui.sub.x < midX) && ((ui.sub.x + ui.sub.w) > midX)))
+        t.ok("footer box covers the horizontal center" ((ui.footer.x < midX) && ((ui.footer.x + ui.footer.w) > midX)))
 
         ; ---- two-level navigation + real game handoff ----------------------
         def ui2:RgLauncherUi (new RgLauncherUi)
@@ -117,6 +130,16 @@ class LauncherUiTest {
         ui2.back()
         t.eqInt("back to the category page" (ui2.currentPage()) 0)
         t.eqStr("restored to the Games category" (ui2.selectedLabel()) "Games")
+
+        ; Tests category lists the prototype physics demos
+        ui2.moveSelection(1)
+        t.eqStr("Tests category is selectable" (ui2.selectedLabel()) "Tests")
+        def aT:int (ui2.activate())
+        t.eqInt("entering Tests does not launch" aT 0)
+        t.eqStr("first Tests entry is Cannon 3D" (ui2.selectedLabel()) "Cannon 3D")
+        ui2.moveSelection(1)
+        t.eqStr("second Tests entry is Pinball" (ui2.selectedLabel()) "Pinball")
+        ui2.back()
 
         ; page 1 renders the game cards (accent present somewhere)
         def _a2:int (ui2.activate())

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
@@ -91,6 +91,11 @@ class RgSdlGameHost {
         def jump:boolean (((bit_and m 1) != 0) || ((bit_and m 4) != 0))
         this.host.bridge.input.setAction(player "jump" jump)
         this.host.bridge.input.setAction(player "action" ((bit_and m 4) != 0))
+        ; Q / Esc (bit 8) — host also exits the game loop on a rising edge; map
+        ; the logical actions so guests that poll "back"/"quit" see them too.
+        def quitHeld:boolean ((bit_and m 8) != 0)
+        this.host.bridge.input.setAction(player "back" quitHeld)
+        this.host.bridge.input.setAction(player "quit" quitHeld)
     }
 
     ; Forward newly-recorded haptic commands (bridge.input records what the guest
@@ -215,14 +220,24 @@ class RgSdlGameHost {
     }
 
     ; Advance the launcher menu one step from an input-mask edge transition:
-    ;   left(16)/right(32) edge -> moveSelection ; down(2) edge -> back ;
+    ;   left(16)/right(32) edge -> moveSelection ;
+    ;   down(2) or quit(8) edge on games page -> back ;
+    ;   quit(8) edge on categories -> return 2 (quit the launcher) ;
     ;   action(4) edge -> activate. Returns 1 when an ENTRY was activated (the
-    ;   caller reads ui.selectedDir()/selectedFile() and hands off), else 0.
-    ; This is the launcher's whole input contract — no gfx, no game, testable.
+    ;   caller reads ui.selectedDir()/selectedFile() and hands off), else 0
+    ;   (or 2 to quit). This is the launcher's whole input contract — no gfx,
+    ;   no game, testable.
     fn launcherStep:int (prev:int cur:int ui:RgLauncherUi) {
         if (this.edge(prev cur 16)) { ui.moveSelection(0 - 1) }
         if (this.edge(prev cur 32)) { ui.moveSelection(1) }
         if (this.edge(prev cur 2))  { ui.back() }
+        if (this.edge(prev cur 8)) {
+            if ((ui.currentPage()) == 1) {
+                ui.back()
+            } {
+                return 2
+            }
+        }
         if (this.edge(prev cur 4)) {
             def r:int (ui.activate())
             if (r == 1) { return 1 }
@@ -249,27 +264,31 @@ class RgSdlGameHost {
             def m:int (gfx_input_source_mask 0)
             def launch:int (this.launcherStep(prev m ui))
             prev = m
-            if (launch == 1) {
-                def d:string (ui.selectedDir())
-                def f:string (ui.selectedFile())
-                def eng:string (ui.selectedEngine())
-                gfx_close
-                this.resetAudioDevice()
-                ; wasm games run through the compiled loop, tsx through the
-                ; interpreted one — both drive the same bridge/presenter.
-                def _g:int 0
-                if (eng == "wasm") { _g = (this.runWasm(d f)) } { _g = (this.run(d f)) }
-                ; back from the game: reopen the launcher and resume on categories
-                gfx_clear_should_close
-                this.resetAudioDevice()
-                if ((gfx_open "Ranger" lw lh) == 0) { return 1 }
-                ui.back()
-                prev = 0
+            if (launch == 2) {
+                go = false
             } {
-                ui.render()
-                gfx_present (ui.raw()) lw lh
-                gfx_delay 16
-                if (gfx_should_close) { go = false }
+                if (launch == 1) {
+                    def d:string (ui.selectedDir())
+                    def f:string (ui.selectedFile())
+                    def eng:string (ui.selectedEngine())
+                    gfx_close
+                    this.resetAudioDevice()
+                    ; wasm games run through the compiled loop, tsx through the
+                    ; interpreted one — both drive the same bridge/presenter.
+                    def _g:int 0
+                    if (eng == "wasm") { _g = (this.runWasm(d f)) } { _g = (this.run(d f)) }
+                    ; back from the game: reopen the launcher and resume on categories
+                    gfx_clear_should_close
+                    this.resetAudioDevice()
+                    if ((gfx_open "Ranger" lw lh) == 0) { return 1 }
+                    ui.back()
+                    prev = 0
+                } {
+                    ui.render()
+                    gfx_present (ui.raw()) lw lh
+                    gfx_delay 16
+                    if (gfx_should_close) { go = false }
+                }
             }
         }
         gfx_close
@@ -310,8 +329,13 @@ class RgSdlGameHost {
         def fbL:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
         def fbR:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
         def go:boolean true
+        def prev:int 0
         while go {
             gfx_input_poll
+            def m:int (gfx_input_source_mask 0)
+            ; Q / Esc rising edge closes the game window (return to launcher)
+            if (this.edge(prev m 8)) { go = false }
+            prev = m
             this.wasmHost.frame(33.333)
             this.presentBridge(this.wasmHost.bridge fbL fbR)
             gfx_delay 16
@@ -339,9 +363,15 @@ class RgSdlGameHost {
         def fbL:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
         def fbR:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
         def go:boolean true
+        def prev:int 0
         while go {
             gfx_input_poll
-            this.mapMask(0 (gfx_input_source_mask 0))
+            def m0:int (gfx_input_source_mask 0)
+            ; Q / Esc rising edge closes the active game window and returns to
+            ; the launcher (v1 gameMenuBackHeld parity). Window-close still works.
+            if (this.edge(prev m0 8)) { go = false }
+            prev = m0
+            this.mapMask(0 m0)
             this.mapMask(1 (gfx_input_source_mask 1))
             this.host.frame(33.333)
             this.forwardRumble()

--- a/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
+++ b/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
@@ -62,11 +62,13 @@ class SdlHostTest {
         ; ---- launcher menu driven purely by input-mask edges ---------------
         def ui:RgLauncherUi (new RgLauncherUi)
         ui.init(480 270)
-        ; the catalog is discovered from the real v2/games folder (one Games
-        ; category with Pomppija); moving on a single category clamps, no launch
+        ; catalog: Games (Pomppija, Ylos3D WASM) + Tests (Cannon 3D, Pinball).
+        ; Right edge moves to Tests; stay on Games for the handoff checks below.
         def s0:int (sdl.launcherStep(0 32 ui))
         t.eqInt("moving selection does not launch" s0 0)
-        t.eqStr("selection stays on the Games category" (ui.selectedLabel()) "Games")
+        t.eqStr("right moves to the Tests category" (ui.selectedLabel()) "Tests")
+        def sL:int (sdl.launcherStep(0 16 ui))
+        t.eqStr("left returns to Games" (ui.selectedLabel()) "Games")
         ; action edge (4) enters the Games category (page 1), no launch yet
         def s2:int (sdl.launcherStep(0 4 ui))
         t.eqInt("entering a category is not a launch" s2 0)
@@ -90,6 +92,21 @@ class SdlHostTest {
         def s4:int (sdl.launcherStep(0 2 ui))
         t.eqInt("back is not a launch" s4 0)
         t.eqInt("back to the category page" (ui.currentPage()) 0)
+        ; quit edge (8 / Q) on categories quits the launcher (return 2)
+        def sQ:int (sdl.launcherStep(0 8 ui))
+        t.eqInt("Q on categories quits the launcher" sQ 2)
+        ; re-enter Games; Q on the games page acts as back (not quit)
+        def _re:int (sdl.launcherStep(0 4 ui))
+        t.eqInt("re-entered games page" (ui.currentPage()) 1)
+        def sQb:int (sdl.launcherStep(0 8 ui))
+        t.eqInt("Q on games page is back, not quit" sQb 0)
+        t.eqInt("Q returned to categories" (ui.currentPage()) 0)
+        ; mapMask exposes quit/back so guests can poll them
+        sdl.mapMask(0 8)
+        t.ok("quit bit maps to quit action" (inp.isDown(0 "quit")))
+        t.ok("quit bit maps to back action" (inp.isDown(0 "back")))
+        sdl.mapMask(0 0)
+        t.no("quit released" (inp.isDown(0 "quit")))
 
         ; ---- host music pump: a guest's music.play(score) is synthesised ----
         ; The bridge records the score (rgcore_music_play); the host owns the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix overlapping / off-centre title, subtitle, and footer on the native SDL v2 launcher (`RgLauncherUi`) by measuring text and stacking chrome with real line heights.
- Make **Q/Esc** close the active game window (return to launcher) and quit from the categories page; map quit/back into the input bridge.
- Move **Cannon 3D** and **Pinball** prototypes from Games → **Tests** so the top-level menu shows both categories.

## Not in this PR
- Submenu still opens a new window (known; intentionally deprioritized).
- Full visual parity with the richer v1 EVG/TSX tile chrome (layout/centering first).

## Test plan
- [x] `menu/tests/launcher_ui_test` — two categories, layout assertions, Tests entries
- [x] `tests/sdl/sdl_host_test` — category nav + Q edge + quit/back mapping
- [x] Full `bash gallery/game_engine/v2/tests/run.sh` — **105/105 suites + boundary gate green**
- [ ] Manual: `npm run engine:game-sdl:launcher:v2` — centred chrome, Games + Tests tiles, Q exits a running game
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db8f561a-0719-4764-8a7c-295688543bda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db8f561a-0719-4764-8a7c-295688543bda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

