### PR TITLE
Spline editor: Edit / Add / Coloring tools + segment materials

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -60,3 +60,13 @@ Open the printed local URL (default `http://localhost:5177`).
 
 Segment styles are lathed as separate mesh parts and previewed through Ranger Three materials (shininess ← roughness, reflectivity ← metalness).
 
+## Shading base
+
+Teapot-inspired modes exercised against Ranger Three:
+
+| Mode | Material |
+|------|----------|
+| Wire | MeshBasic wireframe |
+| Flat | Phong + flatShading |
+| Smooth / Glossy / Reflective | Phong (+ studio env when reflective/metal) |
+

--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -50,14 +50,13 @@ npm run dev
 
 Open the printed local URL (default `http://localhost:5177`).
 
-## Materials
+## Tools
 
-Teapot-inspired modes exercised against Ranger Three:
+| Mode | Behaviour |
+|------|-----------|
+| **Edit** | Drag knots and Bezier handles |
+| **Add** | Click the profile curve to insert a knot (remove from the point list) |
+| **Coloring** | Per-knot colours form a linear height gradient; each segment can override colour, roughness, metalness, opacity, and texture (gradient / checker / stripes / upload) |
 
-| Mode | Material |
-|------|----------|
-| Wire | MeshBasic wireframe |
-| Flat | Phong + flatShading |
-| Smooth | Lambert |
-| Glossy | Phong specular |
-| Reflective | Phong + studio environment cube |
+Segment styles are lathed as separate mesh parts and previewed through Ranger Three materials (shininess ← roughness, reflectivity ← metalness).
+

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -7,12 +7,17 @@ import { useSplineEditor } from "./composables/useSplineEditor.js";
 
 const {
   state,
+  setToolMode,
   select,
+  selectSegment,
   resetDefaults,
-  addKnot,
+  removeKnot,
   removeSelected,
   updateKnot,
+  updateSegment,
   sampleCurvePoints,
+  findClosestOnCurve,
+  insertKnotOnCurve,
   tessellate,
 } = useSplineEditor();
 
@@ -24,7 +29,32 @@ const materials = [
   { id: 4, label: "Reflective" },
 ];
 
+const tools = [
+  { id: "edit", label: "Edit" },
+  { id: "add", label: "Add" },
+  { id: "color", label: "Coloring" },
+];
+
 function onTessellate() {
+  tessellate();
+}
+
+function onAddOnCurve(x, y) {
+  if (insertKnotOnCurve(x, y)) tessellate();
+}
+
+function onRemoveKnot(id) {
+  removeKnot(id);
+  tessellate();
+}
+
+function onUpdateKnot(id, patch) {
+  updateKnot(id, patch);
+  if (patch && patch.color) tessellate();
+}
+
+function onUpdateSegment(index, patch) {
+  updateSegment(index, patch);
   tessellate();
 }
 
