### PR TITLE
Local versioned spline library (filesystem + migrations)

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/.gitignore
+++ b/gallery/game_engine/v2/mesh_editor/.gitignore
@@ -4,5 +4,7 @@ app/dist/
 app/public/ranger/
 app/node_modules/
 tessellate/_raw/
+library/projects/*/
+!library/projects/.gitkeep
 *.log
 .DS_Store

--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -50,6 +50,23 @@ npm run dev
 
 Open the printed local URL (default `http://localhost:5177`).
 
+## Local library (filesystem “database”)
+
+While `npm run dev` is running, the Vite plugin exposes `/api/library` and
+writes versioned JSON projects under:
+
+```text
+gallery/game_engine/v2/mesh_editor/library/projects/<slug>/project.json
+```
+
+That tree is **gitignored** by default. Point elsewhere with
+`MESH_EDITOR_LIBRARY=/abs/or/rel/path`. Schema + migrations live in
+`app/src/library/` (`schemaVersion`, kind `ranger.splineProject`).
+
+Offline fallback: **Export JSON** / **Import JSON** in the Library panel.
+
+See [`library/README.md`](./library/README.md).
+
 ## Tools
 
 | Mode | Behaviour |

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -3,7 +3,9 @@ import { onMounted } from "vue";
 import SplineCanvas from "./components/SplineCanvas.vue";
 import PointEditor from "./components/PointEditor.vue";
 import Preview3D from "./components/Preview3D.vue";
+import LibraryPanel from "./components/LibraryPanel.vue";
 import { useSplineEditor } from "./composables/useSplineEditor.js";
+import { useLibrary } from "./composables/useLibrary.js";
 
 const {
   state,
@@ -19,7 +21,15 @@ const {
   findClosestOnCurve,
   insertKnotOnCurve,
   tessellate,
+  applyProject,
+  snapshotState,
 } = useSplineEditor();
+
+const { lib, refresh, load, save, saveAs, remove, exportJson, importJsonFile } = useLibrary({
+  snapshotState,
+  applyProject,
+  tessellate,
+});
 
 const materials = [
   { id: 0, label: "Wire" },
@@ -178,6 +188,16 @@ onMounted(() => {
         @commit="onListCommit"
       />
       <Preview3D :mesh="state.mesh" :material-mode="state.materialMode" />
+      <LibraryPanel
+        :lib="lib"
+        @refresh="refresh"
+        @load="load"
+        @save="save"
+        @save-as="saveAs"
+        @remove="remove"
+        @export="exportJson"
+        @import-file="importJsonFile"
+      />
     </main>
   </div>
 </template>
@@ -283,16 +303,22 @@ h1 {
 
 .workspace {
   display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(240px, 0.85fr) minmax(260px, 0.9fr);
+  grid-template-columns: minmax(0, 1.15fr) minmax(220px, 0.75fr) minmax(240px, 0.8fr) minmax(220px, 0.7fr);
   gap: 1rem;
   min-height: 0;
   align-items: stretch;
 }
 
-@media (max-width: 1100px) {
+@media (max-width: 1280px) {
   .toolbar {
     grid-template-columns: 1fr 1fr;
   }
+  .workspace {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 800px) {
   .workspace {
     grid-template-columns: 1fr;
   }

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/LibraryPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/LibraryPanel.vue
@@ -1,0 +1,208 @@
+<script setup>
+import { ref } from "vue";
+
+defineProps({
+  lib: { type: Object, required: true },
+});
+
+const emit = defineEmits([
+  "refresh",
+  "load",
+  "save",
+  "save-as",
+  "remove",
+  "export",
+  "import-file",
+]);
+
+const fileRef = ref(null);
+
+function onFile(ev) {
+  const f = ev.target.files?.[0];
+  if (f) emit("import-file", f);
+  ev.target.value = "";
+}
+</script>
+
+<template>
+  <aside class="library">
+    <header>
+      <h2>Library</h2>
+      <p v-if="lib.available" class="path" :title="lib.root">
+        v{{ lib.schemaVersion }} · {{ lib.root }}
+      </p>
+      <p v-else class="path warn">{{ lib.status || "Library offline" }}</p>
+    </header>
+
+    <div class="save-row">
+      <input
+        v-model="lib.saveAsName"
+        type="text"
+        placeholder="Name (e.g. tall vase)"
+        @keyup.enter="emit('save-as', lib.saveAsName)"
+      />
+      <button type="button" class="primary" :disabled="lib.busy" @click="emit('save-as', lib.saveAsName)">
+        Save as
+      </button>
+      <button
+        type="button"
+        :disabled="lib.busy || !lib.currentSlug"
+        @click="emit('save')"
+      >
+        Save
+      </button>
+    </div>
+
+    <div class="row-actions">
+      <button type="button" :disabled="lib.busy" @click="emit('refresh')">Refresh</button>
+      <button type="button" @click="emit('export', lib.saveAsName)">Export JSON</button>
+      <button type="button" @click="fileRef?.click()">Import JSON</button>
+      <input ref="fileRef" type="file" accept="application/json,.json" hidden @change="onFile" />
+    </div>
+
+    <p v-if="lib.currentSlug" class="current">
+      Editing <strong>{{ lib.currentName }}</strong>
+      <span class="slug">{{ lib.currentSlug }}</span>
+    </p>
+
+    <ul class="list">
+      <li v-if="!lib.projects.length" class="empty">No saved splines yet.</li>
+      <li
+        v-for="p in lib.projects"
+        :key="p.slug"
+        :class="{ active: p.slug === lib.currentSlug, bad: !!p.error }"
+      >
+        <button type="button" class="open" :disabled="!!p.error" @click="emit('load', p.slug)">
+          <strong>{{ p.name || p.slug }}</strong>
+          <span>{{ p.error || `${p.knotCount || "?"} pts · ${p.updatedAt?.slice(0, 19) || ""}` }}</span>
+        </button>
+        <button
+          type="button"
+          class="danger"
+          title="Delete"
+          :disabled="lib.busy"
+          @click="emit('remove', p.slug)"
+        >
+          ×
+        </button>
+      </li>
+    </ul>
+
+    <p class="hint">{{ lib.status }}</p>
+  </aside>
+</template>
+
+<style scoped>
+.library {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 0.7rem 0.75rem;
+  gap: 0.55rem;
+}
+
+header h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 400;
+}
+
+.path {
+  margin: 0.2rem 0 0;
+  font-size: 0.65rem;
+  color: var(--ink-dim);
+  word-break: break-all;
+}
+.path.warn {
+  color: #ffb0a4;
+}
+
+.save-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.35rem;
+}
+
+.row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.current {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--ink-dim);
+}
+.current .slug {
+  margin-left: 0.35rem;
+  opacity: 0.7;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+  min-height: 4rem;
+  flex: 1;
+}
+
+li {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.25rem;
+  align-items: center;
+  margin-bottom: 0.25rem;
+  border-radius: 7px;
+  border: 1px solid transparent;
+  padding: 0.15rem;
+}
+li.active {
+  border-color: rgba(126, 207, 106, 0.4);
+  background: rgba(126, 207, 106, 0.08);
+}
+li.bad {
+  opacity: 0.7;
+}
+li.empty {
+  display: block;
+  padding: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--ink-dim);
+}
+
+.open {
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 0.35rem 0.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+.open strong {
+  font-size: 0.82rem;
+}
+.open span {
+  font-size: 0.65rem;
+  color: var(--ink-dim);
+}
+
+.danger {
+  width: 1.6rem;
+  padding: 0.15rem 0;
+  color: #ffb0a4;
+  border-color: rgba(255, 122, 106, 0.3);
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.68rem;
+  color: var(--ink-dim);
+}
+</style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useLibrary.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useLibrary.js
@@ -1,0 +1,180 @@
+import { reactive, onMounted } from "vue";
+import * as api from "../library/api.js";
+import { buildProjectDocument } from "../library/schema.js";
+import { migrateProject } from "../library/migrations.js";
+
+export function useLibrary({ snapshotState, applyProject, tessellate }) {
+  const lib = reactive({
+    available: false,
+    root: "",
+    schemaVersion: 0,
+    projects: [],
+    currentSlug: null,
+    currentName: "",
+    status: "",
+    busy: false,
+    saveAsName: "",
+  });
+
+  async function refresh() {
+    lib.busy = true;
+    try {
+      const data = await api.listLibrary();
+      lib.available = true;
+      lib.root = data.root || "";
+      lib.schemaVersion = data.schemaVersion || 0;
+      lib.projects = data.projects || [];
+      lib.status = `${lib.projects.length} projects · ${lib.root}`;
+    } catch (err) {
+      lib.available = false;
+      lib.projects = [];
+      lib.status = "Local library API offline (use npm run dev). " + (err.message || "");
+    } finally {
+      lib.busy = false;
+    }
+  }
+
+  async function load(slug) {
+    lib.busy = true;
+    try {
+      const doc = await api.loadProject(slug);
+      applyProject(doc);
+      tessellate();
+      lib.currentSlug = doc.slug;
+      lib.currentName = doc.name;
+      lib.saveAsName = doc.name;
+      lib.status = `Loaded ${doc.slug}`;
+      await refresh();
+    } catch (err) {
+      lib.status = "Load failed: " + (err.message || err);
+    } finally {
+      lib.busy = false;
+    }
+  }
+
+  async function save() {
+    if (!lib.currentSlug) {
+      return saveAs(lib.saveAsName || lib.currentName || "Untitled spline");
+    }
+    lib.busy = true;
+    try {
+      const doc = buildProjectDocument({
+        state: snapshotState(),
+        name: lib.currentName || lib.saveAsName || "Untitled spline",
+        id: undefined,
+        slug: lib.currentSlug,
+      });
+      // Keep stable id from disk if present
+      const existing = lib.projects.find((p) => p.slug === lib.currentSlug);
+      if (existing?.id) doc.id = existing.id;
+      const prev = await api.loadProject(lib.currentSlug).catch(() => null);
+      if (prev?.id) {
+        doc.id = prev.id;
+        doc.createdAt = prev.createdAt;
+      }
+      doc.slug = lib.currentSlug;
+      doc.name = lib.currentName || doc.name;
+      const saved = await api.saveProject(lib.currentSlug, doc);
+      lib.currentName = saved.name;
+      lib.status = `Saved ${saved.slug}`;
+      await refresh();
+    } catch (err) {
+      lib.status = "Save failed: " + (err.message || err);
+    } finally {
+      lib.busy = false;
+    }
+  }
+
+  async function saveAs(name) {
+    const n = String(name || lib.saveAsName || "Untitled spline").trim();
+    if (!n) {
+      lib.status = "Enter a name to save.";
+      return;
+    }
+    lib.busy = true;
+    try {
+      const created = await api.createProject({
+        name: n,
+        state: snapshotState(),
+      });
+      lib.currentSlug = created.slug;
+      lib.currentName = created.name;
+      lib.saveAsName = created.name;
+      lib.status = `Created ${created.slug}`;
+      await refresh();
+    } catch (err) {
+      lib.status = "Save As failed: " + (err.message || err);
+    } finally {
+      lib.busy = false;
+    }
+  }
+
+  async function remove(slug) {
+    if (!slug) return;
+    if (!confirm(`Delete local project “${slug}”?`)) return;
+    lib.busy = true;
+    try {
+      await api.deleteProject(slug);
+      if (lib.currentSlug === slug) {
+        lib.currentSlug = null;
+        lib.currentName = "";
+      }
+      lib.status = `Deleted ${slug}`;
+      await refresh();
+    } catch (err) {
+      lib.status = "Delete failed: " + (err.message || err);
+    } finally {
+      lib.busy = false;
+    }
+  }
+
+  /** Fallback when API is offline: download JSON. */
+  function exportJson(name) {
+    const doc = buildProjectDocument({
+      state: snapshotState(),
+      name: name || lib.currentName || "spline",
+      slug: lib.currentSlug || undefined,
+    });
+    const blob = new Blob([JSON.stringify(doc, null, 2)], { type: "application/json" });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = (doc.slug || "spline") + ".json";
+    a.click();
+    URL.revokeObjectURL(a.href);
+    lib.status = "Downloaded " + a.download;
+  }
+
+  async function importJsonFile(file) {
+    const text = await file.text();
+    const raw = JSON.parse(text);
+    const mig = migrateProject(raw);
+    if (!mig.ok) {
+      lib.status = "Import invalid: " + mig.errors.join("; ");
+      return;
+    }
+    if (lib.available) {
+      const created = await api.createProject(mig.doc);
+      await load(created.slug);
+    } else {
+      applyProject(mig.doc);
+      tessellate();
+      lib.currentName = mig.doc.name;
+      lib.status = "Imported into editor (API offline — not written to disk).";
+    }
+  }
+
+  onMounted(() => {
+    refresh();
+  });
+
+  return {
+    lib,
+    refresh,
+    load,
+    save,
+    saveAs,
+    remove,
+    exportJson,
+    importJsonFile,
+  };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -392,6 +392,64 @@ export function useSplineEditor() {
     return state.mesh;
   }
 
