### PR TITLE
Spline editor: editable orbit Bezier rotation path

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -1,8 +1,9 @@
 # Spline Mesh Editor
 
 Vite + Vue editor under `gallery/game_engine/v2/mesh_editor` for building
-**symmetrical spline silhouettes** and lathe-tessellating them into 3D meshes
-rendered with **Ranger Three**.
+**symmetrical spline silhouettes** plus an editable **orbit path** (Bezier
+replacement for cos/sin), lathe-tessellated into 3D meshes rendered with
+**Ranger Three**.
 
 ## Layout
 
@@ -22,20 +23,31 @@ mesh_editor/
 
 ## Coordinate system
 
+### Profile view (default)
+
 - Unit plane: left/top `(-1, 1)`, right/bottom `(1, -1)`, Y up
 - Viewport margin: `(-1.1 … 1.1)`
 - Symmetry axis: vertical line `(0, -1) → (0, 1)`
 - Editable profile is the **right half** (`x ≥ 0`); the left half is mirrored in the 2D view
 - Default knots: bottom `(0,-1)`, mid `(0.5,0)`, top `(0,1)` with Bezier handles
 
+### Orbit view
+
+- Same unit plane; canvas **x → world X**, canvas **y → world Z**
+- Closed Bezier loop; default is a 4-knot **unit circle** (κ ≈ 0.55228475)
+- Dashed unit circle guide shows the classic cos/sin path
+- Knot / segment colours and materials apply to angular wedges of the mesh
+
 ## Tessellate
 
-1. Sample the profile curve (Bezier default, or Catmull-Rom)
-2. Revolve around Y for `N` angular steps
-3. **360° closed** (default): omit the duplicate ring at `2π`, faces wrap
-4. **180°**: same spacing over half a turn, last step omitted, faces do **not** wrap
-5. Start angle places points at `z = 0`, `x = radius`
-6. Assign the selected material and draw with Ranger Three (WebGL if available, else software)
+1. Sample the **profile** curve (Bezier default, or Catmull-Rom)
+2. Sample the closed **orbit** path; each sample `(ox, oy)` replaces `(cos θ, sin θ)`
+   so `position = (r·ox, y, r·oy)`. Unit circle ⇒ nearly identical to classic lathe
+3. **Orbit samples N** is distributed across orbit spans (`≈ N / orbitKnots`)
+4. **360° closed**: faces wrap the last orbit column to the first
+5. **180°**: use the first half of the orbit samples; faces do **not** wrap
+6. Mesh parts are **profile segment × orbit segment** so both colourings affect shading
+7. Draw with Ranger Three (WebGL if available, else software)
 
 ## Run
 
@@ -61,21 +73,28 @@ gallery/game_engine/v2/mesh_editor/library/projects/<slug>/project.json
 
 That tree is **gitignored** by default. Point elsewhere with
 `MESH_EDITOR_LIBRARY=/abs/or/rel/path`. Schema + migrations live in
-`app/src/library/` (`schemaVersion`, kind `ranger.splineProject`).
+`app/src/library/` (`schemaVersion` 2+, kind `ranger.splineProject`, with
+`profile` + closed `orbit` paths).
 
 Offline fallback: **Export JSON** / **Import JSON** in the Library panel.
 
 See [`library/README.md`](./library/README.md).
 
-## Tools
+## Views & tools
+
+| View | Behaviour |
+|------|-----------|
+| **Profile** | Edit the Y-up silhouette (right half) |
+| **Orbit** | Edit the closed XZ rotation path that replaces cos/sin |
 
 | Mode | Behaviour |
 |------|-----------|
 | **Edit** | Drag knots / Bezier handles; mesh refreshes when the drag ends |
-| **Add** | Click the profile curve to insert a knot (remove from the point list) |
-| **Coloring** | Per-knot / per-segment colours & materials |
+| **Add** | Click the active curve to insert a knot |
+| **Coloring** | Per-knot / per-segment colours & materials (profile or orbit) |
 
-The point list is **top → bottom** (matches the canvas). Rows stay compact; **Details** expands numeric / material fields. Colour swatches are always available.
+Profile list is **top → bottom**. Orbit list follows knot order around the loop.
+Rows stay compact; **Details** expands numeric / material fields.
 
 ## Shading base
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted } from "vue";
+import { computed, onMounted } from "vue";
 import SplineCanvas from "./components/SplineCanvas.vue";
 import PointEditor from "./components/PointEditor.vue";
 import Preview3D from "./components/Preview3D.vue";