@@ -41,13 +71,22 @@ onMounted(() => {
         <h1>Spline Mesh Editor</h1>
         <p class="lede">
           Symmetrical Bezier profiles around the Y axis, lathed into a 3D mesh and rendered with
-          Ranger Three.
+          Ranger Three — with Edit / Add / Coloring tools.
         </p>
       </div>
       <div class="actions">
+        <div class="tool-row">
+          <button
+            v-for="t in tools"
+            :key="t.id"
+            :class="{ active: state.toolMode === t.id, primary: state.toolMode === t.id }"
+            @click="setToolMode(t.id)"
+          >
+            {{ t.label }}
+          </button>
+        </div>
         <button @click="resetDefaults">Reset</button>
-        <button @click="addKnot">Add point</button>
-        <button @click="removeSelected">Remove</button>
+        <button @click="removeSelected" :disabled="!state.selectedId">Remove</button>
         <button class="primary" @click="onTessellate">Tessellate</button>
       </div>
     </header>
@@ -80,7 +119,7 @@ onMounted(() => {
         Show mirror
       </label>
       <div class="mats">
-        <span>Material</span>
+        <span>Shading base</span>
         <div class="mat-row">
           <button
             v-for="m in materials"
@@ -92,26 +131,41 @@ onMounted(() => {
           </button>
         </div>
       </div>
-      <p class="status">{{ state.status }} · {{ state.stats.verts }}v / {{ state.stats.tris }}t</p>
+      <p class="status">
+        {{ state.status }} · {{ state.stats.parts || 0 }} parts · {{ state.stats.verts }}v /
+        {{ state.stats.tris }}t
+      </p>
     </section>
 
     <main class="workspace">
       <SplineCanvas
         :knots="state.knots"
+        :segments="state.segments"
         :selected-id="state.selectedId"
+        :selected-segment-index="state.selectedSegmentIndex"
         :curve-type="state.curveType"
         :symmetry="state.symmetry"
+        :tool-mode="state.toolMode"
         :viewport="state.viewport"
         :sample-curve-points="sampleCurvePoints"
+        :find-closest-on-curve="findClosestOnCurve"
         @select="select"
-        @update-knot="updateKnot"
+        @select-segment="selectSegment"
+        @update-knot="onUpdateKnot"
+        @add-on-curve="onAddOnCurve"
       />
       <PointEditor
         :knots="state.knots"
+        :segments="state.segments"
         :selected-id="state.selectedId"
+        :selected-segment-index="state.selectedSegmentIndex"
         :curve-type="state.curveType"
+        :tool-mode="state.toolMode"
         @select="select"
-        @update-knot="updateKnot"
+        @select-segment="selectSegment"
+        @update-knot="onUpdateKnot"
+        @update-segment="onUpdateSegment"
+        @remove-knot="onRemoveKnot"
       />
       <Preview3D :mesh="state.mesh" :material-mode="state.materialMode" />
     </main>
@@ -165,6 +219,17 @@ h1 {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  align-items: center;
+}
+
+.tool-row {
+  display: flex;
+  gap: 0.35rem;
+  margin-right: 0.35rem;
+  padding: 0.2rem;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: rgba(0, 0, 0, 0.2);
 }
 
 .toolbar {
@@ -208,7 +273,7 @@ h1 {
 
 .workspace {
   display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(220px, 0.7fr) minmax(260px, 0.9fr);
+  grid-template-columns: minmax(0, 1.2fr) minmax(240px, 0.85fr) minmax(260px, 0.9fr);
   gap: 1rem;
   min-height: 0;
   align-items: stretch;

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/PointEditor.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/PointEditor.vue
@@ -1,24 +1,58 @@
 <script setup>
 defineProps({
   knots: { type: Array, required: true },
+  segments: { type: Array, default: () => [] },
   selectedId: { type: String, default: null },
+  selectedSegmentIndex: { type: Number, default: -1 },
   curveType: { type: Number, default: 0 },
+  toolMode: { type: String, default: "edit" },
 });
 
-const emit = defineEmits(["select", "update-knot"]);
+const emit = defineEmits([
+  "select",
+  "select-segment",
+  "update-knot",
+  "update-segment",
+  "remove-knot",
+]);
 
 function onNum(id, key, ev) {
   const v = Number(ev.target.value);
   if (Number.isFinite(v)) emit("update-knot", id, { [key]: v });
+}
+
+function onSegNum(index, key, ev) {
+  const v = Number(ev.target.value);
+  if (Number.isFinite(v)) emit("update-segment", index, { [key]: v });
+}
+
+async function onTextureFile(index, ev) {
+  const file = ev.target.files?.[0];
+  if (!file) return;
+  const bmp = await createImageBitmap(file);
+  const w = Math.min(128, bmp.width);
+  const h = Math.min(128, bmp.height);
+  const c = document.createElement("canvas");
+  c.width = w;
+  c.height = h;
+  const ctx = c.getContext("2d");
+  ctx.drawImage(bmp, 0, 0, w, h);
+  const img = ctx.getImageData(0, 0, w, h);
+  emit("update-segment", index, {
+    texture: "upload",
+    textureData: { rgba: img.data.slice(), w, h, name: file.name },
+  });
 }
 </script>
 
 <template>
   <div class="point-editor">
     <header>
-      <h2>Points</h2>
-      <p>Right-side profile (x ≥ 0). Mirror is automatic.</p>
+      <h2>{{ toolMode === "color" ? "Coloring" : "Points" }}</h2>
+      <p v-if="toolMode !== 'color'">Right-side profile (x ≥ 0). Remove from the list.</p>
+      <p v-else>Knot colors form a linear gradient; segments can override material.</p>
     </header>
+
     <ul>
       <li
         v-for="(k, i) in knots"
@@ -27,10 +61,24 @@ function onNum(id, key, ev) {
         @click="emit('select', k.id)"
       >
         <div class="row-title">
-          <strong>#{{ i + 1 }}</strong>
+          <strong>
+            <span class="swatch" :style="{ background: k.color }" />
+            #{{ i + 1 }}
+          </strong>
           <span>{{ i === 0 ? "bottom" : i === knots.length - 1 ? "top" : "mid" }}</span>
         </div>
-        <div class="grid">
+
+        <div v-if="toolMode === 'color'" class="grid">
+          <label class="field wide">
+            Knot color
+            <input
+              type="color"
+              :value="k.color"
+              @input="emit('update-knot', k.id, { color: $event.target.value })"
+            />
+          </label>
+        </div>
+        <div v-else class="grid">
           <label class="field">
             x
             <input type="number" step="0.01" :value="k.x" @change="onNum(k.id, 'x', $event)" />
@@ -49,6 +97,95 @@ function onNum(id, key, ev) {
               <input type="number" step="0.01" :value="k.hy" @change="onNum(k.id, 'hy', $event)" />
             </label>
           </template>
+        </div>
+
+        <div class="row-actions">
+          <button
+            type="button"
+            class="danger"
+            :disabled="knots.length <= 2"
+            @click.stop="emit('remove-knot', k.id)"
+          >
+            Remove
+          </button>
+        </div>
+
+        <!-- segment after this knot -->
+        <div
+          v-if="i < knots.length - 1 && toolMode === 'color'"
+          class="segment"
+          :class="{ active: selectedSegmentIndex === i }"
+          @click.stop="emit('select-segment', i)"
+        >
+          <div class="row-title">
+            <strong>Segment {{ i + 1 }}→{{ i + 2 }}</strong>
+            <span class="swatch" :style="{ background: segments[i]?.color || k.color }" />
+          </div>
+          <div class="grid">
+            <label class="field wide">
+              Segment color
+              <div class="color-row">
+                <input
+                  type="color"
+                  :value="segments[i]?.color || k.color"
+                  @input="emit('update-segment', i, { color: $event.target.value })"
+                />
+                <button type="button" @click.stop="emit('update-segment', i, { color: null })">
+                  Use gradient
+                </button>
+              </div>
+            </label>
+            <label class="field">
+              Roughness
+              <input
+                type="number"
+                min="0"
+                max="1"
+                step="0.05"
+                :value="segments[i]?.roughness ?? 0.4"
+                @change="onSegNum(i, 'roughness', $event)"
+              />
+            </label>
+            <label class="field">
+              Metalness
+              <input
+                type="number"
+                min="0"
+                max="1"
+                step="0.05"
+                :value="segments[i]?.metalness ?? 0"
+                @change="onSegNum(i, 'metalness', $event)"
+              />
+            </label>
+            <label class="field">
+              Opacity
+              <input
+                type="number"
+                min="0"
+                max="1"
+                step="0.05"
+                :value="segments[i]?.opacity ?? 1"
+                @change="onSegNum(i, 'opacity', $event)"
+              />
+            </label>
+            <label class="field wide">
+              Texture
+              <select
+                :value="segments[i]?.texture || 'gradient'"
+                @change="emit('update-segment', i, { texture: $event.target.value })"
+              >
+                <option value="gradient">Linear gradient</option>
+                <option value="none">Solid / none</option>
+                <option value="checker">Checker</option>
+                <option value="stripes">Stripes</option>
+                <option value="upload">Custom upload</option>
+              </select>
+            </label>
+            <label v-if="(segments[i]?.texture || '') === 'upload'" class="field wide">
+              Image file
+              <input type="file" accept="image/*" @change="onTextureFile(i, $event)" />
+            </label>
+          </div>
         </div>
       </li>
     </ul>
@@ -112,14 +249,78 @@ li.active {
 .row-title {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   margin-bottom: 0.45rem;
   font-size: 0.8rem;
   color: var(--ink-dim);
+  gap: 0.4rem;
+}
+
+.swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  margin-right: 0.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  vertical-align: -1px;
 }
 
 .grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0.4rem;
+}
+
+.field.wide {
+  grid-column: 1 / -1;
+}
+
+.row-actions {
+  margin-top: 0.45rem;
+}
+
+button.danger {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.55rem;
+  color: #ffb0a4;
+  border-color: rgba(255, 122, 106, 0.35);
+}
+
+button.danger:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.segment {
+  margin-top: 0.55rem;
+  padding: 0.55rem;
+  border-radius: 8px;
+  border: 1px dashed rgba(180, 210, 170, 0.25);
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.segment.active {
+  border-style: solid;
+  border-color: rgba(110, 200, 255, 0.55);
+}
+
+.color-row {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.color-row input[type="color"] {
+  width: 2.4rem;
+  height: 2rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+.color-row button {
+  font-size: 0.72rem;
+  padding: 0.3rem 0.5rem;
 }
 </style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
@@ -3,34 +3,58 @@ import { computed, onMounted, onBeforeUnmount, ref, watch } from "vue";
 
 const props = defineProps({
   knots: { type: Array, required: true },
+  segments: { type: Array, default: () => [] },
   selectedId: { type: String, default: null },
+  selectedSegmentIndex: { type: Number, default: -1 },
   curveType: { type: Number, default: 0 },
   symmetry: { type: Boolean, default: true },
+  toolMode: { type: String, default: "edit" },
   viewport: { type: Object, required: true },
   sampleCurvePoints: { type: Function, required: true },
+  findClosestOnCurve: { type: Function, required: true },
 });
 
-const emit = defineEmits(["select", "update-knot"]);
+const emit = defineEmits(["select", "select-segment", "update-knot", "add-on-curve"]);
 
 const canvasRef = ref(null);
 const size = 560;
-let dragging = null; // { id, mode: 'point'|'handle' }
+let dragging = null;
 let raf = 0;
+const hoverAdd = ref(null);
 
 const curvePts = computed(() => props.sampleCurvePoints(28));
 
 function worldToScreen(x, y, w, h) {
   const { min, max } = props.viewport;
-  const sx = ((x - min) / (max - min)) * w;
-  const sy = ((max - y) / (max - min)) * h;
-  return [sx, sy];
+  return [((x - min) / (max - min)) * w, ((max - y) / (max - min)) * h];
 }
 
 function screenToWorld(sx, sy, w, h) {
   const { min, max } = props.viewport;
-  const x = min + (sx / w) * (max - min);
-  const y = max - (sy / h) * (max - min);
-  return [x, y];
+  return [min + (sx / w) * (max - min), max - (sy / h) * (max - min)];
+}
+
+function drawGradientStroke(ctx, pts, getColor, w, h) {
+  if (pts.length < 2) return;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const a = pts[i];
+    const b = pts[i + 1];
+    const [x0, y0] = worldToScreen(a.x, a.y, w, h);
+    const [x1, y1] = worldToScreen(b.x, b.y, w, h);
+    ctx.strokeStyle = getColor(a, b, i);
+    ctx.beginPath();
+    ctx.moveTo(x0, y0);
+    ctx.lineTo(x1, y1);
+    ctx.stroke();
+  }
+}
+
+function segmentColor(segIndex) {
+  const seg = props.segments[segIndex];
+  if (seg?.color) return seg.color;
+  const a = props.knots[segIndex];
+  const b = props.knots[segIndex + 1];
+  return a?.color || "#6ec8ff";
 }
 
 function draw() {
@@ -49,21 +73,18 @@ function draw() {
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   ctx.clearRect(0, 0, w, h);
 
-  // atmosphere
   const g = ctx.createLinearGradient(0, 0, w, h);
   g.addColorStop(0, "#141a16");
   g.addColorStop(1, "#0c100e");
   ctx.fillStyle = g;
   ctx.fillRect(0, 0, w, h);
 
-  // unit square
   const [x0, y0] = worldToScreen(-1, 1, w, h);
   const [x1, y1] = worldToScreen(1, -1, w, h);
   ctx.strokeStyle = "rgba(180,210,170,0.18)";
   ctx.lineWidth = 1;
   ctx.strokeRect(x0, y0, x1 - x0, y1 - y0);
 
-  // grid
   ctx.strokeStyle = "rgba(180,210,170,0.08)";
   for (let v = -1; v <= 1; v += 0.5) {
     const [gx] = worldToScreen(v, 0, w, h);
@@ -76,7 +97,6 @@ function draw() {
     ctx.stroke();
   }
 
-  // axis
   const [ax0, ay0] = worldToScreen(0, -1, w, h);
   const [ax1, ay1] = worldToScreen(0, 1, w, h);
   ctx.strokeStyle = "rgba(200,232,122,0.55)";
@@ -86,37 +106,56 @@ function draw() {
   ctx.lineTo(ax1, ay1);
   ctx.stroke();
 
-  // mirrored curve
   const pts = curvePts.value;
+
   if (props.symmetry && pts.length > 1) {
-    ctx.strokeStyle = "rgba(110,200,255,0.35)";
     ctx.lineWidth = 2;
-    ctx.beginPath();
-    pts.forEach((p, i) => {
-      const [sx, sy] = worldToScreen(-p.x, p.y, w, h);
-      if (i === 0) ctx.moveTo(sx, sy);
-      else ctx.lineTo(sx, sy);
-    });
-    ctx.stroke();
+    drawGradientStroke(
+      ctx,
+      pts.map((p) => ({ ...p, x: -p.x })),
+      (a) => {
+        const c = segmentColor(a.segmentIndex ?? 0);
+        return c.length === 7 ? c + "59" : "rgba(110,200,255,0.35)";
+      },
+      w,
+      h,
+    );
   }
 
-  // main curve
   if (pts.length > 1) {
-    ctx.strokeStyle = "#6ec8ff";
-    ctx.lineWidth = 2.5;
-    ctx.beginPath();
-    pts.forEach((p, i) => {
-      const [sx, sy] = worldToScreen(p.x, p.y, w, h);
-      if (i === 0) ctx.moveTo(sx, sy);
-      else ctx.lineTo(sx, sy);
-    });
-    ctx.stroke();
+    ctx.lineWidth = props.toolMode === "color" ? 4 : 2.5;
+    drawGradientStroke(
+      ctx,
+      pts,
+      (a) => {
+        const idx = a.segmentIndex ?? 0;
+        if (props.toolMode === "color" && idx === props.selectedSegmentIndex) return "#ffffff";
+        return segmentColor(idx);
+      },
+      w,
+      h,
+    );
   }
 
-  // bezier handles / catmull direction
+  // segment hit markers in color mode
+  if (props.toolMode === "color") {
+    for (let i = 0; i < props.knots.length - 1; i++) {
+      const mid = evalMid(i);
+      if (!mid) continue;
+      const [sx, sy] = worldToScreen(mid.x, mid.y, w, h);
+      ctx.beginPath();
+      ctx.arc(sx, sy, i === props.selectedSegmentIndex ? 7 : 5, 0, Math.PI * 2);
+      ctx.fillStyle = segmentColor(i);
+      ctx.fill();
+      ctx.strokeStyle = i === props.selectedSegmentIndex ? "#fff" : "rgba(0,0,0,0.45)";
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+    }
+  }
+
   props.knots.forEach((k, i) => {
     const [sx, sy] = worldToScreen(k.x, k.y, w, h);
-    if (props.curveType === 0) {
+    if (props.curveType === 0 && props.toolMode === "edit") {
       const [hx, hy] = worldToScreen(k.x + k.hx, k.y + k.hy, w, h);
       const [ix, iy] = worldToScreen(k.x - k.hx, k.y - k.hy, w, h);
       ctx.strokeStyle = "rgba(255,180,84,0.75)";
@@ -127,19 +166,8 @@ function draw() {
       ctx.stroke();
       drawHandle(ctx, hx, hy, k.id === props.selectedId);
       drawHandle(ctx, ix, iy, false);
-    } else if (i > 0) {
-      // catmull: show direction toward previous for last-but guidance
-      const prev = props.knots[i - 1];
-      const [px, py] = worldToScreen(prev.x, prev.y, w, h);
-      ctx.strokeStyle = "rgba(255,180,84,0.4)";
-      ctx.setLineDash([4, 4]);
-      ctx.beginPath();
-      ctx.moveTo(px, py);
-      ctx.lineTo(sx, sy);
-      ctx.stroke();
-      ctx.setLineDash([]);
     }
-    drawPoint(ctx, sx, sy, k.id === props.selectedId);
+    drawPoint(ctx, sx, sy, k.id === props.selectedId, k.color);
 
     if (props.symmetry && k.x > 0.001) {
       const [mx, my] = worldToScreen(-k.x, k.y, w, h);
@@ -149,15 +177,31 @@ function draw() {
       ctx.fill();
     }
   });
+
+  if (props.toolMode === "add" && hoverAdd.value) {
+    const [sx, sy] = worldToScreen(hoverAdd.value.x, hoverAdd.value.y, w, h);
+    ctx.beginPath();
+    ctx.arc(sx, sy, 6, 0, Math.PI * 2);
+    ctx.fillStyle = "rgba(200,232,122,0.9)";
+    ctx.fill();
+    ctx.strokeStyle = "#7ecf6a";
+    ctx.stroke();
+  }
 }
 
-function drawPoint(ctx, x, y, selected) {
+function evalMid(segIndex) {
+  const pts = curvePts.value.filter((p) => p.segmentIndex === segIndex);
+  if (!pts.length) return null;
+  return pts[(pts.length / 2) | 0];
+}
+
+function drawPoint(ctx, x, y, selected, color) {
   ctx.beginPath();
-  ctx.arc(x, y, selected ? 7 : 5.5, 0, Math.PI * 2);
-  ctx.fillStyle = selected ? "#c8e87a" : "#e8efe6";
+  ctx.arc(x, y, selected ? 8 : 6, 0, Math.PI * 2);
+  ctx.fillStyle = color || (selected ? "#c8e87a" : "#e8efe6");
   ctx.fill();
-  ctx.strokeStyle = selected ? "#7ecf6a" : "rgba(0,0,0,0.45)";
-  ctx.lineWidth = 1.5;
+  ctx.strokeStyle = selected ? "#ffffff" : "rgba(0,0,0,0.45)";
+  ctx.lineWidth = selected ? 2 : 1.5;
   ctx.stroke();
 }
 
@@ -168,27 +212,56 @@ function drawHandle(ctx, x, y, selected) {
   ctx.fill();
 }
 
-function hitTest(sx, sy) {
-  const canvas = canvasRef.value;
-  const w = size;
-  const h = size;
+function hitTestPoint(sx, sy) {
   const thresh = 10;
   for (const k of props.knots) {
-    if (props.curveType === 0) {
-      const [hx, hy] = worldToScreen(k.x + k.hx, k.y + k.hy, w, h);
+    if (props.curveType === 0 && props.toolMode === "edit") {
+      const [hx, hy] = worldToScreen(k.x + k.hx, k.y + k.hy, size, size);
       if (Math.hypot(hx - sx, hy - sy) <= thresh) return { id: k.id, mode: "handle" };
     }
-    const [px, py] = worldToScreen(k.x, k.y, w, h);
+    const [px, py] = worldToScreen(k.x, k.y, size, size);
     if (Math.hypot(px - sx, py - sy) <= thresh) return { id: k.id, mode: "point" };
   }
   return null;
+}
+
+function hitTestSegment(sx, sy) {
+  const thresh = 12;
+  for (let i = 0; i < props.knots.length - 1; i++) {
+    const mid = evalMid(i);
+    if (!mid) continue;
+    const [mx, my] = worldToScreen(mid.x, mid.y, size, size);
+    if (Math.hypot(mx - sx, my - sy) <= thresh) return i;
+  }
+  return -1;
 }
 
 function onPointerDown(e) {
   const rect = canvasRef.value.getBoundingClientRect();
   const sx = e.clientX - rect.left;
   const sy = e.clientY - rect.top;
-  const hit = hitTest(sx, sy);
+  const [wx, wy] = screenToWorld(sx, sy, size, size);
+
+  if (props.toolMode === "add") {
+    emit("add-on-curve", Math.max(0, wx), wy);
+    return;
+  }
+
+  if (props.toolMode === "color") {
+    const pt = hitTestPoint(sx, sy);
+    if (pt) {
+      emit("select", pt.id);
+      return;
+    }
+    const seg = hitTestSegment(sx, sy);
+    if (seg >= 0) {
+      emit("select-segment", seg);
+      return;
+    }
+    return;
+  }
+
+  const hit = hitTestPoint(sx, sy);
   if (!hit) return;
   dragging = hit;
   emit("select", hit.id);
@@ -196,11 +269,18 @@ function onPointerDown(e) {
 }
 
 function onPointerMove(e) {
-  if (!dragging) return;
   const rect = canvasRef.value.getBoundingClientRect();
   const sx = e.clientX - rect.left;
   const sy = e.clientY - rect.top;
   const [wx, wy] = screenToWorld(sx, sy, size, size);
+
+  if (props.toolMode === "add") {
+    hoverAdd.value = props.findClosestOnCurve(Math.max(0, wx), wy, 0.14);
+    schedule();
+    return;
+  }
+
+  if (!dragging || props.toolMode !== "edit") return;
   const k = props.knots.find((n) => n.id === dragging.id);
   if (!k) return;
   if (dragging.mode === "point") {
@@ -219,9 +299,21 @@ function schedule() {
   raf = requestAnimationFrame(draw);
 }
 
-watch(() => [props.knots, props.selectedId, props.curveType, props.symmetry, curvePts.value], schedule, {
-  deep: true,
-});
+watch(
+  () => [
+    props.knots,
+    props.segments,
+    props.selectedId,
+    props.selectedSegmentIndex,
+    props.curveType,
+    props.symmetry,
+    props.toolMode,
+    curvePts.value,
+    hoverAdd.value,
+  ],
+  schedule,
+  { deep: true },
+);
 
 onMounted(() => {
   schedule();
@@ -239,6 +331,7 @@ onBeforeUnmount(() => {
     <canvas
       ref="canvasRef"
       class="spline-canvas"
+      :class="toolMode"
       @pointerdown="onPointerDown"
       @pointermove="onPointerMove"
       @pointerup="onPointerUp"
@@ -246,7 +339,7 @@ onBeforeUnmount(() => {
     />
     <div class="legend">
       <span class="dot axis" /> axis
-      <span class="dot curve" /> profile
+      <span class="dot curve" /> profile / gradient
       <span class="dot handle" /> Bezier handle
     </div>
   </div>
@@ -269,6 +362,12 @@ onBeforeUnmount(() => {
   box-shadow: 0 18px 50px rgba(0, 0, 0, 0.35);
   touch-action: none;
   cursor: crosshair;
+}
+.spline-canvas.add {
+  cursor: copy;
+}
+.spline-canvas.color {
+  cursor: pointer;
 }
 
 .legend {

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -1,64 +1,201 @@
-import { reactive, computed } from "vue";
+import { reactive, computed, watch } from "vue";
 import { SplineLathe, SplineKnot } from "@tessellate";
 
-/** @typedef {{ id: string, x: number, y: number, hx: number, hy: number }} Knot */
+/** @typedef {{ id: string, x: number, y: number, hx: number, hy: number, color: string }} Knot */
+/** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureData: { rgba: Uint8Array, w: number, h: number, name: string }|null }} Segment */
 
 function uid() {
   return "k" + Math.random().toString(36).slice(2, 9);
 }
 
+const DEFAULT_COLORS = ["#7ecf6a", "#6ec8ff", "#ffb454", "#e87ac8", "#c8e87a", "#ff7a6a"];
+
 function defaultKnots() {
   const raw = SplineLathe.defaultKnots();
-  return raw.map((k) => ({
+  return raw.map((k, i) => ({
     id: uid(),
     x: k.x,
     y: k.y,
     hx: k.hx,
     hy: k.hy,
+    color: DEFAULT_COLORS[i % DEFAULT_COLORS.length],
   }));
+}
+
+function defaultSegment(fromId, toId) {
+  return {
+    fromId,
+    toId,
+    color: null,
+    roughness: 0.4,
+    metalness: 0,
+    opacity: 1,
+    texture: "gradient",
+    textureData: null,
+  };
+}
+
+function hexToRgb(hex) {
+  const h = String(hex || "#ffffff").replace("#", "");
+  const full = h.length === 3 ? h.split("").map((c) => c + c).join("") : h.padStart(6, "0");
+  const n = parseInt(full.slice(0, 6), 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function mixHex(a, b, t) {
+  const A = hexToRgb(a);
+  const B = hexToRgb(b);
+  const r = Math.round(lerp(A.r, B.r, t));
+  const g = Math.round(lerp(A.g, B.g, t));
+  const b_ = Math.round(lerp(A.b, B.b, t));
+  return (r << 16) | (g << 8) | b_;
+}
+
+function hexToInt(hex) {
+  const c = hexToRgb(hex);
+  return (c.r << 16) | (c.g << 8) | c.b;
+}
+
+function roughnessToShininess(r) {
+  const t = Math.min(1, Math.max(0, r));
+  return lerp(280, 6, t);
+}
+
+function makeGradientRgba(hexA, hexB, w = 4, h = 64) {
+  const A = hexToRgb(hexA);
+  const B = hexToRgb(hexB);
+  const rgba = new Uint8Array(w * h * 4);
+  for (let y = 0; y < h; y++) {
+    const t = y / Math.max(1, h - 1);
+    const r = Math.round(lerp(A.r, B.r, t));
+    const g = Math.round(lerp(A.g, B.g, t));
+    const b = Math.round(lerp(A.b, B.b, t));
+    for (let x = 0; x < w; x++) {
+      const i = (y * w + x) * 4;
+      rgba[i] = r;
+      rgba[i + 1] = g;
+      rgba[i + 2] = b;
+      rgba[i + 3] = 255;
+    }
+  }
+  return { rgba, w, h };
+}
+
+function makeCheckerRgba(size = 64) {
+  const rgba = new Uint8Array(size * size * 4);
+  const cell = size / 8;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const odd = (((x / cell) | 0) + ((y / cell) | 0)) & 1;
+      const i = (y * size + x) * 4;
+      rgba[i] = odd ? 90 : 220;
+      rgba[i + 1] = odd ? 120 : 220;
+      rgba[i + 2] = odd ? 160 : 210;
+      rgba[i + 3] = 255;
+    }
+  }
+  return { rgba, w: size, h: size };
+}
+
+function makeStripesRgba(size = 64) {
+  const rgba = new Uint8Array(size * size * 4);
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const odd = ((y / 6) | 0) & 1;
+      const i = (y * size + x) * 4;
+      rgba[i] = odd ? 40 : 230;
+      rgba[i + 1] = odd ? 160 : 210;
+      rgba[i + 2] = odd ? 120 : 90;
+      rgba[i + 3] = 255;
+    }
+  }
+  return { rgba, w: size, h: size };
 }
 
 export function useSplineEditor() {
   const state = reactive({
     knots: defaultKnots(),
+    segments: /** @type {Segment[]} */ ([]),
     selectedId: null,
-    curveType: 0, // 0 bezier, 1 catmull
+    selectedSegmentIndex: -1,
+    toolMode: "edit", // edit | add | color
+    curveType: 0,
     pathSegments: 12,
     angularSteps: 24,
-    revolutionDeg: 360, // 180 = open cutaway (last step omitted, no wrap)
+    revolutionDeg: 360,
     materialMode: 3,
     symmetry: true,
     viewport: { min: -1.1, max: 1.1 },
     mesh: null,
-    stats: { verts: 0, tris: 0, profile: 0 },
-    status: "Edit the right-side profile, then Tessellate.",
+    stats: { verts: 0, tris: 0, profile: 0, parts: 0 },
+    status: "Edit mode — drag points. Switch to Add to insert on the curve.",
   });
 
+  function syncSegments() {
+    const next = [];
+    for (let i = 0; i < state.knots.length - 1; i++) {
+      const fromId = state.knots[i].id;
+      const toId = state.knots[i + 1].id;
+      const prev =
+        state.segments.find((s) => s.fromId === fromId && s.toId === toId) ||
+        state.segments.find((s) => s.fromId === fromId) ||
+        state.segments.find((s) => s.toId === toId);
+      next.push(prev ? { ...prev, fromId, toId } : defaultSegment(fromId, toId));
+    }
+    state.segments = next;
+    if (state.selectedSegmentIndex >= next.length) state.selectedSegmentIndex = next.length - 1;
+  }
+
+  syncSegments();
+
   const selected = computed(() => state.knots.find((k) => k.id === state.selectedId) || null);
+  const selectedSegment = computed(() =>
+    state.selectedSegmentIndex >= 0 ? state.segments[state.selectedSegmentIndex] || null : null,
+  );
+
+  function setToolMode(mode) {
+    state.toolMode = mode;
+    if (mode === "edit") state.status = "Edit mode — drag knots and Bezier handles.";
+    if (mode === "add") state.status = "Add mode — click the curve to insert a knot.";
+    if (mode === "color") state.status = "Coloring — pick a knot or segment in the canvas / list.";
+  }
 
   function select(id) {
     state.selectedId = id;
+    state.selectedSegmentIndex = -1;
+  }
+
+  function selectSegment(index) {
+    state.selectedSegmentIndex = index;
+    state.selectedId = null;
   }
 
   function resetDefaults() {
     state.knots = defaultKnots();
+    state.segments = [];
+    syncSegments();
     state.selectedId = state.knots[1]?.id || null;
+    state.selectedSegmentIndex = -1;
     state.mesh = null;
     state.status = "Reset to default silhouette.";
   }
 
-  function addKnot() {
-    const mid = state.knots[Math.floor(state.knots.length / 2)] || { x: 0.35, y: 0 };
-    const k = { id: uid(), x: Math.max(0, mid.x), y: mid.y + 0.15, hx: 0.12, hy: 0 };
-    state.knots.splice(Math.max(1, state.knots.length - 1), 0, k);
-    state.selectedId = k.id;
+  function removeKnot(id) {
+    if (state.knots.length <= 2) return;
+    const idx = state.knots.findIndex((k) => k.id === id);
+    if (idx < 0) return;
+    state.knots.splice(idx, 1);
+    syncSegments();
+    state.selectedId = state.knots[Math.min(idx, state.knots.length - 1)]?.id || null;
+    state.selectedSegmentIndex = -1;
   }
 
   function removeSelected() {
-    if (!selected.value || state.knots.length <= 2) return;
-    const idx = state.knots.findIndex((k) => k.id === state.selectedId);
-    state.knots.splice(idx, 1);
-    state.selectedId = state.knots[Math.min(idx, state.knots.length - 1)]?.id || null;
+    if (state.selectedId) removeKnot(state.selectedId);
   }
 
   function updateKnot(id, patch) {
@@ -68,44 +205,161 @@ export function useSplineEditor() {
     if (typeof patch.x === "number") k.x = Math.max(0, patch.x);
   }
 
-  function toRangerKnots() {
-    return state.knots.map((k) => SplineKnot.of(k.x, k.y, k.hx, k.hy));
+  function updateSegment(index, patch) {
+    const s = state.segments[index];
+    if (!s) return;
+    Object.assign(s, patch);
+  }
+
+  function toRangerKnots(list = state.knots) {
+    return list.map((k) => SplineKnot.of(k.x, k.y, k.hx, k.hy));
+  }
+
+  function evalSpan(a, b, t, curveType) {
+    if (curveType === 0) {
+      return {
+        p: SplineLathe.bezierPoint(a.x, a.y, a.x + a.hx, a.y + a.hy, b.x - b.hx, b.y - b.hy, b.x, b.y, t),
+        tan: SplineLathe.bezierTangent(a.x, a.y, a.x + a.hx, a.y + a.hy, b.x - b.hx, b.y - b.hy, b.x, b.y, t),
+      };
+    }
+    // catmull uses neighbours; approximate with span endpoints as p1/p2 and duplicates
+    return {
+      p: SplineLathe.catmullPoint(a.x, a.y, a.x, a.y, b.x, b.y, b.x, b.y, t),
+      tan: SplineLathe.catmullTangent(a.x, a.y, a.x, a.y, b.x, b.y, b.x, b.y, t),
+    };
   }
 
   function sampleCurvePoints(samplesPerSpan = 24) {
-    const mesh = SplineLathe.sampleProfile(toRangerKnots(), state.curveType, samplesPerSpan);
     const pts = [];
-    for (let i = 0; i < mesh.profileX.length; i++) {
-      pts.push({ x: mesh.profileX[i], y: mesh.profileY[i] });
+    for (let i = 0; i < state.knots.length - 1; i++) {
+      const a = state.knots[i];
+      const b = state.knots[i + 1];
+      const last = i < state.knots.length - 2 ? samplesPerSpan - 1 : samplesPerSpan;
+      for (let s = 0; s <= last; s++) {
+        const t = s / samplesPerSpan;
+        const { p } = evalSpan(a, b, t, state.curveType);
+        pts.push({ x: Math.max(0, p.x), y: p.y, segmentIndex: i, t });
+      }
     }
     return pts;
+  }
+
+  function findClosestOnCurve(wx, wy, maxDist = 0.12) {
+    const pts = sampleCurvePoints(40);
+    let best = null;
+    let bestD = maxDist;
+    for (const p of pts) {
+      const d = Math.hypot(p.x - wx, p.y - wy);
+      if (d < bestD) {
+        bestD = d;
+        best = p;
+      }
+    }
+    return best;
+  }
+
+  function insertKnotOnCurve(wx, wy) {
+    const hit = findClosestOnCurve(wx, wy);
+    if (!hit) {
+      state.status = "Click closer to the curve to add a point.";
+      return null;
+    }
+    const a = state.knots[hit.segmentIndex];
+    const b = state.knots[hit.segmentIndex + 1];
+    const { p, tan } = evalSpan(a, b, hit.t, state.curveType);
+    const tl = Math.hypot(tan.x, tan.y) || 1;
+    const scale = 0.14;
+    const k = {
+      id: uid(),
+      x: Math.max(0, p.x),
+      y: p.y,
+      hx: (tan.x / tl) * scale,
+      hy: (tan.y / tl) * scale,
+      color: DEFAULT_COLORS[state.knots.length % DEFAULT_COLORS.length],
+    };
+    state.knots.splice(hit.segmentIndex + 1, 0, k);
+    syncSegments();
+    state.selectedId = k.id;
+    state.selectedSegmentIndex = -1;
+    state.status = `Added knot #${hit.segmentIndex + 2} on the curve.`;
+    return k;
+  }
+
+  function resolvePartStyle(segIndex) {
+    const a = state.knots[segIndex];
+    const b = state.knots[segIndex + 1];
+    const seg = state.segments[segIndex];
+    const colorA = a.color || "#cccccc";
+    const colorB = b.color || "#cccccc";
+    const solidHex = seg.color ? hexToInt(seg.color) : null;
+    const shininess = roughnessToShininess(seg.roughness ?? 0.4);
+    const reflectivity = Math.min(0.95, Math.max(0, seg.metalness ?? 0));
+    const opacity = seg.opacity ?? 1;
+
+    let map = null;
+    let colorHex = 0xffffff;
+    if (seg.texture === "upload" && seg.textureData) {
+      map = seg.textureData;
+      colorHex = 0xffffff;
+    } else if (seg.texture === "checker") {
+      map = makeCheckerRgba(64);
+      colorHex = solidHex != null ? solidHex : mixHex(colorA, colorB, 0.5);
+    } else if (seg.texture === "stripes") {
+      map = makeStripesRgba(64);
+      colorHex = solidHex != null ? solidHex : mixHex(colorA, colorB, 0.5);
+    } else if (seg.texture === "none" && solidHex != null) {
+      colorHex = solidHex;
+    } else {
+      // linear gradient along the segment (knot A → knot B), or solid override tinted gradient
+      const from = solidHex != null ? seg.color : colorA;
+      const to = solidHex != null ? seg.color : colorB;
+      map = makeGradientRgba(from, to, 4, 64);
+      colorHex = 0xffffff;
+    }
+
+    return { colorHex, shininess, reflectivity, opacity, map };
   }
 
   function tessellate() {
     const phi = (state.revolutionDeg * Math.PI) / 180;
     const closed = state.revolutionDeg >= 359.9;
-    const mesh = SplineLathe.sampleAndLatheEx(
-      toRangerKnots(),
-      state.curveType,
-      state.pathSegments,
-      state.angularSteps,
-      phi,
-      closed,
-    );
-    state.mesh = {
-      positions: mesh.positions.slice(),
-      normals: mesh.normals.slice(),
-      uvs: mesh.uvs.slice(),
-      indices: mesh.indices.slice(),
-      profileX: mesh.profileX.slice(),
-      profileY: mesh.profileY.slice(),
-    };
+    const parts = [];
+    let totalV = 0;
+    let totalT = 0;
+
+    for (let i = 0; i < state.knots.length - 1; i++) {
+      const pair = [state.knots[i], state.knots[i + 1]];
+      const mesh = SplineLathe.sampleAndLatheEx(
+        toRangerKnots(pair),
+        state.curveType,
+        state.pathSegments,
+        state.angularSteps,
+        phi,
+        closed,
+      );
+      const style = resolvePartStyle(i);
+      parts.push({
+        positions: mesh.positions.slice(),
+        normals: mesh.normals.slice(),
+        uvs: mesh.uvs.slice(),
+        indices: mesh.indices.slice(),
+        ...style,
+        mapRgba: style.map ? Array.from(style.map.rgba) : null,
+        mapW: style.map ? style.map.w : 0,
+        mapH: style.map ? style.map.h : 0,
+      });
+      totalV += (mesh.positions.length / 3) | 0;
+      totalT += (mesh.indices.length / 3) | 0;
+    }
+
+    state.mesh = { parts };
     state.stats = {
-      verts: (mesh.positions.length / 3) | 0,
-      tris: (mesh.indices.length / 3) | 0,
-      profile: mesh.profileX.length,
+      verts: totalV,
+      tris: totalT,
+      profile: state.knots.length,
+      parts: parts.length,
     };
-    state.status = `Tessellated ${state.stats.verts} verts / ${state.stats.tris} tris.`;
+    state.status = `Tessellated ${parts.length} parts · ${totalV} verts / ${totalT} tris.`;
     return state.mesh;
   }
 
@@ -113,15 +367,27 @@ export function useSplineEditor() {
     state.selectedId = state.knots[1].id;
   }
 
+  watch(
+    () => state.knots.length,
+    () => syncSegments(),
+  );
+
   return {
     state,
     selected,
+    selectedSegment,
+    setToolMode,
     select,
+    selectSegment,
     resetDefaults,
-    addKnot,
+    removeKnot,
     removeSelected,
     updateKnot,
+    updateSegment,
     sampleCurvePoints,
+    findClosestOnCurve,
+    insertKnotOnCurve,
     tessellate,
+    syncSegments,
   };
 }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/rangerPreview.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/rangerPreview.js
@@ -25,6 +25,8 @@ export async function createPreviewSession(canvas, size = 420) {
   let raf = 0;
   let last = performance.now();
   let running = false;
+  let lastMesh = null;
+  let lastMode = 3;
 
   function blit() {
     if (useGL || !ctx || !image) return;
@@ -61,17 +63,53 @@ export async function createPreviewSession(canvas, size = 420) {
     raf = 0;
   }
 
-  function setMesh(mesh) {
+  function pushMesh(mesh) {
     if (!mesh) return;
-    host.setMesh(mesh.positions, mesh.normals, mesh.uvs, mesh.indices);
-    host.frame(0);
-    blit();
+    host.setMaterialMode(lastMode | 0);
+    // New multi-part format
+    if (mesh.parts && mesh.parts.length) {
+      host.beginParts();
+      for (const part of mesh.parts) {
+        const mapBytes = part.mapRgba && part.mapRgba.length ? part.mapRgba : [];
+        host.addPart(
+          part.positions,
+          part.normals,
+          part.uvs,
+          part.indices,
+          part.colorHex | 0,
+          part.shininess || 120,
+          part.opacity == null ? 1 : part.opacity,
+          part.reflectivity || 0,
+          mapBytes,
+          part.mapW | 0,
+          part.mapH | 0,
+        );
+      }
+      host.frame(0);
+      blit();
+      return;
+    }
+    // Legacy single mesh
+    if (mesh.positions) {
+      host.setMesh(mesh.positions, mesh.normals, mesh.uvs, mesh.indices);
+      host.frame(0);
+      blit();
+    }
+  }
+
+  function setMesh(mesh) {
+    lastMesh = mesh;
+    pushMesh(mesh);
   }
 
   function setMaterialMode(mode) {
-    host.setMaterialMode(mode | 0);
-    host.frame(0);
-    blit();
+    lastMode = mode | 0;
+    host.setMaterialMode(lastMode);
+    if (lastMesh) pushMesh(lastMesh);
+    else {
+      host.frame(0);
+      blit();
+    }
   }
 
   function wirePointer() {

--- a/gallery/game_engine/v2/mesh_editor/host/web_mesh_editor_host.rgr
+++ b/gallery/game_engine/v2/mesh_editor/host/web_mesh_editor_host.rgr
@@ -1,10 +1,9 @@
 ; ==============================================================================
 ; web_mesh_editor_host — Ranger Three preview host for the spline mesh editor.
 ; ==============================================================================
-; Receives a tessellated BufferGeometry (flat arrays from the SplineLathe JS
-; module), assigns a material, and renders via ThreeSceneHost. Prefers the WebGL
-; backend when the browser canvas is available; falls back to the software
-; rasteriser (RGB buffer blitted by the Vue viewer).
+; Supports multi-part lathe meshes (one part per profile segment) with per-part
+; colour, shininess (from roughness), opacity, reflectivity (metalness), and an
+; optional RGBA texture map (gradient / procedural / upload).
 ; ==============================================================================
 
 Import "../../three/port/src/three_scene_host.rgr"
@@ -13,6 +12,7 @@ Import "../../three/port/src/three_gl_backend.rgr"
 Import "../../three/port/src/three_orbit_controls.rgr"
 Import "../../three/port/src/three_mesh.rgr"
 Import "../../three/port/src/three_material.rgr"
+Import "../../three/port/src/three_texture.rgr"
 
 class WebMeshEditorHost {
     def host:ThreeSceneHost (new ThreeSceneHost)
@@ -24,14 +24,12 @@ class WebMeshEditorHost {
     def h:int 480
     def sceneH:int 0
     def camH:int 0
-    def meshH:int 0
-    def matH:int 0
-    def geoH:int 0
-    def hasMesh:boolean false
+    def meshHs:[int]
     def matMode:int 3
     def autoRotate:boolean true
     def angle:double 0.4
     def outBuf:buffer (buffer_alloc 0)
+    def lastMatH:int 0
 
     fn setupGL:boolean (canvasId:string) {
         def ok:boolean (gl.init(canvasId))
@@ -52,8 +50,8 @@ class WebMeshEditorHost {
         camH = (host.cameraNew())
         host.cameraSet(camH 45.0 ((to_double w) / (to_double h)) 0.1 100.0)
         host.cameraPose(camH 2.6 1.4 3.2 0.0 0.0 0.0)
-        host.lightAmbient(sceneH 16777215 0.35)
-        host.lightDirectional(sceneH 16777215 1.15 0.45 0.85 0.35 false 0)
+        host.lightAmbient(sceneH 16777215 0.4)
+        host.lightDirectional(sceneH 16777215 1.2 0.45 0.85 0.35 false 0)
         controls.setCamera((host.cameraAt(camH)))
         controls.setViewport(w h)
         controls.setTarget(0.0 0.0 0.0)
@@ -62,50 +60,47 @@ class WebMeshEditorHost {
         ready = true
     }
 
-    ; Material modes (teapot-inspired): 0 wire, 1 flat, 2 smooth, 3 glossy, 4 reflective.
-    fn buildMaterial:int (mode:int) {
+    fn clearParts:void () {
+        def i:int 0
+        while (i < (array_length meshHs)) {
+            def mh:int (itemAt meshHs i)
+            if (mh > 0) {
+                host.entityRemove(sceneH mh)
+            }
+            i = (i + 1)
+        }
+        clear meshHs
+    }
+
+    ; Build a Phong material tinted by colourHex; shininess/opacity/reflectivity
+    ; come from the segment style. matMode 0 forces wireframe basic.
+    fn buildPartMaterial:int (colorHex:int shininess:double opacity:double reflectivity:double) {
         def side:int 2
-        if (mode == 0) {
-            return (host.materialBasic(12632256 side true))
+        if (matMode == 0) {
+            def wb:int (host.materialBasic(colorHex side true))
+            host.materialSetOpacity(wb opacity)
+            return wb
         }
-        if (mode == 1) {
-            return (host.materialPhong(12632256 0 30.0 true side))
+        def flat:boolean false
+        if (matMode == 1) {
+            flat = true
         }
-        if (mode == 2) {
-            return (host.materialLambert(3512575 side))
-        }
-        if (mode == 4) {
-            def m:int (host.materialPhong(12632256 4210752 300.0 false side))
-            host.materialReflective(m 0.95)
+        def m:int (host.materialPhong(colorHex 4210752 shininess flat side))
+        host.materialSetOpacity(m opacity)
+        if ((reflectivity > 0.05) || (matMode == 4)) {
+            def r:double reflectivity
+            if (matMode == 4) {
+                if (r < 0.5) {
+                    r = 0.85
+                }
+            }
+            host.materialReflective(m r)
             host.sceneEnvironmentStudio(sceneH 64)
-            return m
         }
-        ; glossy default
-        return (host.materialPhong(12632256 4210752 220.0 false side))
+        return m
     }
 
-    fn setMaterialMode:void (mode:int) {
-        matMode = mode
-        if (hasMesh == false) {
-            return
-        }
-        if (meshH > 0) {
-            host.entityRemove(sceneH meshH)
-        }
-        matH = (this.buildMaterial(mode))
-        meshH = (host.meshNew(sceneH geoH matH))
-        host.entityTransform(meshH 0.0 0.0 0.0 0.12 angle 0.0 1.0 1.0 1.0)
-    }
-
-    ; Replace the preview mesh from flat BufferGeometry arrays.
-    fn setMesh:void (positions:[double] normals:[double] uvs:[double] indices:[int]) {
-        if (ready == false) {
-            return
-        }
-        if (hasMesh) {
-            host.entityRemove(sceneH meshH)
-            hasMesh = false
-        }
+    fn fillGeometry:ThreeBufferGeometry (positions:[double] normals:[double] uvs:[double] indices:[int]) {
         def g:ThreeBufferGeometry (new ThreeBufferGeometry)
         def vc:int (idiv (array_length positions) 3)
         def i:int 0
@@ -138,12 +133,53 @@ class WebMeshEditorHost {
             g.pushIndex((itemAt indices ii))
             ii = (ii + 1)
         }
+        return g
+    }
+
+    fn bytesToBuffer:buffer (bytes:[int]) {
+        def n:int (array_length bytes)
+        def buf:buffer (buffer_alloc n)
+        def i:int 0
+        while (i < n) {
+            buffer_set buf i (itemAt bytes i)
+            i = (i + 1)
+        }
+        return buf
+    }
+
+    ; Add one lathed segment. mapBytes empty => no texture.
+    fn addPart:void (positions:[double] normals:[double] uvs:[double] indices:[int] colorHex:int shininess:double opacity:double reflectivity:double mapBytes:[int] mapW:int mapH:int) {
+        if (ready == false) {
+            return
+        }
+        def g:ThreeBufferGeometry (this.fillGeometry(positions normals uvs indices))
         push host.geometries g
-        geoH = (array_length host.geometries)
-        matH = (this.buildMaterial(matMode))
-        meshH = (host.meshNew(sceneH geoH matH))
+        def geoH:int (array_length host.geometries)
+        def matH:int (this.buildPartMaterial(colorHex shininess opacity reflectivity))
+        if (((array_length mapBytes) > 0) && (mapW > 0) && (mapH > 0)) {
+            def tex:ThreeTexture (new ThreeTexture)
+            tex.setImage((this.bytesToBuffer(mapBytes)) mapW mapH)
+            (host.materialAt(matH)).setMap(tex)
+        }
+        lastMatH = matH
+        def meshH:int (host.meshNew(sceneH geoH matH))
         host.entityTransform(meshH 0.0 0.0 0.0 0.12 angle 0.0 1.0 1.0 1.0)
-        hasMesh = true
+        push meshHs meshH
+    }
+
+    fn beginParts:void () {
+        this.clearParts()
+    }
+
+    fn setMaterialMode:void (mode:int) {
+        matMode = mode
+    }
+
+    ; Back-compat single-mesh path used by older callers.
+    fn setMesh:void (positions:[double] normals:[double] uvs:[double] indices:[int]) {
+        this.beginParts()
+        def emptyMap:[int]
+        this.addPart(positions normals uvs indices 12632256 220.0 1.0 0.0 emptyMap 0 0)
     }
 
     fn setAutoRotate:void (on:boolean) {
@@ -171,8 +207,10 @@ class WebMeshEditorHost {
         }
         if (autoRotate) {
             angle = (angle + (dtMs * 0.0009))
-            if (hasMesh) {
-                host.entityTransform(meshH 0.0 0.0 0.0 0.12 angle 0.0 1.0 1.0 1.0)
+            def i:int 0
+            while (i < (array_length meshHs)) {
+                host.entityTransform((itemAt meshHs i) 0.0 0.0 0.0 0.12 angle 0.0 1.0 1.0 1.0)
+                i = (i + 1)
             }
         }
         controls.applyToCamera()
@@ -180,7 +218,6 @@ class WebMeshEditorHost {
             host.render(sceneH camH w h)
             return
         }
-        ; software path: 2× supersample then box-downsample (same as live3d)
         def sw:int (w * 2)
         def sh:int (h * 2)
         host.renderer.setClearColor(0.12 0.13 0.16)
@@ -228,10 +265,7 @@ class WebMeshEditorHost {
         return useGL
     }
 
-    fn vertexHint:int () {
-        if (geoH <= 0) {
-            return 0
-        }
-        return ((host.geometryAt(geoH)).vertexCount())
+    fn partCount:int () {
+        return (array_length meshHs)
     }
 }

--- a/gallery/game_engine/v2/mesh_editor/smoke.mjs
+++ b/gallery/game_engine/v2/mesh_editor/smoke.mjs
@@ -1,8 +1,6 @@
 // ============================================================================
 // smoke.mjs — headless tessellate + software-render smoke for the mesh editor.
 // ============================================================================
-//   node gallery/game_engine/v2/mesh_editor/smoke.mjs
-// ============================================================================
 
 import fs from "node:fs";
 import path from "node:path";
@@ -22,6 +20,20 @@ function loadRuntime() {
   return new engine.WebMeshEditorHost();
 }
 
+function gradientBytes() {
+  const w = 4;
+  const h = 32;
+  const out = [];
+  for (let y = 0; y < h; y++) {
+    const t = y / (h - 1);
+    const r = (126 + (255 - 126) * t) | 0;
+    const g = (207 + (180 - 207) * t) | 0;
+    const b = (106 + (84 - 106) * t) | 0;
+    for (let x = 0; x < w; x++) out.push(r, g, b, 255);
+  }
+  return { bytes: out, w, h };
+}
+
 const knots = SplineLathe.defaultKnots();
 const full = SplineLathe.sampleAndLatheEx(knots, 0, 8, 16, Math.PI * 2, true);
 const half = SplineLathe.sampleAndLatheEx(knots, 0, 8, 16, Math.PI, false);
@@ -31,18 +43,38 @@ if (full.positions.length < 30 || half.indices.length >= full.indices.length) {
 
 const host = loadRuntime();
 host.init(96, 96);
-host.setMesh(full.positions, full.normals, full.uvs, full.indices);
-host.setMaterialMode(3);
+host.beginParts();
+const grad = gradientBytes();
+// two fake parts (same geo) with different colours / map
+const mid = SplineLathe.sampleAndLatheEx(
+  [knots[0], knots[1]],
+  0,
+  6,
+  12,
+  Math.PI * 2,
+  true,
+);
+host.addPart(mid.positions, mid.normals, mid.uvs, mid.indices, 0x7ecf6a, 180, 1, 0, grad.bytes, grad.w, grad.h);
+const top = SplineLathe.sampleAndLatheEx(
+  [knots[1], knots[2]],
+  0,
+  6,
+  12,
+  Math.PI * 2,
+  true,
+);
+host.addPart(top.positions, top.normals, top.uvs, top.indices, 0x6ec8ff, 40, 1, 0.2, [], 0, 0);
 host.frame(16);
 const pix = new Uint8Array(host.framePixels());
 let lit = 0;
 for (let i = 0; i < pix.length; i += 3) {
   if (pix[i] > 40 || pix[i + 1] > 40 || pix[i + 2] > 45) lit++;
 }
-if (lit < 50) throw new Error("software preview produced too few lit pixels: " + lit);
+if (lit < 40) throw new Error("software preview produced too few lit pixels: " + lit);
+if (host.partCount() !== 2) throw new Error("expected 2 parts, got " + host.partCount());
 
 console.log("[mesh-editor smoke] OK", {
   fullVerts: (full.positions.length / 3) | 0,
-  halfTris: (half.indices.length / 3) | 0,
+  parts: host.partCount(),
   litPixels: lit,
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the merged #451 spline mesh editor. Adds editor tool modes that landed after that PR was already merged:

- **Edit** — drag knots / Bezier handles
- **Add** — click the profile curve to insert a knot (remove from the point list)
- **Coloring** — per-knot colours form a linear height gradient; each segment can override colour, roughness, metalness, opacity, and texture (gradient / checker / stripes / custom upload)

Tessellation emits one Ranger Three mesh part per segment (shininess ← roughness, reflectivity ← metalness).

### Run

```bash
cd gallery/game_engine/v2/mesh_editor/app
npm install && npm run dev
```

```bash
node gallery/game_engine/v2/mesh_editor/build-host.mjs
node gallery/game_engine/v2/mesh_editor/smoke.mjs
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

