### PR TITLE
Spline editor: line/arc/bezier segments + undo buffer

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -73,12 +73,30 @@ gallery/game_engine/v2/mesh_editor/library/projects/<slug>/project.json
 
 That tree is **gitignored** by default. Point elsewhere with
 `MESH_EDITOR_LIBRARY=/abs/or/rel/path`. Schema + migrations live in
-`app/src/library/` (`schemaVersion` 3+, kind `ranger.splineProject`, with
-`profile`, closed `orbit`, `assetGuid`, `embeddedAssets`, and `children`).
+`app/src/library/` (`schemaVersion` 4+, kind `ranger.splineProject`, with
+`profile`, closed `orbit`, per-segment `pathType`, `assetGuid`, `embeddedAssets`, and `children`).
 
 Offline fallback: **Export JSON** / **Import JSON** in the Library panel.
 
 See [`library/README.md`](./library/README.md).
+
+## Path types (SVG-style segments)
+
+Each profile / orbit **segment** can be independently:
+
+| Type | Behaviour |
+|------|-----------|
+| **Bezier** | Cubic with knot handles (default) |
+| **Line** | Straight chord between endpoints |
+| **Arc** | Circular arc; optional **bulge** (signed sagitta), else auto ≈ ¼ chord |
+
+Mix freely along a path (Bezier → line → arc…), like SVG subpaths. Choose the type
+in the segment **Details** menu.
+
+## Undo / redo
+
+Edits push immutable shape snapshots into an in-memory buffer (no Zustand dependency).
+**Undo** / **Redo** in the toolbar, or `Ctrl+Z` / `Ctrl+Shift+Z` (`Ctrl+Y`).
 
 ## Views & tools
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted } from "vue";
+import { computed, onMounted, onBeforeUnmount } from "vue";
 import SplineCanvas from "./components/SplineCanvas.vue";
 import PointEditor from "./components/PointEditor.vue";
 import Preview3D from "./components/Preview3D.vue";
@@ -39,6 +39,9 @@ const {
   centerChildOnAxis,
   toggleChildSymmetry,
   addSymmetricTwin,
+  undo,
+  redo,
+  endGesture,
   isEditingChild,
 } = useSplineEditor();
 
@@ -99,10 +102,12 @@ function onUpdateSegment(index, patch) {
 }
 
 function onDragEnd() {
+  endGesture();
   tessellate();
 }
 
 function onListCommit() {
+  endGesture();
   tessellate();
 }
 
@@ -130,6 +135,27 @@ function onMoveChild(guid, patch) {
   updateChildTransform(guid, patch);
 }
 
