### PR TITLE
Spline editor: bulk colour, GUIDs, and sub-object assembly

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -73,8 +73,8 @@ gallery/game_engine/v2/mesh_editor/library/projects/<slug>/project.json
 
 That tree is **gitignored** by default. Point elsewhere with
 `MESH_EDITOR_LIBRARY=/abs/or/rel/path`. Schema + migrations live in
-`app/src/library/` (`schemaVersion` 2+, kind `ranger.splineProject`, with
-`profile` + closed `orbit` paths).
+`app/src/library/` (`schemaVersion` 3+, kind `ranger.splineProject`, with
+`profile`, closed `orbit`, `assetGuid`, `embeddedAssets`, and `children`).
 
 Offline fallback: **Export JSON** / **Import JSON** in the Library panel.
 
@@ -84,17 +84,29 @@ See [`library/README.md`](./library/README.md).
 
 | View | Behaviour |
 |------|-----------|
-| **Profile** | Edit the Y-up silhouette (right half) |
+| **Profile** | Edit the Y-up silhouette (right half); place **sub-object** attach boxes |
 | **Orbit** | Edit the closed XZ rotation path that replaces cos/sin |
 
 | Mode | Behaviour |
 |------|-----------|
-| **Edit** | Drag knots / Bezier handles; mesh refreshes when the drag ends |
+| **Edit** | Drag knots / Bezier handles / attach boxes; mesh refreshes on drag end |
 | **Add** | Click the active curve to insert a knot |
-| **Coloring** | Per-knot / per-segment colours & materials (profile or orbit) |
+| **Coloring** | Per-knot / segment colours; **Shift+click** multi-select; bulk whole / selection |
+
+### Bulk colour
+
+Toolbar **Bulk colour** → *Whole object* paints every knot/segment (+ object material) on the
+active edit target; *Selection* paints only the multi-selected points.
+
+### Sub-objects (schema v3)
+
+- Attach another library project as a **copy** (new `assetGuid`, independent of later Saves of the source) or **link** (shared `assetGuid`)
+- **Copy×2** / **Twin** / **Sym** for mirrored pairs that share content (e.g. two eyes)
+- Placement: `(x,y)` on the profile plane, Y-rotation, **bbox scale**, **Center** on the axis
+- **Edit** a sub-object to load it large in the canvas; the 3D preview always shows the **full assembly**
+- Instance GUID ≠ content GUID: instances can differ in transform while linked content stays in sync
 
 Profile list is **top → bottom**. Orbit list follows knot order around the loop.
-Rows stay compact; **Details** expands numeric / material fields.
 
 ## Shading base
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -4,11 +4,15 @@ import SplineCanvas from "./components/SplineCanvas.vue";
 import PointEditor from "./components/PointEditor.vue";
 import Preview3D from "./components/Preview3D.vue";
 import LibraryPanel from "./components/LibraryPanel.vue";
+import ChildrenPanel from "./components/ChildrenPanel.vue";
 import { useSplineEditor } from "./composables/useSplineEditor.js";
 import { useLibrary } from "./composables/useLibrary.js";