+  function applyProject(doc) {
+    if (!doc?.profile?.knots) return false;
+    const ed = doc.editor || {};
+    state.curveType = ed.curveType | 0;
+    state.pathSegments = ed.pathSegments || 12;
+    state.angularSteps = ed.angularSteps || 24;
+    state.revolutionDeg = ed.revolutionDeg || 360;
+    state.materialMode = ed.materialMode ?? 3;
+    state.symmetry = ed.symmetry !== false;
+    state.knots = doc.profile.knots.map((k) => ({
+      id: k.id,
+      x: k.x,
+      y: k.y,
+      hx: k.hx,
+      hy: k.hy,
+      color: k.color || "#cccccc",
+    }));
+    state.segments = (doc.profile.segments || []).map((s) => ({
+      fromId: s.fromId,
+      toId: s.toId,
+      color: s.color == null ? null : s.color,
+      roughness: s.roughness ?? 0.4,
+      metalness: s.metalness ?? 0,
+      opacity: s.opacity ?? 1,
+      texture: s.texture || "gradient",
+      textureData: null,
+      textureAsset: s.textureAsset || null,
+    }));
+    syncSegments();
+    state.selectedId = state.knots[1]?.id || state.knots[0]?.id || null;
+    state.selectedSegmentIndex = -1;
+    state.status = `Loaded “${doc.name}” (schema v${doc.schemaVersion}).`;
+    return true;
+  }
+
+  /** Plain snapshot for library create/save (no reactive proxy / mesh buffers). */
+  function snapshotState() {
+    return {
+      curveType: state.curveType,
+      pathSegments: state.pathSegments,
+      angularSteps: state.angularSteps,
+      revolutionDeg: state.revolutionDeg,
+      materialMode: state.materialMode,
+      symmetry: state.symmetry,
+      knots: state.knots.map((k) => ({ ...k })),
+      segments: state.segments.map((s) => ({
+        fromId: s.fromId,
+        toId: s.toId,
+        color: s.color,
+        roughness: s.roughness,
+        metalness: s.metalness,
+        opacity: s.opacity,
+        texture: s.texture,
+        textureAsset: s.textureAsset || null,
+      })),
+    };
+  }
+
   if (!state.selectedId && state.knots.length) {
     state.selectedId = state.knots[1].id;
   }