+function onUndo() {
+  if (undo()) tessellate();
+}
+
+function onRedo() {
+  if (redo()) tessellate();
+}
+
+function onKeyDown(e) {
+  const mod = e.metaKey || e.ctrlKey;
+  if (!mod) return;
+  const key = e.key.toLowerCase();
+  if (key === "z" && !e.shiftKey) {
+    e.preventDefault();
+    onUndo();
+  } else if ((key === "z" && e.shiftKey) || key === "y") {
+    e.preventDefault();
+    onRedo();
+  }
+}
+
 async function onAttach({ slug, mode, symmetric }) {
   try {
     const doc = await api.loadProject(slug);
@@ -142,6 +168,11 @@ async function onAttach({ slug, mode, symmetric }) {
 
 onMounted(() => {
   tessellate();
+  window.addEventListener("keydown", onKeyDown);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener("keydown", onKeyDown);
 });
 </script>
 
@@ -178,6 +209,10 @@ onMounted(() => {
           </button>
         </div>
         <button @click="resetDefaults">Reset</button>
+        <button @click="onUndo" :disabled="!state.history.canUndo" title="Ctrl+Z">Undo</button>
+        <button @click="onRedo" :disabled="!state.history.canRedo" title="Ctrl+Shift+Z">
+          Redo
+        </button>
         <button @click="removeSelected" :disabled="!state.selectedId">Remove</button>
         <button class="primary" @click="onTessellate">Tessellate</button>
       </div>

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/PointEditor.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/PointEditor.vue
@@ -232,7 +232,10 @@ function segLabel(i) {
             </label>
             <div class="meta">
               <strong>{{ segLabel(row.index) }}</strong>
-              <span>{{ segments[row.index]?.texture || "gradient" }}</span>
+              <span
+                >{{ segments[row.index]?.pathType || "bezier" }} ·
+                {{ segments[row.index]?.texture || "gradient" }}</span
+              >
             </div>
             <button
               type="button"
@@ -252,6 +255,39 @@ function segLabel(i) {
 
           <div v-if="expandedKey === 'seg:' + row.index" class="details" @click.stop>
             <div class="grid">
+              <label class="field wide">
+                Path type
+                <select
+                  :value="segments[row.index]?.pathType || 'bezier'"
+                  @change="
+                    emit('update-segment', row.index, { pathType: $event.target.value });
+                    emit('commit');
+                  "
+                >
+                  <option value="bezier">Bezier (cubic)</option>
+                  <option value="line">Straight line</option>
+                  <option value="arc">Circular arc</option>
+                </select>
+              </label>
+              <label
+                v-if="(segments[row.index]?.pathType || 'bezier') === 'arc'"
+                class="field"
+              >
+                Arc bulge
+                <input
+                  type="number"
+                  step="0.05"
+                  :value="segments[row.index]?.arcBulge ?? ''"
+                  placeholder="auto"
+                  @change="
+                    emit('update-segment', row.index, {
+                      arcBulge:
+                        $event.target.value === '' ? null : Number($event.target.value),
+                    });
+                    emit('commit');
+                  "
+                />
+              </label>
               <label class="field">
                 Roughness
                 <input

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
@@ -75,6 +75,23 @@ function segmentColor(segIndex) {
   return a?.color || "#6ec8ff";
 }
 
+function knotUsesBezierHandles(knotIndex) {
+  // Show handles if any adjacent segment is bezier (SVG-style mix).
+  const segs = props.segments || [];
+  if (isOrbit.value) {
+    const n = props.knots.length;
+    const prev = segs[(knotIndex - 1 + n) % n];
+    const next = segs[knotIndex];
+    return (prev?.pathType || "bezier") === "bezier" || (next?.pathType || "bezier") === "bezier";
+  }
+  const prev = knotIndex > 0 ? segs[knotIndex - 1] : null;
+  const next = knotIndex < props.knots.length - 1 ? segs[knotIndex] : null;
+  return (
+    (prev && (prev.pathType || "bezier") === "bezier") ||
+    (next && (next.pathType || "bezier") === "bezier")
+  );
+}
+
 function drawUnitCircle(ctx, w, h) {
   const steps = 64;
   ctx.strokeStyle = "rgba(200,232,122,0.22)";
@@ -204,9 +221,13 @@ function draw() {
     }
   }
 
-  props.knots.forEach((k) => {
+  props.knots.forEach((k, ki) => {
     const [sx, sy] = worldToScreen(k.x, k.y, w, h);
-    if (props.curveType === 0 && props.toolMode === "edit") {
+    const showHandles =
+      props.curveType === 0 &&
+      props.toolMode === "edit" &&
+      knotUsesBezierHandles(ki);
+    if (showHandles) {
       const [hx, hy] = worldToScreen(k.x + k.hx, k.y + k.hy, w, h);
       const [ix, iy] = worldToScreen(k.x - k.hx, k.y - k.hy, w, h);
       ctx.strokeStyle = "rgba(255,180,84,0.75)";
@@ -296,8 +317,9 @@ function drawHandle(ctx, x, y, selected) {
 
 function hitTestPoint(sx, sy) {
   const thresh = 10;
-  for (const k of props.knots) {
-    if (props.curveType === 0 && props.toolMode === "edit") {
+  for (let ki = 0; ki < props.knots.length; ki++) {
+    const k = props.knots[ki];
+    if (props.curveType === 0 && props.toolMode === "edit" && knotUsesBezierHandles(ki)) {
       const [hx, hy] = worldToScreen(k.x + k.hx, k.y + k.hy, size, size);
       if (Math.hypot(hx - sx, hy - sy) <= thresh) return { id: k.id, mode: "handle" };
     }

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -2,6 +2,8 @@ import { reactive, computed, watch } from "vue";
 import { SplineLathe } from "../../../tessellate/spline_lathe.mjs";
 import { tessellateBody } from "../lib/latheTessellate.js";
 import { transformParts } from "../lib/meshTransform.js";
+import { evalSpan as evalPathSpan } from "../lib/pathSample.js";
+import { createEditHistory } from "../lib/editHistory.js";
 import {
   newGuid,
   cloneBodyContent,
@@ -9,7 +11,7 @@ import {
 } from "../lib/assetClone.js";
 
 /** @typedef {{ id: string, x: number, y: number, hx: number, hy: number, color: string }} Knot */
-/** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureData: any, textureAsset?: string|null }} Segment */
+/** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureData: any, textureAsset?: string|null, pathType?: string, arcBulge?: number|null }} Segment */
 
 function uid() {
   return "k" + Math.random().toString(36).slice(2, 9);
@@ -50,6 +52,8 @@ function defaultSegment(fromId, toId) {
     texture: "gradient",
     textureData: null,
     textureAsset: null,
+    pathType: "bezier",
+    arcBulge: null,
   };
 }
 
@@ -58,7 +62,14 @@ function defaultObjectMaterial() {
 }
 
 function cloneSeg(s, fromId, toId) {
-  return { ...s, fromId, toId, textureData: s.textureData || null };
+  return {
+    ...s,
+    fromId,
+    toId,
+    textureData: s.textureData || null,
+    pathType: s.pathType === "line" || s.pathType === "arc" ? s.pathType : "bezier",
+    arcBulge: s.arcBulge ?? null,
+  };
 }
 
 function projectDocToBody(doc, { newGuidForCopy = true } = {}) {
@@ -113,7 +124,135 @@ export function useSplineEditor() {
     mesh: null,
     stats: { verts: 0, tris: 0, profile: 0, parts: 0 },
     status: "Edit mode — drag points. Sub-objects attach in Profile view.",
+    history: { canUndo: false, canRedo: false, past: 0, future: 0 },
   });
+
+  const history = createEditHistory({ limit: 80 });
+
+  function refreshHistoryFlags() {
+    const info = history.info();
+    state.history.canUndo = info.canUndo;
+    state.history.canRedo = info.canRedo;
+    state.history.past = info.past;
+    state.history.future = info.future;
+  }
+
+  /** Shape-only snapshot for the undo buffer (immutable clone). */
+  function snapshotShape() {
+    return JSON.parse(
+      JSON.stringify({
+        editTarget: state.editTarget,
+        viewMode: state.viewMode,
+        knots: state.knots,
+        segments: state.segments.map((s) => ({
+          fromId: s.fromId,
+          toId: s.toId,
+          color: s.color,
+          roughness: s.roughness,
+          metalness: s.metalness,
+          opacity: s.opacity,
+          texture: s.texture,
+          textureAsset: s.textureAsset || null,
+          pathType: s.pathType || "bezier",
+          arcBulge: s.arcBulge ?? null,
+        })),
+        orbitKnots: state.orbitKnots,
+        orbitSegments: state.orbitSegments.map((s) => ({
+          fromId: s.fromId,
+          toId: s.toId,
+          color: s.color,
+          roughness: s.roughness,
+          metalness: s.metalness,
+          opacity: s.opacity,
+          texture: s.texture,
+          textureAsset: s.textureAsset || null,
+          pathType: s.pathType || "bezier",
+          arcBulge: s.arcBulge ?? null,
+        })),
+        objectMaterial: state.objectMaterial,
+        embeddedAssets: state.embeddedAssets,
+        children: state.children,
+        selectedId: state.selectedId,
+        selectedIds: state.selectedIds,
+        selectedSegmentIndex: state.selectedSegmentIndex,
+        selectedChildGuid: state.selectedChildGuid,
+      }),
+    );
+  }
+
+  function restoreShape(snap) {
+    if (!snap) return;
+    state.editTarget = snap.editTarget || "root";
+    state.viewMode = snap.viewMode === "orbit" ? "orbit" : "profile";
+    state.knots = (snap.knots || []).map((k) => ({ ...k }));
+    state.segments = (snap.segments || []).map((s) => ({ ...s, textureData: null }));
+    state.orbitKnots = (snap.orbitKnots || []).map((k) => ({ ...k }));
+    state.orbitSegments = (snap.orbitSegments || []).map((s) => ({ ...s, textureData: null }));
+    state.objectMaterial = { ...defaultObjectMaterial(), ...(snap.objectMaterial || {}) };
+    state.embeddedAssets = {};
+    for (const [guid, body] of Object.entries(snap.embeddedAssets || {})) {
+      state.embeddedAssets[guid] = {
+        ...body,
+        knots: (body.knots || []).map((k) => ({ ...k })),
+        segments: (body.segments || []).map((s) => ({ ...s, textureData: null })),
+        orbitKnots: (body.orbitKnots || []).map((k) => ({ ...k })),
+        orbitSegments: (body.orbitSegments || []).map((s) => ({ ...s, textureData: null })),
+        objectMaterial: { ...defaultObjectMaterial(), ...(body.objectMaterial || {}) },
+      };
+    }
+    state.children = (snap.children || []).map((c) => ({
+      ...c,
+      transform: { ...defaultChildTransform(), ...(c.transform || {}) },
+    }));
+    state.selectedId = snap.selectedId || null;
+    state.selectedIds = snap.selectedIds || [];
+    state.selectedSegmentIndex = snap.selectedSegmentIndex ?? -1;
+    state.selectedChildGuid = snap.selectedChildGuid || null;
+    syncSegments();
+  }
+
+  /** Push current shape onto the undo buffer before a mutating edit. */
+  function commitToHistory(label = "") {
+    history.push(snapshotShape(), label);
+    refreshHistoryFlags();
+  }
+
+  function undo() {
+    const prev = history.undo(snapshotShape());
+    if (!prev) {
+      state.status = "Nothing to undo.";
+      return false;
+    }
+    restoreShape(prev);
+    refreshHistoryFlags();
+    state.status = `Undo (${state.history.past} left).`;
+    return true;
+  }
+
+  function redo() {
+    const next = history.redo(snapshotShape());
+    if (!next) {
+      state.status = "Nothing to redo.";
+      return false;
+    }
+    restoreShape(next);
+    refreshHistoryFlags();
+    state.status = `Redo (${state.history.future} ahead).`;
+    return true;
+  }
+
+  let gestureOpen = false;
+  function beginGesture(label = "edit") {
+    if (gestureOpen) return;
+    commitToHistory(label);
+    gestureOpen = true;
+  }
+  function endGesture() {
+    if (!gestureOpen) return;
+    gestureOpen = false;
+    history.baseline(snapshotShape());
+    refreshHistoryFlags();
+  }
 
   function isOrbit() {
     return state.viewMode === "orbit";
@@ -245,6 +384,7 @@ export function useSplineEditor() {
   }
 
   function resetDefaults() {
+    commitToHistory("reset");
     state.assetGuid = newGuid();
     state.knots = defaultKnots();
     state.segments = [];
@@ -261,6 +401,9 @@ export function useSplineEditor() {
     state.selectedIds = [];
     state.selectedSegmentIndex = -1;
     state.mesh = null;
+    history.clear();
+    history.baseline(snapshotShape());
+    refreshHistoryFlags();
     state.status = "Reset to default silhouette + unit-circle orbit.";
   }
 
@@ -268,6 +411,7 @@ export function useSplineEditor() {
     const knots = activeKnots();
     const min = isOrbit() ? 3 : 2;
     if (knots.length <= min) return;
+    commitToHistory("remove-knot");
     const idx = knots.findIndex((k) => k.id === id);
     if (idx < 0) return;
     knots.splice(idx, 1);
@@ -282,6 +426,10 @@ export function useSplineEditor() {
   }
 
   function updateKnot(id, patch) {
+    const moving =
+      patch.x != null || patch.y != null || patch.hx != null || patch.hy != null;
+    if (moving) beginGesture("move-knot");
+    else commitToHistory("knot");
     const k = activeKnots().find((n) => n.id === id);
     if (!k) return;
     Object.assign(k, patch);
@@ -289,6 +437,7 @@ export function useSplineEditor() {
   }
 
   function updateSegment(index, patch) {
+    commitToHistory("segment");
     const s = activeSegments()[index];
     if (!s) return;
     Object.assign(s, patch);
@@ -304,6 +453,7 @@ export function useSplineEditor() {
 
   /** Bulk: whole active body (knots + segment solids + object material). */
   function applyMaterialToWhole(patch) {
+    commitToHistory("bulk-material");
     const mat = activeObjectMaterial();
     Object.assign(mat, patch);
     const knots = activeKnots();
@@ -325,35 +475,32 @@ export function useSplineEditor() {
       state.status = "Select one or more points first (Shift+click in Coloring).";
       return;
     }
+    commitToHistory("color-selection");
     applyColorToKnots(ids, color);
     state.status = `Colored ${ids.length} point(s).`;
   }
 
-  function evalSpan(a, b, t, curveType) {
-    if (curveType === 0) {
-      return {
-        p: SplineLathe.bezierPoint(a.x, a.y, a.x + a.hx, a.y + a.hy, b.x - b.hx, b.y - b.hy, b.x, b.y, t),
-        tan: SplineLathe.bezierTangent(a.x, a.y, a.x + a.hx, a.y + a.hy, b.x - b.hx, b.y - b.hy, b.x, b.y, t),
-      };
-    }
-    return {
-      p: SplineLathe.catmullPoint(a.x, a.y, a.x, a.y, b.x, b.y, b.x, b.y, t),
-      tan: SplineLathe.catmullTangent(a.x, a.y, a.x, a.y, b.x, b.y, b.x, b.y, t),
-    };
+  function evalSpan(a, b, t, pathType = "bezier", arcBulge = null) {
+    return evalPathSpan(a, b, t, {
+      pathType,
+      curveType: activeCurveType(),
+      arcBulge,
+    });
   }
 
   function sampleCurvePoints(samplesPerSpan = 24) {
     const knots = activeKnots();
-    const ct = activeCurveType();
+    const segs = activeSegments();
     const pts = [];
     if (isOrbit()) {
       const n = knots.length;
       for (let i = 0; i < n; i++) {
         const a = knots[i];
         const b = knots[(i + 1) % n];
+        const seg = segs[i];
         for (let s = 0; s < samplesPerSpan; s++) {
           const t = s / samplesPerSpan;
-          const { p } = evalSpan(a, b, t, ct);
+          const { p } = evalSpan(a, b, t, seg?.pathType || "bezier", seg?.arcBulge);
           pts.push({ x: p.x, y: p.y, segmentIndex: i, t });
         }
       }
@@ -363,10 +510,11 @@ export function useSplineEditor() {
     for (let i = 0; i < knots.length - 1; i++) {
       const a = knots[i];
       const b = knots[i + 1];
+      const seg = segs[i];
       const last = i < knots.length - 2 ? samplesPerSpan - 1 : samplesPerSpan;
       for (let s = 0; s <= last; s++) {
         const t = s / samplesPerSpan;
-        const { p } = evalSpan(a, b, t, ct);
+        const { p } = evalSpan(a, b, t, seg?.pathType || "bezier", seg?.arcBulge);
         pts.push({ x: Math.max(0, p.x), y: p.y, segmentIndex: i, t });
       }
     }
@@ -395,6 +543,7 @@ export function useSplineEditor() {
       state.status = "Click closer to the curve to add a point.";
       return null;
     }
+    commitToHistory("add-knot");
     const knots = activeKnots();
     const segs = activeSegments();
     const segIndex = hit.segmentIndex;
@@ -402,7 +551,13 @@ export function useSplineEditor() {
     const a = knots[segIndex];
     const b = isOrbit() ? knots[(segIndex + 1) % n] : knots[segIndex + 1];
     const oldSeg = segs[segIndex] ? { ...segs[segIndex] } : defaultSegment(a.id, b.id);
-    const { p, tan } = evalSpan(a, b, hit.t, activeCurveType());
+    const { p, tan } = evalSpan(
+      a,
+      b,
+      hit.t,
+      oldSeg.pathType || "bezier",
+      oldSeg.arcBulge,
+    );
     const tl = Math.hypot(tan.x, tan.y) || 1;
     const k = {
       id: uid(),
@@ -553,6 +708,9 @@ export function useSplineEditor() {
   function updateChildTransform(instanceGuid, patch) {
     const ch = state.children.find((c) => c.instanceGuid === instanceGuid);
     if (!ch) return;
+    const moving = patch.x != null || patch.y != null;
+    if (moving) beginGesture("move-child");
+    else commitToHistory("child-transform");
     Object.assign(ch.transform, patch);
     if (patch.snapCenterline) {
       ch.transform.x = 0;
@@ -563,6 +721,7 @@ export function useSplineEditor() {
   function removeChild(instanceGuid) {
     const ch = state.children.find((c) => c.instanceGuid === instanceGuid);
     if (!ch) return;
+    commitToHistory("remove-child");
     state.children = state.children.filter((c) => c.instanceGuid !== instanceGuid);
     const stillUsed = state.children.some((c) => c.contentGuid === ch.contentGuid);
     if (!stillUsed && ch.mode === "copy") {
@@ -574,7 +733,12 @@ export function useSplineEditor() {
   }
 
   function centerChildOnAxis(instanceGuid) {
-    updateChildTransform(instanceGuid, { snapCenterline: true, x: 0, useSymmetry: false });
+    const ch = state.children.find((c) => c.instanceGuid === instanceGuid);
+    if (!ch) return;
+    commitToHistory("center-child");
+    ch.transform.snapCenterline = true;
+    ch.transform.x = 0;
+    ch.transform.useSymmetry = false;
     state.status = "Centered sub-object on the symmetry axis.";
   }
 
@@ -589,6 +753,7 @@ export function useSplineEditor() {
       state.status = "Project needs profile + orbit to attach.";
       return null;
     }
+    commitToHistory("attach");
     const asCopy = mode !== "link";
     let contentGuid;
     let bodyName = name || doc.name || "Sub-object";
@@ -640,6 +805,7 @@ export function useSplineEditor() {
   function toggleChildSymmetry(instanceGuid) {
     const ch = state.children.find((c) => c.instanceGuid === instanceGuid);
     if (!ch) return;
+    commitToHistory("child-sym");
     ch.transform.useSymmetry = !ch.transform.useSymmetry;
     if (ch.transform.useSymmetry) ch.transform.snapCenterline = false;
     state.status = ch.transform.useSymmetry
@@ -651,6 +817,7 @@ export function useSplineEditor() {
   function addSymmetricTwin(instanceGuid) {
     const ch = state.children.find((c) => c.instanceGuid === instanceGuid);
     if (!ch) return;
+    commitToHistory("twin");
     const twin = {
       instanceGuid: newGuid(),
       contentGuid: ch.contentGuid,
@@ -694,6 +861,8 @@ export function useSplineEditor() {
       ...s,
       textureData: null,
       textureAsset: s.textureAsset || null,
+      pathType: s.pathType === "line" || s.pathType === "arc" ? s.pathType : "bezier",
+      arcBulge: s.arcBulge ?? null,
     }));
     if (doc.orbit?.knots?.length >= 3) {
       state.orbitKnots = doc.orbit.knots.map((k) => ({ ...k }));
@@ -701,6 +870,8 @@ export function useSplineEditor() {
         ...s,
         textureData: null,
         textureAsset: s.textureAsset || null,
+        pathType: s.pathType === "line" || s.pathType === "arc" ? s.pathType : "bezier",
+        arcBulge: s.arcBulge ?? null,
       }));
     } else {
       state.orbitKnots = defaultOrbitKnots();
@@ -728,6 +899,9 @@ export function useSplineEditor() {
     state.selectedId = state.knots[1]?.id || state.knots[0]?.id || null;
     state.selectedIds = [];
     state.selectedSegmentIndex = -1;
+    history.clear();
+    history.baseline(snapshotShape());
+    refreshHistoryFlags();
     state.status = `Loaded “${doc.name}” (schema v${doc.schemaVersion}, GUID ${state.assetGuid.slice(0, 8)}…).`;
     return true;
   }
@@ -753,6 +927,8 @@ export function useSplineEditor() {
           opacity: s.opacity,
           texture: s.texture,
           textureAsset: s.textureAsset || null,
+          pathType: s.pathType || "bezier",
+          arcBulge: s.arcBulge ?? null,
         })),
         orbitKnots: body.orbitKnots.map((k) => ({ ...k })),
         orbitSegments: body.orbitSegments.map((s) => ({
@@ -764,6 +940,8 @@ export function useSplineEditor() {
           opacity: s.opacity,
           texture: s.texture,
           textureAsset: s.textureAsset || null,
+          pathType: s.pathType || "bezier",
+          arcBulge: s.arcBulge ?? null,
         })),
       };
     }
@@ -787,6 +965,8 @@ export function useSplineEditor() {
         opacity: s.opacity,
         texture: s.texture,
         textureAsset: s.textureAsset || null,
+        pathType: s.pathType || "bezier",
+        arcBulge: s.arcBulge ?? null,
       })),
       orbitKnots: state.orbitKnots.map((k) => ({ ...k })),
       orbitSegments: state.orbitSegments.map((s) => ({
@@ -798,6 +978,8 @@ export function useSplineEditor() {
         opacity: s.opacity,
         texture: s.texture,
         textureAsset: s.textureAsset || null,
+        pathType: s.pathType || "bezier",
+        arcBulge: s.arcBulge ?? null,
       })),
       embeddedAssets: embedded,
       children: state.children.map((c) => ({
@@ -817,6 +999,9 @@ export function useSplineEditor() {
     state.selectedId = state.knots[1].id;
     state.selectedIds = [state.selectedId];
   }
+
+  history.baseline(snapshotShape());
+  refreshHistoryFlags();
 
   watch(
     () => [
@@ -865,5 +1050,10 @@ export function useSplineEditor() {
     centerChildOnAxis,
     toggleChildSymmetry,
     addSymmetricTwin,
+    undo,
+    redo,
+    beginGesture,
+    endGesture,
+    commitToHistory,
   };
 }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/assetClone.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/assetClone.js
@@ -37,6 +37,8 @@ function remapSegments(segments, idMap) {
     texture: s.texture || "gradient",
     textureAsset: s.textureAsset || null,
     textureData: null,
+    pathType: s.pathType === "line" || s.pathType === "arc" ? s.pathType : "bezier",
+    arcBulge: s.arcBulge == null || s.arcBulge === "" ? null : Number(s.arcBulge),
   }));
 }
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/editHistory.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/editHistory.js
@@ -1,0 +1,81 @@
+// ============================================================================
+// editHistory.js — immutable undo/redo buffer for editor shape snapshots.
+// ============================================================================
+
+/**
+ * Lightweight history stack (no Zustand). Snapshots are plain JSON-safe clones.
+ * Call push() *before* a mutating edit with the current (pre-edit) shape.
+ */
+export function createEditHistory({ limit = 80 } = {}) {
+  /** @type {{ label: string, data: any }[]} */
+  let past = [];
+  /** @type {{ label: string, data: any }[]} */
+  let future = [];
+
+  function canUndo() {
+    return past.length > 0;
+  }
+  function canRedo() {
+    return future.length > 0;
+  }
+
+  function clear() {
+    past = [];
+    future = [];
+  }
+
+  /**
+   * @param {any} snapshot plain object from snapshotShape() — state *before* the edit
+   * @param {string} [label]
+   */
+  function push(snapshot, label = "") {
+    const data = JSON.parse(JSON.stringify(snapshot));
+    const serialized = JSON.stringify(data);
+    // Skip only consecutive duplicate pre-states (e.g. double commitToHistory).
+    if (past.length && JSON.stringify(past[past.length - 1].data) === serialized) {
+      return false;
+    }
+    past.push({ label, data });
+    if (past.length > limit) past.shift();
+    future = [];
+    return true;
+  }
+
+  /** Reset stacks after load/reset (does not push). */
+  function baseline(_snapshot) {
+    future = [];
+  }
+
+  /**
+   * @param {any} currentSnapshot state *after* edits (goes onto redo stack)
+   * @returns {any|null} previous snapshot to restore
+   */
+  function undo(currentSnapshot) {
+    if (!past.length) return null;
+    future.push({ label: "redo", data: JSON.parse(JSON.stringify(currentSnapshot)) });
+    const prev = past.pop();
+    return prev.data;
+  }
+
+  /**
+   * @param {any} currentSnapshot
+   * @returns {any|null}
+   */
+  function redo(currentSnapshot) {
+    if (!future.length) return null;
+    past.push({ label: "undo-point", data: JSON.parse(JSON.stringify(currentSnapshot)) });
+    const next = future.pop();
+    return next.data;
+  }
+
+  function info() {
+    return {
+      canUndo: canUndo(),
+      canRedo: canRedo(),
+      past: past.length,
+      future: future.length,
+    };
+  }
+
+  return { push, baseline, undo, redo, clear, canUndo, canRedo, info };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/latheTessellate.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/latheTessellate.js
@@ -1,8 +1,14 @@
 // ============================================================================
 // latheTessellate.js — profile×orbit lathe for one body (root or embedded asset).
+// Per-segment pathType: bezier | line | arc (SVG-path style mixes).
 // ============================================================================
 
-import { SplineLathe, SplineKnot } from "../../../tessellate/spline_lathe.mjs";
+import {
+  sampleOpenPath,
+  sampleClosedPath,
+  latheProfileWithOrbit,
+  splitLatheBySegments,
+} from "./pathSample.js";
 
 function hexToRgb(hex) {
   const h = String(hex || "#ffffff").replace("#", "");
@@ -107,56 +113,9 @@ function defaultSegment(fromId, toId) {
     opacity: 1,
     texture: "gradient",
     textureData: null,
+    pathType: "bezier",
+    arcBulge: null,
   };
-}
-
-function toRangerKnots(list) {
-  return list.map((k) => SplineKnot.of(k.x, k.y, k.hx, k.hy));
-}
-
-function splitMeshByOrbitSegments(mesh, steps, oSeg, numOrbitSegs, closed) {
-  const vertCount = (mesh.positions.length / 3) | 0;
-  if (steps < 2 || vertCount < steps * 2) return [];
-  const rows = (vertCount / steps) | 0;
-  const out = [];
-
-  for (let oi = 0; oi < numOrbitSegs; oi++) {
-    const faces = [];
-    for (let r = 0; r < rows - 1; r++) {
-      const colMax = closed ? steps : steps - 1;
-      for (let c = 0; c < colMax; c++) {
-        if ((oSeg[c] | 0) !== oi) continue;
-        const cNext = c + 1 >= steps ? 0 : c + 1;
-        const a = r * steps + c;
-        const b = r * steps + cNext;
-        const cc = (r + 1) * steps + cNext;
-        const d = (r + 1) * steps + c;
-        faces.push(a, d, b, b, d, cc);
-      }
-    }
-    if (!faces.length) continue;
-
-    const used = new Map();
-    const positions = [];
-    const normals = [];
-    const uvs = [];
-    const indices = [];
-    const mapV = (g) => {
-      let local = used.get(g);
-      if (local != null) return local;
-      local = used.size;
-      used.set(g, local);
-      const i3 = g * 3;
-      const i2 = g * 2;
-      positions.push(mesh.positions[i3], mesh.positions[i3 + 1], mesh.positions[i3 + 2]);
-      normals.push(mesh.normals[i3], mesh.normals[i3 + 1], mesh.normals[i3 + 2]);
-      uvs.push(mesh.uvs[i2], mesh.uvs[i2 + 1]);
-      return local;
-    };
-    for (let i = 0; i < faces.length; i++) indices.push(mapV(faces[i]));
-    out.push({ orbitSeg: oi, positions, normals, uvs, indices });
-  }
-  return out;
 }
 
 function resolvePartStyle(body, segIndex, which) {
@@ -187,7 +146,7 @@ function resolvePartStyle(body, segIndex, which) {
     const to = solidHex != null ? seg.color : colorB;
     map = makeGradientRgba(from, to, 4, 64);
   }
-  return { colorHex, map, colorA, colorB, seg };
+  return { colorHex, map };
 }
 
 function midColorInt(body, segIndex, which) {
@@ -214,7 +173,6 @@ function resolveCombinedStyle(body, pi, oi) {
   } else {
     colorHex = mulColorHex(midColorInt(body, pi, "profile"), midColorInt(body, oi, "orbit"));
   }
-  // Object-level material tint (bulk default)
   const om = body.objectMaterial;
   if (om?.color) {
     colorHex = mulColorHex(colorHex === 0xffffff ? 0xffffff : colorHex, hexToInt(om.color));
@@ -223,8 +181,7 @@ function resolveCombinedStyle(body, pi, oi) {
   const rough =
     ((pSeg?.roughness ?? om?.roughness ?? 0.4) + (oSeg?.roughness ?? om?.roughness ?? 0.4)) / 2;
   const metal = Math.max(pSeg?.metalness ?? 0, oSeg?.metalness ?? 0, om?.metalness ?? 0);
-  const opacity =
-    (pSeg?.opacity ?? 1) * (oSeg?.opacity ?? 1) * (om?.opacity ?? 1);
+  const opacity = (pSeg?.opacity ?? 1) * (oSeg?.opacity ?? 1) * (om?.opacity ?? 1);
   return {
     colorHex,
     shininess: roughnessToShininess(rough),
@@ -235,13 +192,7 @@ function resolveCombinedStyle(body, pi, oi) {
 }
 
 /**
- * Tessellate one spline body into mesh parts.
- * @param {{
- *   knots: any[], segments: any[],
- *   orbitKnots: any[], orbitSegments: any[],
- *   curveType?: number, pathSegments?: number, angularSteps?: number, revolutionDeg?: number,
- *   objectMaterial?: object
- * }} body
+ * Tessellate one spline body into mesh parts (mixed path types per segment).
  */
 export function tessellateBody(body) {
   const curveType = body.curveType | 0;
@@ -251,59 +202,47 @@ export function tessellateBody(body) {
   const closed = revolutionDeg >= 359.9;
   const nOrb = body.orbitKnots.length;
   const perSpan = Math.max(3, Math.round(angularSteps / Math.max(1, nOrb)));
-  const sampled = SplineLathe.sampleClosedOrbit(
-    toRangerKnots(body.orbitKnots),
-    curveType,
-    perSpan,
-  );
-  let ox = sampled.orbitX.slice();
-  let oy = sampled.orbitY.slice();
-  let oSeg = sampled.profileX.map((x) => x | 0);
 
+  let orbitPts = sampleClosedPath(body.orbitKnots, body.orbitSegments, perSpan, curveType);
   if (!closed) {
-    const half = Math.max(3, Math.floor(ox.length / 2) + 1);
-    ox = ox.slice(0, half);
-    oy = oy.slice(0, half);
-    oSeg = oSeg.slice(0, half);
+    const half = Math.max(3, Math.floor(orbitPts.length / 2) + 1);
+    orbitPts = orbitPts.slice(0, half);
   }
 
-  const steps = ox.length;
+  const profilePts = sampleOpenPath(body.knots, body.segments, pathSegments, curveType);
+  if (profilePts.length < 2 || orbitPts.length < 3) {
+    return { parts: [], verts: 0, tris: 0, orbitCols: 0 };
+  }
+
+  const mesh = latheProfileWithOrbit(profilePts, orbitPts, closed);
+  const pieces = splitLatheBySegments(
+    mesh,
+    Math.max(0, body.knots.length - 1),
+    nOrb,
+    closed,
+  );
+
   const parts = [];
   let totalV = 0;
   let totalT = 0;
-
-  for (let pi = 0; pi < body.knots.length - 1; pi++) {
-    const pair = [body.knots[pi], body.knots[pi + 1]];
-    const mesh = SplineLathe.sampleAndLatheOrbit(
-      toRangerKnots(pair),
-      curveType,
-      pathSegments,
-      ox,
-      oy,
-      0,
-      steps,
-      closed,
-    );
-    const pieces = splitMeshByOrbitSegments(mesh, steps, oSeg, nOrb, closed);
-    for (const piece of pieces) {
-      const style = resolveCombinedStyle(body, pi, piece.orbitSeg);
-      parts.push({
-        positions: piece.positions,
-        normals: piece.normals,
-        uvs: piece.uvs,
-        indices: piece.indices,
-        colorHex: style.colorHex,
-        shininess: style.shininess,
-        reflectivity: style.reflectivity,
-        opacity: style.opacity,
-        mapRgba: style.map ? Array.from(style.map.rgba) : null,
-        mapW: style.map ? style.map.w : 0,
-        mapH: style.map ? style.map.h : 0,
-      });
-      totalV += (piece.positions.length / 3) | 0;
-      totalT += (piece.indices.length / 3) | 0;
-    }
+  for (const piece of pieces) {
+    const style = resolveCombinedStyle(body, piece.profileSeg, piece.orbitSeg);
+    parts.push({
+      positions: piece.positions,
+      normals: piece.normals,
+      uvs: piece.uvs,
+      indices: piece.indices,
+      colorHex: style.colorHex,
+      shininess: style.shininess,
+      reflectivity: style.reflectivity,
+      opacity: style.opacity,
+      mapRgba: style.map ? Array.from(style.map.rgba) : null,
+      mapW: style.map ? style.map.w : 0,
+      mapH: style.map ? style.map.h : 0,
+    });
+    totalV += (piece.positions.length / 3) | 0;
+    totalT += (piece.indices.length / 3) | 0;
   }
 
-  return { parts, verts: totalV, tris: totalT, orbitCols: steps };
+  return { parts, verts: totalV, tris: totalT, orbitCols: orbitPts.length };
 }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/pathSample.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/pathSample.js
@@ -1,0 +1,312 @@
+// ============================================================================
+// pathSample.js — per-segment path types (bezier | line | arc), SVG-path style.
+// ============================================================================
+
+import { SplineLathe } from "../../../tessellate/spline_lathe.mjs";
+
+/** @typedef {'bezier'|'line'|'arc'} PathType */
+
+export function normalizePathType(t) {
+  if (t === "line" || t === "linear" || t === "L") return "line";
+  if (t === "arc" || t === "A") return "arc";
+  return "bezier";
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function sampleLine(a, b, t) {
+  return {
+    p: { x: lerp(a.x, b.x, t), y: lerp(a.y, b.y, t) },
+    tan: { x: b.x - a.x, y: b.y - a.y },
+  };
+}
+
+function sampleBezier(a, b, t) {
+  return {
+    p: SplineLathe.bezierPoint(
+      a.x,
+      a.y,
+      a.x + a.hx,
+      a.y + a.hy,
+      b.x - b.hx,
+      b.y - b.hy,
+      b.x,
+      b.y,
+      t,
+    ),
+    tan: SplineLathe.bezierTangent(
+      a.x,
+      a.y,
+      a.x + a.hx,
+      a.y + a.hy,
+      b.x - b.hx,
+      b.y - b.hy,
+      b.x,
+      b.y,
+      t,
+    ),
+  };
+}
+
+function sampleCatmull(a, b, t) {
+  return {
+    p: SplineLathe.catmullPoint(a.x, a.y, a.x, a.y, b.x, b.y, b.x, b.y, t),
+    tan: SplineLathe.catmullTangent(a.x, a.y, a.x, a.y, b.x, b.y, b.x, b.y, t),
+  };
+}
+
+function circumcenter(ax, ay, bx, by, cx, cy) {
+  const d = 2 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by));
+  if (Math.abs(d) < 1e-12) return null;
+  const ax2 = ax * ax + ay * ay;
+  const bx2 = bx * bx + by * by;
+  const cx2 = cx * cx + cy * cy;
+  const ux = (ax2 * (by - cy) + bx2 * (cy - ay) + cx2 * (ay - by)) / d;
+  const uy = (ax2 * (cx - bx) + bx2 * (ax - cx) + cx2 * (bx - ax)) / d;
+  return { x: ux, y: uy };
+}
+
+function angleDelta(from, to) {
+  let d = to - from;
+  while (d > Math.PI) d -= Math.PI * 2;
+  while (d < -Math.PI) d += Math.PI * 2;
+  return d;
+}
+
+/**
+ * Circular arc A→B. `bulge` = signed sagitta (distance of arc midpoint from chord).
+ * Positive = left of A→B chord.
+ */
+export function sampleArc(a, b, t, bulge) {
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const chord = Math.hypot(dx, dy);
+  if (chord < 1e-9) return sampleLine(a, b, t);
+  const nx = -dy / chord;
+  const ny = dx / chord;
+  const bul =
+    bulge != null && Number.isFinite(bulge) ? bulge : defaultArcBulge(a, b);
+  if (Math.abs(bul) < 1e-9) return sampleLine(a, b, t);
+
+  const mx = (a.x + b.x) / 2 + nx * bul;
+  const my = (a.y + b.y) / 2 + ny * bul;
+  const c = circumcenter(a.x, a.y, mx, my, b.x, b.y);
+  if (!c) return sampleLine(a, b, t);
+
+  const a0 = Math.atan2(a.y - c.y, a.x - c.x);
+  const am = Math.atan2(my - c.y, mx - c.x);
+  const a1 = Math.atan2(b.y - c.y, b.x - c.x);
+  const sweep = angleDelta(a0, am) + angleDelta(am, a1);
+  const ang = a0 + sweep * t;
+  const r = Math.hypot(a.x - c.x, a.y - c.y);
+  const s = Math.sign(sweep) || 1;
+  return {
+    p: { x: c.x + r * Math.cos(ang), y: c.y + r * Math.sin(ang) },
+    tan: { x: -r * Math.sin(ang) * s, y: r * Math.cos(ang) * s },
+  };
+}
+
+export function defaultArcBulge(a, b) {
+  const chord = Math.hypot(b.x - a.x, b.y - a.y) || 1;
+  // Prefer handle bias when present
+  const hx = a.hx || 0;
+  const hy = a.hy || 0;
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  const cross = dx * hy - dy * hx;
+  const sign = cross === 0 ? 1 : Math.sign(cross);
+  return sign * chord * 0.25;
+}
+
+/**
+ * Evaluate one span. `curveType` 0=bezier family, 1=catmull (only when pathType bezier).
+ */
+export function evalSpan(a, b, t, { pathType = "bezier", curveType = 0, arcBulge = null } = {}) {
+  const kind = normalizePathType(pathType);
+  if (kind === "line") return sampleLine(a, b, t);
+  if (kind === "arc") return sampleArc(a, b, t, arcBulge);
+  if (curveType === 1) return sampleCatmull(a, b, t);
+  return sampleBezier(a, b, t);
+}
+
+/**
+ * Sample an open knot chain (profile). Each span uses segments[i].pathType.
+ * @returns {{ x:number, y:number, tx:number, ty:number, segmentIndex:number, t:number }[]}
+ */
+export function sampleOpenPath(knots, segments, samplesPerSpan, curveType = 0) {
+  const pts = [];
+  if (!knots || knots.length < 2) return pts;
+  const segN = Math.max(1, samplesPerSpan | 0);
+  for (let i = 0; i < knots.length - 1; i++) {
+    const a = knots[i];
+    const b = knots[i + 1];
+    const seg = segments?.[i];
+    const opts = {
+      pathType: seg?.pathType || "bezier",
+      curveType,
+      arcBulge: seg?.arcBulge ?? null,
+    };
+    const last = i < knots.length - 2 ? segN - 1 : segN;
+    for (let s = 0; s <= last; s++) {
+      const t = s / segN;
+      const { p, tan } = evalSpan(a, b, t, opts);
+      pts.push({
+        x: Math.max(0, p.x),
+        y: p.y,
+        tx: tan.x,
+        ty: tan.y,
+        segmentIndex: i,
+        t,
+      });
+    }
+  }
+  return pts;
+}
+
+/**
+ * Sample a closed knot loop (orbit). segments.length === knots.length.
+ */
+export function sampleClosedPath(knots, segments, samplesPerSpan, curveType = 0) {
+  const pts = [];
+  if (!knots || knots.length < 2) return pts;
+  const n = knots.length;
+  const segN = Math.max(1, samplesPerSpan | 0);
+  for (let i = 0; i < n; i++) {
+    const a = knots[i];
+    const b = knots[(i + 1) % n];
+    const seg = segments?.[i];
+    const opts = {
+      pathType: seg?.pathType || "bezier",
+      curveType,
+      arcBulge: seg?.arcBulge ?? null,
+    };
+    for (let s = 0; s < segN; s++) {
+      const t = s / segN;
+      const { p, tan } = evalSpan(a, b, t, opts);
+      pts.push({
+        x: p.x,
+        y: p.y,
+        tx: tan.x,
+        ty: tan.y,
+        segmentIndex: i,
+        t,
+      });
+    }
+  }
+  return pts;
+}
+
+/**
+ * Revolve a sampled open profile around Y using orbit direction samples (ox, oy).
+ * Returns a single mesh buffer (all profile rows × orbit cols) plus rowSeg meta.
+ */
+export function latheProfileWithOrbit(profilePts, orbitPts, closed) {
+  const rows = profilePts.length;
+  const steps = orbitPts.length;
+  const positions = [];
+  const normals = [];
+  const uvs = [];
+  const indices = [];
+  const rowSeg = profilePts.map((p) => p.segmentIndex | 0);
+  const colSeg = orbitPts.map((p) => p.segmentIndex | 0);
+
+  for (let row = 0; row < rows; row++) {
+    const pr = profilePts[row];
+    const radius = Math.max(0, pr.x);
+    const yy = pr.y;
+    let pnx = pr.ty;
+    let pny = -pr.tx;
+    let pnl = Math.hypot(pnx, pny);
+    if (pnl < 1e-9) {
+      pnx = 1;
+      pny = 0;
+      pnl = 1;
+    }
+    pnx /= pnl;
+    pny /= pnl;
+    if (pnx < 0) {
+      pnx = -pnx;
+      pny = -pny;
+    }
+
+    for (let col = 0; col < steps; col++) {
+      const o = orbitPts[col];
+      const ct = o.x;
+      const st = o.y;
+      const olen = Math.hypot(ct, st);
+      const nct = olen < 1e-9 ? 1 : ct / olen;
+      const nst = olen < 1e-9 ? 0 : st / olen;
+      positions.push(radius * ct, yy, radius * st);
+      normals.push(pnx * nct, pny, pnx * nst);
+      uvs.push(col / steps, rows <= 1 ? 0 : row / (rows - 1));
+    }
+  }
+
+  for (let r = 0; r < rows - 1; r++) {
+    const colMax = closed ? steps : steps - 1;
+    for (let c = 0; c < colMax; c++) {
+      const cNext = c + 1 >= steps ? 0 : c + 1;
+      const a = r * steps + c;
+      const b = r * steps + cNext;
+      const cc = (r + 1) * steps + cNext;
+      const d = (r + 1) * steps + c;
+      indices.push(a, d, b, b, d, cc);
+    }
+  }
+
+  return { positions, normals, uvs, indices, rowSeg, colSeg, rows, steps };
+}
+
+/**
+ * Split a full lathe mesh into profileSeg × orbitSeg parts (own buffers).
+ */
+export function splitLatheBySegments(mesh, numProfileSegs, numOrbitSegs, closed) {
+  const { positions, normals, uvs, indices, rowSeg, colSeg, rows, steps } = mesh;
+  const out = [];
+
+  for (let pi = 0; pi < numProfileSegs; pi++) {
+    for (let oi = 0; oi < numOrbitSegs; oi++) {
+      const faces = [];
+      for (let r = 0; r < rows - 1; r++) {
+        if ((rowSeg[r] | 0) !== pi && (rowSeg[r + 1] | 0) !== pi) {
+          // allow row on boundary: use rowSeg[r]
+        }
+        if ((rowSeg[r] | 0) !== pi) continue;
+        const colMax = closed ? steps : steps - 1;
+        for (let c = 0; c < colMax; c++) {
+          if ((colSeg[c] | 0) !== oi) continue;
+          const cNext = c + 1 >= steps ? 0 : c + 1;
+          const a = r * steps + c;
+          const b = r * steps + cNext;
+          const cc = (r + 1) * steps + cNext;
+          const d = (r + 1) * steps + c;
+          faces.push(a, d, b, b, d, cc);
+        }
+      }
+      if (!faces.length) continue;
+
+      const used = new Map();
+      const p = [];
+      const n = [];
+      const u = [];
+      const idx = [];
+      const mapV = (g) => {
+        let local = used.get(g);
+        if (local != null) return local;
+        local = used.size;
+        used.set(g, local);
+        const i3 = g * 3;
+        const i2 = g * 2;
+        p.push(positions[i3], positions[i3 + 1], positions[i3 + 2]);
+        n.push(normals[i3], normals[i3 + 1], normals[i3 + 2]);
+        u.push(uvs[i2], uvs[i2 + 1]);
+        return local;
+      };
+      for (let i = 0; i < faces.length; i++) idx.push(mapV(faces[i]));
+      out.push({ profileSeg: pi, orbitSeg: oi, positions: p, normals: n, uvs: u, indices: idx });
+    }
+  }
+  return out;
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -62,6 +62,8 @@ function mapSegments(list, knots, closed) {
     opacity: Number(s.opacity ?? 1),
     texture: s.texture || "gradient",
     textureAsset: s.textureAsset || null,
+    pathType: s.pathType === "line" || s.pathType === "arc" ? s.pathType : "bezier",
+    arcBulge: s.arcBulge == null || s.arcBulge === "" ? null : Number(s.arcBulge),
   }));
   while (segments.length < want) {
     const i = segments.length;
@@ -76,6 +78,8 @@ function mapSegments(list, knots, closed) {
       opacity: 1,
       texture: "gradient",
       textureAsset: null,
+      pathType: "bezier",
+      arcBulge: null,
     });
   }
   return segments.slice(0, want);
@@ -195,6 +199,37 @@ function normalizeV3(doc) {
   };
 }
 
+function ensureSegPathTypes(segments) {
+  return (segments || []).map((s) => ({
+    ...s,
+    pathType: s.pathType === "line" || s.pathType === "arc" ? s.pathType : "bezier",
+    arcBulge: s.arcBulge == null || s.arcBulge === "" ? null : Number(s.arcBulge),
+  }));
+}
+
+function normalizeV4(doc) {
+  const v3 = normalizeV3(doc);
+  v3.schemaVersion = 4;
+  v3.profile = {
+    ...v3.profile,
+    segments: ensureSegPathTypes(v3.profile.segments),
+  };
+  v3.orbit = {
+    ...v3.orbit,
+    segments: ensureSegPathTypes(v3.orbit.segments),
+  };
+  const emb = {};
+  for (const [guid, body] of Object.entries(v3.embeddedAssets || {})) {
+    emb[guid] = {
+      ...body,
+      segments: ensureSegPathTypes(body.segments),
+      orbitSegments: ensureSegPathTypes(body.orbitSegments),
+    };
+  }
+  v3.embeddedAssets = emb;
+  return v3;
+}
+
 /** @type {Record<number, (doc: any) => any>} */
 const STEPS = {
   1(doc) {
@@ -203,9 +238,12 @@ const STEPS = {
   2(doc) {
     return normalizeV2(doc);
   },
-  // 2 → 3: assetGuid, objectMaterial, embeddedAssets, children
   3(doc) {
     return normalizeV3(doc);
+  },
+  // 3 → 4: per-segment pathType (bezier|line|arc) + optional arcBulge
+  4(doc) {
+    return normalizeV4(doc);
   },
 };
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -2,7 +2,7 @@
 // schema.js — semantic spline-project document + versioned migrations.
 // ============================================================================
 
-export const CURRENT_SCHEMA_VERSION = 3;
+export const CURRENT_SCHEMA_VERSION = 4;
 
 export const SCHEMA_KIND = "ranger.splineProject";
 
@@ -43,6 +43,8 @@ export function newId() {
 }
 
 export function serializeSegment(seg) {
+  const pathType =
+    seg.pathType === "line" || seg.pathType === "arc" ? seg.pathType : "bezier";
   return {
     fromId: seg.fromId,
     toId: seg.toId,
@@ -52,6 +54,8 @@ export function serializeSegment(seg) {
     opacity: Number(seg.opacity ?? 1),
     texture: seg.texture || "gradient",
     textureAsset: seg.textureAsset || null,
+    pathType,
+    arcBulge: seg.arcBulge == null || seg.arcBulge === "" ? null : Number(seg.arcBulge),
   };
 }
 

--- a/gallery/game_engine/v2/mesh_editor/library/README.md
+++ b/gallery/game_engine/v2/mesh_editor/library/README.md
@@ -35,6 +35,7 @@ copy or symlink selected folders into a tracked tree, or temporarily force-add.
 - Migrations: `app/src/library/migrations.js` — every load upgrades to current
 - v2 adds a closed `orbit` Bezier path (unit circle by default) alongside `profile`
 - v3 adds `assetGuid`, `objectMaterial`, `embeddedAssets`, and `children` (sub-object instances)
+- v4 adds per-segment `pathType` (`bezier` \| `line` \| `arc`) and optional `arcBulge`
 
 When you change the document shape, bump the version and add a step; old folders
 keep working.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Path types (SVG-style)
Each profile / orbit segment can be independently:
- **Bezier** — cubic with handles (default)
- **Line** — straight chord
- **Arc** — circular arc; optional **bulge** (signed sagitta), else ~¼ chord

Mix along a path (Bezier → line → arc…). Choose in segment **Details**. Handles only show when an adjacent segment is Bezier.

Tessellation samples in JS (`pathSample.js`) so mixed types work for both profile and orbit.

### Undo / redo
Immutable shape snapshot buffer (`editHistory.js`) — no new dependency (Zustand not required).
- Toolbar **Undo** / **Redo**
- `Ctrl+Z` / `Ctrl+Shift+Z` (or `Ctrl+Y`)
- Gestures (drag) push once at start; discrete edits push before mutate

### Schema
**v4**: `pathType` + optional `arcBulge` on segments; migrates from v3.

### Verify
1. Open a segment’s Details → set **Straight line** / **Circular arc** → Tessellate
2. Drag a knot → **Undo** restores previous shape
3. Mix Bezier + line on the silhouette and confirm the canvas matches the mesh
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

