### PR TITLE
Spline editor UX: compact list, drag-end preview, insert order

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -54,11 +54,11 @@ Open the printed local URL (default `http://localhost:5177`).
 
 | Mode | Behaviour |
 |------|-----------|
-| **Edit** | Drag knots and Bezier handles |
+| **Edit** | Drag knots / Bezier handles; mesh refreshes when the drag ends |
 | **Add** | Click the profile curve to insert a knot (remove from the point list) |
-| **Coloring** | Per-knot colours form a linear height gradient; each segment can override colour, roughness, metalness, opacity, and texture (gradient / checker / stripes / upload) |
+| **Coloring** | Per-knot / per-segment colours & materials |
 
-Segment styles are lathed as separate mesh parts and previewed through Ranger Three materials (shininess ← roughness, reflectivity ← metalness).
+The point list is **top → bottom** (matches the canvas). Rows stay compact; **Details** expands numeric / material fields. Colour swatches are always available.
 
 ## Shading base
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -50,11 +50,19 @@ function onRemoveKnot(id) {
 
 function onUpdateKnot(id, patch) {
   updateKnot(id, patch);
-  if (patch && patch.color) tessellate();
+  if (patch && patch.color != null) tessellate();
 }
 
 function onUpdateSegment(index, patch) {
   updateSegment(index, patch);
+  tessellate();
+}
+
+function onDragEnd() {
+  tessellate();
+}
+
+function onListCommit() {
   tessellate();
 }
 
@@ -153,6 +161,7 @@ onMounted(() => {
         @select-segment="selectSegment"
         @update-knot="onUpdateKnot"
         @add-on-curve="onAddOnCurve"
+        @drag-end="onDragEnd"
       />
       <PointEditor
         :knots="state.knots"
@@ -166,6 +175,7 @@ onMounted(() => {
         @update-knot="onUpdateKnot"
         @update-segment="onUpdateSegment"
         @remove-knot="onRemoveKnot"
+        @commit="onListCommit"
       />
       <Preview3D :mesh="state.mesh" :material-mode="state.materialMode" />
     </main>

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/PointEditor.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/PointEditor.vue
@@ -1,5 +1,7 @@
 <script setup>
-defineProps({
+import { computed, ref, watch } from "vue";
+
+const props = defineProps({
   knots: { type: Array, required: true },
   segments: { type: Array, default: () => [] },
   selectedId: { type: String, default: null },
@@ -14,11 +16,39 @@ const emit = defineEmits([
   "update-knot",
   "update-segment",
   "remove-knot",
+  "commit",
 ]);
+
+/** Top-of-canvas first so a newly added high point appears near the top of the list. */
+const rows = computed(() => {
+  const out = [];
+  for (let i = props.knots.length - 1; i >= 0; i--) {
+    out.push({ kind: "knot", index: i, knot: props.knots[i] });
+    if (i > 0) out.push({ kind: "segment", index: i - 1 });
+  }
+  return out;
+});
+
+const expandedKey = ref(null);
+
+watch(
+  () => [props.selectedId, props.selectedSegmentIndex],
+  () => {
+    if (props.selectedId) expandedKey.value = "knot:" + props.selectedId;
+    else if (props.selectedSegmentIndex >= 0) expandedKey.value = "seg:" + props.selectedSegmentIndex;
+  },
+);
+
+function toggleDetails(key) {
+  expandedKey.value = expandedKey.value === key ? null : key;
+}
 
 function onNum(id, key, ev) {
   const v = Number(ev.target.value);
-  if (Number.isFinite(v)) emit("update-knot", id, { [key]: v });
+  if (Number.isFinite(v)) {
+    emit("update-knot", id, { [key]: v });
+    emit("commit");
+  }
 }
 
 function onSegNum(index, key, ev) {
@@ -43,151 +73,214 @@ async function onTextureFile(index, ev) {
     textureData: { rgba: img.data.slice(), w, h, name: file.name },
   });
 }
+
+function knotLabel(i) {
+  if (i === 0) return "bottom";
+  if (i === props.knots.length - 1) return "top";
+  return "mid";
+}
 </script>
 
 <template>
   <div class="point-editor">
     <header>
       <h2>{{ toolMode === "color" ? "Coloring" : "Points" }}</h2>
-      <p v-if="toolMode !== 'color'">Right-side profile (x ≥ 0). Remove from the list.</p>
-      <p v-else>Knot colors form a linear gradient; segments can override material.</p>
+      <p>Top → bottom (matches the canvas). Color always editable; Details for numbers.</p>
     </header>
 
     <ul>
-      <li
-        v-for="(k, i) in knots"
-        :key="k.id"
-        :class="{ active: k.id === selectedId }"
-        @click="emit('select', k.id)"
-      >
-        <div class="row-title">
-          <strong>
-            <span class="swatch" :style="{ background: k.color }" />
-            #{{ i + 1 }}
-          </strong>
-          <span>{{ i === 0 ? "bottom" : i === knots.length - 1 ? "top" : "mid" }}</span>
-        </div>
-
-        <div v-if="toolMode === 'color'" class="grid">
-          <label class="field wide">
-            Knot color
-            <input
-              type="color"
-              :value="k.color"
-              @input="emit('update-knot', k.id, { color: $event.target.value })"
-            />
-          </label>
-        </div>
-        <div v-else class="grid">
-          <label class="field">
-            x
-            <input type="number" step="0.01" :value="k.x" @change="onNum(k.id, 'x', $event)" />
-          </label>
-          <label class="field">
-            y
-            <input type="number" step="0.01" :value="k.y" @change="onNum(k.id, 'y', $event)" />
-          </label>
-          <template v-if="curveType === 0">
-            <label class="field">
-              hx
-              <input type="number" step="0.01" :value="k.hx" @change="onNum(k.id, 'hx', $event)" />
-            </label>
-            <label class="field">
-              hy
-              <input type="number" step="0.01" :value="k.hy" @change="onNum(k.id, 'hy', $event)" />
-            </label>
-          </template>
-        </div>
-
-        <div class="row-actions">
-          <button
-            type="button"
-            class="danger"
-            :disabled="knots.length <= 2"
-            @click.stop="emit('remove-knot', k.id)"
-          >
-            Remove
-          </button>
-        </div>
-
-        <!-- segment after this knot -->
-        <div
-          v-if="i < knots.length - 1 && toolMode === 'color'"
-          class="segment"
-          :class="{ active: selectedSegmentIndex === i }"
-          @click.stop="emit('select-segment', i)"
+      <template v-for="row in rows" :key="row.kind + '-' + (row.knot?.id || row.index)">
+        <!-- knot row -->
+        <li
+          v-if="row.kind === 'knot'"
+          class="knot-row"
+          :class="{ active: row.knot.id === selectedId }"
+          @click="emit('select', row.knot.id)"
         >
-          <div class="row-title">
-            <strong>Segment {{ i + 1 }}→{{ i + 2 }}</strong>
-            <span class="swatch" :style="{ background: segments[i]?.color || k.color }" />
+          <div class="compact">
+            <label class="swatch-wrap" @click.stop>
+              <input
+                type="color"
+                :value="row.knot.color"
+                @input="emit('update-knot', row.knot.id, { color: $event.target.value })"
+              />
+            </label>
+            <div class="meta">
+              <strong>#{{ row.index + 1 }}</strong>
+              <span>{{ knotLabel(row.index) }}</span>
+            </div>
+            <button
+              type="button"
+              class="chip"
+              title="x"
+              @click.stop="toggleDetails('knot:' + row.knot.id)"
+            >
+              {{ row.knot.x.toFixed(2) }}
+            </button>
+            <button
+              type="button"
+              class="chip"
+              title="y"
+              @click.stop="toggleDetails('knot:' + row.knot.id)"
+            >
+              {{ row.knot.y.toFixed(2) }}
+            </button>
+            <button
+              type="button"
+              class="link"
+              @click.stop="toggleDetails('knot:' + row.knot.id)"
+            >
+              {{ expandedKey === "knot:" + row.knot.id ? "Hide" : "Details" }}
+            </button>
+            <button
+              type="button"
+              class="danger icon"
+              :disabled="knots.length <= 2"
+              title="Remove"
+              @click.stop="emit('remove-knot', row.knot.id)"
+            >
+              ×
+            </button>
           </div>
-          <div class="grid">
-            <label class="field wide">
-              Segment color
-              <div class="color-row">
+
+          <div v-if="expandedKey === 'knot:' + row.knot.id" class="details" @click.stop>
+            <div class="grid">
+              <label class="field">
+                x
                 <input
-                  type="color"
-                  :value="segments[i]?.color || k.color"
-                  @input="emit('update-segment', i, { color: $event.target.value })"
+                  type="number"
+                  step="0.01"
+                  :value="row.knot.x"
+                  @change="onNum(row.knot.id, 'x', $event)"
                 />
-                <button type="button" @click.stop="emit('update-segment', i, { color: null })">
-                  Use gradient
-                </button>
-              </div>
-            </label>
-            <label class="field">
-              Roughness
-              <input
-                type="number"
-                min="0"
-                max="1"
-                step="0.05"
-                :value="segments[i]?.roughness ?? 0.4"
-                @change="onSegNum(i, 'roughness', $event)"
-              />
-            </label>
-            <label class="field">
-              Metalness
-              <input
-                type="number"
-                min="0"
-                max="1"
-                step="0.05"
-                :value="segments[i]?.metalness ?? 0"
-                @change="onSegNum(i, 'metalness', $event)"
-              />
-            </label>
-            <label class="field">
-              Opacity
-              <input
-                type="number"
-                min="0"
-                max="1"
-                step="0.05"
-                :value="segments[i]?.opacity ?? 1"
-                @change="onSegNum(i, 'opacity', $event)"
-              />
-            </label>
-            <label class="field wide">
-              Texture
-              <select
-                :value="segments[i]?.texture || 'gradient'"
-                @change="emit('update-segment', i, { texture: $event.target.value })"
-              >
-                <option value="gradient">Linear gradient</option>
-                <option value="none">Solid / none</option>
-                <option value="checker">Checker</option>
-                <option value="stripes">Stripes</option>
-                <option value="upload">Custom upload</option>
-              </select>
-            </label>
-            <label v-if="(segments[i]?.texture || '') === 'upload'" class="field wide">
-              Image file
-              <input type="file" accept="image/*" @change="onTextureFile(i, $event)" />
-            </label>
+              </label>
+              <label class="field">
+                y
+                <input
+                  type="number"
+                  step="0.01"
+                  :value="row.knot.y"
+                  @change="onNum(row.knot.id, 'y', $event)"
+                />
+              </label>
+              <template v-if="curveType === 0">
+                <label class="field">
+                  hx
+                  <input
+                    type="number"
+                    step="0.01"
+                    :value="row.knot.hx"
+                    @change="onNum(row.knot.id, 'hx', $event)"
+                  />
+                </label>
+                <label class="field">
+                  hy
+                  <input
+                    type="number"
+                    step="0.01"
+                    :value="row.knot.hy"
+                    @change="onNum(row.knot.id, 'hy', $event)"
+                  />
+                </label>
+              </template>
+            </div>
           </div>
-        </div>
-      </li>
+        </li>
+
+        <!-- segment row (compact; expand for material) -->
+        <li
+          v-else
+          class="seg-row"
+          :class="{ active: selectedSegmentIndex === row.index }"
+          @click="emit('select-segment', row.index)"
+        >
+          <div class="compact">
+            <label class="swatch-wrap" @click.stop>
+              <input
+                type="color"
+                :value="segments[row.index]?.color || knots[row.index]?.color || '#888888'"
+                @input="emit('update-segment', row.index, { color: $event.target.value })"
+              />
+            </label>
+            <div class="meta">
+              <strong>seg {{ row.index + 1 }}→{{ row.index + 2 }}</strong>
+              <span>{{ segments[row.index]?.texture || "gradient" }}</span>
+            </div>
+            <button
+              type="button"
+              class="chip"
+              @click.stop="emit('update-segment', row.index, { color: null })"
+            >
+              gradient
+            </button>
+            <button
+              type="button"
+              class="link"
+              @click.stop="toggleDetails('seg:' + row.index)"
+            >
+              {{ expandedKey === "seg:" + row.index ? "Hide" : "Details" }}
+            </button>
+          </div>
+
+          <div v-if="expandedKey === 'seg:' + row.index" class="details" @click.stop>
+            <div class="grid">
+              <label class="field">
+                Roughness
+                <input
+                  type="number"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  :value="segments[row.index]?.roughness ?? 0.4"
+                  @change="onSegNum(row.index, 'roughness', $event)"
+                />
+              </label>
+              <label class="field">
+                Metalness
+                <input
+                  type="number"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  :value="segments[row.index]?.metalness ?? 0"
+                  @change="onSegNum(row.index, 'metalness', $event)"
+                />
+              </label>
+              <label class="field">
+                Opacity
+                <input
+                  type="number"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  :value="segments[row.index]?.opacity ?? 1"
+                  @change="onSegNum(row.index, 'opacity', $event)"
+                />
+              </label>
+              <label class="field wide">
+                Texture
+                <select
+                  :value="segments[row.index]?.texture || 'gradient'"
+                  @change="emit('update-segment', row.index, { texture: $event.target.value })"
+                >
+                  <option value="gradient">Linear gradient</option>
+                  <option value="none">Solid / none</option>
+                  <option value="checker">Checker</option>
+                  <option value="stripes">Stripes</option>
+                  <option value="upload">Custom upload</option>
+                </select>
+              </label>
+              <label
+                v-if="(segments[row.index]?.texture || '') === 'upload'"
+                class="field wide"
+              >
+                Image file
+                <input type="file" accept="image/*" @change="onTextureFile(row.index, $event)" />
+              </label>
+            </div>
+          </div>
+        </li>
+      </template>
     </ul>
   </div>
 </template>
@@ -204,37 +297,35 @@ async function onTextureFile(index, ev) {
 }
 
 header {
-  padding: 0.9rem 1rem 0.5rem;
+  padding: 0.7rem 0.85rem 0.45rem;
   border-bottom: 1px solid var(--line);
 }
 
 h2 {
   margin: 0;
   font-family: var(--font-display);
-  font-size: 1.45rem;
+  font-size: 1.25rem;
   font-weight: 400;
 }
 
 p {
-  margin: 0.2rem 0 0;
+  margin: 0.15rem 0 0;
   color: var(--ink-dim);
-  font-size: 0.78rem;
+  font-size: 0.72rem;
 }
 
 ul {
   list-style: none;
   margin: 0;
-  padding: 0.4rem;
+  padding: 0.3rem;
   overflow: auto;
 }
 
 li {
-  padding: 0.65rem 0.7rem;
-  border-radius: 8px;
+  border-radius: 7px;
   border: 1px solid transparent;
-  margin-bottom: 0.35rem;
+  margin-bottom: 0.2rem;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease;
 }
 
 li:hover {
@@ -246,81 +337,105 @@ li.active {
   background: rgba(126, 207, 106, 0.08);
 }
 
-.row-title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.45rem;
-  font-size: 0.8rem;
-  color: var(--ink-dim);
-  gap: 0.4rem;
+.seg-row {
+  background: rgba(0, 0, 0, 0.14);
+}
+.seg-row.active {
+  border-color: rgba(110, 200, 255, 0.5);
+  background: rgba(110, 200, 255, 0.08);
 }
 
-.swatch {
-  display: inline-block;
-  width: 12px;
-  height: 12px;
-  border-radius: 3px;
-  margin-right: 0.35rem;
+.compact {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto auto auto;
+  gap: 0.3rem;
+  align-items: center;
+  padding: 0.28rem 0.4rem;
+}
+
+.seg-row .compact {
+  grid-template-columns: auto 1fr auto auto;
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.15;
+}
+.meta strong {
+  font-size: 0.78rem;
+}
+.meta span {
+  font-size: 0.65rem;
+  color: var(--ink-dim);
+}
+
+.swatch-wrap {
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 4px;
+  overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.25);
-  vertical-align: -1px;
+  padding: 0;
+  margin: 0;
+}
+.swatch-wrap input[type="color"] {
+  width: 160%;
+  height: 160%;
+  margin: -30%;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.chip,
+.link,
+.danger.icon {
+  font-size: 0.68rem;
+  padding: 0.18rem 0.4rem;
+  border-radius: 5px;
+}
+
+.chip {
+  font-variant-numeric: tabular-nums;
+  background: rgba(0, 0, 0, 0.25);
+  border-color: transparent;
+  color: var(--ink-dim);
+}
+
+.link {
+  background: transparent;
+  border-color: transparent;
+  color: var(--accent-2);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.danger.icon {
+  color: #ffb0a4;
+  border-color: rgba(255, 122, 106, 0.3);
+  width: 1.5rem;
+  padding: 0.1rem 0;
+}
+.danger.icon:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.details {
+  padding: 0.35rem 0.45rem 0.5rem;
+  border-top: 1px solid var(--line);
 }
 
 .grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 0.4rem;
+  gap: 0.35rem;
 }
 
 .field.wide {
   grid-column: 1 / -1;
-}
-
-.row-actions {
-  margin-top: 0.45rem;
-}
-
-button.danger {
-  font-size: 0.75rem;
-  padding: 0.25rem 0.55rem;
-  color: #ffb0a4;
-  border-color: rgba(255, 122, 106, 0.35);
-}
-
-button.danger:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.segment {
-  margin-top: 0.55rem;
-  padding: 0.55rem;
-  border-radius: 8px;
-  border: 1px dashed rgba(180, 210, 170, 0.25);
-  background: rgba(0, 0, 0, 0.18);
-}
-
-.segment.active {
-  border-style: solid;
-  border-color: rgba(110, 200, 255, 0.55);
-}
-
-.color-row {
-  display: flex;
-  gap: 0.4rem;
-  align-items: center;
-}
-
-.color-row input[type="color"] {
-  width: 2.4rem;
-  height: 2rem;
-  padding: 0;
-  border: none;
-  background: transparent;
-}
-
-.color-row button {
-  font-size: 0.72rem;
-  padding: 0.3rem 0.5rem;
 }
 </style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
@@ -14,7 +14,7 @@ const props = defineProps({
   findClosestOnCurve: { type: Function, required: true },
 });
 
-const emit = defineEmits(["select", "select-segment", "update-knot", "add-on-curve"]);
+const emit = defineEmits(["select", "select-segment", "update-knot", "add-on-curve", "drag-end"]);
 
 const canvasRef = ref(null);
 const size = 560;
@@ -291,6 +291,9 @@ function onPointerMove(e) {
 }
 
 function onPointerUp() {
+  if (dragging && props.toolMode === "edit") {
+    emit("drag-end");
+  }
   dragging = null;
 }
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -136,15 +136,21 @@ export function useSplineEditor() {
   });
 
   function syncSegments() {
+    const byPair = new Map();
+    for (const s of state.segments) {
+      byPair.set(s.fromId + ">" + s.toId, s);
+    }
     const next = [];
     for (let i = 0; i < state.knots.length - 1; i++) {
       const fromId = state.knots[i].id;
       const toId = state.knots[i + 1].id;
-      const prev =
-        state.segments.find((s) => s.fromId === fromId && s.toId === toId) ||
-        state.segments.find((s) => s.fromId === fromId) ||
-        state.segments.find((s) => s.toId === toId);
-      next.push(prev ? { ...prev, fromId, toId } : defaultSegment(fromId, toId));
+      const key = fromId + ">" + toId;
+      const exact = byPair.get(key);
+      if (exact) {
+        next.push({ ...exact, fromId, toId });
+      } else {
+        next.push(defaultSegment(fromId, toId));
+      }
     }
     state.segments = next;
     if (state.selectedSegmentIndex >= next.length) state.selectedSegmentIndex = next.length - 1;
@@ -264,8 +270,12 @@ export function useSplineEditor() {
       state.status = "Click closer to the curve to add a point.";
       return null;
     }
-    const a = state.knots[hit.segmentIndex];
-    const b = state.knots[hit.segmentIndex + 1];
+    const segIndex = hit.segmentIndex;
+    const a = state.knots[segIndex];
+    const b = state.knots[segIndex + 1];
+    const oldSeg = state.segments[segIndex]
+      ? { ...state.segments[segIndex] }
+      : defaultSegment(a.id, b.id);
     const { p, tan } = evalSpan(a, b, hit.t, state.curveType);
     const tl = Math.hypot(tan.x, tan.y) || 1;
     const scale = 0.14;
@@ -277,11 +287,30 @@ export function useSplineEditor() {
       hy: (tan.y / tl) * scale,
       color: DEFAULT_COLORS[state.knots.length % DEFAULT_COLORS.length],
     };
-    state.knots.splice(hit.segmentIndex + 1, 0, k);
-    syncSegments();
+    // Insert knot, then rebuild segments with the split styles in the correct slots.
+    state.knots.splice(segIndex + 1, 0, k);
+    const next = [];
+    for (let i = 0; i < state.knots.length - 1; i++) {
+      const fromId = state.knots[i].id;
+      const toId = state.knots[i + 1].id;
+      if (i === segIndex || i === segIndex + 1) {
+        next.push({
+          ...oldSeg,
+          fromId,
+          toId,
+          textureData: oldSeg.textureData,
+        });
+      } else if (i < segIndex) {
+        next.push({ ...state.segments[i], fromId, toId });
+      } else {
+        // i >= segIndex + 2 → old segment index was i - 1
+        next.push({ ...state.segments[i - 1], fromId, toId });
+      }
+    }
+    state.segments = next;
     state.selectedId = k.id;
     state.selectedSegmentIndex = -1;
-    state.status = `Added knot #${hit.segmentIndex + 2} on the curve.`;
+    state.status = `Added knot at y=${k.y.toFixed(2)} (between #${segIndex + 1} and #${segIndex + 2}).`;
     return k;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

UX follow-up for the spline mesh editor (new branch after #452 merged):

- **Compact list** — top→bottom order matching the canvas; colour swatch always visible; numeric / material fields behind **Details**
- **Live preview** — Edit-mode drag updates the 3D view when the pointer is released (retessellate on `drag-end`)
- **Colours in Points** — knot/segment colour pickers work outside Coloring mode too
- **Insert position fix** — list is top-first, and segment split on add keeps the new knot/segment in the correct slot near the top when clicking high on the curve

### Run

```bash
cd gallery/game_engine/v2/mesh_editor/app
npm install && npm run dev
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

