### PR TITLE
Fix sub-object rendering: shared bbox transform

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -1,7 +1,7 @@
 import { reactive, computed, watch } from "vue";
 import { SplineLathe } from "../../../tessellate/spline_lathe.mjs";
 import { tessellateBody } from "../lib/latheTessellate.js";
-import { transformPart } from "../lib/meshTransform.js";
+import { transformParts } from "../lib/meshTransform.js";
 import {
   newGuid,
   cloneBodyContent,
@@ -474,18 +474,15 @@ export function useSplineEditor() {
   }
 
   function pushTransformedParts(parts, childParts, xf, mirrorX) {
-    for (const p of childParts) {
-      parts.push(
-        transformPart(p, {
-          x: xf.x,
-          y: xf.y,
-          rotationYDeg: xf.rotationYDeg,
-          scale: xf.scale,
-          snapCenterline: xf.snapCenterline,
-          mirrorX,
-        }),
-      );
-    }
+    const placed = transformParts(childParts, {
+      x: xf.x,
+      y: xf.y,
+      rotationYDeg: xf.rotationYDeg,
+      scale: xf.scale,
+      snapCenterline: xf.snapCenterline,
+      mirrorX,
+    });
+    for (const p of placed) parts.push(p);
   }
 
   function tessellate() {

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/meshTransform.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/meshTransform.js
@@ -43,25 +43,37 @@ export function computeBBox(positions) {
   };
 }
 
+/** Union AABB of many parts (must use one shared center when placing a child). */
+export function partsBBox(parts) {
+  const all = [];
+  for (const p of parts || []) {
+    const pos = p.positions || [];
+    for (let i = 0; i < pos.length; i++) all.push(pos[i]);
+  }
+  return computeBBox(all);
+}
+
+function reverseWinding(indices) {
+  const out = indices.slice();
+  for (let i = 0; i + 2 < out.length; i += 3) {
+    const t = out[i + 1];
+    out[i + 1] = out[i + 2];
+    out[i + 2] = t;
+  }
+  return out;
+}
+
 /**
- * Bake TRS into a part (positions + normals). Attachment is in profile space:
- * x = radial (+X), y = height. Optional mirror across the Y axis (x → −x).
- *
- * @param {object} part
- * @param {{
- *   x: number, y: number,
- *   rotationYDeg?: number,
- *   scale?: number,
- *   snapCenterline?: boolean,
- *   mirrorX?: boolean,
- * }} xf
+ * Bake TRS into one part using a SHARED object-space center (not this part's bbox).
+ * Centering each profile×orbit wedge on its own AABB tears the child mesh apart.
  */
-export function transformPart(part, xf) {
+export function transformPart(part, xf, sharedCenter) {
   const positions = part.positions.slice();
   const normals = part.normals ? part.normals.slice() : null;
-  const bbox = computeBBox(positions);
-  const extent = Math.max(1e-6, bbox.maxExtent);
-  // scale: user bbox size multiplier — 1 keeps natural size; typical sub-object ~0.2–0.5
+  const indices = part.indices ? part.indices.slice() : [];
+  const cx = sharedCenter?.[0] ?? 0;
+  const cy = sharedCenter?.[1] ?? 0;
+  const cz = sharedCenter?.[2] ?? 0;
   const s = Math.max(0.001, xf.scale ?? 1);
   const ax = xf.snapCenterline ? 0 : Number(xf.x) || 0;
   const ay = Number(xf.y) || 0;
@@ -71,12 +83,10 @@ export function transformPart(part, xf) {
   const sr = Math.sin(rot);
 
   for (let i = 0; i < positions.length; i += 3) {
-    // Center on bbox, then uniform scale
-    let x = (positions[i] - bbox.center[0]) * s;
-    let y = (positions[i + 1] - bbox.center[1]) * s;
-    let z = (positions[i + 2] - bbox.center[2]) * s;
+    let x = (positions[i] - cx) * s;
+    let y = (positions[i + 1] - cy) * s;
+    let z = (positions[i + 2] - cz) * s;
 
-    // Rotate around Y
     const rx = x * cr + z * sr;
     const rz = -x * sr + z * cr;
     x = rx;
@@ -84,6 +94,7 @@ export function transformPart(part, xf) {
 
     if (mirror) x = -x;
 
+    // Place at ±attach: mirrored copies go to the opposite side of the axis.
     positions[i] = x + (mirror ? -ax : ax);
     positions[i + 1] = y + ay;
     positions[i + 2] = z;
@@ -110,14 +121,20 @@ export function transformPart(part, xf) {
     ...part,
     positions,
     normals: normals || part.normals,
+    // Mirroring flips triangle winding — reverse so fronts stay outward.
+    indices: mirror ? reverseWinding(indices) : indices,
+    // Defensive copies so mirrored pass never shares buffers with the primary.
+    uvs: part.uvs ? part.uvs.slice() : part.uvs,
+    mapRgba: part.mapRgba ? part.mapRgba.slice() : part.mapRgba,
   };
 }
 
-/** Union bbox of many parts (for UI readout). */
-export function partsBBox(parts) {
-  const all = [];
-  for (const p of parts || []) {
-    for (let i = 0; i < p.positions.length; i++) all.push(p.positions[i]);
-  }
-  return computeBBox(all);
+/**
+ * Transform every part of a child mesh with one shared bbox center so wedges
+ * stay welded. Returns new part objects (never mutates inputs).
+ */
+export function transformParts(parts, xf) {
+  if (!parts?.length) return [];
+  const bbox = partsBBox(parts);
+  return parts.map((p) => transformPart(p, xf, bbox.center));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Bug
Sub-objects rendered as exploded / crossed triangles. The root body was fine.

### Cause
Placement centered **each** profile×orbit mesh part on that part’s own AABB, then scaled and moved it to the attach point. A lathe child is many wedges, so every wedge collapsed onto the attach point — vertices from different parts stacked on top of each other.

Confirmed: per-part centering → part-center spread `0`; shared-object centering → spread scales correctly with bbox scale.

### Fix
- `transformParts()` computes one shared bbox for the whole child, then transforms every part with that center
- Fresh copies of positions / normals / indices / uvs / maps so primary and mirrored instances stay isolated
- Reverse triangle winding when `mirrorX` is set

### Verify
Re-attach a sub-object (or reload the assembly) — eyes/attachments should stay coherent solids at the attach boxes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