@@ -418,5 +476,7 @@ export function useSplineEditor() {
     insertKnotOnCurve,
     tessellate,
     syncSegments,
+    applyProject,
+    snapshotState,
   };
 }

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/api.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/api.js
@@ -1,0 +1,66 @@
+// ============================================================================
+// api.js — browser client for the Vite library middleware (local folder DB).
+// ============================================================================
+
+const BASE = "/api/library";
+
+async function req(path, opts) {
+  const res = await fetch(BASE + path, {
+    headers: { "Content-Type": "application/json", ...(opts?.headers || {}) },
+    ...opts,
+  });
+  const text = await res.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = { error: text };
+  }
+  if (!res.ok) {
+    const err = new Error(body?.error || res.statusText || "request failed");
+    err.status = res.status;
+    err.body = body;
+    throw err;
+  }
+  return body;
+}
+
+export async function libraryMeta() {
+  return req("/meta");
+}
+
+export async function listLibrary() {
+  return req("");
+}
+
+export async function loadProject(slug) {
+  return req("/" + encodeURIComponent(slug));
+}
+
+export async function saveProject(slug, doc) {
+  return req("/" + encodeURIComponent(slug), {
+    method: "PUT",
+    body: JSON.stringify(doc),
+  });
+}
+
+export async function createProject(payload) {
+  return req("", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteProject(slug) {
+  return req("/" + encodeURIComponent(slug), { method: "DELETE" });
+}
+
+/** True when the Vite library middleware answers. */
+export async function libraryAvailable() {
+  try {
+    await libraryMeta();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -1,0 +1,134 @@
+// ============================================================================
+// migrations.js — upgrade on-disk spline projects to CURRENT_SCHEMA_VERSION.
+// ============================================================================
+
+import {
+  CURRENT_SCHEMA_VERSION,
+  SCHEMA_KIND,
+  newId,
+  nowIso,
+  slugify,
+  validateProject,
+} from "./schema.js";
+
+/** @type {Record<number, (doc: any) => any>} */
+const STEPS = {
+  // 0 / missing → 1: wrap a loose editor dump into the semantic envelope.
+  1(doc) {
+    if (doc && doc.schemaVersion === 1 && doc.kind === SCHEMA_KIND) {
+      return normalizeV1(doc);
+    }
+    // Accept earlier ad-hoc shapes: { knots, segments, ...editor fields }
+    const knots = doc.profile?.knots || doc.knots || [];
+    const segments = doc.profile?.segments || doc.segments || [];
+    const name = doc.name || "Migrated spline";
+    return normalizeV1({
+      kind: SCHEMA_KIND,
+      schemaVersion: 1,
+      id: doc.id || newId(),
+      slug: doc.slug || slugify(name),
+      name,
+      description: doc.description || "",
+      tags: doc.tags || [],
+      createdAt: doc.createdAt || nowIso(),
+      updatedAt: doc.updatedAt || nowIso(),
+      editor: {
+        curveType: doc.editor?.curveType ?? doc.curveType ?? 0,
+        pathSegments: doc.editor?.pathSegments ?? doc.pathSegments ?? 12,
+        angularSteps: doc.editor?.angularSteps ?? doc.angularSteps ?? 24,
+        revolutionDeg: doc.editor?.revolutionDeg ?? doc.revolutionDeg ?? 360,
+        materialMode: doc.editor?.materialMode ?? doc.materialMode ?? 3,
+        symmetry: doc.editor?.symmetry ?? doc.symmetry ?? true,
+      },
+      profile: { knots, segments },
+    });
+  },
+};
+
+function normalizeV1(doc) {
+  const knots = (doc.profile?.knots || []).map((k, i) => ({
+    id: k.id || `k${i}`,
+    x: Number(k.x) || 0,
+    y: Number(k.y) || 0,
+    hx: Number(k.hx) || 0,
+    hy: Number(k.hy) || 0,
+    color: k.color || "#cccccc",
+  }));
+  const segments = (doc.profile?.segments || []).map((s, i) => ({
+    fromId: s.fromId || knots[i]?.id || `k${i}`,
+    toId: s.toId || knots[i + 1]?.id || `k${i + 1}`,
+    color: s.color == null ? null : s.color,
+    roughness: Number(s.roughness ?? 0.4),
+    metalness: Number(s.metalness ?? 0),
+    opacity: Number(s.opacity ?? 1),
+    texture: s.texture || "gradient",
+    textureAsset: s.textureAsset || null,
+  }));
+  // Ensure segment count matches knot spans.
+  while (segments.length < Math.max(0, knots.length - 1)) {
+    const i = segments.length;
+    segments.push({
+      fromId: knots[i].id,
+      toId: knots[i + 1].id,
+      color: null,
+      roughness: 0.4,
+      metalness: 0,
+      opacity: 1,
+      texture: "gradient",
+      textureAsset: null,
+    });
+  }
+  return {
+    kind: SCHEMA_KIND,
+    schemaVersion: 1,
+    id: doc.id || newId(),
+    slug: doc.slug || slugify(doc.name || "spline"),
+    name: doc.name || "Untitled spline",
+    description: doc.description || "",
+    tags: Array.isArray(doc.tags) ? doc.tags : [],
+    createdAt: doc.createdAt || nowIso(),
+    updatedAt: doc.updatedAt || nowIso(),
+    editor: {
+      curveType: Number(doc.editor?.curveType ?? 0),
+      pathSegments: Number(doc.editor?.pathSegments ?? 12),
+      angularSteps: Number(doc.editor?.angularSteps ?? 24),
+      revolutionDeg: Number(doc.editor?.revolutionDeg ?? 360),
+      materialMode: Number(doc.editor?.materialMode ?? 3),
+      symmetry: doc.editor?.symmetry !== false,
+    },
+    profile: { knots, segments: segments.slice(0, Math.max(0, knots.length - 1)) },
+  };
+}
+
+/**
+ * Migrate any readable project blob to the current schema version.
+ * @param {any} raw
+ * @returns {{ ok: true, doc: import('./schema.js').SplineProjectV1 } | { ok: false, errors: string[] }}
+ */
+export function migrateProject(raw) {
+  if (raw == null || typeof raw !== "object") {
+    return { ok: false, errors: ["not an object"] };
+  }
+  let doc = structuredClone(raw);
+  let v = Number(doc.schemaVersion || 0);
+  if (v > CURRENT_SCHEMA_VERSION) {
+    return {
+      ok: false,
+      errors: [`schemaVersion ${v} is newer than this app (${CURRENT_SCHEMA_VERSION})`],
+    };
+  }
+  while (v < CURRENT_SCHEMA_VERSION) {
+    const next = v + 1;
+    const step = STEPS[next];
+    if (!step) {
+      return { ok: false, errors: [`missing migration step to v${next}`] };
+    }
+    doc = step(doc);
+    doc.schemaVersion = next;
+    v = next;
+  }
+  doc = STEPS[CURRENT_SCHEMA_VERSION](doc);
+  const errors = validateProject(doc);
+  if (errors.length) return { ok: false, errors };
+  return { ok: true, doc };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -1,0 +1,141 @@
+// ============================================================================
+// schema.js — semantic spline-project document + versioned migrations.
+// ============================================================================
+// On-disk layout (default):
+//   mesh_editor/library/projects/<slug>/project.json
+// Optional binary textures (future / upload):
+//   mesh_editor/library/projects/<slug>/assets/<name>.png
+//
+// Bump CURRENT_SCHEMA_VERSION when the document shape changes and add a
+// migration step in migrations.js. loadProject() always returns the current
+// version so older folders remain readable.
+// ============================================================================
+
+export const CURRENT_SCHEMA_VERSION = 1;
+
+export const SCHEMA_KIND = "ranger.splineProject";
+
+/** @typedef {{ id: string, x: number, y: number, hx: number, hy: number, color: string }} KnotV1 */
+/** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureAsset?: string|null }} SegmentV1 */
+
+/**
+ * @typedef {object} SplineProjectV1
+ * @property {typeof SCHEMA_KIND} kind
+ * @property {1} schemaVersion
+ * @property {string} id
+ * @property {string} slug
+ * @property {string} name
+ * @property {string} [description]
+ * @property {string[]} [tags]
+ * @property {string} createdAt
+ * @property {string} updatedAt
+ * @property {{
+ *   curveType: number,
+ *   pathSegments: number,
+ *   angularSteps: number,
+ *   revolutionDeg: number,
+ *   materialMode: number,
+ *   symmetry: boolean
+ * }} editor
+ * @property {{ knots: KnotV1[], segments: SegmentV1[] }} profile
+ */
+
+export function nowIso() {
+  return new Date().toISOString();
+}
+
+export function slugify(name) {
+  const s = String(name || "spline")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  return s || "spline";
+}
+
+export function newId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) return crypto.randomUUID();
+  return "sp_" + Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
+}
+
+/** Strip non-JSON-friendly fields (e.g. in-memory textureData buffers). */
+export function serializeSegment(seg) {
+  return {
+    fromId: seg.fromId,
+    toId: seg.toId,
+    color: seg.color == null ? null : seg.color,
+    roughness: Number(seg.roughness ?? 0.4),
+    metalness: Number(seg.metalness ?? 0),
+    opacity: Number(seg.opacity ?? 1),
+    texture: seg.texture || "gradient",
+    textureAsset: seg.textureAsset || null,
+  };
+}
+
+export function serializeKnot(k) {
+  return {
+    id: k.id,
+    x: Number(k.x),
+    y: Number(k.y),
+    hx: Number(k.hx),
+    hy: Number(k.hy),
+    color: k.color || "#cccccc",
+  };
+}
+
+/**
+ * Build a v1 project document from the live editor state.
+ * @param {object} opts
+ * @param {object} opts.state - useSplineEditor reactive state
+ * @param {string} opts.name
+ * @param {string} [opts.id]
+ * @param {string} [opts.slug]
+ * @param {string} [opts.description]
+ * @param {string[]} [opts.tags]
+ * @param {string} [opts.createdAt]
+ */
+export function buildProjectDocument(opts) {
+  const st = opts.state;
+  const name = String(opts.name || "Untitled spline").trim() || "Untitled spline";
+  const createdAt = opts.createdAt || nowIso();
+  return {
+    kind: SCHEMA_KIND,
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+    id: opts.id || newId(),
+    slug: opts.slug || slugify(name),
+    name,
+    description: opts.description || "",
+    tags: Array.isArray(opts.tags) ? opts.tags.slice() : [],
+    createdAt,
+    updatedAt: nowIso(),
+    editor: {
+      curveType: st.curveType | 0,
+      pathSegments: st.pathSegments | 0,
+      angularSteps: st.angularSteps | 0,
+      revolutionDeg: st.revolutionDeg | 0,
+      materialMode: st.materialMode | 0,
+      symmetry: !!st.symmetry,
+    },
+    profile: {
+      knots: (st.knots || []).map(serializeKnot),
+      segments: (st.segments || []).map(serializeSegment),
+    },
+  };
+}
+
+export function validateProject(doc) {
+  const errors = [];
+  if (!doc || typeof doc !== "object") {
+    errors.push("document is not an object");
+    return errors;
+  }
+  if (doc.kind && doc.kind !== SCHEMA_KIND) {
+    errors.push(`unexpected kind "${doc.kind}" (expected ${SCHEMA_KIND})`);
+  }
+  if (!doc.name) errors.push("missing name");
+  if (!doc.profile || !Array.isArray(doc.profile.knots)) errors.push("missing profile.knots");
+  if (doc.profile && doc.profile.knots && doc.profile.knots.length < 2) {
+    errors.push("profile.knots needs at least 2 points");
+  }
+  return errors;
+}

--- a/gallery/game_engine/v2/mesh_editor/app/vite-plugin-library.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/vite-plugin-library.mjs
@@ -1,0 +1,210 @@
+// ============================================================================
+// vite-plugin-library.mjs — local folder "database" for spline projects.
+// ============================================================================
+// Default root: gallery/game_engine/v2/mesh_editor/library/projects
+// Override with MESH_EDITOR_LIBRARY=/absolute/or/relative/path
+//
+// Each project is a folder:
+//   <slug>/project.json
+// Semantically versioned via schemaVersion; GET always migrates to current.
+// ============================================================================
+
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+import { migrateProject } from "./src/library/migrations.js";
+import {
+  CURRENT_SCHEMA_VERSION,
+  buildProjectDocument,
+  nowIso,
+  slugify,
+  validateProject,
+} from "./src/library/schema.js";
+
+const HERE = path.dirname(url.fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = path.resolve(HERE, "../library/projects");
+
+function resolveRoot() {
+  const env = process.env.MESH_EDITOR_LIBRARY;
+  if (env && env.trim()) return path.resolve(process.cwd(), env.trim());
+  return DEFAULT_ROOT;
+}
+
+function ensureRoot(root) {
+  fs.mkdirSync(root, { recursive: true });
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeJson(file, obj) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(obj, null, 2) + "\n", "utf8");
+}
+
+function listProjects(root) {
+  ensureRoot(root);
+  const out = [];
+  for (const name of fs.readdirSync(root)) {
+    const dir = path.join(root, name);
+    if (!fs.statSync(dir).isDirectory()) continue;
+    const file = path.join(dir, "project.json");
+    if (!fs.existsSync(file)) continue;
+    try {
+      const raw = readJson(file);
+      const mig = migrateProject(raw);
+      if (!mig.ok) {
+        out.push({
+          slug: name,
+          id: raw.id || name,
+          name: raw.name || name,
+          updatedAt: raw.updatedAt || null,
+          schemaVersion: raw.schemaVersion || 0,
+          error: mig.errors.join("; "),
+        });
+        continue;
+      }
+      const d = mig.doc;
+      out.push({
+        slug: d.slug || name,
+        id: d.id,
+        name: d.name,
+        description: d.description || "",
+        tags: d.tags || [],
+        updatedAt: d.updatedAt,
+        createdAt: d.createdAt,
+        schemaVersion: d.schemaVersion,
+        knotCount: d.profile.knots.length,
+      });
+    } catch (err) {
+      out.push({ slug: name, name, error: String(err.message || err) });
+    }
+  }
+  out.sort((a, b) => String(b.updatedAt || "").localeCompare(String(a.updatedAt || "")));
+  return out;
+}
+
+function uniqueSlug(root, base) {
+  let slug = slugify(base);
+  let n = 0;
+  while (fs.existsSync(path.join(root, slug))) {
+    n += 1;
+    slug = `${slugify(base)}-${n}`;
+  }
+  return slug;
+}
+
+function sendJson(res, status, body) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(body));
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  if (!chunks.length) return null;
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+export function splineLibraryPlugin() {
+  const root = resolveRoot();
+  ensureRoot(root);
+
+  return {
+    name: "spline-library",
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        const urlPath = req.url?.split("?")[0] || "";
+        if (!urlPath.startsWith("/api/library")) return next();
+
+        try {
+          if (req.method === "GET" && urlPath === "/api/library") {
+            return sendJson(res, 200, {
+              root,
+              schemaVersion: CURRENT_SCHEMA_VERSION,
+              projects: listProjects(root),
+            });
+          }
+
+          if (req.method === "GET" && urlPath === "/api/library/meta") {
+            return sendJson(res, 200, {
+              root,
+              schemaVersion: CURRENT_SCHEMA_VERSION,
+              kind: "ranger.splineProject",
+              envOverride: process.env.MESH_EDITOR_LIBRARY || null,
+            });
+          }
+
+          const m = urlPath.match(/^\/api\/library\/([^/]+)\/?$/);
+          if (m) {
+            const slug = decodeURIComponent(m[1]);
+            const dir = path.join(root, slug);
+            const file = path.join(dir, "project.json");
+
+            if (req.method === "GET") {
+              if (!fs.existsSync(file)) return sendJson(res, 404, { error: "not found" });
+              const mig = migrateProject(readJson(file));
+              if (!mig.ok) return sendJson(res, 422, { error: "migrate failed", errors: mig.errors });
+              // Persist migrated form so the folder stays current.
+              if ((readJson(file).schemaVersion || 0) < CURRENT_SCHEMA_VERSION) {
+                writeJson(file, mig.doc);
+              }
+              return sendJson(res, 200, mig.doc);
+            }
+
+            if (req.method === "PUT") {
+              const body = await readBody(req);
+              if (!body) return sendJson(res, 400, { error: "empty body" });
+              const mig = migrateProject({ ...body, slug, updatedAt: nowIso() });
+              if (!mig.ok) return sendJson(res, 422, { error: "invalid", errors: mig.errors });
+              mig.doc.slug = slug;
+              mig.doc.updatedAt = nowIso();
+              writeJson(file, mig.doc);
+              return sendJson(res, 200, mig.doc);
+            }
+
+            if (req.method === "DELETE") {
+              if (!fs.existsSync(dir)) return sendJson(res, 404, { error: "not found" });
+              fs.rmSync(dir, { recursive: true, force: true });
+              return sendJson(res, 200, { ok: true, slug });
+            }
+          }
+
+          if (req.method === "POST" && urlPath === "/api/library") {
+            const body = await readBody(req);
+            if (!body) return sendJson(res, 400, { error: "empty body" });
+            // Accept either a full document or { name, state-like fields }.
+            let doc;
+            if (body.profile && body.editor) {
+              const mig = migrateProject(body);
+              if (!mig.ok) return sendJson(res, 422, { error: "invalid", errors: mig.errors });
+              doc = mig.doc;
+            } else if (body.state) {
+              doc = buildProjectDocument({
+                state: body.state,
+                name: body.name,
+                description: body.description,
+                tags: body.tags,
+              });
+            } else {
+              return sendJson(res, 400, { error: "expected project document or { name, state }" });
+            }
+            const errors = validateProject(doc);
+            if (errors.length) return sendJson(res, 422, { error: "invalid", errors });
+            doc.slug = uniqueSlug(root, body.slug || doc.slug || doc.name);
+            doc.updatedAt = nowIso();
+            if (!doc.createdAt) doc.createdAt = doc.updatedAt;
+            writeJson(path.join(root, doc.slug, "project.json"), doc);
+            return sendJson(res, 201, doc);
+          }
+
+          return sendJson(res, 404, { error: "unknown library route" });
+        } catch (err) {
+          return sendJson(res, 500, { error: String(err.message || err) });
+        }
+      });
+    },
+  };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/vite.config.js
+++ b/gallery/game_engine/v2/mesh_editor/app/vite.config.js
@@ -2,11 +2,12 @@ import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import path from "node:path";
 import url from "node:url";