+import * as api from "./library/api.js";
 
 const {
   state,
+  activeKnots,
+  activeSegments,
   setViewMode,
   setToolMode,
   select,
@@ -18,12 +22,24 @@ const {
   removeSelected,
   updateKnot,
   updateSegment,
+  applyMaterialToWhole,
+  applyColorToSelection,
   sampleCurvePoints,
   findClosestOnCurve,
   insertKnotOnCurve,
   tessellate,
   applyProject,
   snapshotState,
+  attachFromProject,
+  selectChild,
+  editRoot,
+  editChildContent,
+  updateChildTransform,
+  removeChild,
+  centerChildOnAxis,
+  toggleChildSymmetry,
+  addSymmetricTwin,
+  isEditingChild,
 } = useSplineEditor();
 
 const { lib, refresh, load, save, saveAs, remove, exportJson, importJsonFile } = useLibrary({
@@ -51,11 +67,12 @@ const views = [
   { id: "orbit", label: "Orbit" },
 ];
 
-const activeKnots = computed(() =>
-  state.viewMode === "orbit" ? state.orbitKnots : state.knots,
-);
-const activeSegments = computed(() =>
-  state.viewMode === "orbit" ? state.orbitSegments : state.segments,
+const knots = computed(() => activeKnots());
+const segments = computed(() => activeSegments());
+const editingLabel = computed(() =>
+  isEditingChild()
+    ? state.embeddedAssets[state.editTarget]?.name || "sub-object"
+    : "root",
 );
 
 function onTessellate() {
@@ -89,6 +106,40 @@ function onListCommit() {
   tessellate();
 }
 
+function onSelect(id, opts) {
+  select(id, opts || {});
+}
+
+function onBulkWhole() {
+  applyMaterialToWhole({
+    color: state.bulkColor,
+    roughness: state.objectMaterial.roughness,
+    metalness: state.objectMaterial.metalness,
+    opacity: state.objectMaterial.opacity,
+    texture: state.objectMaterial.texture,
+  });
+  tessellate();
+}
+
+function onBulkSelection() {
+  applyColorToSelection(state.bulkColor);
+  tessellate();
+}
+
+function onMoveChild(guid, patch) {
+  updateChildTransform(guid, patch);
+}
+
+async function onAttach({ slug, mode, symmetric }) {
+  try {
+    const doc = await api.loadProject(slug);
+    attachFromProject(doc, { mode, symmetric });
+    tessellate();
+  } catch (err) {
+    state.status = "Attach failed: " + (err.message || err);
+  }
+}
+
 onMounted(() => {
   tessellate();
 });
@@ -101,8 +152,8 @@ onMounted(() => {
         <p class="eyebrow">Ranger · gallery/game_engine/v2</p>
         <h1>Spline Mesh Editor</h1>
         <p class="lede">
-          Bezier profile + editable orbit path (replaces cos/sin) lathed into a mesh with Ranger
-          Three — Edit / Add / Coloring on either view.
+          Profile + orbit lathe, bulk colouring, and sub-objects (copy / link GUIDs) with assembly
+          preview — editing <strong>{{ editingLabel }}</strong>.
         </p>
       </div>
       <div class="actions">
@@ -172,47 +223,111 @@ onMounted(() => {
           </button>
         </div>
       </div>
+      <div class="bulk">
+        <span>Bulk colour</span>
+        <div class="bulk-row">
+          <input v-model="state.bulkColor" type="color" />
+          <button type="button" @click="onBulkWhole">Whole object</button>
+          <button type="button" @click="onBulkSelection">Selection</button>
+        </div>
+      </div>
       <p class="status">
         {{ state.status }} · {{ state.stats.parts || 0 }} parts · {{ state.stats.verts }}v /
-        {{ state.stats.tris }}t
+        {{ state.stats.tris }}t · GUID {{ state.assetGuid.slice(0, 8) }}…
       </p>
     </section>
 
     <main class="workspace">
       <SplineCanvas
-        :knots="activeKnots"
-        :segments="activeSegments"
+        :knots="knots"
+        :segments="segments"
         :selected-id="state.selectedId"
+        :selected-ids="state.selectedIds"
         :selected-segment-index="state.selectedSegmentIndex"
         :curve-type="state.curveType"
         :symmetry="state.symmetry"
         :tool-mode="state.toolMode"
         :view-mode="state.viewMode"
+        :children="state.children"
+        :selected-child-guid="state.selectedChildGuid"
+        :edit-target="state.editTarget"
         :viewport="state.viewport"
         :sample-curve-points="sampleCurvePoints"
         :find-closest-on-curve="findClosestOnCurve"
-        @select="select"
+        @select="onSelect"
         @select-segment="selectSegment"
         @update-knot="onUpdateKnot"
         @add-on-curve="onAddOnCurve"
         @drag-end="onDragEnd"
+        @select-child="selectChild"
+        @move-child="onMoveChild"
       />
       <PointEditor
-        :knots="activeKnots"
-        :segments="activeSegments"
+        :knots="knots"
+        :segments="segments"
         :selected-id="state.selectedId"
         :selected-segment-index="state.selectedSegmentIndex"
         :curve-type="state.curveType"
         :tool-mode="state.toolMode"
         :view-mode="state.viewMode"
-        @select="select"
+        @select="onSelect"
         @select-segment="selectSegment"
         @update-knot="onUpdateKnot"
         @update-segment="onUpdateSegment"
         @remove-knot="onRemoveKnot"
         @commit="onListCommit"
       />
-      <Preview3D :mesh="state.mesh" :material-mode="state.materialMode" />
+      <div class="side-stack">
+        <Preview3D :mesh="state.mesh" :material-mode="state.materialMode" />
+        <ChildrenPanel
+          :children="state.children"
+          :embedded-assets="state.embeddedAssets"
+          :selected-child-guid="state.selectedChildGuid"
+          :edit-target="state.editTarget"
+          :projects="lib.projects"
+          :asset-guid="state.assetGuid"
+          @select-child="selectChild"
+          @edit-child="
+            (g) => {
+              editChildContent(g);
+              tessellate();
+            }
+          "
+          @edit-root="
+            () => {
+              editRoot();
+              tessellate();
+            }
+          "
+          @update-transform="updateChildTransform"
+          @remove-child="
+            (g) => {
+              removeChild(g);
+              tessellate();
+            }
+          "
+          @center="
+            (g) => {
+              centerChildOnAxis(g);
+              tessellate();
+            }
+          "
+          @toggle-symmetry="
+            (g) => {
+              toggleChildSymmetry(g);
+              tessellate();
+            }
+          "
+          @add-twin="
+            (g) => {
+              addSymmetricTwin(g);
+              tessellate();
+            }
+          "
+          @attach="onAttach"
+          @tessellate="onTessellate"
+        />
+      </div>
       <LibraryPanel
         :lib="lib"
         @refresh="refresh"
@@ -264,7 +379,7 @@ h1 {
 
 .lede {
   margin: 0;
-  max-width: 38rem;
+  max-width: 42rem;
   color: var(--ink-dim);
   font-size: 0.95rem;
   line-height: 1.45;
@@ -289,7 +404,7 @@ h1 {
 
 .toolbar {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr)) 1.4fr;
+  grid-template-columns: repeat(5, minmax(0, 1fr)) 1.2fr 1fr;
   gap: 0.75rem;
   align-items: end;
   padding: 0.85rem 1rem;
@@ -308,17 +423,28 @@ h1 {
   opacity: 0.45;
 }
 
-.mats span {
+.mats span,
+.bulk span {
   display: block;
   font-size: 0.78rem;
   color: var(--ink-dim);
   margin-bottom: 0.3rem;
 }
 
-.mat-row {
+.mat-row,
+.bulk-row {
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem;
+  align-items: center;
+}
+
+.bulk-row input[type="color"] {
+  width: 2rem;
+  height: 1.6rem;
+  padding: 0;
+  border: none;
+  background: transparent;
 }
 
 .status {
@@ -331,22 +457,26 @@ h1 {
 
 .workspace {
   display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(220px, 0.75fr) minmax(240px, 0.8fr) minmax(220px, 0.7fr);
+  grid-template-columns: minmax(0, 1.15fr) minmax(220px, 0.75fr) minmax(260px, 0.95fr) minmax(
+      200px,
+      0.7fr
+    );
   gap: 1rem;
   min-height: 0;
   align-items: stretch;
 }
 
-@media (max-width: 1280px) {
+.side-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 0;
+}
+
+@media (max-width: 1200px) {
   .toolbar {
     grid-template-columns: 1fr 1fr;
   }
-  .workspace {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
-@media (max-width: 800px) {
   .workspace {
     grid-template-columns: 1fr;
   }

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/ChildrenPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/ChildrenPanel.vue
@@ -1,0 +1,284 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  children: { type: Array, default: () => [] },
+  embeddedAssets: { type: Object, default: () => ({}) },
+  selectedChildGuid: { type: String, default: null },
+  editTarget: { type: String, default: "root" },
+  projects: { type: Array, default: () => [] },
+  assetGuid: { type: String, default: "" },
+});
+
+const emit = defineEmits([
+  "select-child",
+  "edit-child",
+  "edit-root",
+  "update-transform",
+  "remove-child",
+  "center",
+  "toggle-symmetry",
+  "add-twin",
+  "attach",
+  "tessellate",
+]);
+
+const selected = computed(() =>
+  props.children.find((c) => c.instanceGuid === props.selectedChildGuid) || null,
+);
+
+function shortGuid(g) {
+  return g ? g.slice(0, 8) + "…" : "—";
+}
+
+function onAttach(slug, mode, symmetric) {
+  emit("attach", { slug, mode, symmetric });
+}
+</script>
+
+<template>
+  <aside class="children">
+    <header>
+      <h2>Sub-objects</h2>
+      <p>
+        Root GUID <code>{{ shortGuid(assetGuid) }}</code>. Copy = new GUID; link / twins share
+        content GUID.
+      </p>
+    </header>
+
+    <div class="row">
+      <button type="button" :class="{ active: editTarget === 'root' }" @click="emit('edit-root')">
+        Edit root
+      </button>
+    </div>
+
+    <ul class="list">
+      <li
+        v-for="ch in children"
+        :key="ch.instanceGuid"
+        :class="{
+          active: ch.instanceGuid === selectedChildGuid,
+          editing: editTarget === ch.contentGuid,
+        }"
+        @click="emit('select-child', ch.instanceGuid)"
+      >
+        <div class="title">
+          <strong>{{ ch.name }}</strong>
+          <span class="badge">{{ ch.mode }}</span>
+          <span v-if="ch.transform.useSymmetry" class="badge sym">sym</span>
+        </div>
+        <div class="meta">
+          content {{ shortGuid(ch.contentGuid) }}
+          · ({{ ch.transform.x.toFixed(2) }}, {{ ch.transform.y.toFixed(2) }})
+          · ×{{ ch.transform.scale.toFixed(2) }}
+        </div>
+        <div class="actions" @click.stop>
+          <button type="button" @click="emit('edit-child', ch.instanceGuid)">Edit</button>
+          <button type="button" @click="emit('toggle-symmetry', ch.instanceGuid)">Sym</button>
+          <button type="button" @click="emit('add-twin', ch.instanceGuid)">Twin</button>
+          <button type="button" @click="emit('center', ch.instanceGuid)">Center</button>
+          <button type="button" class="danger" @click="emit('remove-child', ch.instanceGuid)">
+            ×
+          </button>
+        </div>
+      </li>
+      <li v-if="!children.length" class="empty">No sub-objects yet — attach from the library.</li>
+    </ul>
+
+    <div v-if="selected" class="xform">
+      <h3>Placement</h3>
+      <label>
+        x
+        <input
+          type="number"
+          step="0.01"
+          :value="selected.transform.x"
+          :disabled="selected.transform.snapCenterline"
+          @change="
+            emit('update-transform', selected.instanceGuid, {
+              x: Number($event.target.value),
+              snapCenterline: false,
+            });
+            emit('tessellate');
+          "
+        />
+      </label>
+      <label>
+        y
+        <input
+          type="number"
+          step="0.01"
+          :value="selected.transform.y"
+          @change="
+            emit('update-transform', selected.instanceGuid, { y: Number($event.target.value) });
+            emit('tessellate');
+          "
+        />
+      </label>
+      <label>
+        rot Y°
+        <input
+          type="number"
+          step="1"
+          :value="selected.transform.rotationYDeg"
+          @change="
+            emit('update-transform', selected.instanceGuid, {
+              rotationYDeg: Number($event.target.value),
+            });
+            emit('tessellate');
+          "
+        />
+      </label>
+      <label>
+        bbox scale
+        <input
+          type="number"
+          step="0.01"
+          min="0.01"
+          :value="selected.transform.scale"
+          @change="
+            emit('update-transform', selected.instanceGuid, { scale: Number($event.target.value) });
+            emit('tessellate');
+          "
+        />
+      </label>
+    </div>
+
+    <div class="attach">
+      <h3>Attach from library</h3>
+      <p v-if="!projects.length" class="hint">Save another spline first, then attach it here.</p>
+      <div v-for="p in projects" :key="p.slug" class="proj">
+        <span>{{ p.name || p.slug }}</span>
+        <button type="button" @click="onAttach(p.slug, 'copy', false)">Copy</button>
+        <button type="button" @click="onAttach(p.slug, 'copy', true)">Copy×2</button>
+        <button type="button" @click="onAttach(p.slug, 'link', false)">Link</button>
+      </div>
+    </div>
+  </aside>
+</template>
+
+<style scoped>
+.children {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  min-height: 0;
+  padding: 0.7rem 0.75rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: auto;
+}
+header h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 400;
+}
+header p,
+.hint {
+  margin: 0.2rem 0 0;
+  font-size: 0.7rem;
+  color: var(--ink-dim);
+}
+code {
+  font-size: 0.68rem;
+}
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.list li {
+  padding: 0.45rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  cursor: pointer;
+}
+.list li.active {
+  border-color: rgba(126, 207, 106, 0.55);
+}
+.list li.editing {
+  background: rgba(126, 207, 106, 0.08);
+}
+.empty {
+  cursor: default;
+  color: var(--ink-dim);
+  font-size: 0.75rem;
+}
+.title {
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+.badge {
+  font-size: 0.62rem;
+  padding: 0.05rem 0.3rem;
+  border-radius: 4px;
+  border: 1px solid var(--line);
+  color: var(--ink-dim);
+}
+.badge.sym {
+  color: var(--accent-2);
+}
+.meta {
+  font-size: 0.68rem;
+  color: var(--ink-dim);
+  margin-top: 0.15rem;
+}
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.35rem;
+}
+.actions button,
+.row button,
+.proj button {
+  font-size: 0.68rem;
+  padding: 0.2rem 0.4rem;
+}
+.danger {
+  color: #ffb0a4;
+}
+.xform,
+.attach {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.35rem;
+  border-top: 1px solid var(--line);
+  padding-top: 0.45rem;
+}
+.xform h3,
+.attach h3 {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+.xform label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.68rem;
+  color: var(--ink-dim);
+}
+.proj {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: center;
+  font-size: 0.75rem;
+}
+.proj span {
+  flex: 1;
+  min-width: 4rem;
+}
+button.active {
+  border-color: rgba(126, 207, 106, 0.6);
+}
+</style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
@@ -5,25 +5,41 @@ const props = defineProps({
   knots: { type: Array, required: true },
   segments: { type: Array, default: () => [] },
   selectedId: { type: String, default: null },
+  selectedIds: { type: Array, default: () => [] },
   selectedSegmentIndex: { type: Number, default: -1 },
   curveType: { type: Number, default: 0 },
   symmetry: { type: Boolean, default: true },
   toolMode: { type: String, default: "edit" },
   viewMode: { type: String, default: "profile" },
+  children: { type: Array, default: () => [] },
+  selectedChildGuid: { type: String, default: null },
+  editTarget: { type: String, default: "root" },
   viewport: { type: Object, required: true },
   sampleCurvePoints: { type: Function, required: true },
   findClosestOnCurve: { type: Function, required: true },
 });
 
-const emit = defineEmits(["select", "select-segment", "update-knot", "add-on-curve", "drag-end"]);
+const emit = defineEmits([
+  "select",
+  "select-segment",
+  "update-knot",
+  "add-on-curve",
+  "drag-end",
+  "select-child",
+  "move-child",
+]);
 
 const canvasRef = ref(null);
 const size = 560;
 let dragging = null;
+let draggingChild = null;
 let raf = 0;
 const hoverAdd = ref(null);
 
 const isOrbit = computed(() => props.viewMode === "orbit");
+const showAttachments = computed(
+  () => !isOrbit.value && props.editTarget === "root" && props.children?.length,
+);
 const curvePts = computed(() => props.sampleCurvePoints(28));
 
 function worldToScreen(x, y, w, h) {
@@ -202,7 +218,8 @@ function draw() {
       drawHandle(ctx, hx, hy, k.id === props.selectedId);
       drawHandle(ctx, ix, iy, false);
     }
-    drawPoint(ctx, sx, sy, k.id === props.selectedId, k.color);
+    const multi = props.selectedIds?.includes(k.id);
+    drawPoint(ctx, sx, sy, k.id === props.selectedId || multi, k.color, multi);
 
     if (!isOrbit.value && props.symmetry && k.x > 0.001) {
       const [mx, my] = worldToScreen(-k.x, k.y, w, h);
@@ -212,6 +229,19 @@ function draw() {
       ctx.fill();
     }
   });
+
+  if (showAttachments.value) {
+    for (const ch of props.children) {
+      if (ch.visible === false) continue;
+      const ax = ch.transform.snapCenterline ? 0 : ch.transform.x;
+      const ay = ch.transform.y;
+      const half = 0.06 * Math.max(0.5, ch.transform.scale / 0.28);
+      drawAttachBox(ctx, ax, ay, half, ch.instanceGuid === props.selectedChildGuid, w, h, ch.name);
+      if (ch.transform.useSymmetry && !ch.transform.snapCenterline && Math.abs(ax) > 0.001) {
+        drawAttachBox(ctx, -ax, ay, half, false, w, h, "");
+      }
+    }
+  }
 
   if (props.toolMode === "add" && hoverAdd.value) {
     const [sx, sy] = worldToScreen(hoverAdd.value.x, hoverAdd.value.y, w, h);
@@ -230,14 +260,31 @@ function evalMid(segIndex) {
   return pts[(pts.length / 2) | 0];
 }
 
-function drawPoint(ctx, x, y, selected, color) {
+function drawPoint(ctx, x, y, selected, color, multi = false) {
   ctx.beginPath();
   ctx.arc(x, y, selected ? 8 : 6, 0, Math.PI * 2);
   ctx.fillStyle = color || (selected ? "#c8e87a" : "#e8efe6");
   ctx.fill();
-  ctx.strokeStyle = selected ? "#ffffff" : "rgba(0,0,0,0.45)";
-  ctx.lineWidth = selected ? 2 : 1.5;
+  ctx.strokeStyle = multi ? "#ffe08a" : selected ? "#ffffff" : "rgba(0,0,0,0.45)";
+  ctx.lineWidth = selected || multi ? 2 : 1.5;
   ctx.stroke();
+}
+
+function drawAttachBox(ctx, ax, ay, half, selected, w, h, label) {
+  const [x0, y0] = worldToScreen(ax - half, ay + half, w, h);
+  const [x1, y1] = worldToScreen(ax + half, ay - half, w, h);
+  ctx.strokeStyle = selected ? "#c8e87a" : "rgba(232,122,200,0.85)";
+  ctx.fillStyle = selected ? "rgba(200,232,122,0.18)" : "rgba(232,122,200,0.12)";
+  ctx.lineWidth = selected ? 2 : 1.25;
+  ctx.beginPath();
+  ctx.rect(x0, y0, x1 - x0, y1 - y0);
+  ctx.fill();
+  ctx.stroke();
+  if (label) {
+    ctx.fillStyle = "rgba(232,200,220,0.9)";
+    ctx.font = "11px sans-serif";
+    ctx.fillText(label.slice(0, 18), x0, y0 - 4);
+  }
 }
 
 function drawHandle(ctx, x, y, selected) {
@@ -272,6 +319,24 @@ function hitTestSegment(sx, sy) {
   return -1;
 }
 
+function hitTestChild(sx, sy) {
+  if (!showAttachments.value) return null;
+  for (const ch of props.children) {
+    if (ch.visible === false) continue;
+    const ax = ch.transform.snapCenterline ? 0 : ch.transform.x;
+    const ay = ch.transform.y;
+    const half = 0.06 * Math.max(0.5, ch.transform.scale / 0.28);
+    const [x0, y0] = worldToScreen(ax - half, ay + half, size, size);
+    const [x1, y1] = worldToScreen(ax + half, ay - half, size, size);
+    const left = Math.min(x0, x1);
+    const right = Math.max(x0, x1);
+    const top = Math.min(y0, y1);
+    const bottom = Math.max(y0, y1);
+    if (sx >= left && sx <= right && sy >= top && sy <= bottom) return ch.instanceGuid;
+  }
+  return null;
+}
+
 function onPointerDown(e) {
   const rect = canvasRef.value.getBoundingClientRect();
   const sx = e.clientX - rect.left;
@@ -283,10 +348,20 @@ function onPointerDown(e) {
     return;
   }
 
+  if (props.toolMode === "edit" && showAttachments.value) {
+    const cid = hitTestChild(sx, sy);
+    if (cid) {
+      draggingChild = cid;
+      emit("select-child", cid);
+      canvasRef.value.setPointerCapture(e.pointerId);
+      return;
+    }
+  }
+
   if (props.toolMode === "color") {
     const pt = hitTestPoint(sx, sy);
     if (pt) {
-      emit("select", pt.id);
+      emit("select", pt.id, { additive: !!(e.shiftKey || e.metaKey) });
       return;
     }
     const seg = hitTestSegment(sx, sy);
@@ -316,6 +391,15 @@ function onPointerMove(e) {
     return;
   }
 
+  if (draggingChild && props.toolMode === "edit") {
+    emit("move-child", draggingChild, {
+      x: Math.max(0, wx),
+      y: wy,
+      snapCenterline: false,
+    });
+    return;
+  }
+
   if (!dragging || props.toolMode !== "edit") return;
   const k = props.knots.find((n) => n.id === dragging.id);
   if (!k) return;
@@ -327,10 +411,11 @@ function onPointerMove(e) {
 }
 
 function onPointerUp() {
-  if (dragging && props.toolMode === "edit") {
+  if ((dragging || draggingChild) && props.toolMode === "edit") {
     emit("drag-end");
   }
   dragging = null;
+  draggingChild = null;
 }
 
 function schedule() {
@@ -343,11 +428,15 @@ watch(
     props.knots,
     props.segments,
     props.selectedId,
+    props.selectedIds,
     props.selectedSegmentIndex,
     props.curveType,
     props.symmetry,
     props.toolMode,
     props.viewMode,
+    props.children,
+    props.selectedChildGuid,
+    props.editTarget,
     curvePts.value,
     hoverAdd.value,
   ],

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -1,8 +1,15 @@
 import { reactive, computed, watch } from "vue";
-import { SplineLathe, SplineKnot } from "@tessellate";
+import { SplineLathe } from "../../../tessellate/spline_lathe.mjs";
+import { tessellateBody } from "../lib/latheTessellate.js";
+import { transformPart } from "../lib/meshTransform.js";
+import {
+  newGuid,
+  cloneBodyContent,
+  defaultChildTransform,
+} from "../lib/assetClone.js";
 
 /** @typedef {{ id: string, x: number, y: number, hx: number, hy: number, color: string }} Knot */
-/** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureData: { rgba: Uint8Array, w: number, h: number, name: string }|null, textureAsset?: string|null }} Segment */
+/** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureData: any, textureAsset?: string|null }} Segment */
 
 function uid() {
   return "k" + Math.random().toString(36).slice(2, 9);
@@ -11,8 +18,7 @@ function uid() {
 const DEFAULT_COLORS = ["#7ecf6a", "#6ec8ff", "#ffb454", "#e87ac8", "#c8e87a", "#ff7a6a"];
 
 function defaultKnots() {
-  const raw = SplineLathe.defaultKnots();
-  return raw.map((k, i) => ({
+  return SplineLathe.defaultKnots().map((k, i) => ({
     id: uid(),
     x: k.x,
     y: k.y,
@@ -23,8 +29,7 @@ function defaultKnots() {
 }
 
 function defaultOrbitKnots() {
-  const raw = SplineLathe.defaultOrbitKnots();
-  return raw.map((k, i) => ({
+  return SplineLathe.defaultOrbitKnots().map((k, i) => ({
     id: uid(),
     x: k.x,
     y: k.y,
@@ -48,166 +53,48 @@ function defaultSegment(fromId, toId) {
   };
 }
 
-function hexToRgb(hex) {
-  const h = String(hex || "#ffffff").replace("#", "");
-  const full = h.length === 3 ? h.split("").map((c) => c + c).join("") : h.padStart(6, "0");
-  const n = parseInt(full.slice(0, 6), 16);
-  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
-}
-
-function lerp(a, b, t) {
-  return a + (b - a) * t;
-}
-
-function mixHex(a, b, t) {
-  const A = hexToRgb(a);
-  const B = hexToRgb(b);
-  const r = Math.round(lerp(A.r, B.r, t));
-  const g = Math.round(lerp(A.g, B.g, t));
-  const b_ = Math.round(lerp(A.b, B.b, t));
-  return (r << 16) | (g << 8) | b_;
-}
-
-function hexToInt(hex) {
-  const c = hexToRgb(hex);
-  return (c.r << 16) | (c.g << 8) | c.b;
-}
-
-function mulColorHex(a, b) {
-  if (a === 0xffffff) return b;
-  if (b === 0xffffff) return a;
-  const ar = (a >> 16) & 255;
-  const ag = (a >> 8) & 255;
-  const ab = a & 255;
-  const br = (b >> 16) & 255;
-  const bg = (b >> 8) & 255;
-  const bb = b & 255;
-  return (((ar * br) / 255) | 0) << 16 | (((ag * bg) / 255) | 0) << 8 | (((ab * bb) / 255) | 0);
-}
-
-function roughnessToShininess(r) {
-  const t = Math.min(1, Math.max(0, r));
-  return lerp(280, 6, t);
-}
-
-function makeGradientRgba(hexA, hexB, w = 4, h = 64) {
-  const A = hexToRgb(hexA);
-  const B = hexToRgb(hexB);
-  const rgba = new Uint8Array(w * h * 4);
-  for (let y = 0; y < h; y++) {
-    const t = y / Math.max(1, h - 1);
-    const r = Math.round(lerp(A.r, B.r, t));
-    const g = Math.round(lerp(A.g, B.g, t));
-    const b = Math.round(lerp(A.b, B.b, t));
-    for (let x = 0; x < w; x++) {
-      const i = (y * w + x) * 4;
-      rgba[i] = r;
-      rgba[i + 1] = g;
-      rgba[i + 2] = b;
-      rgba[i + 3] = 255;
-    }
-  }
-  return { rgba, w, h };
-}
-
-function makeCheckerRgba(size = 64) {
-  const rgba = new Uint8Array(size * size * 4);
-  const cell = size / 8;
-  for (let y = 0; y < size; y++) {
-    for (let x = 0; x < size; x++) {
-      const odd = (((x / cell) | 0) + ((y / cell) | 0)) & 1;
-      const i = (y * size + x) * 4;
-      rgba[i] = odd ? 90 : 220;
-      rgba[i + 1] = odd ? 120 : 220;
-      rgba[i + 2] = odd ? 160 : 210;
-      rgba[i + 3] = 255;
-    }
-  }
-  return { rgba, w: size, h: size };
-}
-
-function makeStripesRgba(size = 64) {
-  const rgba = new Uint8Array(size * size * 4);
-  for (let y = 0; y < size; y++) {
-    for (let x = 0; x < size; x++) {
-      const odd = ((y / 6) | 0) & 1;
-      const i = (y * size + x) * 4;
-      rgba[i] = odd ? 40 : 230;
-      rgba[i + 1] = odd ? 160 : 210;
-      rgba[i + 2] = odd ? 120 : 90;
-      rgba[i + 3] = 255;
-    }
-  }
-  return { rgba, w: size, h: size };
+function defaultObjectMaterial() {
+  return { color: null, roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient" };
 }
 
 function cloneSeg(s, fromId, toId) {
-  return {
-    ...s,
-    fromId,
-    toId,
-    textureData: s.textureData || null,
-  };
+  return { ...s, fromId, toId, textureData: s.textureData || null };
 }
 
-/**
- * Split a full-orbit lathe band into per-orbit-segment parts (own vertex buffers).
- */
-function splitMeshByOrbitSegments(mesh, steps, oSeg, numOrbitSegs, closed) {
-  const vertCount = (mesh.positions.length / 3) | 0;
-  if (steps < 2 || vertCount < steps * 2) return [];
-  const rows = (vertCount / steps) | 0;
-  const out = [];
-
-  for (let oi = 0; oi < numOrbitSegs; oi++) {
-    const faces = [];
-    for (let r = 0; r < rows - 1; r++) {
-      const colMax = closed ? steps : steps - 1;
-      for (let c = 0; c < colMax; c++) {
-        if ((oSeg[c] | 0) !== oi) continue;
-        const cNext = c + 1 >= steps ? 0 : c + 1;
-        const a = r * steps + c;
-        const b = r * steps + cNext;
-        const cc = (r + 1) * steps + cNext;
-        const d = (r + 1) * steps + c;
-        faces.push(a, d, b, b, d, cc);
-      }
-    }
-    if (!faces.length) continue;
-
-    const used = new Map();
-    const positions = [];
-    const normals = [];
-    const uvs = [];
-    const indices = [];
-    const mapV = (g) => {
-      let local = used.get(g);
-      if (local != null) return local;
-      local = used.size;
-      used.set(g, local);
-      const i3 = g * 3;
-      const i2 = g * 2;
-      positions.push(mesh.positions[i3], mesh.positions[i3 + 1], mesh.positions[i3 + 2]);
-      normals.push(mesh.normals[i3], mesh.normals[i3 + 1], mesh.normals[i3 + 2]);
-      uvs.push(mesh.uvs[i2], mesh.uvs[i2 + 1]);
-      return local;
-    };
-    for (let i = 0; i < faces.length; i++) indices.push(mapV(faces[i]));
-    out.push({ orbitSeg: oi, positions, normals, uvs, indices });
-  }
-  return out;
+function projectDocToBody(doc, { newGuidForCopy = true } = {}) {
+  return cloneBodyContent(
+    {
+      assetGuid: doc.assetGuid,
+      name: doc.name,
+      profile: doc.profile,
+      orbit: doc.orbit,
+      editor: doc.editor,
+      objectMaterial: doc.objectMaterial,
+      knots: doc.profile?.knots,
+      segments: doc.profile?.segments,
+      orbitKnots: doc.orbit?.knots,
+      orbitSegments: doc.orbit?.segments,
+    },
+    {
+      preserveGuid: !newGuidForCopy && !!doc.assetGuid,
+      name: doc.name || "Sub-object",
+    },
+  );
 }
 
 export function useSplineEditor() {
   const state = reactive({
-    viewMode: "profile", // profile | orbit
+    assetGuid: newGuid(),
+    viewMode: "profile",
     knots: defaultKnots(),
     segments: /** @type {Segment[]} */ ([]),
     orbitKnots: defaultOrbitKnots(),
     orbitSegments: /** @type {Segment[]} */ ([]),
+    objectMaterial: defaultObjectMaterial(),
     selectedId: null,
+    selectedIds: /** @type {string[]} */ ([]),
     selectedSegmentIndex: -1,
-    toolMode: "edit", // edit | add | color
+    toolMode: "edit",
     curveType: 0,
     pathSegments: 12,
     angularSteps: 24,
@@ -215,59 +102,98 @@ export function useSplineEditor() {
     materialMode: 3,
     symmetry: true,
     viewport: { min: -1.1, max: 1.1 },
+    /** @type {Record<string, any>} */
+    embeddedAssets: {},
+    /** @type {any[]} */
+    children: [],
+    selectedChildGuid: null,
+    /** 'root' | contentGuid */
+    editTarget: "root",
+    bulkColor: "#7ecf6a",
     mesh: null,
     stats: { verts: 0, tris: 0, profile: 0, parts: 0 },
-    status: "Edit mode — drag points. Switch view to edit the orbit path.",
+    status: "Edit mode — drag points. Sub-objects attach in Profile view.",
   });
 
   function isOrbit() {
     return state.viewMode === "orbit";
   }
 
+  function isEditingChild() {
+    return state.editTarget !== "root" && !!state.embeddedAssets[state.editTarget];
+  }
+
+  function bodyRef() {
+    if (isEditingChild()) return state.embeddedAssets[state.editTarget];
+    return null;
+  }
+
   function activeKnots() {
+    const b = bodyRef();
+    if (b) return isOrbit() ? b.orbitKnots : b.knots;
     return isOrbit() ? state.orbitKnots : state.knots;
   }
 
   function activeSegments() {
+    const b = bodyRef();
+    if (b) return isOrbit() ? b.orbitSegments : b.segments;
     return isOrbit() ? state.orbitSegments : state.segments;
   }
 
-  function syncOpenSegments() {
-    const byPair = new Map();
-    for (const s of state.segments) byPair.set(s.fromId + ">" + s.toId, s);
-    const next = [];
-    for (let i = 0; i < state.knots.length - 1; i++) {
-      const fromId = state.knots[i].id;
-      const toId = state.knots[i + 1].id;
-      const exact = byPair.get(fromId + ">" + toId);
-      next.push(exact ? cloneSeg(exact, fromId, toId) : defaultSegment(fromId, toId));
-    }
-    state.segments = next;
-    if (!isOrbit() && state.selectedSegmentIndex >= next.length) {
-      state.selectedSegmentIndex = next.length - 1;
-    }
+  function activeObjectMaterial() {
+    const b = bodyRef();
+    return b ? b.objectMaterial : state.objectMaterial;
   }
 
-  function syncOrbitSegments() {
+  function activeCurveType() {
+    const b = bodyRef();
+    return b ? b.curveType : state.curveType;
+  }
+
+  function setActiveCurveType(v) {
+    const b = bodyRef();
+    if (b) b.curveType = v;
+    else state.curveType = v;
+  }
+
+  function syncOpenSegmentsOn(knots, segments) {
     const byPair = new Map();
-    for (const s of state.orbitSegments) byPair.set(s.fromId + ">" + s.toId, s);
+    for (const s of segments) byPair.set(s.fromId + ">" + s.toId, s);
     const next = [];
-    const n = state.orbitKnots.length;
-    for (let i = 0; i < n; i++) {
-      const fromId = state.orbitKnots[i].id;
-      const toId = state.orbitKnots[(i + 1) % n].id;
+    for (let i = 0; i < knots.length - 1; i++) {
+      const fromId = knots[i].id;
+      const toId = knots[i + 1].id;
       const exact = byPair.get(fromId + ">" + toId);
       next.push(exact ? cloneSeg(exact, fromId, toId) : defaultSegment(fromId, toId));
     }
-    state.orbitSegments = next;
-    if (isOrbit() && state.selectedSegmentIndex >= next.length) {
-      state.selectedSegmentIndex = next.length - 1;
+    return next;
+  }
+
+  function syncOrbitSegmentsOn(knots, segments) {
+    const byPair = new Map();
+    for (const s of segments) byPair.set(s.fromId + ">" + s.toId, s);
+    const next = [];
+    const n = knots.length;
+    for (let i = 0; i < n; i++) {
+      const fromId = knots[i].id;
+      const toId = knots[(i + 1) % n].id;
+      const exact = byPair.get(fromId + ">" + toId);
+      next.push(exact ? cloneSeg(exact, fromId, toId) : defaultSegment(fromId, toId));
     }
+    return next;
   }
 
   function syncSegments() {
-    syncOpenSegments();
-    syncOrbitSegments();
+    const b = bodyRef();
+    if (b) {
+      b.segments = syncOpenSegmentsOn(b.knots, b.segments);
+      b.orbitSegments = syncOrbitSegmentsOn(b.orbitKnots, b.orbitSegments);
+    } else {
+      state.segments = syncOpenSegmentsOn(state.knots, state.segments);
+      state.orbitSegments = syncOrbitSegmentsOn(state.orbitKnots, state.orbitSegments);
+    }
+    const segs = activeSegments();
+    if (state.selectedSegmentIndex >= segs.length) state.selectedSegmentIndex = segs.length - 1;
   }
 
   syncSegments();
@@ -280,40 +206,59 @@ export function useSplineEditor() {
   function setViewMode(mode) {
     state.viewMode = mode === "orbit" ? "orbit" : "profile";
     state.selectedId = null;
+    state.selectedIds = [];
     state.selectedSegmentIndex = -1;
-    const knots = activeKnots();
-    state.selectedId = knots[0]?.id || null;
+    state.selectedId = activeKnots()[0]?.id || null;
     state.status =
       state.viewMode === "orbit"
-        ? "Orbit view — closed Bezier path replaces cos/sin for the lathe."
-        : "Profile view — right-half silhouette (x ≥ 0), lathed around Y.";
+        ? "Orbit view — closed Bezier path replaces cos/sin."
+        : "Profile view — attach sub-objects here (boxes on the silhouette).";
   }
 
   function setToolMode(mode) {
     state.toolMode = mode;
     if (mode === "edit") state.status = "Edit mode — drag knots and Bezier handles.";
     if (mode === "add") state.status = "Add mode — click the curve to insert a knot.";
-    if (mode === "color") state.status = "Coloring — pick a knot or segment in the canvas / list.";
+    if (mode === "color") {
+      state.status = "Coloring — click points (Shift = multi-select). Use bulk apply for all / selection.";
+    }
   }
 
-  function select(id) {
-    state.selectedId = id;
+  function select(id, { additive = false } = {}) {
     state.selectedSegmentIndex = -1;
+    if (additive && state.toolMode === "color") {
+      const set = new Set(state.selectedIds);
+      if (set.has(id)) set.delete(id);
+      else set.add(id);
+      state.selectedIds = [...set];
+      state.selectedId = id;
+    } else {
+      state.selectedId = id;
+      state.selectedIds = id ? [id] : [];
+    }
   }
 
   function selectSegment(index) {
     state.selectedSegmentIndex = index;
     state.selectedId = null;
+    state.selectedIds = [];
   }
 
   function resetDefaults() {
+    state.assetGuid = newGuid();
     state.knots = defaultKnots();
     state.segments = [];
     state.orbitKnots = defaultOrbitKnots();
     state.orbitSegments = [];
+    state.objectMaterial = defaultObjectMaterial();
+    state.embeddedAssets = {};
+    state.children = [];
+    state.editTarget = "root";
+    state.selectedChildGuid = null;
     syncSegments();
     state.viewMode = "profile";
     state.selectedId = state.knots[1]?.id || null;
+    state.selectedIds = [];
     state.selectedSegmentIndex = -1;
     state.mesh = null;
     state.status = "Reset to default silhouette + unit-circle orbit.";
@@ -326,6 +271,7 @@ export function useSplineEditor() {
     const idx = knots.findIndex((k) => k.id === id);
     if (idx < 0) return;
     knots.splice(idx, 1);
+    state.selectedIds = state.selectedIds.filter((x) => x !== id);
     syncSegments();
     state.selectedId = knots[Math.min(idx, knots.length - 1)]?.id || null;
     state.selectedSegmentIndex = -1;
@@ -348,8 +294,39 @@ export function useSplineEditor() {
     Object.assign(s, patch);
   }
 
-  function toRangerKnots(list) {
-    return list.map((k) => SplineKnot.of(k.x, k.y, k.hx, k.hy));
+  function applyColorToKnots(ids, color) {
+    const knots = activeKnots();
+    for (const id of ids) {
+      const k = knots.find((n) => n.id === id);
+      if (k) k.color = color;
+    }
+  }
+
+  /** Bulk: whole active body (knots + segment solids + object material). */
+  function applyMaterialToWhole(patch) {
+    const mat = activeObjectMaterial();
+    Object.assign(mat, patch);
+    const knots = activeKnots();
+    const segs = activeSegments();
+    if (patch.color != null) {
+      for (const k of knots) k.color = patch.color;
+      for (const s of segs) s.color = patch.color;
+    }
+    if (patch.roughness != null) for (const s of segs) s.roughness = patch.roughness;
+    if (patch.metalness != null) for (const s of segs) s.metalness = patch.metalness;
+    if (patch.opacity != null) for (const s of segs) s.opacity = patch.opacity;
+    if (patch.texture != null) for (const s of segs) s.texture = patch.texture;
+    state.status = "Applied material to whole object.";
+  }
+
+  function applyColorToSelection(color) {
+    const ids = state.selectedIds.length ? state.selectedIds : state.selectedId ? [state.selectedId] : [];
+    if (!ids.length) {
+      state.status = "Select one or more points first (Shift+click in Coloring).";
+      return;
+    }
+    applyColorToKnots(ids, color);
+    state.status = `Colored ${ids.length} point(s).`;
   }
 
   function evalSpan(a, b, t, curveType) {
@@ -367,6 +344,7 @@ export function useSplineEditor() {
 
   function sampleCurvePoints(samplesPerSpan = 24) {
     const knots = activeKnots();
+    const ct = activeCurveType();
     const pts = [];
     if (isOrbit()) {
       const n = knots.length;
@@ -375,7 +353,7 @@ export function useSplineEditor() {
         const b = knots[(i + 1) % n];
         for (let s = 0; s < samplesPerSpan; s++) {
           const t = s / samplesPerSpan;
-          const { p } = evalSpan(a, b, t, state.curveType);
+          const { p } = evalSpan(a, b, t, ct);
           pts.push({ x: p.x, y: p.y, segmentIndex: i, t });
         }
       }
@@ -388,7 +366,7 @@ export function useSplineEditor() {
       const last = i < knots.length - 2 ? samplesPerSpan - 1 : samplesPerSpan;
       for (let s = 0; s <= last; s++) {
         const t = s / samplesPerSpan;
-        const { p } = evalSpan(a, b, t, state.curveType);
+        const { p } = evalSpan(a, b, t, ct);
         pts.push({ x: Math.max(0, p.x), y: p.y, segmentIndex: i, t });
       }
     }
@@ -397,7 +375,6 @@ export function useSplineEditor() {
 
   function findClosestOnCurve(wx, wy, maxDist = 0.12) {
     const pts = sampleCurvePoints(40);
-    // Ignore the duplicate closing sample when measuring
     const limit = isOrbit() && pts.length > 1 ? pts.length - 1 : pts.length;
     let best = null;
     let bestD = maxDist;
@@ -419,26 +396,25 @@ export function useSplineEditor() {
       return null;
     }
     const knots = activeKnots();
+    const segs = activeSegments();
     const segIndex = hit.segmentIndex;
     const n = knots.length;
     const a = knots[segIndex];
     const b = isOrbit() ? knots[(segIndex + 1) % n] : knots[segIndex + 1];
-    const segs = activeSegments();
     const oldSeg = segs[segIndex] ? { ...segs[segIndex] } : defaultSegment(a.id, b.id);
-    const { p, tan } = evalSpan(a, b, hit.t, state.curveType);
+    const { p, tan } = evalSpan(a, b, hit.t, activeCurveType());
     const tl = Math.hypot(tan.x, tan.y) || 1;
-    const scale = 0.14;
     const k = {
       id: uid(),
       x: isOrbit() ? p.x : Math.max(0, p.x),
       y: p.y,
-      hx: (tan.x / tl) * scale,
-      hy: (tan.y / tl) * scale,
+      hx: (tan.x / tl) * 0.14,
+      hy: (tan.y / tl) * 0.14,
       color: DEFAULT_COLORS[knots.length % DEFAULT_COLORS.length],
     };
 
     if (isOrbit()) {
-      const old = state.orbitSegments.slice();
+      const old = segs.slice();
       knots.splice(segIndex + 1, 0, k);
       const next = [];
       const nn = knots.length;
@@ -452,7 +428,9 @@ export function useSplineEditor() {
           next.push(cloneSeg(old[oldIdx] || oldSeg, fromId, toId));
         }
       }
-      state.orbitSegments = next;
+      const body = bodyRef();
+      if (body) body.orbitSegments = next;
+      else state.orbitSegments = next;
     } else {
       knots.splice(segIndex + 1, 0, k);
       const next = [];
@@ -462,149 +440,75 @@ export function useSplineEditor() {
         if (i === segIndex || i === segIndex + 1) {
           next.push({ ...oldSeg, fromId, toId, textureData: oldSeg.textureData });
         } else if (i < segIndex) {
-          next.push(cloneSeg(state.segments[i], fromId, toId));
+          next.push(cloneSeg(segs[i], fromId, toId));
         } else {
-          next.push(cloneSeg(state.segments[i - 1], fromId, toId));
+          next.push(cloneSeg(segs[i - 1], fromId, toId));
         }
       }
-      state.segments = next;
+      const body = bodyRef();
+      if (body) body.segments = next;
+      else state.segments = next;
     }
 
     state.selectedId = k.id;
+    state.selectedIds = [k.id];
     state.selectedSegmentIndex = -1;
-    state.status = isOrbit()
-      ? `Added orbit knot (segment ${segIndex + 1}).`
-      : `Added knot at y=${k.y.toFixed(2)} (between #${segIndex + 1} and #${segIndex + 2}).`;
+    state.status = `Added knot.`;
     return k;
   }
 
-  function resolvePartStyle(segIndex, which) {
-    const closed = which === "orbit";
-    const knots = closed ? state.orbitKnots : state.knots;
-    const segments = closed ? state.orbitSegments : state.segments;
-    const a = knots[segIndex];
-    const b = knots[closed ? (segIndex + 1) % knots.length : segIndex + 1];
-    const seg = segments[segIndex] || defaultSegment(a?.id, b?.id);
-    const colorA = a?.color || "#cccccc";
-    const colorB = b?.color || "#cccccc";
-    const solidHex = seg.color ? hexToInt(seg.color) : null;
-    const shininess = roughnessToShininess(seg.roughness ?? 0.4);
-    const reflectivity = Math.min(0.95, Math.max(0, seg.metalness ?? 0));
-    const opacity = seg.opacity ?? 1;
-
-    let map = null;
-    let colorHex = 0xffffff;
-    if (seg.texture === "upload" && seg.textureData) {
-      map = seg.textureData;
-      colorHex = 0xffffff;
-    } else if (seg.texture === "checker") {
-      map = makeCheckerRgba(64);
-      colorHex = solidHex != null ? solidHex : mixHex(colorA, colorB, 0.5);
-    } else if (seg.texture === "stripes") {
-      map = makeStripesRgba(64);
-      colorHex = solidHex != null ? solidHex : mixHex(colorA, colorB, 0.5);
-    } else if (seg.texture === "none" && solidHex != null) {
-      colorHex = solidHex;
-    } else {
-      const from = solidHex != null ? seg.color : colorA;
-      const to = solidHex != null ? seg.color : colorB;
-      map = makeGradientRgba(from, to, 4, 64);
-      colorHex = 0xffffff;
-    }
-
-    return { colorHex, shininess, reflectivity, opacity, map, midColor: mixHex(colorA, colorB, 0.5) };
-  }
-
-  function midColorInt(segIndex, which) {
-    const closed = which === "orbit";
-    const knots = closed ? state.orbitKnots : state.knots;
-    const segments = closed ? state.orbitSegments : state.segments;
-    const a = knots[segIndex];
-    const b = knots[closed ? (segIndex + 1) % knots.length : segIndex + 1];
-    const seg = segments[segIndex];
-    if (seg?.color) return hexToInt(seg.color);
-    return mixHex(a?.color || "#cccccc", b?.color || "#cccccc", 0.5);
-  }
-
-  function resolveCombinedStyle(pi, oi) {
-    const p = resolvePartStyle(pi, "profile");
-    const o = resolvePartStyle(oi, "orbit");
-    const pSeg = state.segments[pi];
-    const oSeg = state.orbitSegments[oi];
-    const map = p.map || o.map;
-    let colorHex;
-    if (map) {
-      // Texture from one dimension; tint with the other so both read in shading.
-      colorHex = p.map ? midColorInt(oi, "orbit") : midColorInt(pi, "profile");
-      if (colorHex === 0xffffff) colorHex = mulColorHex(p.colorHex, o.colorHex);
-    } else {
-      colorHex = mulColorHex(midColorInt(pi, "profile"), midColorInt(oi, "orbit"));
-    }
-    const rough = ((pSeg?.roughness ?? 0.4) + (oSeg?.roughness ?? 0.4)) / 2;
+  function rootBodySnapshot() {
     return {
-      colorHex,
-      shininess: roughnessToShininess(rough),
-      reflectivity: Math.min(0.95, Math.max(pSeg?.metalness ?? 0, oSeg?.metalness ?? 0)),
-      opacity: (pSeg?.opacity ?? 1) * (oSeg?.opacity ?? 1),
-      map,
+      assetGuid: state.assetGuid,
+      name: "root",
+      curveType: state.curveType,
+      pathSegments: state.pathSegments,
+      angularSteps: state.angularSteps,
+      revolutionDeg: state.revolutionDeg,
+      objectMaterial: state.objectMaterial,
+      knots: state.knots,
+      segments: state.segments,
+      orbitKnots: state.orbitKnots,
+      orbitSegments: state.orbitSegments,
     };
   }
 
-  function tessellate() {
-    const closed = state.revolutionDeg >= 359.9;
-    const nOrb = state.orbitKnots.length;
-    const perSpan = Math.max(3, Math.round(state.angularSteps / Math.max(1, nOrb)));
-    const sampled = SplineLathe.sampleClosedOrbit(
-      toRangerKnots(state.orbitKnots),
-      state.curveType,
-      perSpan,
-    );
-    let ox = sampled.orbitX.slice();
-    let oy = sampled.orbitY.slice();
-    let oSeg = sampled.profileX.map((x) => x | 0);
-
-    if (!closed) {
-      const half = Math.max(3, Math.floor(ox.length / 2) + 1);
-      ox = ox.slice(0, half);
-      oy = oy.slice(0, half);
-      oSeg = oSeg.slice(0, half);
-    }
-
-    const steps = ox.length;
-    const parts = [];
-    let totalV = 0;
-    let totalT = 0;
-
-    for (let pi = 0; pi < state.knots.length - 1; pi++) {
-      const pair = [state.knots[pi], state.knots[pi + 1]];
-      const mesh = SplineLathe.sampleAndLatheOrbit(
-        toRangerKnots(pair),
-        state.curveType,
-        state.pathSegments,
-        ox,
-        oy,
-        0,
-        steps,
-        closed,
+  function pushTransformedParts(parts, childParts, xf, mirrorX) {
+    for (const p of childParts) {
+      parts.push(
+        transformPart(p, {
+          x: xf.x,
+          y: xf.y,
+          rotationYDeg: xf.rotationYDeg,
+          scale: xf.scale,
+          snapCenterline: xf.snapCenterline,
+          mirrorX,
+        }),
       );
-      const pieces = splitMeshByOrbitSegments(mesh, steps, oSeg, nOrb, closed);
-      for (const piece of pieces) {
-        const style = resolveCombinedStyle(pi, piece.orbitSeg);
-        parts.push({
-          positions: piece.positions,
-          normals: piece.normals,
-          uvs: piece.uvs,
-          indices: piece.indices,
-          colorHex: style.colorHex,
-          shininess: style.shininess,
-          reflectivity: style.reflectivity,
-          opacity: style.opacity,
-          mapRgba: style.map ? Array.from(style.map.rgba) : null,
-          mapW: style.map ? style.map.w : 0,
-          mapH: style.map ? style.map.h : 0,
-        });
-        totalV += (piece.positions.length / 3) | 0;
-        totalT += (piece.indices.length / 3) | 0;
+    }
+  }
+
+  function tessellate() {
+    // Always assemble from ROOT + children (preview shows full object even when editing a child).
+    const root = tessellateBody(rootBodySnapshot());
+    const parts = root.parts.slice();
+    let totalV = root.verts;
+    let totalT = root.tris;
+
+    for (const ch of state.children) {
+      if (ch.visible === false) continue;
+      const body = state.embeddedAssets[ch.contentGuid];
+      if (!body || body.knots.length < 2 || body.orbitKnots.length < 3) continue;
+      const child = tessellateBody(body);
+      const xf = ch.transform || defaultChildTransform();
+      pushTransformedParts(parts, child.parts, xf, false);
+      totalV += child.verts;
+      totalT += child.tris;
+      // Symmetry: same content, mirrored placement (linked eyes without a second instance).
+      if (xf.useSymmetry && !xf.snapCenterline && Math.abs(xf.x) > 0.001) {
+        pushTransformedParts(parts, child.parts, xf, true);
+        totalV += child.verts;
+        totalT += child.tris;
       }
     }
 
@@ -615,13 +519,165 @@ export function useSplineEditor() {
       profile: state.knots.length,
       parts: parts.length,
     };
-    state.status = `Tessellated ${parts.length} parts (profile × orbit) · ${totalV} verts / ${totalT} tris · ${steps} orbit cols.`;
+    const focus = isEditingChild()
+      ? `editing sub “${state.embeddedAssets[state.editTarget]?.name || state.editTarget.slice(0, 8)}”`
+      : "editing root";
+    state.status = `Assembly · ${parts.length} parts · ${totalV}v / ${totalT}t · ${focus}`;
     return state.mesh;
+  }
+
+  function selectChild(instanceGuid) {
+    state.selectedChildGuid = instanceGuid;
+  }
+
+  function editRoot() {
+    state.editTarget = "root";
+    state.selectedId = state.knots[0]?.id || null;
+    state.selectedIds = [];
+    state.status = "Editing root body — preview shows full assembly.";
+  }
+
+  function editChildContent(instanceGuid) {
+    const ch = state.children.find((c) => c.instanceGuid === instanceGuid);
+    if (!ch) return;
+    const body = state.embeddedAssets[ch.contentGuid];
+    if (!body) {
+      state.status = "Missing embedded content for this sub-object.";
+      return;
+    }
+    state.selectedChildGuid = instanceGuid;
+    state.editTarget = ch.contentGuid;
+    state.viewMode = "profile";
+    state.selectedId = body.knots[0]?.id || null;
+    state.selectedIds = [];
+    state.status = `Editing “${ch.name}” (GUID ${ch.contentGuid.slice(0, 8)}…) — linked instances share this content. Preview = full assembly.`;
+  }
+
+  function updateChildTransform(instanceGuid, patch) {
+    const ch = state.children.find((c) => c.instanceGuid === instanceGuid);
+    if (!ch) return;
+    Object.assign(ch.transform, patch);
+    if (patch.snapCenterline) {
+      ch.transform.x = 0;
+      ch.transform.useSymmetry = false;
+    }
+  }
+
+  function removeChild(instanceGuid) {
+    const ch = state.children.find((c) => c.instanceGuid === instanceGuid);
+    if (!ch) return;
+    state.children = state.children.filter((c) => c.instanceGuid !== instanceGuid);
+    const stillUsed = state.children.some((c) => c.contentGuid === ch.contentGuid);
+    if (!stillUsed && ch.mode === "copy") {
+      delete state.embeddedAssets[ch.contentGuid];
+    }
+    if (state.selectedChildGuid === instanceGuid) state.selectedChildGuid = null;
+    if (state.editTarget === ch.contentGuid && !stillUsed) editRoot();
+    state.status = `Removed sub-object “${ch.name}”.`;
+  }
+
+  function centerChildOnAxis(instanceGuid) {
+    updateChildTransform(instanceGuid, { snapCenterline: true, x: 0, useSymmetry: false });
+    state.status = "Centered sub-object on the symmetry axis.";
+  }
+
+  /**
+   * Attach a library/project document as a sub-object.
+   * mode 'copy' → new assetGuid (Save of original won't affect this).
+   * mode 'link' → keep source assetGuid so edits stay linked.
+   * symmetric → also add a mirrored instance sharing the same contentGuid.
+   */
+  function attachFromProject(doc, { mode = "copy", symmetric = false, name } = {}) {
+    if (!doc?.profile?.knots || !doc?.orbit?.knots) {
+      state.status = "Project needs profile + orbit to attach.";
+      return null;
+    }
+    const asCopy = mode !== "link";
+    let contentGuid;
+    let bodyName = name || doc.name || "Sub-object";
+
+    if (!asCopy && doc.assetGuid && state.embeddedAssets[doc.assetGuid]) {
+      contentGuid = doc.assetGuid;
+      bodyName = state.embeddedAssets[contentGuid].name || bodyName;
+    } else {
+      const body = projectDocToBody(doc, { newGuidForCopy: asCopy });
+      if (!asCopy && doc.assetGuid) body.assetGuid = doc.assetGuid;
+      body.name = bodyName;
+      state.embeddedAssets[body.assetGuid] = body;
+      contentGuid = body.assetGuid;
+    }
+
+    const makeInst = (xf, label) => ({
+      instanceGuid: newGuid(),
+      contentGuid,
+      mode: asCopy ? "copy" : "link",
+      name: label,
+      sourceId: doc.id || null,
+      sourceSlug: doc.slug || null,
+      transform: defaultChildTransform(xf),
+      visible: true,
+    });
+
+    const primary = makeInst(
+      { x: 0.45, y: 0.35, useSymmetry: false },
+      bodyName + (symmetric ? " (R)" : ""),
+    );
+    state.children.push(primary);
+    if (symmetric) {
+      state.children.push(
+        makeInst(
+          { x: -0.45, y: 0.35, rotationYDeg: 0, useSymmetry: false },
+          bodyName + " (L)",
+        ),
+      );
+    }
+
+    state.selectedChildGuid = primary.instanceGuid;
+    state.status = asCopy
+      ? `Attached copy “${bodyName}” (new GUID ${contentGuid.slice(0, 8)}…).`
+      : `Attached link “${bodyName}” (shared GUID ${contentGuid.slice(0, 8)}…).`;
+    return primary;
+  }
+
+  /** Toggle symmetry flag on an instance (mirror render without second instance). */
+  function toggleChildSymmetry(instanceGuid) {
+    const ch = state.children.find((c) => c.instanceGuid === instanceGuid);
+    if (!ch) return;
+    ch.transform.useSymmetry = !ch.transform.useSymmetry;
+    if (ch.transform.useSymmetry) ch.transform.snapCenterline = false;
+    state.status = ch.transform.useSymmetry
+      ? "Symmetry on — mirrored twin uses the same content GUID."
+      : "Symmetry off.";
+  }
+
+  /** Add a mirrored instance sharing content (separate transform, linked edits). */
+  function addSymmetricTwin(instanceGuid) {
+    const ch = state.children.find((c) => c.instanceGuid === instanceGuid);
+    if (!ch) return;
+    const twin = {
+      instanceGuid: newGuid(),
+      contentGuid: ch.contentGuid,
+      mode: ch.mode,
+      name: ch.name.replace(/ \(R\)$/, "") + " (L)",
+      sourceId: ch.sourceId,
+      sourceSlug: ch.sourceSlug,
+      transform: {
+        ...ch.transform,
+        x: -Math.abs(ch.transform.x || 0.45),
+        useSymmetry: false,
+        snapCenterline: false,
+      },
+      visible: true,
+    };
+    state.children.push(twin);
+    state.status = `Added symmetric twin — shared content GUID ${ch.contentGuid.slice(0, 8)}…`;
+    return twin;
   }
 
   function applyProject(doc) {
     if (!doc?.profile?.knots) return false;
     const ed = doc.editor || {};
+    state.assetGuid = doc.assetGuid || newGuid();
     state.curveType = ed.curveType | 0;
     state.pathSegments = ed.pathSegments || 12;
     state.angularSteps = ed.angularSteps || 24;
@@ -629,43 +685,23 @@ export function useSplineEditor() {
     state.materialMode = ed.materialMode ?? 3;
     state.symmetry = ed.symmetry !== false;
     state.viewMode = ed.viewMode === "orbit" ? "orbit" : "profile";
-    state.knots = doc.profile.knots.map((k) => ({
-      id: k.id,
-      x: k.x,
-      y: k.y,
-      hx: k.hx,
-      hy: k.hy,
-      color: k.color || "#cccccc",
-    }));
+    state.objectMaterial = {
+      color: doc.objectMaterial?.color ?? null,
+      roughness: doc.objectMaterial?.roughness ?? 0.4,
+      metalness: doc.objectMaterial?.metalness ?? 0,
+      opacity: doc.objectMaterial?.opacity ?? 1,
+      texture: doc.objectMaterial?.texture || "gradient",
+    };
+    state.knots = doc.profile.knots.map((k) => ({ ...k }));
     state.segments = (doc.profile.segments || []).map((s) => ({
-      fromId: s.fromId,
-      toId: s.toId,
-      color: s.color == null ? null : s.color,
-      roughness: s.roughness ?? 0.4,
-      metalness: s.metalness ?? 0,
-      opacity: s.opacity ?? 1,
-      texture: s.texture || "gradient",
+      ...s,
       textureData: null,
       textureAsset: s.textureAsset || null,
     }));
-
     if (doc.orbit?.knots?.length >= 3) {
-      state.orbitKnots = doc.orbit.knots.map((k) => ({
-        id: k.id,
-        x: k.x,
-        y: k.y,
-        hx: k.hx,
-        hy: k.hy,
-        color: k.color || "#cccccc",
-      }));
+      state.orbitKnots = doc.orbit.knots.map((k) => ({ ...k }));
       state.orbitSegments = (doc.orbit.segments || []).map((s) => ({
-        fromId: s.fromId,
-        toId: s.toId,
-        color: s.color == null ? null : s.color,
-        roughness: s.roughness ?? 0.4,
-        metalness: s.metalness ?? 0,
-        opacity: s.opacity ?? 1,
-        texture: s.texture || "gradient",
+        ...s,
         textureData: null,
         textureAsset: s.textureAsset || null,
       }));
@@ -674,16 +710,68 @@ export function useSplineEditor() {
       state.orbitSegments = [];
     }
 
+    state.embeddedAssets = {};
+    for (const [guid, body] of Object.entries(doc.embeddedAssets || {})) {
+      state.embeddedAssets[guid] = {
+        ...body,
+        knots: (body.knots || []).map((k) => ({ ...k })),
+        segments: (body.segments || []).map((s) => ({ ...s, textureData: null })),
+        orbitKnots: (body.orbitKnots || []).map((k) => ({ ...k })),
+        orbitSegments: (body.orbitSegments || []).map((s) => ({ ...s, textureData: null })),
+        objectMaterial: { ...defaultObjectMaterial(), ...(body.objectMaterial || {}) },
+      };
+    }
+    state.children = (doc.children || []).map((ch) => ({
+      ...ch,
+      transform: { ...defaultChildTransform(), ...(ch.transform || {}) },
+    }));
+    state.editTarget = "root";
+    state.selectedChildGuid = null;
     syncSegments();
-    const knots = activeKnots();
-    state.selectedId = knots[0]?.id || null;
+    state.selectedId = state.knots[1]?.id || state.knots[0]?.id || null;
+    state.selectedIds = [];
     state.selectedSegmentIndex = -1;
-    state.status = `Loaded “${doc.name}” (schema v${doc.schemaVersion}).`;
+    state.status = `Loaded “${doc.name}” (schema v${doc.schemaVersion}, GUID ${state.assetGuid.slice(0, 8)}…).`;
     return true;
   }
 
   function snapshotState() {
+    const embedded = {};
+    for (const [guid, body] of Object.entries(state.embeddedAssets)) {
+      embedded[guid] = {
+        assetGuid: body.assetGuid,
+        name: body.name,
+        curveType: body.curveType,
+        pathSegments: body.pathSegments,
+        angularSteps: body.angularSteps,
+        revolutionDeg: body.revolutionDeg,
+        objectMaterial: { ...body.objectMaterial },
+        knots: body.knots.map((k) => ({ ...k })),
+        segments: body.segments.map((s) => ({
+          fromId: s.fromId,
+          toId: s.toId,
+          color: s.color,
+          roughness: s.roughness,
+          metalness: s.metalness,
+          opacity: s.opacity,
+          texture: s.texture,
+          textureAsset: s.textureAsset || null,
+        })),
+        orbitKnots: body.orbitKnots.map((k) => ({ ...k })),
+        orbitSegments: body.orbitSegments.map((s) => ({
+          fromId: s.fromId,
+          toId: s.toId,
+          color: s.color,
+          roughness: s.roughness,
+          metalness: s.metalness,
+          opacity: s.opacity,
+          texture: s.texture,
+          textureAsset: s.textureAsset || null,
+        })),
+      };
+    }
     return {
+      assetGuid: state.assetGuid,
       curveType: state.curveType,
       pathSegments: state.pathSegments,
       angularSteps: state.angularSteps,
@@ -691,6 +779,7 @@ export function useSplineEditor() {
       materialMode: state.materialMode,
       symmetry: state.symmetry,
       viewMode: state.viewMode,
+      objectMaterial: { ...state.objectMaterial },
       knots: state.knots.map((k) => ({ ...k })),
       segments: state.segments.map((s) => ({
         fromId: s.fromId,
@@ -713,15 +802,32 @@ export function useSplineEditor() {
         texture: s.texture,
         textureAsset: s.textureAsset || null,
       })),
+      embeddedAssets: embedded,
+      children: state.children.map((c) => ({
+        instanceGuid: c.instanceGuid,
+        contentGuid: c.contentGuid,
+        mode: c.mode,
+        name: c.name,
+        sourceId: c.sourceId,
+        sourceSlug: c.sourceSlug,
+        transform: { ...c.transform },
+        visible: c.visible !== false,
+      })),
     };
   }
 
   if (!state.selectedId && state.knots.length) {
     state.selectedId = state.knots[1].id;
+    state.selectedIds = [state.selectedId];
   }
 
   watch(
-    () => [state.knots.length, state.orbitKnots.length],
+    () => [
+      state.knots.length,
+      state.orbitKnots.length,
+      state.editTarget,
+      Object.keys(state.embeddedAssets).length,
+    ],
     () => syncSegments(),
   );
 
@@ -729,6 +835,12 @@ export function useSplineEditor() {
     state,
     selected,
     selectedSegment,
+    activeKnots,
+    activeSegments,
+    activeObjectMaterial,
+    activeCurveType,
+    setActiveCurveType,
+    isEditingChild,
     setViewMode,
     setToolMode,
     select,
@@ -738,6 +850,8 @@ export function useSplineEditor() {
     removeSelected,
     updateKnot,
     updateSegment,
+    applyMaterialToWhole,
+    applyColorToSelection,
     sampleCurvePoints,
     findClosestOnCurve,
     insertKnotOnCurve,
@@ -745,5 +859,14 @@ export function useSplineEditor() {
     syncSegments,
     applyProject,
     snapshotState,
+    attachFromProject,
+    selectChild,
+    editRoot,
+    editChildContent,
+    updateChildTransform,
+    removeChild,
+    centerChildOnAxis,
+    toggleChildSymmetry,
+    addSymmetricTwin,
   };
 }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/assetClone.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/assetClone.js
@@ -1,0 +1,119 @@
+// ============================================================================
+// assetClone.js — deep-clone spline body content with remapped ids + new GUID.
+// ============================================================================
+
+export function newGuid() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) return crypto.randomUUID();
+  return "g_" + Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
+}
+
+function knotUid() {
+  return "k" + Math.random().toString(36).slice(2, 9);
+}
+
+function remapKnots(knots, idMap) {
+  return (knots || []).map((k) => {
+    const nid = knotUid();
+    idMap.set(k.id, nid);
+    return {
+      id: nid,
+      x: Number(k.x) || 0,
+      y: Number(k.y) || 0,
+      hx: Number(k.hx) || 0,
+      hy: Number(k.hy) || 0,
+      color: k.color || "#cccccc",
+    };
+  });
+}
+
+function remapSegments(segments, idMap) {
+  return (segments || []).map((s) => ({
+    fromId: idMap.get(s.fromId) || s.fromId,
+    toId: idMap.get(s.toId) || s.toId,
+    color: s.color == null ? null : s.color,
+    roughness: Number(s.roughness ?? 0.4),
+    metalness: Number(s.metalness ?? 0),
+    opacity: Number(s.opacity ?? 1),
+    texture: s.texture || "gradient",
+    textureAsset: s.textureAsset || null,
+    textureData: null,
+  }));
+}
+
+/**
+ * Clone profile+orbit (+ optional objectMaterial) into an embedded asset body.
+ * Always assigns a fresh assetGuid unless preserveGuid is set (link cache).
+ */
+export function cloneBodyContent(src, { preserveGuid = false, name = "Sub-object" } = {}) {
+  const idMap = new Map();
+  const profileKnots = remapKnots(src.profile?.knots || src.knots, idMap);
+  const profileSegments = remapSegments(src.profile?.segments || src.segments, idMap);
+  const orbitMap = new Map();
+  const orbitKnots = remapKnots(src.orbit?.knots || src.orbitKnots, orbitMap);
+  const orbitSegments = remapSegments(src.orbit?.segments || src.orbitSegments, orbitMap);
+  const ed = src.editor || src;
+  return {
+    assetGuid: preserveGuid && src.assetGuid ? src.assetGuid : newGuid(),
+    name: name || src.name || "Sub-object",
+    curveType: ed.curveType | 0,
+    pathSegments: ed.pathSegments || 12,
+    angularSteps: ed.angularSteps || 24,
+    revolutionDeg: ed.revolutionDeg || 360,
+    objectMaterial: src.objectMaterial
+      ? { ...src.objectMaterial }
+      : { color: null, roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient" },
+    knots: profileKnots,
+    segments: profileSegments,
+    orbitKnots,
+    orbitSegments,
+  };
+}
+
+/** Snapshot the live root editor fields into body-content shape. */
+export function snapshotRootAsBody(state) {
+  return {
+    assetGuid: state.assetGuid,
+    name: "root",
+    curveType: state.curveType,
+    pathSegments: state.pathSegments,
+    angularSteps: state.angularSteps,
+    revolutionDeg: state.revolutionDeg,
+    objectMaterial: { ...state.objectMaterial },
+    knots: state.knots.map((k) => ({ ...k })),
+    segments: state.segments.map((s) => ({
+      fromId: s.fromId,
+      toId: s.toId,
+      color: s.color,
+      roughness: s.roughness,
+      metalness: s.metalness,
+      opacity: s.opacity,
+      texture: s.texture,
+      textureAsset: s.textureAsset || null,
+      textureData: null,
+    })),
+    orbitKnots: state.orbitKnots.map((k) => ({ ...k })),
+    orbitSegments: state.orbitSegments.map((s) => ({
+      fromId: s.fromId,
+      toId: s.toId,
+      color: s.color,
+      roughness: s.roughness,
+      metalness: s.metalness,
+      opacity: s.opacity,
+      texture: s.texture,
+      textureAsset: s.textureAsset || null,
+      textureData: null,
+    })),
+  };
+}
+
+export function defaultChildTransform(overrides = {}) {
+  return {
+    x: 0.45,
+    y: 0.35,
+    rotationYDeg: 0,
+    scale: 0.28,
+    useSymmetry: false,
+    snapCenterline: false,
+    ...overrides,
+  };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/latheTessellate.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/latheTessellate.js
@@ -1,0 +1,309 @@
+// ============================================================================
+// latheTessellate.js — profile×orbit lathe for one body (root or embedded asset).
+// ============================================================================
+
+import { SplineLathe, SplineKnot } from "../../../tessellate/spline_lathe.mjs";
+
+function hexToRgb(hex) {
+  const h = String(hex || "#ffffff").replace("#", "");
+  const full = h.length === 3 ? h.split("").map((c) => c + c).join("") : h.padStart(6, "0");
+  const n = parseInt(full.slice(0, 6), 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function mixHex(a, b, t) {
+  const A = hexToRgb(a);
+  const B = hexToRgb(b);
+  const r = Math.round(lerp(A.r, B.r, t));
+  const g = Math.round(lerp(A.g, B.g, t));
+  const b_ = Math.round(lerp(A.b, B.b, t));
+  return (r << 16) | (g << 8) | b_;
+}
+
+function hexToInt(hex) {
+  const c = hexToRgb(hex);
+  return (c.r << 16) | (c.g << 8) | c.b;
+}
+
+function mulColorHex(a, b) {
+  if (a === 0xffffff) return b;
+  if (b === 0xffffff) return a;
+  const ar = (a >> 16) & 255;
+  const ag = (a >> 8) & 255;
+  const ab = a & 255;
+  const br = (b >> 16) & 255;
+  const bg = (b >> 8) & 255;
+  const bb = b & 255;
+  return (((ar * br) / 255) | 0) << 16 | (((ag * bg) / 255) | 0) << 8 | (((ab * bb) / 255) | 0);
+}
+
+function roughnessToShininess(r) {
+  const t = Math.min(1, Math.max(0, r));
+  return lerp(280, 6, t);
+}
+
+function makeGradientRgba(hexA, hexB, w = 4, h = 64) {
+  const A = hexToRgb(hexA);
+  const B = hexToRgb(hexB);
+  const rgba = new Uint8Array(w * h * 4);
+  for (let y = 0; y < h; y++) {
+    const t = y / Math.max(1, h - 1);
+    const r = Math.round(lerp(A.r, B.r, t));
+    const g = Math.round(lerp(A.g, B.g, t));
+    const b = Math.round(lerp(A.b, B.b, t));
+    for (let x = 0; x < w; x++) {
+      const i = (y * w + x) * 4;
+      rgba[i] = r;
+      rgba[i + 1] = g;
+      rgba[i + 2] = b;
+      rgba[i + 3] = 255;
+    }
+  }
+  return { rgba, w, h };
+}
+
+function makeCheckerRgba(size = 64) {
+  const rgba = new Uint8Array(size * size * 4);
+  const cell = size / 8;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const odd = (((x / cell) | 0) + ((y / cell) | 0)) & 1;
+      const i = (y * size + x) * 4;
+      rgba[i] = odd ? 90 : 220;
+      rgba[i + 1] = odd ? 120 : 220;
+      rgba[i + 2] = odd ? 160 : 210;
+      rgba[i + 3] = 255;
+    }
+  }
+  return { rgba, w: size, h: size };
+}
+
+function makeStripesRgba(size = 64) {
+  const rgba = new Uint8Array(size * size * 4);
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const odd = ((y / 6) | 0) & 1;
+      const i = (y * size + x) * 4;
+      rgba[i] = odd ? 40 : 230;
+      rgba[i + 1] = odd ? 160 : 210;
+      rgba[i + 2] = odd ? 120 : 90;
+      rgba[i + 3] = 255;
+    }
+  }
+  return { rgba, w: size, h: size };
+}
+
+function defaultSegment(fromId, toId) {
+  return {
+    fromId,
+    toId,
+    color: null,
+    roughness: 0.4,
+    metalness: 0,
+    opacity: 1,
+    texture: "gradient",
+    textureData: null,
+  };
+}
+
+function toRangerKnots(list) {
+  return list.map((k) => SplineKnot.of(k.x, k.y, k.hx, k.hy));
+}
+
+function splitMeshByOrbitSegments(mesh, steps, oSeg, numOrbitSegs, closed) {
+  const vertCount = (mesh.positions.length / 3) | 0;
+  if (steps < 2 || vertCount < steps * 2) return [];
+  const rows = (vertCount / steps) | 0;
+  const out = [];
+
+  for (let oi = 0; oi < numOrbitSegs; oi++) {
+    const faces = [];
+    for (let r = 0; r < rows - 1; r++) {
+      const colMax = closed ? steps : steps - 1;
+      for (let c = 0; c < colMax; c++) {
+        if ((oSeg[c] | 0) !== oi) continue;
+        const cNext = c + 1 >= steps ? 0 : c + 1;
+        const a = r * steps + c;
+        const b = r * steps + cNext;
+        const cc = (r + 1) * steps + cNext;
+        const d = (r + 1) * steps + c;
+        faces.push(a, d, b, b, d, cc);
+      }
+    }
+    if (!faces.length) continue;
+
+    const used = new Map();
+    const positions = [];
+    const normals = [];
+    const uvs = [];
+    const indices = [];
+    const mapV = (g) => {
+      let local = used.get(g);
+      if (local != null) return local;
+      local = used.size;
+      used.set(g, local);
+      const i3 = g * 3;
+      const i2 = g * 2;
+      positions.push(mesh.positions[i3], mesh.positions[i3 + 1], mesh.positions[i3 + 2]);
+      normals.push(mesh.normals[i3], mesh.normals[i3 + 1], mesh.normals[i3 + 2]);
+      uvs.push(mesh.uvs[i2], mesh.uvs[i2 + 1]);
+      return local;
+    };
+    for (let i = 0; i < faces.length; i++) indices.push(mapV(faces[i]));
+    out.push({ orbitSeg: oi, positions, normals, uvs, indices });
+  }
+  return out;
+}
+
+function resolvePartStyle(body, segIndex, which) {
+  const closed = which === "orbit";
+  const knots = closed ? body.orbitKnots : body.knots;
+  const segments = closed ? body.orbitSegments : body.segments;
+  const a = knots[segIndex];
+  const b = knots[closed ? (segIndex + 1) % knots.length : segIndex + 1];
+  const seg = segments[segIndex] || defaultSegment(a?.id, b?.id);
+  const colorA = a?.color || "#cccccc";
+  const colorB = b?.color || "#cccccc";
+  const solidHex = seg.color ? hexToInt(seg.color) : null;
+
+  let map = null;
+  let colorHex = 0xffffff;
+  if (seg.texture === "upload" && seg.textureData) {
+    map = seg.textureData;
+  } else if (seg.texture === "checker") {
+    map = makeCheckerRgba(64);
+    colorHex = solidHex != null ? solidHex : mixHex(colorA, colorB, 0.5);
+  } else if (seg.texture === "stripes") {
+    map = makeStripesRgba(64);
+    colorHex = solidHex != null ? solidHex : mixHex(colorA, colorB, 0.5);
+  } else if (seg.texture === "none" && solidHex != null) {
+    colorHex = solidHex;
+  } else {
+    const from = solidHex != null ? seg.color : colorA;
+    const to = solidHex != null ? seg.color : colorB;
+    map = makeGradientRgba(from, to, 4, 64);
+  }
+  return { colorHex, map, colorA, colorB, seg };
+}
+
+function midColorInt(body, segIndex, which) {
+  const closed = which === "orbit";
+  const knots = closed ? body.orbitKnots : body.knots;
+  const segments = closed ? body.orbitSegments : body.segments;
+  const a = knots[segIndex];
+  const b = knots[closed ? (segIndex + 1) % knots.length : segIndex + 1];
+  const seg = segments[segIndex];
+  if (seg?.color) return hexToInt(seg.color);
+  return mixHex(a?.color || "#cccccc", b?.color || "#cccccc", 0.5);
+}
+
+function resolveCombinedStyle(body, pi, oi) {
+  const p = resolvePartStyle(body, pi, "profile");
+  const o = resolvePartStyle(body, oi, "orbit");
+  const pSeg = body.segments[pi];
+  const oSeg = body.orbitSegments[oi];
+  const map = p.map || o.map;
+  let colorHex;
+  if (map) {
+    colorHex = p.map ? midColorInt(body, oi, "orbit") : midColorInt(body, pi, "profile");
+    if (colorHex === 0xffffff) colorHex = mulColorHex(p.colorHex, o.colorHex);
+  } else {
+    colorHex = mulColorHex(midColorInt(body, pi, "profile"), midColorInt(body, oi, "orbit"));
+  }
+  // Object-level material tint (bulk default)
+  const om = body.objectMaterial;
+  if (om?.color) {
+    colorHex = mulColorHex(colorHex === 0xffffff ? 0xffffff : colorHex, hexToInt(om.color));
+    if (colorHex === 0xffffff) colorHex = hexToInt(om.color);
+  }
+  const rough =
+    ((pSeg?.roughness ?? om?.roughness ?? 0.4) + (oSeg?.roughness ?? om?.roughness ?? 0.4)) / 2;
+  const metal = Math.max(pSeg?.metalness ?? 0, oSeg?.metalness ?? 0, om?.metalness ?? 0);
+  const opacity =
+    (pSeg?.opacity ?? 1) * (oSeg?.opacity ?? 1) * (om?.opacity ?? 1);
+  return {
+    colorHex,
+    shininess: roughnessToShininess(rough),
+    reflectivity: Math.min(0.95, metal),
+    opacity,
+    map,
+  };
+}
+
+/**
+ * Tessellate one spline body into mesh parts.
+ * @param {{
+ *   knots: any[], segments: any[],
+ *   orbitKnots: any[], orbitSegments: any[],
+ *   curveType?: number, pathSegments?: number, angularSteps?: number, revolutionDeg?: number,
+ *   objectMaterial?: object
+ * }} body
+ */
+export function tessellateBody(body) {
+  const curveType = body.curveType | 0;
+  const pathSegments = body.pathSegments || 12;
+  const angularSteps = body.angularSteps || 24;
+  const revolutionDeg = body.revolutionDeg || 360;
+  const closed = revolutionDeg >= 359.9;
+  const nOrb = body.orbitKnots.length;
+  const perSpan = Math.max(3, Math.round(angularSteps / Math.max(1, nOrb)));
+  const sampled = SplineLathe.sampleClosedOrbit(
+    toRangerKnots(body.orbitKnots),
+    curveType,
+    perSpan,
+  );
+  let ox = sampled.orbitX.slice();
+  let oy = sampled.orbitY.slice();
+  let oSeg = sampled.profileX.map((x) => x | 0);
+
+  if (!closed) {
+    const half = Math.max(3, Math.floor(ox.length / 2) + 1);
+    ox = ox.slice(0, half);
+    oy = oy.slice(0, half);
+    oSeg = oSeg.slice(0, half);
+  }
+
+  const steps = ox.length;
+  const parts = [];
+  let totalV = 0;
+  let totalT = 0;
+
+  for (let pi = 0; pi < body.knots.length - 1; pi++) {
+    const pair = [body.knots[pi], body.knots[pi + 1]];
+    const mesh = SplineLathe.sampleAndLatheOrbit(
+      toRangerKnots(pair),
+      curveType,
+      pathSegments,
+      ox,
+      oy,
+      0,
+      steps,
+      closed,
+    );
+    const pieces = splitMeshByOrbitSegments(mesh, steps, oSeg, nOrb, closed);
+    for (const piece of pieces) {
+      const style = resolveCombinedStyle(body, pi, piece.orbitSeg);
+      parts.push({
+        positions: piece.positions,
+        normals: piece.normals,
+        uvs: piece.uvs,
+        indices: piece.indices,
+        colorHex: style.colorHex,
+        shininess: style.shininess,
+        reflectivity: style.reflectivity,
+        opacity: style.opacity,
+        mapRgba: style.map ? Array.from(style.map.rgba) : null,
+        mapW: style.map ? style.map.w : 0,
+        mapH: style.map ? style.map.h : 0,
+      });
+      totalV += (piece.positions.length / 3) | 0;
+      totalT += (piece.indices.length / 3) | 0;
+    }
+  }
+
+  return { parts, verts: totalV, tris: totalT, orbitCols: steps };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/meshTransform.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/meshTransform.js
@@ -1,0 +1,123 @@
+// ============================================================================
+// meshTransform.js — place / scale / mirror lathe part buffers in parent space.
+// ============================================================================
+
+/**
+ * @param {number[]} positions flat xyz
+ * @returns {{ min:[number,number,number], max:[number,number,number], center:[number,number,number], size:[number,number,number], maxExtent:number }}
+ */
+export function computeBBox(positions) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let minZ = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let maxZ = -Infinity;
+  for (let i = 0; i < positions.length; i += 3) {
+    const x = positions[i];
+    const y = positions[i + 1];
+    const z = positions[i + 2];
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (z < minZ) minZ = z;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+    if (z > maxZ) maxZ = z;
+  }
+  if (!Number.isFinite(minX)) {
+    return {
+      min: [0, 0, 0],
+      max: [0, 0, 0],
+      center: [0, 0, 0],
+      size: [0, 0, 0],
+      maxExtent: 0,
+    };
+  }
+  const size = [maxX - minX, maxY - minY, maxZ - minZ];
+  return {
+    min: [minX, minY, minZ],
+    max: [maxX, maxY, maxZ],
+    center: [(minX + maxX) / 2, (minY + maxY) / 2, (minZ + maxZ) / 2],
+    size,
+    maxExtent: Math.max(size[0], size[1], size[2]),
+  };
+}
+
+/**
+ * Bake TRS into a part (positions + normals). Attachment is in profile space:
+ * x = radial (+X), y = height. Optional mirror across the Y axis (x → −x).
+ *
+ * @param {object} part
+ * @param {{
+ *   x: number, y: number,
+ *   rotationYDeg?: number,
+ *   scale?: number,
+ *   snapCenterline?: boolean,
+ *   mirrorX?: boolean,
+ * }} xf
+ */
+export function transformPart(part, xf) {
+  const positions = part.positions.slice();
+  const normals = part.normals ? part.normals.slice() : null;
+  const bbox = computeBBox(positions);
+  const extent = Math.max(1e-6, bbox.maxExtent);
+  // scale: user bbox size multiplier — 1 keeps natural size; typical sub-object ~0.2–0.5
+  const s = Math.max(0.001, xf.scale ?? 1);
+  const ax = xf.snapCenterline ? 0 : Number(xf.x) || 0;
+  const ay = Number(xf.y) || 0;
+  const mirror = !!xf.mirrorX;
+  const rot = ((Number(xf.rotationYDeg) || 0) * Math.PI) / 180;
+  const cr = Math.cos(rot);
+  const sr = Math.sin(rot);
+
+  for (let i = 0; i < positions.length; i += 3) {
+    // Center on bbox, then uniform scale
+    let x = (positions[i] - bbox.center[0]) * s;
+    let y = (positions[i + 1] - bbox.center[1]) * s;
+    let z = (positions[i + 2] - bbox.center[2]) * s;
+
+    // Rotate around Y
+    const rx = x * cr + z * sr;
+    const rz = -x * sr + z * cr;
+    x = rx;
+    z = rz;
+
+    if (mirror) x = -x;
+
+    positions[i] = x + (mirror ? -ax : ax);
+    positions[i + 1] = y + ay;
+    positions[i + 2] = z;
+  }
+
+  if (normals) {
+    for (let i = 0; i < normals.length; i += 3) {
+      let nx = normals[i];
+      let ny = normals[i + 1];
+      let nz = normals[i + 2];
+      const rx = nx * cr + nz * sr;
+      const rz = -nx * sr + nz * cr;
+      nx = rx;
+      nz = rz;
+      if (mirror) nx = -nx;
+      const len = Math.hypot(nx, ny, nz) || 1;
+      normals[i] = nx / len;
+      normals[i + 1] = ny / len;
+      normals[i + 2] = nz / len;
+    }
+  }
+
+  return {
+    ...part,
+    positions,
+    normals: normals || part.normals,
+  };
+}
+
+/** Union bbox of many parts (for UI readout). */
+export function partsBBox(parts) {
+  const all = [];
+  for (const p of parts || []) {
+    for (let i = 0; i < p.positions.length; i++) all.push(p.positions[i]);
+  }
+  return computeBBox(all);
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -128,18 +128,84 @@ function normalizeV2(doc) {
   };
 }
 
+function normalizeEmbeddedBody(body, fallbackGuid) {
+  if (!body) return null;
+  const knots = mapKnots(body.knots);
+  const orbitKnots = mapKnots(body.orbitKnots || body.orbit?.knots);
+  if (orbitKnots.length < 3) return null;
+  return {
+    assetGuid: body.assetGuid || fallbackGuid || newId(),
+    name: body.name || "Sub-object",
+    curveType: Number(body.curveType ?? 0),
+    pathSegments: Number(body.pathSegments ?? 12),
+    angularSteps: Number(body.angularSteps ?? 24),
+    revolutionDeg: Number(body.revolutionDeg ?? 360),
+    objectMaterial: {
+      color: body.objectMaterial?.color ?? null,
+      roughness: Number(body.objectMaterial?.roughness ?? 0.4),
+      metalness: Number(body.objectMaterial?.metalness ?? 0),
+      opacity: Number(body.objectMaterial?.opacity ?? 1),
+      texture: body.objectMaterial?.texture || "gradient",
+    },
+    knots,
+    segments: mapSegments(body.segments, knots, false),
+    orbitKnots,
+    orbitSegments: mapSegments(body.orbitSegments || body.orbit?.segments, orbitKnots, true),
+  };
+}
+
+function normalizeV3(doc) {
+  const v2 = normalizeV2(doc);
+  const embeddedAssets = {};
+  const rawEmb = doc.embeddedAssets || {};
+  for (const [guid, body] of Object.entries(rawEmb)) {
+    const n = normalizeEmbeddedBody(body, guid);
+    if (n) embeddedAssets[n.assetGuid] = n;
+  }
+  const children = (doc.children || []).map((ch, i) => ({
+    instanceGuid: ch.instanceGuid || newId(),
+    contentGuid: ch.contentGuid || ch.assetGuid || `missing_${i}`,
+    mode: ch.mode === "link" ? "link" : "copy",
+    name: ch.name || "Sub-object",
+    sourceId: ch.sourceId || null,
+    sourceSlug: ch.sourceSlug || null,
+    transform: {
+      x: Number(ch.transform?.x ?? 0.45),
+      y: Number(ch.transform?.y ?? 0.35),
+      rotationYDeg: Number(ch.transform?.rotationYDeg ?? 0),
+      scale: Number(ch.transform?.scale ?? 0.28),
+      useSymmetry: !!ch.transform?.useSymmetry,
+      snapCenterline: !!ch.transform?.snapCenterline,
+    },
+    visible: ch.visible !== false,
+  }));
+  return {
+    ...v2,
+    schemaVersion: 3,
+    assetGuid: doc.assetGuid || v2.id || newId(),
+    objectMaterial: {
+      color: doc.objectMaterial?.color ?? null,
+      roughness: Number(doc.objectMaterial?.roughness ?? 0.4),
+      metalness: Number(doc.objectMaterial?.metalness ?? 0),
+      opacity: Number(doc.objectMaterial?.opacity ?? 1),
+      texture: doc.objectMaterial?.texture || "gradient",
+    },
+    embeddedAssets,
+    children,
+  };
+}
+
 /** @type {Record<number, (doc: any) => any>} */
 const STEPS = {
-  // 0 / missing → 1
   1(doc) {
-    if (doc && doc.schemaVersion === 1 && doc.kind === SCHEMA_KIND && doc.profile) {
-      return normalizeV1(doc);
-    }
     return normalizeV1(doc);
   },
-  // 1 → 2: add closed orbit path (unit circle Bezier) + viewMode
   2(doc) {
     return normalizeV2(doc);
+  },
+  // 2 → 3: assetGuid, objectMaterial, embeddedAssets, children
+  3(doc) {
+    return normalizeV3(doc);
   },
 };
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -1,45 +1,27 @@
 // ============================================================================
 // schema.js — semantic spline-project document + versioned migrations.
 // ============================================================================
-// On-disk layout (default):
-//   mesh_editor/library/projects/<slug>/project.json
-// Optional binary textures (future / upload):
-//   mesh_editor/library/projects/<slug>/assets/<name>.png
-//
-// Bump CURRENT_SCHEMA_VERSION when the document shape changes and add a
-// migration step in migrations.js. loadProject() always returns the current
-// version so older folders remain readable.
-// ============================================================================
 
-export const CURRENT_SCHEMA_VERSION = 2;
+export const CURRENT_SCHEMA_VERSION = 3;
 
 export const SCHEMA_KIND = "ranger.splineProject";
 
-/** @typedef {{ id: string, x: number, y: number, hx: number, hy: number, color: string }} KnotV2 */
-/** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureAsset?: string|null }} SegmentV2 */
-
 /**
- * @typedef {object} SplineProjectV2
- * @property {typeof SCHEMA_KIND} kind
- * @property {2} schemaVersion
- * @property {string} id
- * @property {string} slug
+ * @typedef {object} ChildInstanceV3
+ * @property {string} instanceGuid
+ * @property {string} contentGuid  // shared → linked; unique copy → independent
+ * @property {'copy'|'link'} mode
  * @property {string} name
- * @property {string} [description]
- * @property {string[]} [tags]
- * @property {string} createdAt
- * @property {string} updatedAt
+ * @property {string|null} [sourceId]
+ * @property {string|null} [sourceSlug]
  * @property {{
- *   curveType: number,
- *   pathSegments: number,
- *   angularSteps: number,
- *   revolutionDeg: number,
- *   materialMode: number,
- *   symmetry: boolean,
- *   viewMode?: 'profile'|'orbit'
- * }} editor
- * @property {{ knots: KnotV2[], segments: SegmentV2[] }} profile
- * @property {{ knots: KnotV2[], segments: SegmentV2[] }} orbit
+ *   x: number, y: number,
+ *   rotationYDeg: number,
+ *   scale: number,
+ *   useSymmetry: boolean,
+ *   snapCenterline: boolean
+ * }} transform
+ * @property {boolean} [visible]
  */
 
 export function nowIso() {
@@ -60,7 +42,6 @@ export function newId() {
   return "sp_" + Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
 }
 
-/** Strip non-JSON-friendly fields (e.g. in-memory textureData buffers). */
 export function serializeSegment(seg) {
   return {
     fromId: seg.fromId,
@@ -85,25 +66,64 @@ export function serializeKnot(k) {
   };
 }
 
+function serializeBodyContent(body) {
+  return {
+    assetGuid: body.assetGuid,
+    name: body.name || "asset",
+    curveType: body.curveType | 0,
+    pathSegments: body.pathSegments | 0,
+    angularSteps: body.angularSteps | 0,
+    revolutionDeg: body.revolutionDeg | 0,
+    objectMaterial: {
+      color: body.objectMaterial?.color ?? null,
+      roughness: Number(body.objectMaterial?.roughness ?? 0.4),
+      metalness: Number(body.objectMaterial?.metalness ?? 0),
+      opacity: Number(body.objectMaterial?.opacity ?? 1),
+      texture: body.objectMaterial?.texture || "gradient",
+    },
+    knots: (body.knots || []).map(serializeKnot),
+    segments: (body.segments || []).map(serializeSegment),
+    orbitKnots: (body.orbitKnots || []).map(serializeKnot),
+    orbitSegments: (body.orbitSegments || []).map(serializeSegment),
+  };
+}
+
+function serializeChild(ch) {
+  return {
+    instanceGuid: ch.instanceGuid,
+    contentGuid: ch.contentGuid,
+    mode: ch.mode === "link" ? "link" : "copy",
+    name: ch.name || "Sub-object",
+    sourceId: ch.sourceId || null,
+    sourceSlug: ch.sourceSlug || null,
+    transform: {
+      x: Number(ch.transform?.x ?? 0.45),
+      y: Number(ch.transform?.y ?? 0.35),
+      rotationYDeg: Number(ch.transform?.rotationYDeg ?? 0),
+      scale: Number(ch.transform?.scale ?? 0.28),
+      useSymmetry: !!ch.transform?.useSymmetry,
+      snapCenterline: !!ch.transform?.snapCenterline,
+    },
+    visible: ch.visible !== false,
+  };
+}
+
 /**
  * Build a current-version project document from the live editor state.
- * @param {object} opts
- * @param {object} opts.state - useSplineEditor reactive state (or snapshotState())
- * @param {string} opts.name
- * @param {string} [opts.id]
- * @param {string} [opts.slug]
- * @param {string} [opts.description]
- * @param {string[]} [opts.tags]
- * @param {string} [opts.createdAt]
  */
 export function buildProjectDocument(opts) {
   const st = opts.state;
   const name = String(opts.name || "Untitled spline").trim() || "Untitled spline";
   const createdAt = opts.createdAt || nowIso();
+  const embedded = {};
+  for (const [guid, body] of Object.entries(st.embeddedAssets || {})) {
+    embedded[guid] = serializeBodyContent(body);
+  }
   return {
     kind: SCHEMA_KIND,
     schemaVersion: CURRENT_SCHEMA_VERSION,
     id: opts.id || newId(),
+    assetGuid: st.assetGuid || newId(),
     slug: opts.slug || slugify(name),
     name,
     description: opts.description || "",
@@ -119,6 +139,13 @@ export function buildProjectDocument(opts) {
       symmetry: !!st.symmetry,
       viewMode: st.viewMode === "orbit" ? "orbit" : "profile",
     },
+    objectMaterial: {
+      color: st.objectMaterial?.color ?? null,
+      roughness: Number(st.objectMaterial?.roughness ?? 0.4),
+      metalness: Number(st.objectMaterial?.metalness ?? 0),
+      opacity: Number(st.objectMaterial?.opacity ?? 1),
+      texture: st.objectMaterial?.texture || "gradient",
+    },
     profile: {
       knots: (st.knots || []).map(serializeKnot),
       segments: (st.segments || []).map(serializeSegment),
@@ -127,6 +154,8 @@ export function buildProjectDocument(opts) {
       knots: (st.orbitKnots || []).map(serializeKnot),
       segments: (st.orbitSegments || []).map(serializeSegment),
     },
+    embeddedAssets: embedded,
+    children: (st.children || []).map(serializeChild),
   };
 }
 
@@ -149,6 +178,10 @@ export function validateProject(doc) {
     if (doc.orbit && doc.orbit.knots && doc.orbit.knots.length < 3) {
       errors.push("orbit.knots needs at least 3 points");
     }
+  }
+  if (doc.schemaVersion >= 3) {
+    if (!doc.assetGuid) errors.push("missing assetGuid");
+    if (doc.children && !Array.isArray(doc.children)) errors.push("children must be an array");
   }
   return errors;
 }

--- a/gallery/game_engine/v2/mesh_editor/library/README.md
+++ b/gallery/game_engine/v2/mesh_editor/library/README.md
@@ -34,6 +34,7 @@ copy or symlink selected folders into a tracked tree, or temporarily force-add.
 - Current version: see `app/src/library/schema.js` (`CURRENT_SCHEMA_VERSION`)
 - Migrations: `app/src/library/migrations.js` — every load upgrades to current
 - v2 adds a closed `orbit` Bezier path (unit circle by default) alongside `profile`
+- v3 adds `assetGuid`, `objectMaterial`, `embeddedAssets`, and `children` (sub-object instances)
 
 When you change the document shape, bump the version and add a step; old folders
 keep working.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the requested assembly workflow on top of the orbit lathe editor.

### 1–2 · Bulk colour / material
- Toolbar **Bulk colour**: *Whole object* paints all knots + segments (+ `objectMaterial`) on the active edit target
- *Selection* paints multi-selected points (**Shift+click** in Coloring mode)

### 3–9 · Sub-objects
- Profile view shows **attach boxes**; drag to place, adjust **bbox scale**, **rot Y**, **Center** on the axis
- **Sub-objects** panel: attach from library as **Copy** (new `assetGuid`) or **Link** (shared GUID)
- **Copy×2** / **Twin** / **Sym** for mirrored pairs that share content (e.g. two eyes with independent transforms)
- **Edit** loads the child large in the canvas; **3D preview always tessellates the full assembly**

### 10 · GUIDs
- Every project has an `assetGuid` (content identity)
- **Copy** attach → new GUID (later Save of the source does not affect the embedded snapshot)
- **Link** / twins → same `contentGuid` so colour/shape edits propagate to all instances
- Instance GUID is separate from content GUID

### Schema
- Bump to **v3**: `assetGuid`, `objectMaterial`, `embeddedAssets`, `children`
- v1/v2 projects migrate cleanly

### Verify
```bash
node gallery/game_engine/v2/mesh_editor/smoke.mjs
cd gallery/game_engine/v2/mesh_editor/app && npm run dev
```
1. Save two splines (e.g. body + eye)
2. On body: Sub-objects → **Copy×2** the eye → tweak bbox scale / Center / Sym
3. **Edit** one eye → change colour → both linked instances update in the assembly preview
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