@@ -9,6 +9,7 @@ import { useLibrary } from "./composables/useLibrary.js";
 
 const {
   state,
+  setViewMode,
   setToolMode,
   select,
   selectSegment,
@@ -44,6 +45,18 @@ const tools = [
   { id: "add", label: "Add" },
   { id: "color", label: "Coloring" },
 ];
+
+const views = [
+  { id: "profile", label: "Profile" },
+  { id: "orbit", label: "Orbit" },
+];
+
+const activeKnots = computed(() =>
+  state.viewMode === "orbit" ? state.orbitKnots : state.knots,
+);
+const activeSegments = computed(() =>
+  state.viewMode === "orbit" ? state.orbitSegments : state.segments,
+);
 
 function onTessellate() {
   tessellate();
@@ -88,11 +101,21 @@ onMounted(() => {
         <p class="eyebrow">Ranger · gallery/game_engine/v2</p>
         <h1>Spline Mesh Editor</h1>
         <p class="lede">
-          Symmetrical Bezier profiles around the Y axis, lathed into a 3D mesh and rendered with
-          Ranger Three — with Edit / Add / Coloring tools.
+          Bezier profile + editable orbit path (replaces cos/sin) lathed into a mesh with Ranger
+          Three — Edit / Add / Coloring on either view.
         </p>
       </div>
       <div class="actions">
+        <div class="tool-row">
+          <button
+            v-for="v in views"
+            :key="v.id"
+            :class="{ active: state.viewMode === v.id, primary: state.viewMode === v.id }"
+            @click="setViewMode(v.id)"
+          >
+            {{ v.label }}
+          </button>
+        </div>
         <div class="tool-row">
           <button
             v-for="t in tools"
@@ -122,18 +145,18 @@ onMounted(() => {
         <input v-model.number="state.pathSegments" type="number" min="2" max="64" />
       </label>
       <label class="field">
-        Angular steps N
-        <input v-model.number="state.angularSteps" type="number" min="3" max="64" />
+        Orbit samples N
+        <input v-model.number="state.angularSteps" type="number" min="3" max="96" />
       </label>
       <label class="field">
         Revolution
-        <select v-model.number="state.revolutionDeg">
+        <select v-model.number="state.revolutionDeg" @change="onTessellate">
           <option :value="360">360° closed</option>
-          <option :value="180">180° (skip last)</option>
+          <option :value="180">180° (half orbit)</option>
         </select>
       </label>
-      <label class="field check">
-        <input v-model="state.symmetry" type="checkbox" />
+      <label class="field check" :class="{ dim: state.viewMode === 'orbit' }">
+        <input v-model="state.symmetry" type="checkbox" :disabled="state.viewMode === 'orbit'" />
         Show mirror
       </label>
       <div class="mats">
@@ -157,13 +180,14 @@ onMounted(() => {
 
     <main class="workspace">
       <SplineCanvas
-        :knots="state.knots"
-        :segments="state.segments"
+        :knots="activeKnots"
+        :segments="activeSegments"
         :selected-id="state.selectedId"
         :selected-segment-index="state.selectedSegmentIndex"
         :curve-type="state.curveType"
         :symmetry="state.symmetry"
         :tool-mode="state.toolMode"
+        :view-mode="state.viewMode"
         :viewport="state.viewport"
         :sample-curve-points="sampleCurvePoints"
         :find-closest-on-curve="findClosestOnCurve"
@@ -174,12 +198,13 @@ onMounted(() => {
         @drag-end="onDragEnd"
       />
       <PointEditor
-        :knots="state.knots"
-        :segments="state.segments"
+        :knots="activeKnots"
+        :segments="activeSegments"
         :selected-id="state.selectedId"
         :selected-segment-index="state.selectedSegmentIndex"
         :curve-type="state.curveType"
         :tool-mode="state.toolMode"
+        :view-mode="state.viewMode"
         @select="select"
         @select-segment="selectSegment"
         @update-knot="onUpdateKnot"
@@ -278,6 +303,9 @@ h1 {
   align-items: center;
   gap: 0.45rem;
   padding-bottom: 0.35rem;
+}
+.check.dim {
+  opacity: 0.45;
 }
 
 .mats span {

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/PointEditor.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/PointEditor.vue
@@ -8,6 +8,7 @@ const props = defineProps({
   selectedSegmentIndex: { type: Number, default: -1 },
   curveType: { type: Number, default: 0 },
   toolMode: { type: String, default: "edit" },
+  viewMode: { type: String, default: "profile" },
 });
 
 const emit = defineEmits([
@@ -19,9 +20,20 @@ const emit = defineEmits([
   "commit",
 ]);
 
-/** Top-of-canvas first so a newly added high point appears near the top of the list. */
+const closed = computed(() => props.viewMode === "orbit");
+const minKnots = computed(() => (closed.value ? 3 : 2));
+
+/** Profile: top→bottom. Orbit: around the closed loop in knot order. */
 const rows = computed(() => {
   const out = [];
+  if (closed.value) {
+    const n = props.knots.length;
+    for (let i = 0; i < n; i++) {
+      out.push({ kind: "knot", index: i, knot: props.knots[i] });
+      out.push({ kind: "segment", index: i });
+    }
+    return out;
+  }
   for (let i = props.knots.length - 1; i >= 0; i--) {
     out.push({ kind: "knot", index: i, knot: props.knots[i] });
     if (i > 0) out.push({ kind: "segment", index: i - 1 });
@@ -75,17 +87,33 @@ async function onTextureFile(index, ev) {
 }
 
 function knotLabel(i) {
+  if (closed.value) {
+    if (i === 0) return "+X";
+    return "pt";
+  }
   if (i === 0) return "bottom";
   if (i === props.knots.length - 1) return "top";
   return "mid";
+}
+
+function segLabel(i) {
+  if (!closed.value) return `seg ${i + 1}→${i + 2}`;
+  const n = props.knots.length;
+  const to = (i + 1) % n;
+  return `seg ${i + 1}→${to + 1}`;
 }
 </script>
 
 <template>
   <div class="point-editor">
     <header>
-      <h2>{{ toolMode === "color" ? "Coloring" : "Points" }}</h2>
-      <p>Top → bottom (matches the canvas). Color always editable; Details for numbers.</p>
+      <h2>
+        {{ toolMode === "color" ? "Coloring" : viewMode === "orbit" ? "Orbit points" : "Points" }}
+      </h2>
+      <p v-if="viewMode === 'orbit'">
+        Closed loop (canvas X→world X, Y→world Z). Color always editable; Details for numbers.
+      </p>
+      <p v-else>Top → bottom (matches the canvas). Color always editable; Details for numbers.</p>
     </header>
 
     <ul>
@@ -135,7 +163,7 @@ function knotLabel(i) {
             <button
               type="button"
               class="danger icon"
-              :disabled="knots.length <= 2"
+              :disabled="knots.length <= minKnots"
               title="Remove"
               @click.stop="emit('remove-knot', row.knot.id)"
             >
@@ -203,7 +231,7 @@ function knotLabel(i) {
               />
             </label>
             <div class="meta">
-              <strong>seg {{ row.index + 1 }}→{{ row.index + 2 }}</strong>
+              <strong>{{ segLabel(row.index) }}</strong>
               <span>{{ segments[row.index]?.texture || "gradient" }}</span>
             </div>
             <button

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
@@ -9,6 +9,7 @@ const props = defineProps({
   curveType: { type: Number, default: 0 },
   symmetry: { type: Boolean, default: true },
   toolMode: { type: String, default: "edit" },
+  viewMode: { type: String, default: "profile" },
   viewport: { type: Object, required: true },
   sampleCurvePoints: { type: Function, required: true },
   findClosestOnCurve: { type: Function, required: true },
@@ -22,6 +23,7 @@ let dragging = null;
 let raf = 0;
 const hoverAdd = ref(null);
 
+const isOrbit = computed(() => props.viewMode === "orbit");
 const curvePts = computed(() => props.sampleCurvePoints(28));
 
 function worldToScreen(x, y, w, h) {
@@ -53,8 +55,24 @@ function segmentColor(segIndex) {
   const seg = props.segments[segIndex];
   if (seg?.color) return seg.color;
   const a = props.knots[segIndex];
-  const b = props.knots[segIndex + 1];
+  const b = props.knots[isOrbit.value ? (segIndex + 1) % props.knots.length : segIndex + 1];
   return a?.color || "#6ec8ff";
+}
+
+function drawUnitCircle(ctx, w, h) {
+  const steps = 64;
+  ctx.strokeStyle = "rgba(200,232,122,0.22)";
+  ctx.lineWidth = 1.25;
+  ctx.setLineDash([4, 4]);
+  ctx.beginPath();
+  for (let i = 0; i <= steps; i++) {
+    const t = (i / steps) * Math.PI * 2;
+    const [sx, sy] = worldToScreen(Math.cos(t), Math.sin(t), w, h);
+    if (i === 0) ctx.moveTo(sx, sy);
+    else ctx.lineTo(sx, sy);
+  }
+  ctx.stroke();
+  ctx.setLineDash([]);
 }
 
 function draw() {
@@ -97,18 +115,35 @@ function draw() {
     ctx.stroke();
   }
 
-  const [ax0, ay0] = worldToScreen(0, -1, w, h);
-  const [ax1, ay1] = worldToScreen(0, 1, w, h);
-  ctx.strokeStyle = "rgba(200,232,122,0.55)";
-  ctx.lineWidth = 1.5;
-  ctx.beginPath();
-  ctx.moveTo(ax0, ay0);
-  ctx.lineTo(ax1, ay1);
-  ctx.stroke();
+  if (isOrbit.value) {
+    // XZ plane: canvas x → world X, canvas y → world Z
+    const [ax0, ay0] = worldToScreen(-1, 0, w, h);
+    const [ax1, ay1] = worldToScreen(1, 0, w, h);
+    const [az0, az1y] = worldToScreen(0, -1, w, h);
+    const [az1, az0y] = worldToScreen(0, 1, w, h);
+    ctx.strokeStyle = "rgba(200,232,122,0.45)";
+    ctx.lineWidth = 1.25;
+    ctx.beginPath();
+    ctx.moveTo(ax0, ay0);
+    ctx.lineTo(ax1, ay1);
+    ctx.moveTo(az0, az0y);
+    ctx.lineTo(az1, az1y);
+    ctx.stroke();
+    drawUnitCircle(ctx, w, h);
+  } else {
+    const [ax0, ay0] = worldToScreen(0, -1, w, h);
+    const [ax1, ay1] = worldToScreen(0, 1, w, h);
+    ctx.strokeStyle = "rgba(200,232,122,0.55)";
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(ax0, ay0);
+    ctx.lineTo(ax1, ay1);
+    ctx.stroke();
+  }
 
   const pts = curvePts.value;
 
-  if (props.symmetry && pts.length > 1) {
+  if (!isOrbit.value && props.symmetry && pts.length > 1) {
     ctx.lineWidth = 2;
     drawGradientStroke(
       ctx,
@@ -137,9 +172,9 @@ function draw() {
     );
   }
 
-  // segment hit markers in color mode
+  const segCount = isOrbit.value ? props.knots.length : props.knots.length - 1;
   if (props.toolMode === "color") {
-    for (let i = 0; i < props.knots.length - 1; i++) {
+    for (let i = 0; i < segCount; i++) {
       const mid = evalMid(i);
       if (!mid) continue;
       const [sx, sy] = worldToScreen(mid.x, mid.y, w, h);
@@ -153,7 +188,7 @@ function draw() {
     }
   }
 
-  props.knots.forEach((k, i) => {
+  props.knots.forEach((k) => {
     const [sx, sy] = worldToScreen(k.x, k.y, w, h);
     if (props.curveType === 0 && props.toolMode === "edit") {
       const [hx, hy] = worldToScreen(k.x + k.hx, k.y + k.hy, w, h);
@@ -169,7 +204,7 @@ function draw() {
     }
     drawPoint(ctx, sx, sy, k.id === props.selectedId, k.color);
 
-    if (props.symmetry && k.x > 0.001) {
+    if (!isOrbit.value && props.symmetry && k.x > 0.001) {
       const [mx, my] = worldToScreen(-k.x, k.y, w, h);
       ctx.fillStyle = "rgba(110,200,255,0.35)";
       ctx.beginPath();
@@ -227,7 +262,8 @@ function hitTestPoint(sx, sy) {
 
 function hitTestSegment(sx, sy) {
   const thresh = 12;
-  for (let i = 0; i < props.knots.length - 1; i++) {
+  const segCount = isOrbit.value ? props.knots.length : props.knots.length - 1;
+  for (let i = 0; i < segCount; i++) {
     const mid = evalMid(i);
     if (!mid) continue;
     const [mx, my] = worldToScreen(mid.x, mid.y, size, size);
@@ -243,7 +279,7 @@ function onPointerDown(e) {
   const [wx, wy] = screenToWorld(sx, sy, size, size);
 
   if (props.toolMode === "add") {
-    emit("add-on-curve", Math.max(0, wx), wy);
+    emit("add-on-curve", isOrbit.value ? wx : Math.max(0, wx), wy);
     return;
   }
 
@@ -275,7 +311,7 @@ function onPointerMove(e) {
   const [wx, wy] = screenToWorld(sx, sy, size, size);
 
   if (props.toolMode === "add") {
-    hoverAdd.value = props.findClosestOnCurve(Math.max(0, wx), wy, 0.14);
+    hoverAdd.value = props.findClosestOnCurve(isOrbit.value ? wx : Math.max(0, wx), wy, 0.14);
     schedule();
     return;
   }
@@ -284,7 +320,7 @@ function onPointerMove(e) {
   const k = props.knots.find((n) => n.id === dragging.id);
   if (!k) return;
   if (dragging.mode === "point") {
-    emit("update-knot", dragging.id, { x: Math.max(0, wx), y: wy });
+    emit("update-knot", dragging.id, isOrbit.value ? { x: wx, y: wy } : { x: Math.max(0, wx), y: wy });
   } else {
     emit("update-knot", dragging.id, { hx: wx - k.x, hy: wy - k.y });
   }
@@ -311,6 +347,7 @@ watch(
     props.curveType,
     props.symmetry,
     props.toolMode,
+    props.viewMode,
     curvePts.value,
     hoverAdd.value,
   ],
@@ -334,16 +371,23 @@ onBeforeUnmount(() => {
     <canvas
       ref="canvasRef"
       class="spline-canvas"
-      :class="toolMode"
+      :class="[toolMode, viewMode]"
       @pointerdown="onPointerDown"
       @pointermove="onPointerMove"
       @pointerup="onPointerUp"
       @pointercancel="onPointerUp"
     />
     <div class="legend">
-      <span class="dot axis" /> axis
-      <span class="dot curve" /> profile / gradient
-      <span class="dot handle" /> Bezier handle
+      <template v-if="viewMode === 'orbit'">
+        <span class="dot axis" /> XZ axes
+        <span class="dot curve" /> orbit path
+        <span class="dot handle" /> unit circle
+      </template>
+      <template v-else>
+        <span class="dot axis" /> axis
+        <span class="dot curve" /> profile / gradient
+        <span class="dot handle" /> Bezier handle
+      </template>
     </div>
   </div>
 </template>

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -2,7 +2,7 @@ import { reactive, computed, watch } from "vue";
 import { SplineLathe, SplineKnot } from "@tessellate";
 
 /** @typedef {{ id: string, x: number, y: number, hx: number, hy: number, color: string }} Knot */
-/** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureData: { rgba: Uint8Array, w: number, h: number, name: string }|null }} Segment */
+/** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureData: { rgba: Uint8Array, w: number, h: number, name: string }|null, textureAsset?: string|null }} Segment */
 
 function uid() {
   return "k" + Math.random().toString(36).slice(2, 9);
@@ -22,6 +22,18 @@ function defaultKnots() {
   }));
 }
 
+function defaultOrbitKnots() {
+  const raw = SplineLathe.defaultOrbitKnots();
+  return raw.map((k, i) => ({
+    id: uid(),
+    x: k.x,
+    y: k.y,
+    hx: k.hx,
+    hy: k.hy,
+    color: DEFAULT_COLORS[(i + 2) % DEFAULT_COLORS.length],
+  }));
+}
+
 function defaultSegment(fromId, toId) {
   return {
     fromId,
@@ -32,6 +44,7 @@ function defaultSegment(fromId, toId) {
     opacity: 1,
     texture: "gradient",
     textureData: null,
+    textureAsset: null,
   };
 }
 
@@ -58,6 +71,18 @@ function mixHex(a, b, t) {
 function hexToInt(hex) {
   const c = hexToRgb(hex);
   return (c.r << 16) | (c.g << 8) | c.b;
+}
+
+function mulColorHex(a, b) {
+  if (a === 0xffffff) return b;
+  if (b === 0xffffff) return a;
+  const ar = (a >> 16) & 255;
+  const ag = (a >> 8) & 255;
+  const ab = a & 255;
+  const br = (b >> 16) & 255;
+  const bg = (b >> 8) & 255;
+  const bb = b & 255;
+  return (((ar * br) / 255) | 0) << 16 | (((ag * bg) / 255) | 0) << 8 | (((ab * bb) / 255) | 0);
 }
 
 function roughnessToShininess(r) {
@@ -116,10 +141,70 @@ function makeStripesRgba(size = 64) {
   return { rgba, w: size, h: size };
 }
 
+function cloneSeg(s, fromId, toId) {
+  return {
+    ...s,
+    fromId,
+    toId,
+    textureData: s.textureData || null,
+  };
+}
+
+/**
+ * Split a full-orbit lathe band into per-orbit-segment parts (own vertex buffers).
+ */
+function splitMeshByOrbitSegments(mesh, steps, oSeg, numOrbitSegs, closed) {
+  const vertCount = (mesh.positions.length / 3) | 0;
+  if (steps < 2 || vertCount < steps * 2) return [];
+  const rows = (vertCount / steps) | 0;
+  const out = [];
+
+  for (let oi = 0; oi < numOrbitSegs; oi++) {
+    const faces = [];
+    for (let r = 0; r < rows - 1; r++) {
+      const colMax = closed ? steps : steps - 1;
+      for (let c = 0; c < colMax; c++) {
+        if ((oSeg[c] | 0) !== oi) continue;
+        const cNext = c + 1 >= steps ? 0 : c + 1;
+        const a = r * steps + c;
+        const b = r * steps + cNext;
+        const cc = (r + 1) * steps + cNext;
+        const d = (r + 1) * steps + c;
+        faces.push(a, d, b, b, d, cc);
+      }
+    }
+    if (!faces.length) continue;
+
+    const used = new Map();
+    const positions = [];
+    const normals = [];
+    const uvs = [];
+    const indices = [];
+    const mapV = (g) => {
+      let local = used.get(g);
+      if (local != null) return local;
+      local = used.size;
+      used.set(g, local);
+      const i3 = g * 3;
+      const i2 = g * 2;
+      positions.push(mesh.positions[i3], mesh.positions[i3 + 1], mesh.positions[i3 + 2]);
+      normals.push(mesh.normals[i3], mesh.normals[i3 + 1], mesh.normals[i3 + 2]);
+      uvs.push(mesh.uvs[i2], mesh.uvs[i2 + 1]);
+      return local;
+    };
+    for (let i = 0; i < faces.length; i++) indices.push(mapV(faces[i]));
+    out.push({ orbitSeg: oi, positions, normals, uvs, indices });
+  }
+  return out;
+}
+
 export function useSplineEditor() {
   const state = reactive({
+    viewMode: "profile", // profile | orbit
     knots: defaultKnots(),
     segments: /** @type {Segment[]} */ ([]),
+    orbitKnots: defaultOrbitKnots(),
+    orbitSegments: /** @type {Segment[]} */ ([]),
     selectedId: null,
     selectedSegmentIndex: -1,
     toolMode: "edit", // edit | add | color
@@ -132,36 +217,77 @@ export function useSplineEditor() {
     viewport: { min: -1.1, max: 1.1 },
     mesh: null,
     stats: { verts: 0, tris: 0, profile: 0, parts: 0 },
-    status: "Edit mode — drag points. Switch to Add to insert on the curve.",
+    status: "Edit mode — drag points. Switch view to edit the orbit path.",
   });
 
-  function syncSegments() {
+  function isOrbit() {
+    return state.viewMode === "orbit";
+  }
+
+  function activeKnots() {
+    return isOrbit() ? state.orbitKnots : state.knots;
+  }
+
+  function activeSegments() {
+    return isOrbit() ? state.orbitSegments : state.segments;
+  }
+
+  function syncOpenSegments() {
     const byPair = new Map();
-    for (const s of state.segments) {
-      byPair.set(s.fromId + ">" + s.toId, s);
-    }
+    for (const s of state.segments) byPair.set(s.fromId + ">" + s.toId, s);
     const next = [];
     for (let i = 0; i < state.knots.length - 1; i++) {
       const fromId = state.knots[i].id;
       const toId = state.knots[i + 1].id;
-      const key = fromId + ">" + toId;
-      const exact = byPair.get(key);
-      if (exact) {
-        next.push({ ...exact, fromId, toId });
-      } else {
-        next.push(defaultSegment(fromId, toId));
-      }
+      const exact = byPair.get(fromId + ">" + toId);
+      next.push(exact ? cloneSeg(exact, fromId, toId) : defaultSegment(fromId, toId));
     }
     state.segments = next;
-    if (state.selectedSegmentIndex >= next.length) state.selectedSegmentIndex = next.length - 1;
+    if (!isOrbit() && state.selectedSegmentIndex >= next.length) {
+      state.selectedSegmentIndex = next.length - 1;
+    }
+  }
+
+  function syncOrbitSegments() {
+    const byPair = new Map();
+    for (const s of state.orbitSegments) byPair.set(s.fromId + ">" + s.toId, s);
+    const next = [];
+    const n = state.orbitKnots.length;
+    for (let i = 0; i < n; i++) {
+      const fromId = state.orbitKnots[i].id;
+      const toId = state.orbitKnots[(i + 1) % n].id;
+      const exact = byPair.get(fromId + ">" + toId);
+      next.push(exact ? cloneSeg(exact, fromId, toId) : defaultSegment(fromId, toId));
+    }
+    state.orbitSegments = next;
+    if (isOrbit() && state.selectedSegmentIndex >= next.length) {
+      state.selectedSegmentIndex = next.length - 1;
+    }
+  }
+
+  function syncSegments() {
+    syncOpenSegments();
+    syncOrbitSegments();
   }
 
   syncSegments();
 
-  const selected = computed(() => state.knots.find((k) => k.id === state.selectedId) || null);
+  const selected = computed(() => activeKnots().find((k) => k.id === state.selectedId) || null);
   const selectedSegment = computed(() =>
-    state.selectedSegmentIndex >= 0 ? state.segments[state.selectedSegmentIndex] || null : null,
+    state.selectedSegmentIndex >= 0 ? activeSegments()[state.selectedSegmentIndex] || null : null,
   );
+
+  function setViewMode(mode) {
+    state.viewMode = mode === "orbit" ? "orbit" : "profile";
+    state.selectedId = null;
+    state.selectedSegmentIndex = -1;
+    const knots = activeKnots();
+    state.selectedId = knots[0]?.id || null;
+    state.status =
+      state.viewMode === "orbit"
+        ? "Orbit view — closed Bezier path replaces cos/sin for the lathe."
+        : "Profile view — right-half silhouette (x ≥ 0), lathed around Y.";
+  }
 
   function setToolMode(mode) {
     state.toolMode = mode;
@@ -183,20 +309,25 @@ export function useSplineEditor() {
   function resetDefaults() {
     state.knots = defaultKnots();
     state.segments = [];
+    state.orbitKnots = defaultOrbitKnots();
+    state.orbitSegments = [];
     syncSegments();
+    state.viewMode = "profile";
     state.selectedId = state.knots[1]?.id || null;
     state.selectedSegmentIndex = -1;
     state.mesh = null;
-    state.status = "Reset to default silhouette.";
+    state.status = "Reset to default silhouette + unit-circle orbit.";
   }
 
   function removeKnot(id) {
-    if (state.knots.length <= 2) return;
-    const idx = state.knots.findIndex((k) => k.id === id);
+    const knots = activeKnots();
+    const min = isOrbit() ? 3 : 2;
+    if (knots.length <= min) return;
+    const idx = knots.findIndex((k) => k.id === id);
     if (idx < 0) return;
-    state.knots.splice(idx, 1);
+    knots.splice(idx, 1);
     syncSegments();
-    state.selectedId = state.knots[Math.min(idx, state.knots.length - 1)]?.id || null;
+    state.selectedId = knots[Math.min(idx, knots.length - 1)]?.id || null;
     state.selectedSegmentIndex = -1;
   }
 
@@ -205,19 +336,19 @@ export function useSplineEditor() {
   }
 
   function updateKnot(id, patch) {
-    const k = state.knots.find((n) => n.id === id);
+    const k = activeKnots().find((n) => n.id === id);
     if (!k) return;
     Object.assign(k, patch);
-    if (typeof patch.x === "number") k.x = Math.max(0, patch.x);
+    if (!isOrbit() && typeof patch.x === "number") k.x = Math.max(0, patch.x);
   }
 
   function updateSegment(index, patch) {
-    const s = state.segments[index];
+    const s = activeSegments()[index];
     if (!s) return;
     Object.assign(s, patch);
   }
 
-  function toRangerKnots(list = state.knots) {
+  function toRangerKnots(list) {
     return list.map((k) => SplineKnot.of(k.x, k.y, k.hx, k.hy));
   }
 
@@ -228,7 +359,6 @@ export function useSplineEditor() {
         tan: SplineLathe.bezierTangent(a.x, a.y, a.x + a.hx, a.y + a.hy, b.x - b.hx, b.y - b.hy, b.x, b.y, t),
       };
     }
-    // catmull uses neighbours; approximate with span endpoints as p1/p2 and duplicates
     return {
       p: SplineLathe.catmullPoint(a.x, a.y, a.x, a.y, b.x, b.y, b.x, b.y, t),
       tan: SplineLathe.catmullTangent(a.x, a.y, a.x, a.y, b.x, b.y, b.x, b.y, t),
@@ -236,11 +366,26 @@ export function useSplineEditor() {
   }
 
   function sampleCurvePoints(samplesPerSpan = 24) {
+    const knots = activeKnots();
     const pts = [];
-    for (let i = 0; i < state.knots.length - 1; i++) {
-      const a = state.knots[i];
-      const b = state.knots[i + 1];
-      const last = i < state.knots.length - 2 ? samplesPerSpan - 1 : samplesPerSpan;
+    if (isOrbit()) {
+      const n = knots.length;
+      for (let i = 0; i < n; i++) {
+        const a = knots[i];
+        const b = knots[(i + 1) % n];
+        for (let s = 0; s < samplesPerSpan; s++) {
+          const t = s / samplesPerSpan;
+          const { p } = evalSpan(a, b, t, state.curveType);
+          pts.push({ x: p.x, y: p.y, segmentIndex: i, t });
+        }
+      }
+      if (pts.length) pts.push({ ...pts[0], t: 1 });
+      return pts;
+    }
+    for (let i = 0; i < knots.length - 1; i++) {
+      const a = knots[i];
+      const b = knots[i + 1];
+      const last = i < knots.length - 2 ? samplesPerSpan - 1 : samplesPerSpan;
       for (let s = 0; s <= last; s++) {
         const t = s / samplesPerSpan;
         const { p } = evalSpan(a, b, t, state.curveType);
@@ -252,9 +397,12 @@ export function useSplineEditor() {
 
   function findClosestOnCurve(wx, wy, maxDist = 0.12) {
     const pts = sampleCurvePoints(40);
+    // Ignore the duplicate closing sample when measuring
+    const limit = isOrbit() && pts.length > 1 ? pts.length - 1 : pts.length;
     let best = null;
     let bestD = maxDist;
-    for (const p of pts) {
+    for (let i = 0; i < limit; i++) {
+      const p = pts[i];
       const d = Math.hypot(p.x - wx, p.y - wy);
       if (d < bestD) {
         bestD = d;
@@ -270,56 +418,75 @@ export function useSplineEditor() {
       state.status = "Click closer to the curve to add a point.";
       return null;
     }
+    const knots = activeKnots();
     const segIndex = hit.segmentIndex;
-    const a = state.knots[segIndex];
-    const b = state.knots[segIndex + 1];
-    const oldSeg = state.segments[segIndex]
-      ? { ...state.segments[segIndex] }
-      : defaultSegment(a.id, b.id);
+    const n = knots.length;
+    const a = knots[segIndex];
+    const b = isOrbit() ? knots[(segIndex + 1) % n] : knots[segIndex + 1];
+    const segs = activeSegments();
+    const oldSeg = segs[segIndex] ? { ...segs[segIndex] } : defaultSegment(a.id, b.id);
     const { p, tan } = evalSpan(a, b, hit.t, state.curveType);
     const tl = Math.hypot(tan.x, tan.y) || 1;
     const scale = 0.14;
     const k = {
       id: uid(),
-      x: Math.max(0, p.x),
+      x: isOrbit() ? p.x : Math.max(0, p.x),
       y: p.y,
       hx: (tan.x / tl) * scale,
       hy: (tan.y / tl) * scale,
-      color: DEFAULT_COLORS[state.knots.length % DEFAULT_COLORS.length],
+      color: DEFAULT_COLORS[knots.length % DEFAULT_COLORS.length],
     };
-    // Insert knot, then rebuild segments with the split styles in the correct slots.
-    state.knots.splice(segIndex + 1, 0, k);
-    const next = [];
-    for (let i = 0; i < state.knots.length - 1; i++) {
-      const fromId = state.knots[i].id;
-      const toId = state.knots[i + 1].id;
-      if (i === segIndex || i === segIndex + 1) {
-        next.push({
-          ...oldSeg,
-          fromId,
-          toId,
-          textureData: oldSeg.textureData,
-        });
-      } else if (i < segIndex) {
-        next.push({ ...state.segments[i], fromId, toId });
-      } else {
-        // i >= segIndex + 2 → old segment index was i - 1
-        next.push({ ...state.segments[i - 1], fromId, toId });
+
+    if (isOrbit()) {
+      const old = state.orbitSegments.slice();
+      knots.splice(segIndex + 1, 0, k);
+      const next = [];
+      const nn = knots.length;
+      for (let i = 0; i < nn; i++) {
+        const fromId = knots[i].id;
+        const toId = knots[(i + 1) % nn].id;
+        if (i === segIndex || i === segIndex + 1) {
+          next.push({ ...oldSeg, fromId, toId, textureData: oldSeg.textureData });
+        } else {
+          const oldIdx = i < segIndex ? i : i - 1;
+          next.push(cloneSeg(old[oldIdx] || oldSeg, fromId, toId));
+        }
       }
+      state.orbitSegments = next;
+    } else {
+      knots.splice(segIndex + 1, 0, k);
+      const next = [];
+      for (let i = 0; i < knots.length - 1; i++) {
+        const fromId = knots[i].id;
+        const toId = knots[i + 1].id;
+        if (i === segIndex || i === segIndex + 1) {
+          next.push({ ...oldSeg, fromId, toId, textureData: oldSeg.textureData });
+        } else if (i < segIndex) {
+          next.push(cloneSeg(state.segments[i], fromId, toId));
+        } else {
+          next.push(cloneSeg(state.segments[i - 1], fromId, toId));
+        }
+      }
+      state.segments = next;
     }
-    state.segments = next;
+
     state.selectedId = k.id;
     state.selectedSegmentIndex = -1;
-    state.status = `Added knot at y=${k.y.toFixed(2)} (between #${segIndex + 1} and #${segIndex + 2}).`;
+    state.status = isOrbit()
+      ? `Added orbit knot (segment ${segIndex + 1}).`
+      : `Added knot at y=${k.y.toFixed(2)} (between #${segIndex + 1} and #${segIndex + 2}).`;
     return k;
   }
 
-  function resolvePartStyle(segIndex) {
-    const a = state.knots[segIndex];
-    const b = state.knots[segIndex + 1];
-    const seg = state.segments[segIndex];
-    const colorA = a.color || "#cccccc";
-    const colorB = b.color || "#cccccc";
+  function resolvePartStyle(segIndex, which) {
+    const closed = which === "orbit";
+    const knots = closed ? state.orbitKnots : state.knots;
+    const segments = closed ? state.orbitSegments : state.segments;
+    const a = knots[segIndex];
+    const b = knots[closed ? (segIndex + 1) % knots.length : segIndex + 1];
+    const seg = segments[segIndex] || defaultSegment(a?.id, b?.id);
+    const colorA = a?.color || "#cccccc";
+    const colorB = b?.color || "#cccccc";
     const solidHex = seg.color ? hexToInt(seg.color) : null;
     const shininess = roughnessToShininess(seg.roughness ?? 0.4);
     const reflectivity = Math.min(0.95, Math.max(0, seg.metalness ?? 0));
@@ -339,46 +506,106 @@ export function useSplineEditor() {
     } else if (seg.texture === "none" && solidHex != null) {
       colorHex = solidHex;
     } else {
-      // linear gradient along the segment (knot A → knot B), or solid override tinted gradient
       const from = solidHex != null ? seg.color : colorA;
       const to = solidHex != null ? seg.color : colorB;
       map = makeGradientRgba(from, to, 4, 64);
       colorHex = 0xffffff;
     }
 
-    return { colorHex, shininess, reflectivity, opacity, map };
+    return { colorHex, shininess, reflectivity, opacity, map, midColor: mixHex(colorA, colorB, 0.5) };
+  }
+
+  function midColorInt(segIndex, which) {
+    const closed = which === "orbit";
+    const knots = closed ? state.orbitKnots : state.knots;
+    const segments = closed ? state.orbitSegments : state.segments;
+    const a = knots[segIndex];
+    const b = knots[closed ? (segIndex + 1) % knots.length : segIndex + 1];
+    const seg = segments[segIndex];
+    if (seg?.color) return hexToInt(seg.color);
+    return mixHex(a?.color || "#cccccc", b?.color || "#cccccc", 0.5);
+  }
+
+  function resolveCombinedStyle(pi, oi) {
+    const p = resolvePartStyle(pi, "profile");
+    const o = resolvePartStyle(oi, "orbit");
+    const pSeg = state.segments[pi];
+    const oSeg = state.orbitSegments[oi];
+    const map = p.map || o.map;
+    let colorHex;
+    if (map) {
+      // Texture from one dimension; tint with the other so both read in shading.
+      colorHex = p.map ? midColorInt(oi, "orbit") : midColorInt(pi, "profile");
+      if (colorHex === 0xffffff) colorHex = mulColorHex(p.colorHex, o.colorHex);
+    } else {
+      colorHex = mulColorHex(midColorInt(pi, "profile"), midColorInt(oi, "orbit"));
+    }
+    const rough = ((pSeg?.roughness ?? 0.4) + (oSeg?.roughness ?? 0.4)) / 2;
+    return {
+      colorHex,
+      shininess: roughnessToShininess(rough),
+      reflectivity: Math.min(0.95, Math.max(pSeg?.metalness ?? 0, oSeg?.metalness ?? 0)),
+      opacity: (pSeg?.opacity ?? 1) * (oSeg?.opacity ?? 1),
+      map,
+    };
   }
 
   function tessellate() {
-    const phi = (state.revolutionDeg * Math.PI) / 180;
     const closed = state.revolutionDeg >= 359.9;
+    const nOrb = state.orbitKnots.length;
+    const perSpan = Math.max(3, Math.round(state.angularSteps / Math.max(1, nOrb)));
+    const sampled = SplineLathe.sampleClosedOrbit(
+      toRangerKnots(state.orbitKnots),
+      state.curveType,
+      perSpan,
+    );
+    let ox = sampled.orbitX.slice();
+    let oy = sampled.orbitY.slice();
+    let oSeg = sampled.profileX.map((x) => x | 0);
+
+    if (!closed) {
+      const half = Math.max(3, Math.floor(ox.length / 2) + 1);
+      ox = ox.slice(0, half);
+      oy = oy.slice(0, half);
+      oSeg = oSeg.slice(0, half);
+    }
+
+    const steps = ox.length;
     const parts = [];
     let totalV = 0;
     let totalT = 0;
 
-    for (let i = 0; i < state.knots.length - 1; i++) {
-      const pair = [state.knots[i], state.knots[i + 1]];
-      const mesh = SplineLathe.sampleAndLatheEx(
+    for (let pi = 0; pi < state.knots.length - 1; pi++) {
+      const pair = [state.knots[pi], state.knots[pi + 1]];
+      const mesh = SplineLathe.sampleAndLatheOrbit(
         toRangerKnots(pair),
         state.curveType,
         state.pathSegments,
-        state.angularSteps,
-        phi,
+        ox,
+        oy,
+        0,
+        steps,
         closed,
       );
-      const style = resolvePartStyle(i);
-      parts.push({
-        positions: mesh.positions.slice(),
-        normals: mesh.normals.slice(),
-        uvs: mesh.uvs.slice(),
-        indices: mesh.indices.slice(),
-        ...style,
-        mapRgba: style.map ? Array.from(style.map.rgba) : null,
-        mapW: style.map ? style.map.w : 0,
-        mapH: style.map ? style.map.h : 0,
-      });
-      totalV += (mesh.positions.length / 3) | 0;
-      totalT += (mesh.indices.length / 3) | 0;
+      const pieces = splitMeshByOrbitSegments(mesh, steps, oSeg, nOrb, closed);
+      for (const piece of pieces) {
+        const style = resolveCombinedStyle(pi, piece.orbitSeg);
+        parts.push({
+          positions: piece.positions,
+          normals: piece.normals,
+          uvs: piece.uvs,
+          indices: piece.indices,
+          colorHex: style.colorHex,
+          shininess: style.shininess,
+          reflectivity: style.reflectivity,
+          opacity: style.opacity,
+          mapRgba: style.map ? Array.from(style.map.rgba) : null,
+          mapW: style.map ? style.map.w : 0,
+          mapH: style.map ? style.map.h : 0,
+        });
+        totalV += (piece.positions.length / 3) | 0;
+        totalT += (piece.indices.length / 3) | 0;
+      }
     }
 
     state.mesh = { parts };
@@ -388,7 +615,7 @@ export function useSplineEditor() {
       profile: state.knots.length,
       parts: parts.length,
     };
-    state.status = `Tessellated ${parts.length} parts · ${totalV} verts / ${totalT} tris.`;
+    state.status = `Tessellated ${parts.length} parts (profile × orbit) · ${totalV} verts / ${totalT} tris · ${steps} orbit cols.`;
     return state.mesh;
   }
 
@@ -401,6 +628,7 @@ export function useSplineEditor() {
     state.revolutionDeg = ed.revolutionDeg || 360;
     state.materialMode = ed.materialMode ?? 3;
     state.symmetry = ed.symmetry !== false;
+    state.viewMode = ed.viewMode === "orbit" ? "orbit" : "profile";
     state.knots = doc.profile.knots.map((k) => ({
       id: k.id,
       x: k.x,
@@ -420,14 +648,40 @@ export function useSplineEditor() {
       textureData: null,
       textureAsset: s.textureAsset || null,
     }));
+
+    if (doc.orbit?.knots?.length >= 3) {
+      state.orbitKnots = doc.orbit.knots.map((k) => ({
+        id: k.id,
+        x: k.x,
+        y: k.y,
+        hx: k.hx,
+        hy: k.hy,
+        color: k.color || "#cccccc",
+      }));
+      state.orbitSegments = (doc.orbit.segments || []).map((s) => ({
+        fromId: s.fromId,
+        toId: s.toId,
+        color: s.color == null ? null : s.color,
+        roughness: s.roughness ?? 0.4,
+        metalness: s.metalness ?? 0,
+        opacity: s.opacity ?? 1,
+        texture: s.texture || "gradient",
+        textureData: null,
+        textureAsset: s.textureAsset || null,
+      }));
+    } else {
+      state.orbitKnots = defaultOrbitKnots();
+      state.orbitSegments = [];
+    }
+
     syncSegments();
-    state.selectedId = state.knots[1]?.id || state.knots[0]?.id || null;
+    const knots = activeKnots();
+    state.selectedId = knots[0]?.id || null;
     state.selectedSegmentIndex = -1;
     state.status = `Loaded “${doc.name}” (schema v${doc.schemaVersion}).`;
     return true;
   }
 
-  /** Plain snapshot for library create/save (no reactive proxy / mesh buffers). */
   function snapshotState() {
     return {
       curveType: state.curveType,
@@ -436,8 +690,20 @@ export function useSplineEditor() {
       revolutionDeg: state.revolutionDeg,
       materialMode: state.materialMode,
       symmetry: state.symmetry,
+      viewMode: state.viewMode,
       knots: state.knots.map((k) => ({ ...k })),
       segments: state.segments.map((s) => ({
+        fromId: s.fromId,
+        toId: s.toId,
+        color: s.color,
+        roughness: s.roughness,
+        metalness: s.metalness,
+        opacity: s.opacity,
+        texture: s.texture,
+        textureAsset: s.textureAsset || null,
+      })),
+      orbitKnots: state.orbitKnots.map((k) => ({ ...k })),
+      orbitSegments: state.orbitSegments.map((s) => ({
         fromId: s.fromId,
         toId: s.toId,
         color: s.color,
@@ -455,7 +721,7 @@ export function useSplineEditor() {
   }
 
   watch(
-    () => state.knots.length,
+    () => [state.knots.length, state.orbitKnots.length],
     () => syncSegments(),
   );
 
@@ -463,6 +729,7 @@ export function useSplineEditor() {
     state,
     selected,
     selectedSegment,
+    setViewMode,
     setToolMode,
     select,
     selectSegment,

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -2,6 +2,7 @@
 // migrations.js — upgrade on-disk spline projects to CURRENT_SCHEMA_VERSION.
 // ============================================================================
 
+import { SplineLathe } from "../../../tessellate/spline_lathe.mjs";
 import {
   CURRENT_SCHEMA_VERSION,
   SCHEMA_KIND,
@@ -11,42 +12,32 @@ import {
   validateProject,
 } from "./schema.js";
 
-/** @type {Record<number, (doc: any) => any>} */
-const STEPS = {
-  // 0 / missing → 1: wrap a loose editor dump into the semantic envelope.
-  1(doc) {
-    if (doc && doc.schemaVersion === 1 && doc.kind === SCHEMA_KIND) {
-      return normalizeV1(doc);
-    }
-    // Accept earlier ad-hoc shapes: { knots, segments, ...editor fields }
-    const knots = doc.profile?.knots || doc.knots || [];
-    const segments = doc.profile?.segments || doc.segments || [];
-    const name = doc.name || "Migrated spline";
-    return normalizeV1({
-      kind: SCHEMA_KIND,
-      schemaVersion: 1,
-      id: doc.id || newId(),
-      slug: doc.slug || slugify(name),
-      name,
-      description: doc.description || "",
-      tags: doc.tags || [],
-      createdAt: doc.createdAt || nowIso(),
-      updatedAt: doc.updatedAt || nowIso(),
-      editor: {
-        curveType: doc.editor?.curveType ?? doc.curveType ?? 0,
-        pathSegments: doc.editor?.pathSegments ?? doc.pathSegments ?? 12,
-        angularSteps: doc.editor?.angularSteps ?? doc.angularSteps ?? 24,
-        revolutionDeg: doc.editor?.revolutionDeg ?? doc.revolutionDeg ?? 360,
-        materialMode: doc.editor?.materialMode ?? doc.materialMode ?? 3,
-        symmetry: doc.editor?.symmetry ?? doc.symmetry ?? true,
-      },
-      profile: { knots, segments },
-    });
-  },
-};
+function defaultOrbitDoc() {
+  const raw = SplineLathe.defaultOrbitKnots();
+  const colors = ["#ffb454", "#e87ac8", "#c8e87a", "#ff7a6a"];
+  const knots = raw.map((k, i) => ({
+    id: `o${i}`,
+    x: k.x,
+    y: k.y,
+    hx: k.hx,
+    hy: k.hy,
+    color: colors[i % colors.length],
+  }));
+  const segments = knots.map((k, i) => ({
+    fromId: k.id,
+    toId: knots[(i + 1) % knots.length].id,
+    color: null,
+    roughness: 0.4,
+    metalness: 0,
+    opacity: 1,
+    texture: "gradient",
+    textureAsset: null,
+  }));
+  return { knots, segments };
+}
 
-function normalizeV1(doc) {
-  const knots = (doc.profile?.knots || []).map((k, i) => ({
+function mapKnots(list) {
+  return (list || []).map((k, i) => ({
     id: k.id || `k${i}`,
     x: Number(k.x) || 0,
     y: Number(k.y) || 0,
@@ -54,9 +45,17 @@ function normalizeV1(doc) {
     hy: Number(k.hy) || 0,
     color: k.color || "#cccccc",
   }));
-  const segments = (doc.profile?.segments || []).map((s, i) => ({
+}
+
+function mapSegments(list, knots, closed) {
+  const n = knots.length;
+  const want = closed ? n : Math.max(0, n - 1);
+  const segments = (list || []).map((s, i) => ({
     fromId: s.fromId || knots[i]?.id || `k${i}`,
-    toId: s.toId || knots[i + 1]?.id || `k${i + 1}`,
+    toId:
+      s.toId ||
+      knots[closed ? (i + 1) % n : i + 1]?.id ||
+      `k${i + 1}`,
     color: s.color == null ? null : s.color,
     roughness: Number(s.roughness ?? 0.4),
     metalness: Number(s.metalness ?? 0),
@@ -64,12 +63,13 @@ function normalizeV1(doc) {
     texture: s.texture || "gradient",
     textureAsset: s.textureAsset || null,
   }));
-  // Ensure segment count matches knot spans.
-  while (segments.length < Math.max(0, knots.length - 1)) {
+  while (segments.length < want) {
     const i = segments.length;
+    const fromId = knots[i].id;
+    const toId = knots[closed ? (i + 1) % n : i + 1].id;
     segments.push({
-      fromId: knots[i].id,
-      toId: knots[i + 1].id,
+      fromId,
+      toId,
       color: null,
       roughness: 0.4,
       metalness: 0,
@@ -78,6 +78,12 @@ function normalizeV1(doc) {
       textureAsset: null,
     });
   }
+  return segments.slice(0, want);
+}
+
+function normalizeV1(doc) {
+  const knots = mapKnots(doc.profile?.knots || doc.knots);
+  const segments = mapSegments(doc.profile?.segments || doc.segments, knots, false);
   return {
     kind: SCHEMA_KIND,
     schemaVersion: 1,
@@ -89,21 +95,58 @@ function normalizeV1(doc) {
     createdAt: doc.createdAt || nowIso(),
     updatedAt: doc.updatedAt || nowIso(),
     editor: {
-      curveType: Number(doc.editor?.curveType ?? 0),
-      pathSegments: Number(doc.editor?.pathSegments ?? 12),
-      angularSteps: Number(doc.editor?.angularSteps ?? 24),
-      revolutionDeg: Number(doc.editor?.revolutionDeg ?? 360),
-      materialMode: Number(doc.editor?.materialMode ?? 3),
-      symmetry: doc.editor?.symmetry !== false,
+      curveType: Number(doc.editor?.curveType ?? doc.curveType ?? 0),
+      pathSegments: Number(doc.editor?.pathSegments ?? doc.pathSegments ?? 12),
+      angularSteps: Number(doc.editor?.angularSteps ?? doc.angularSteps ?? 24),
+      revolutionDeg: Number(doc.editor?.revolutionDeg ?? doc.revolutionDeg ?? 360),
+      materialMode: Number(doc.editor?.materialMode ?? doc.materialMode ?? 3),
+      symmetry: doc.editor?.symmetry !== false && doc.symmetry !== false,
     },
-    profile: { knots, segments: segments.slice(0, Math.max(0, knots.length - 1)) },
+    profile: { knots, segments },
   };
 }
+
+function normalizeV2(doc) {
+  const v1 = normalizeV1(doc);
+  const orbitSrc = doc.orbit?.knots?.length >= 3 ? doc.orbit : defaultOrbitDoc();
+  const orbitKnots = mapKnots(orbitSrc.knots);
+  // Re-id default orbit if colliding with profile ids
+  const used = new Set(v1.profile.knots.map((k) => k.id));
+  for (const k of orbitKnots) {
+    if (used.has(k.id)) k.id = `o_${k.id}_${Math.random().toString(36).slice(2, 6)}`;
+    used.add(k.id);
+  }
+  const orbitSegments = mapSegments(orbitSrc.segments, orbitKnots, true);
+  return {
+    ...v1,
+    schemaVersion: 2,
+    editor: {
+      ...v1.editor,
+      viewMode: doc.editor?.viewMode === "orbit" ? "orbit" : "profile",
+    },
+    orbit: { knots: orbitKnots, segments: orbitSegments },
+  };
+}
+
+/** @type {Record<number, (doc: any) => any>} */
+const STEPS = {
+  // 0 / missing → 1
+  1(doc) {
+    if (doc && doc.schemaVersion === 1 && doc.kind === SCHEMA_KIND && doc.profile) {
+      return normalizeV1(doc);
+    }
+    return normalizeV1(doc);
+  },
+  // 1 → 2: add closed orbit path (unit circle Bezier) + viewMode
+  2(doc) {
+    return normalizeV2(doc);
+  },
+};
 
 /**
  * Migrate any readable project blob to the current schema version.
  * @param {any} raw
- * @returns {{ ok: true, doc: import('./schema.js').SplineProjectV1 } | { ok: false, errors: string[] }}
+ * @returns {{ ok: true, doc: object } | { ok: false, errors: string[] }}
  */
 export function migrateProject(raw) {
   if (raw == null || typeof raw !== "object") {

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -11,17 +11,17 @@
 // version so older folders remain readable.
 // ============================================================================
 
-export const CURRENT_SCHEMA_VERSION = 1;
+export const CURRENT_SCHEMA_VERSION = 2;
 
 export const SCHEMA_KIND = "ranger.splineProject";
 
-/** @typedef {{ id: string, x: number, y: number, hx: number, hy: number, color: string }} KnotV1 */
-/** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureAsset?: string|null }} SegmentV1 */
+/** @typedef {{ id: string, x: number, y: number, hx: number, hy: number, color: string }} KnotV2 */
+/** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureAsset?: string|null }} SegmentV2 */
 
 /**
- * @typedef {object} SplineProjectV1
+ * @typedef {object} SplineProjectV2
  * @property {typeof SCHEMA_KIND} kind
- * @property {1} schemaVersion
+ * @property {2} schemaVersion
  * @property {string} id
  * @property {string} slug
  * @property {string} name
@@ -35,9 +35,11 @@ export const SCHEMA_KIND = "ranger.splineProject";
  *   angularSteps: number,
  *   revolutionDeg: number,
  *   materialMode: number,
- *   symmetry: boolean
+ *   symmetry: boolean,
+ *   viewMode?: 'profile'|'orbit'
  * }} editor
- * @property {{ knots: KnotV1[], segments: SegmentV1[] }} profile
+ * @property {{ knots: KnotV2[], segments: SegmentV2[] }} profile
+ * @property {{ knots: KnotV2[], segments: SegmentV2[] }} orbit
  */
 
 export function nowIso() {
@@ -84,9 +86,9 @@ export function serializeKnot(k) {
 }
 
 /**
- * Build a v1 project document from the live editor state.
+ * Build a current-version project document from the live editor state.
  * @param {object} opts
- * @param {object} opts.state - useSplineEditor reactive state
+ * @param {object} opts.state - useSplineEditor reactive state (or snapshotState())
  * @param {string} opts.name
  * @param {string} [opts.id]
  * @param {string} [opts.slug]
@@ -115,10 +117,15 @@ export function buildProjectDocument(opts) {
       revolutionDeg: st.revolutionDeg | 0,
       materialMode: st.materialMode | 0,
       symmetry: !!st.symmetry,
+      viewMode: st.viewMode === "orbit" ? "orbit" : "profile",
     },
     profile: {
       knots: (st.knots || []).map(serializeKnot),
       segments: (st.segments || []).map(serializeSegment),
+    },
+    orbit: {
+      knots: (st.orbitKnots || []).map(serializeKnot),
+      segments: (st.orbitSegments || []).map(serializeSegment),
     },
   };
 }
@@ -136,6 +143,12 @@ export function validateProject(doc) {
   if (!doc.profile || !Array.isArray(doc.profile.knots)) errors.push("missing profile.knots");
   if (doc.profile && doc.profile.knots && doc.profile.knots.length < 2) {
     errors.push("profile.knots needs at least 2 points");
+  }
+  if (doc.schemaVersion >= 2) {
+    if (!doc.orbit || !Array.isArray(doc.orbit.knots)) errors.push("missing orbit.knots");
+    if (doc.orbit && doc.orbit.knots && doc.orbit.knots.length < 3) {
+      errors.push("orbit.knots needs at least 3 points");
+    }
   }
   return errors;
 }

--- a/gallery/game_engine/v2/mesh_editor/library/README.md
+++ b/gallery/game_engine/v2/mesh_editor/library/README.md
@@ -33,6 +33,7 @@ copy or symlink selected folders into a tracked tree, or temporarily force-add.
 - Kind: `ranger.splineProject`
 - Current version: see `app/src/library/schema.js` (`CURRENT_SCHEMA_VERSION`)
 - Migrations: `app/src/library/migrations.js` — every load upgrades to current
+- v2 adds a closed `orbit` Bezier path (unit circle by default) alongside `profile`
 
 When you change the document shape, bump the version and add a step; old folders
 keep working.

--- a/gallery/game_engine/v2/mesh_editor/smoke.mjs
+++ b/gallery/game_engine/v2/mesh_editor/smoke.mjs
@@ -41,6 +41,30 @@ if (full.positions.length < 30 || half.indices.length >= full.indices.length) {
   throw new Error("unexpected tessellation sizes");
 }
 
+const orbitKnots = SplineLathe.defaultOrbitKnots();
+const orbit = SplineLathe.sampleClosedOrbit(orbitKnots, 0, 8);
+const viaOrbit = SplineLathe.sampleAndLatheOrbit(
+  knots,
+  0,
+  8,
+  orbit.orbitX,
+  orbit.orbitY,
+  0,
+  orbit.orbitX.length,
+  true,
+);
+const classicMatch = SplineLathe.sampleAndLatheEx(knots, 0, 8, orbit.orbitX.length, Math.PI * 2, true);
+let maxAbs = 0;
+for (let i = 0; i < classicMatch.positions.length; i++) {
+  maxAbs = Math.max(maxAbs, Math.abs(classicMatch.positions[i] - viaOrbit.positions[i]));
+}
+if (maxAbs > 0.02) {
+  throw new Error("orbit unit-circle lathe diverges from cos/sin: maxAbs=" + maxAbs);
+}
+if (viaOrbit.orbitX.length !== orbit.orbitX.length) {
+  throw new Error("orbit samples not stashed on mesh");
+}
+
 const host = loadRuntime();
 host.init(96, 96);
 host.beginParts();
@@ -75,6 +99,8 @@ if (host.partCount() !== 2) throw new Error("expected 2 parts, got " + host.part
 
 console.log("[mesh-editor smoke] OK", {
   fullVerts: (full.positions.length / 3) | 0,
+  orbitVerts: (viaOrbit.positions.length / 3) | 0,
+  orbitMaxAbsDiff: maxAbs,
   parts: host.partCount(),
   litPixels: lit,
 });

--- a/gallery/game_engine/v2/mesh_editor/tessellate/spline_lathe.mjs
+++ b/gallery/game_engine/v2/mesh_editor/tessellate/spline_lathe.mjs
@@ -34,6 +34,8 @@ class SplineMesh  {
     this.indices = [];
     this.profileX = [];
     this.profileY = [];
+    this.orbitX = [];
+    this.orbitY = [];
   }
 }
 class SplineLathe  {
@@ -292,6 +294,220 @@ SplineLathe.defaultKnots = function() {
   knots.push(SplineKnot.of(0.5, 0.0, 0.0, 0.28));
   knots.push(SplineKnot.of(0.0, 1.0, (0.0 - 0.22), 0.0));
   return knots;
+};
+SplineLathe.defaultOrbitKnots = function() {
+  const k = 0.5522847498307936;
+  let knots = [];
+  knots.push(SplineKnot.of(1.0, 0.0, 0.0, k));
+  knots.push(SplineKnot.of(0.0, 1.0, (0.0 - k), 0.0));
+  knots.push(SplineKnot.of((0.0 - 1.0), 0.0, 0.0, (0.0 - k)));
+  knots.push(SplineKnot.of(0.0, (0.0 - 1.0), k, 0.0));
+  return knots;
+};
+SplineLathe.sampleClosedOrbit = function(knots, curveType, segmentsPerSpan) {
+  const out = new SplineMesh();
+  const n = knots.length;
+  if ( n < 2 ) {
+    return out;
+  }
+  let seg = segmentsPerSpan;
+  if ( seg < 1 ) {
+    seg = 1;
+  }
+  let i = 0;
+  while (i < n) {
+    const a = knots[i];
+    let ni = i + 1;
+    if ( ni >= n ) {
+      ni = 0;
+    }
+    const b = knots[ni];
+    let s = 0;
+    while (s < seg) {
+      const t = (s) / (seg);
+      let p = new SplineVec2();
+      if ( curveType == 0 ) {
+        const c0x = a.x + a.hx;
+        const c0y = a.y + a.hy;
+        const c1x = b.x - b.hx;
+        const c1y = b.y - b.hy;
+        p = SplineLathe.bezierPoint(a.x, a.y, c0x, c0y, c1x, c1y, b.x, b.y, t);
+      } else {
+        let i0 = i - 1;
+        if ( i0 < 0 ) {
+          i0 = n - 1;
+        }
+        let i3 = ni + 1;
+        if ( i3 >= n ) {
+          i3 = 0;
+        }
+        const p0 = knots[i0];
+        const p3 = knots[i3];
+        p = SplineLathe.catmullPoint(p0.x, p0.y, a.x, a.y, b.x, b.y, p3.x, p3.y, t);
+      }
+      out.orbitX.push(p.x);
+      out.orbitY.push(p.y);
+      out.profileX.push(i);
+      s = s + 1;
+    };
+    i = i + 1;
+  };
+  return out;
+};
+SplineLathe.sampleAndLatheOrbit = function(knots, curveType, pathSegments, orbitX, orbitY, colStart, colCount, closed) {
+  const mesh = new SplineMesh();
+  const n = knots.length;
+  const oLen = orbitX.length;
+  if ( (n < 2) || (oLen < 3) ) {
+    return mesh;
+  }
+  let steps = colCount;
+  if ( steps < 1 ) {
+    steps = 1;
+  }
+  if ( (colStart + steps) > oLen ) {
+    steps = oLen - colStart;
+  }
+  if ( steps < 1 ) {
+    return mesh;
+  }
+  let seg = pathSegments;
+  if ( seg < 1 ) {
+    seg = 1;
+  }
+  let px = [];
+  let py = [];
+  let tx = [];
+  let ty = [];
+  let i = 0;
+  while (i < (n - 1)) {
+    const a = knots[i];
+    const b = knots[(i + 1)];
+    let s = 0;
+    let last = seg;
+    if ( i < (n - 2) ) {
+      last = seg - 1;
+    }
+    while (s <= last) {
+      const t = (s) / (seg);
+      let p = new SplineVec2();
+      let tan = new SplineVec2();
+      if ( curveType == 0 ) {
+        const c0x = a.x + a.hx;
+        const c0y = a.y + a.hy;
+        const c1x = b.x - b.hx;
+        const c1y = b.y - b.hy;
+        p = SplineLathe.bezierPoint(a.x, a.y, c0x, c0y, c1x, c1y, b.x, b.y, t);
+        tan = SplineLathe.bezierTangent(a.x, a.y, c0x, c0y, c1x, c1y, b.x, b.y, t);
+      } else {
+        let i0 = i - 1;
+        if ( i0 < 0 ) {
+          i0 = 0;
+        }
+        let i3 = i + 2;
+        if ( i3 >= n ) {
+          i3 = n - 1;
+        }
+        const p0 = knots[i0];
+        const p3 = knots[i3];
+        p = SplineLathe.catmullPoint(p0.x, p0.y, a.x, a.y, b.x, b.y, p3.x, p3.y, t);
+        tan = SplineLathe.catmullTangent(p0.x, p0.y, a.x, a.y, b.x, b.y, p3.x, p3.y, t);
+      }
+      px.push(SplineLathe.clampRadius(p.x));
+      py.push(p.y);
+      tx.push(tan.x);
+      ty.push(tan.y);
+      s = s + 1;
+    };
+    i = i + 1;
+  };
+  const rows = px.length;
+  if ( rows < 2 ) {
+    return mesh;
+  }
+  mesh.profileX = px;
+  mesh.profileY = py;
+  let row = 0;
+  while (row < rows) {
+    const radius = px[row];
+    const yy = py[row];
+    const tdx = tx[row];
+    const tdy = ty[row];
+    let pnx = tdy;
+    let pny = 0.0 - tdx;
+    let pnl = Math.sqrt(((pnx * pnx) + (pny * pny)));
+    if ( pnl < 1e-9 ) {
+      pnx = 1.0;
+      pny = 0.0;
+      pnl = 1.0;
+    }
+    pnx = pnx / pnl;
+    pny = pny / pnl;
+    if ( pnx < 0.0 ) {
+      pnx = 0.0 - pnx;
+      pny = 0.0 - pny;
+    }
+    let col = 0;
+    while (col < steps) {
+      const oi = colStart + col;
+      const ct = orbitX[oi];
+      const st = orbitY[oi];
+      const olen = Math.sqrt(((ct * ct) + (st * st)));
+      let nct = ct;
+      let nst = st;
+      if ( olen < 1e-9 ) {
+        nct = 1.0;
+        nst = 0.0;
+      } else {
+        nct = ct / olen;
+        nst = st / olen;
+      }
+      const u = (oi) / (oLen);
+      mesh.positions.push(radius * ct);
+      mesh.positions.push(yy);
+      mesh.positions.push(radius * st);
+      mesh.normals.push(pnx * nct);
+      mesh.normals.push(pny);
+      mesh.normals.push(pnx * nst);
+      mesh.uvs.push(u);
+      mesh.uvs.push((row) / ((rows - 1)));
+      col = col + 1;
+    };
+    row = row + 1;
+  };
+  let oi2 = 0;
+  while (oi2 < oLen) {
+    mesh.orbitX.push(orbitX[oi2]);
+    mesh.orbitY.push(orbitY[oi2]);
+    oi2 = oi2 + 1;
+  };
+  let r2 = 0;
+  while (r2 < (rows - 1)) {
+    let c2 = 0;
+    let colMax = steps;
+    if ( closed == false ) {
+      colMax = steps - 1;
+    }
+    while (c2 < colMax) {
+      const a2 = (r2 * steps) + c2;
+      let cNext = c2 + 1;
+      if ( cNext >= steps ) {
+        cNext = 0;
+      }
+      const b2 = (r2 * steps) + cNext;
+      const c3 = ((r2 + 1) * steps) + cNext;
+      const d3 = ((r2 + 1) * steps) + c2;
+      mesh.indices.push(a2);
+      mesh.indices.push(d3);
+      mesh.indices.push(b2);
+      mesh.indices.push(b2);
+      mesh.indices.push(d3);
+      mesh.indices.push(c3);
+      c2 = c2 + 1;
+    };
+    r2 = r2 + 1;
+  };
+  return mesh;
 };
 
 export { SplineVec2, SplineKnot, SplineMesh, SplineLathe };

--- a/gallery/game_engine/v2/mesh_editor/tessellate/spline_lathe.rgr
+++ b/gallery/game_engine/v2/mesh_editor/tessellate/spline_lathe.rgr
@@ -47,6 +47,9 @@ class SplineMesh {
     def indices:[int]
     def profileX:[double]
     def profileY:[double]
+    ; Unit-orbit samples used for this mesh (cos/sin replacements): parallel arrays.
+    def orbitX:[double]
+    def orbitY:[double]
 }
 
 class SplineLathe {
@@ -333,5 +336,241 @@ class SplineLathe {
         push knots (SplineKnot.of(0.5 0.0 0.0 0.28))
         push knots (SplineKnot.of(0.0 1.0 (0.0 - 0.22) 0.0))
         return knots
+    }
+
+    ; Closed unit-circle Bezier (4 cubics). κ = 4*(√2-1)/3 ≈ 0.55228475 —
+    ; with coupled outgoing handles this matches cos/sin lathe when used as orbit.
+    ; Canvas mapping: x → world X (cos), y → world Z (sin). Starts at (1,0).
+    sfn defaultOrbitKnots:[SplineKnot] () {
+        def k:double 0.5522847498307936
+        def knots:[SplineKnot]
+        push knots (SplineKnot.of(1.0 0.0 0.0 k))
+        push knots (SplineKnot.of(0.0 1.0 (0.0 - k) 0.0))
+        push knots (SplineKnot.of((0.0 - 1.0) 0.0 0.0 (0.0 - k)))
+        push knots (SplineKnot.of(0.0 (0.0 - 1.0) k 0.0))
+        return knots
+    }
+
+    ; Sample a CLOSED knot loop into orbitX/orbitY (no duplicate closing sample).
+    ; segmentIndex for each sample is written into mesh.indices temporarily as
+    ; parallel meta — callers use sampleClosedOrbit which returns SplineMesh
+    ; with orbitX/orbitY and profileX holding segment indices as doubles.
+    sfn sampleClosedOrbit:SplineMesh (knots:[SplineKnot] curveType:int segmentsPerSpan:int) {
+        def out:SplineMesh (new SplineMesh)
+        def n:int (array_length knots)
+        if (n < 2) {
+            return out
+        }
+        def seg:int segmentsPerSpan
+        if (seg < 1) {
+            seg = 1
+        }
+        def i:int 0
+        while (i < n) {
+            def a:SplineKnot (itemAt knots i)
+            def ni:int (i + 1)
+            if (ni >= n) {
+                ni = 0
+            }
+            def b:SplineKnot (itemAt knots ni)
+            def s:int 0
+            while (s < seg) {
+                def t:double ((to_double s) / (to_double seg))
+                def p:SplineVec2 (new SplineVec2)
+                if (curveType == 0) {
+                    def c0x:double (a.x + a.hx)
+                    def c0y:double (a.y + a.hy)
+                    def c1x:double (b.x - b.hx)
+                    def c1y:double (b.y - b.hy)
+                    p = (SplineLathe.bezierPoint(a.x a.y c0x c0y c1x c1y b.x b.y t))
+                } {
+                    def i0:int (i - 1)
+                    if (i0 < 0) {
+                        i0 = (n - 1)
+                    }
+                    def i3:int (ni + 1)
+                    if (i3 >= n) {
+                        i3 = 0
+                    }
+                    def p0:SplineKnot (itemAt knots i0)
+                    def p3:SplineKnot (itemAt knots i3)
+                    p = (SplineLathe.catmullPoint(p0.x p0.y a.x a.y b.x b.y p3.x p3.y t))
+                }
+                push out.orbitX p.x
+                push out.orbitY p.y
+                push out.profileX (to_double i)
+                s = (s + 1)
+            }
+            i = (i + 1)
+        }
+        return out
+    }
+
+    ; Lathe profile using an orbit path instead of cos/sin.
+    ; orbitX/orbitY are direction scales (unit circle ⇒ identical to classic lathe).
+    ; colStart/colCount select a wedge; closed wraps the last column to the first
+    ; of the FULL orbit (use closed=true only when colStart=0 and colCount=full).
+    sfn sampleAndLatheOrbit:SplineMesh (knots:[SplineKnot] curveType:int pathSegments:int orbitX:[double] orbitY:[double] colStart:int colCount:int closed:boolean) {
+        def mesh:SplineMesh (new SplineMesh)
+        def n:int (array_length knots)
+        def oLen:int (array_length orbitX)
+        if ((n < 2) || (oLen < 3)) {
+            return mesh
+        }
+        def steps:int colCount
+        if (steps < 1) {
+            steps = 1
+        }
+        if ((colStart + steps) > oLen) {
+            steps = (oLen - colStart)
+        }
+        if (steps < 1) {
+            return mesh
+        }
+        def seg:int pathSegments
+        if (seg < 1) {
+            seg = 1
+        }
+
+        def px:[double]
+        def py:[double]
+        def tx:[double]
+        def ty:[double]
+        def i:int 0
+        while (i < (n - 1)) {
+            def a:SplineKnot (itemAt knots i)
+            def b:SplineKnot (itemAt knots (i + 1))
+            def s:int 0
+            def last:int seg
+            if (i < (n - 2)) {
+                last = (seg - 1)
+            }
+            while (s <= last) {
+                def t:double ((to_double s) / (to_double seg))
+                def p:SplineVec2 (new SplineVec2)
+                def tan:SplineVec2 (new SplineVec2)
+                if (curveType == 0) {
+                    def c0x:double (a.x + a.hx)
+                    def c0y:double (a.y + a.hy)
+                    def c1x:double (b.x - b.hx)
+                    def c1y:double (b.y - b.hy)
+                    p = (SplineLathe.bezierPoint(a.x a.y c0x c0y c1x c1y b.x b.y t))
+                    tan = (SplineLathe.bezierTangent(a.x a.y c0x c0y c1x c1y b.x b.y t))
+                } {
+                    def i0:int (i - 1)
+                    if (i0 < 0) {
+                        i0 = 0
+                    }
+                    def i3:int (i + 2)
+                    if (i3 >= n) {
+                        i3 = (n - 1)
+                    }
+                    def p0:SplineKnot (itemAt knots i0)
+                    def p3:SplineKnot (itemAt knots i3)
+                    p = (SplineLathe.catmullPoint(p0.x p0.y a.x a.y b.x b.y p3.x p3.y t))
+                    tan = (SplineLathe.catmullTangent(p0.x p0.y a.x a.y b.x b.y p3.x p3.y t))
+                }
+                push px (SplineLathe.clampRadius(p.x))
+                push py p.y
+                push tx tan.x
+                push ty tan.y
+                s = (s + 1)
+            }
+            i = (i + 1)
+        }
+
+        def rows:int (array_length px)
+        if (rows < 2) {
+            return mesh
+        }
+        mesh.profileX = px
+        mesh.profileY = py
+
+        def row:int 0
+        while (row < rows) {
+            def radius:double (itemAt px row)
+            def yy:double (itemAt py row)
+            def tdx:double (itemAt tx row)
+            def tdy:double (itemAt ty row)
+            def pnx:double tdy
+            def pny:double (0.0 - tdx)
+            def pnl:double (sqrt((pnx * pnx) + (pny * pny)))
+            if (pnl < 0.000000001) {
+                pnx = 1.0
+                pny = 0.0
+                pnl = 1.0
+            }
+            pnx = (pnx / pnl)
+            pny = (pny / pnl)
+            if (pnx < 0.0) {
+                pnx = (0.0 - pnx)
+                pny = (0.0 - pny)
+            }
+
+            def col:int 0
+            while (col < steps) {
+                def oi:int (colStart + col)
+                def ct:double (itemAt orbitX oi)
+                def st:double (itemAt orbitY oi)
+                ; Normal uses unit direction of the orbit sample (non-circular paths).
+                def olen:double (sqrt((ct * ct) + (st * st)))
+                def nct:double ct
+                def nst:double st
+                if (olen < 0.000000001) {
+                    nct = 1.0
+                    nst = 0.0
+                } {
+                    nct = (ct / olen)
+                    nst = (st / olen)
+                }
+                def u:double ((to_double oi) / (to_double oLen))
+                push mesh.positions (radius * ct)
+                push mesh.positions yy
+                push mesh.positions (radius * st)
+                push mesh.normals (pnx * nct)
+                push mesh.normals pny
+                push mesh.normals (pnx * nst)
+                push mesh.uvs u
+                push mesh.uvs ((to_double row) / (to_double (rows - 1)))
+                col = (col + 1)
+            }
+            row = (row + 1)
+        }
+
+        ; Stash the orbit samples used (full arrays passed in).
+        def oi2:int 0
+        while (oi2 < oLen) {
+            push mesh.orbitX (itemAt orbitX oi2)
+            push mesh.orbitY (itemAt orbitY oi2)
+            oi2 = (oi2 + 1)
+        }
+
+        def r2:int 0
+        while (r2 < (rows - 1)) {
+            def c2:int 0
+            def colMax:int steps
+            if (closed == false) {
+                colMax = (steps - 1)
+            }
+            while (c2 < colMax) {
+                def a2:int ((r2 * steps) + c2)
+                def cNext:int (c2 + 1)
+                if (cNext >= steps) {
+                    cNext = 0
+                }
+                def b2:int ((r2 * steps) + cNext)
+                def c3:int (((r2 + 1) * steps) + cNext)
+                def d3:int (((r2 + 1) * steps) + c2)
+                push mesh.indices a2
+                push mesh.indices d3
+                push mesh.indices b2
+                push mesh.indices b2
+                push mesh.indices d3
+                push mesh.indices c3
+                c2 = (c2 + 1)
+            }
+            r2 = (r2 + 1)
+        }
+        return mesh
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a second tessellation dimension: a closed **orbit** Bezier path that replaces classic `cos/sin` lathe angles.

### What
- **Orbit view** in the editor (alongside Profile) — same Edit / Add / Coloring tools on a closed XZ loop
- Default path is a 4-knot **unit circle** (κ ≈ 0.55228475), so results stay nearly identical to the previous cos/sin lathe (~0.003 max abs error in smoke)
- Dragging / adding orbit points deforms the rotation path; more knots get more angular samples (`Orbit samples N` distributed across spans)
- Mesh parts are **profile segment × orbit segment**, so colours and segment materials from both views affect shading
- Library **schema v2** persists `orbit` knots/segments; v1 projects migrate to a default unit-circle orbit

### Ranger
- `defaultOrbitKnots`, `sampleClosedOrbit`, `sampleAndLatheOrbit` in `tessellate/spline_lathe.rgr`
- Normals use the unit direction of each orbit sample (works for non-circular paths)

### Verify
```bash
node gallery/game_engine/v2/mesh_editor/smoke.mjs
cd gallery/game_engine/v2/mesh_editor/app && npm run dev
```
Switch **Orbit**, nudge a knot off the dashed unit circle, Tessellate — cross-section should deform. Colour an orbit segment and confirm angular wedges pick it up.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