+import { splineLibraryPlugin } from "./vite-plugin-library.mjs";
 
 const HERE = path.dirname(url.fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), splineLibraryPlugin()],
   resolve: {
     alias: {
       "@tessellate": path.resolve(HERE, "../tessellate/spline_lathe.mjs"),

--- a/gallery/game_engine/v2/mesh_editor/library-smoke.mjs
+++ b/gallery/game_engine/v2/mesh_editor/library-smoke.mjs
@@ -1,0 +1,53 @@
+// ============================================================================
+// library-smoke.mjs — schema migrate + on-disk roundtrip (no browser).
+// ============================================================================
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { migrateProject } from "./app/src/library/migrations.js";
+import {
+  CURRENT_SCHEMA_VERSION,
+  buildProjectDocument,
+  SCHEMA_KIND,
+} from "./app/src/library/schema.js";
+
+const legacy = {
+  name: "Old dump",
+  knots: [
+    { id: "a", x: 0, y: -1, hx: 0.2, hy: 0, color: "#7ecf6a" },
+    { id: "b", x: 0.5, y: 0, hx: 0, hy: 0.2, color: "#6ec8ff" },
+    { id: "c", x: 0, y: 1, hx: -0.2, hy: 0, color: "#ffb454" },
+  ],
+  segments: [],
+  pathSegments: 8,
+};
+
+const mig = migrateProject(legacy);
+if (!mig.ok) throw new Error(mig.errors.join("; "));
+if (mig.doc.schemaVersion !== CURRENT_SCHEMA_VERSION) throw new Error("version");
+if (mig.doc.kind !== SCHEMA_KIND) throw new Error("kind");
+if (mig.doc.profile.knots.length !== 3) throw new Error("knots");
+if (mig.doc.profile.segments.length !== 2) throw new Error("segments filled");
+
+const doc = buildProjectDocument({
+  state: {
+    ...mig.doc.editor,
+    knots: mig.doc.profile.knots,
+    segments: mig.doc.profile.segments,
+  },
+  name: "Tall vase",
+});
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "spline-lib-"));
+const file = path.join(dir, "tall-vase", "project.json");
+fs.mkdirSync(path.dirname(file), { recursive: true });
+fs.writeFileSync(file, JSON.stringify(doc, null, 2));
+const again = migrateProject(JSON.parse(fs.readFileSync(file, "utf8")));
+if (!again.ok || again.doc.name !== "Tall vase") throw new Error("roundtrip");
+
+console.log("[library-smoke] OK", {
+  schemaVersion: CURRENT_SCHEMA_VERSION,
+  slug: doc.slug,
+  dir,
+});

--- a/gallery/game_engine/v2/mesh_editor/library/.gitignore
+++ b/gallery/game_engine/v2/mesh_editor/library/.gitignore
@@ -1,0 +1,3 @@
+# Ignore local project data (keep the folder + README tracked).
+projects/*
+!projects/.gitkeep

--- a/gallery/game_engine/v2/mesh_editor/library/README.md
+++ b/gallery/game_engine/v2/mesh_editor/library/README.md
@@ -1,0 +1,38 @@
+# Local spline library
+
+Default on-disk store for the Vite mesh editor. **Not IndexedDB** — plain
+folders + JSON so you can optionally put a *copy* under version control.
+
+```text
+library/
+  projects/
+    <slug>/
+      project.json     # schemaVersioned document (ranger.splineProject)
+      assets/          # optional texture files (future)
+```
+
+## Location
+
+Default root (relative to this folder):
+
+```text
+gallery/game_engine/v2/mesh_editor/library/projects
+```
+
+Override when starting Vite:
+
+```bash
+MESH_EDITOR_LIBRARY=/path/to/my-splines npm run dev
+```
+
+`projects/*` contents are **gitignored** by default. To version a curated set,
+copy or symlink selected folders into a tracked tree, or temporarily force-add.
+
+## Schema
+
+- Kind: `ranger.splineProject`
+- Current version: see `app/src/library/schema.js` (`CURRENT_SCHEMA_VERSION`)
+- Migrations: `app/src/library/migrations.js` — every load upgrades to current
+
+When you change the document shape, bump the version and add a step; old folders
+keep working.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Local, version-controllable spline “database” for the mesh editor — not IndexedDB.

- Default store: `gallery/game_engine/v2/mesh_editor/library/projects/<slug>/project.json` (**gitignored** project folders)
- Override path: `MESH_EDITOR_LIBRARY=/path npm run dev`
- Semantic document: `kind: ranger.splineProject`, `schemaVersion`, name/tags/editor/profile
- Migrations in `app/src/library/migrations.js` upgrade older files on load
- Vite middleware `/api/library` CRUD while `npm run dev` runs
- Library panel: Save / Save as / Load / Delete + Export/Import JSON fallback

### Run

```bash
cd gallery/game_engine/v2/mesh_editor/app
npm install && npm run dev
# optional: MESH_EDITOR_LIBRARY=~/my-splines npm run dev
```

```bash
node gallery/game_engine/v2/mesh_editor/library-smoke.mjs
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

