### PR TITLE
Fix spine lathe to keep raw orbit scale on positions

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-spine.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-spine.mjs
@@ -33,6 +33,23 @@ function sampleUnitOrbit() {
   return pts;
 }
 
+/** Non-unit ellipse — classic lathe must keep radius scale, not unitize positions. */
+function sampleScaledOrbit() {
+  const n = 8;
+  const pts = [];
+  for (let i = 0; i < n; i++) {
+    const t = (i / n) * Math.PI * 2;
+    pts.push({
+      x: 1.5 * Math.cos(t),
+      y: 0.6 * Math.sin(t),
+      tx: -1.5 * Math.sin(t),
+      ty: 0.6 * Math.cos(t),
+      segmentIndex: 0,
+    });
+  }
+  return pts;
+}
+
 const profile = sampleDiscProfile();
 const orbit = sampleUnitOrbit();
 
@@ -54,6 +71,33 @@ for (let i = 0; i < straight.positions.length; i++) {
   maxDiff = Math.max(maxDiff, Math.abs(straight.positions[i] - classic.positions[i]));
 }
 assert.ok(maxDiff < 1e-4, `straight spine should match classic (maxDiff=${maxDiff})`);
+
+const scaled = sampleScaledOrbit();
+const classicScaled = latheProfileWithOrbitOnSpine(profile, scaled, true, null, null);
+const spineScaled = latheProfileWithOrbitOnSpine(
+  profile,
+  scaled,
+  true,
+  { knots: straightK, segments: straightS },
+  { knots: straightK, segments: straightS },
+);
+let scaledDiff = 0;
+for (let i = 0; i < classicScaled.positions.length; i++) {
+  scaledDiff = Math.max(
+    scaledDiff,
+    Math.abs(classicScaled.positions[i] - spineScaled.positions[i]),
+  );
+}
+assert.ok(
+  scaledDiff < 1e-4,
+  `straight spine must keep raw orbit scale (scaledDiff=${scaledDiff})`,
+);
+// Sanity: scaled orbit must actually stretch vs unit orbit
+let stretch = 0;
+for (let i = 0; i < classic.positions.length; i++) {
+  stretch = Math.max(stretch, Math.abs(classicScaled.positions[i] - classic.positions[i]));
+}
+assert.ok(stretch > 0.1, `scaled orbit should differ from unit (stretch=${stretch})`);
 
 const bentK = [
   { id: "b0", x: 0, y: -1, hx: 0, hy: 0, color: "#fff" },
@@ -153,6 +197,7 @@ assert.equal(errs.length, 0, errs.join("; "));
 
 console.log("smoke-spine: ok", {
   maxDiffStraight: maxDiff,
+  scaledOrbitDiff: scaledDiff,
   bentMoved: moved,
   schema: mig.doc.schemaVersion,
 });

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/spineLathe.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/spineLathe.js
@@ -131,7 +131,8 @@ export function buildSpineFrames(centers) {
 }
 
 /**
- * Lathe along spine. When spines are straight x=0, matches classic (r·ox, y, r·oy).
+ * Lathe along spine. When spines are straight x=0, matches classic
+ * `(r·ox, y, r·oy)` — orbit is a scale on positions; only normals unitize.
  */
 export function latheProfileWithOrbitOnSpine(profilePts, orbitPts, closed, spineProfile, spineOrbit) {
   const rows = profilePts.length;
@@ -204,13 +205,15 @@ export function latheProfileWithOrbitOnSpine(profilePts, orbitPts, closed, spine
       const o = orbitPts[col];
       const ct = o.x;
       const st = o.y;
+      // Positions use raw orbit as a scale (same as classic lathe / Ranger).
+      // Normals use the unit direction so non-circular orbits still shade cleanly.
       const olen = Math.hypot(ct, st);
       const nct = olen < 1e-9 ? 1 : ct / olen;
       const nst = olen < 1e-9 ? 0 : st / olen;
 
-      const ox = fr.N.x * (radius * nct) + fr.B.x * (radius * nst);
-      const oy = fr.N.y * (radius * nct) + fr.B.y * (radius * nst);
-      const oz = fr.N.z * (radius * nct) + fr.B.z * (radius * nst);
+      const ox = fr.N.x * (radius * ct) + fr.B.x * (radius * st);
+      const oy = fr.N.y * (radius * ct) + fr.B.y * (radius * st);
+      const oz = fr.N.z * (radius * ct) + fr.B.z * (radius * st);
       positions.push(fr.C.x + ox, fr.C.y + oy, fr.C.z + oz);
 
       const nx = fr.N.x * (pnx * nct) + fr.T.x * pny + fr.B.x * (pnx * nst);


### PR DESCRIPTION
Match classic/Ranger: positions use radius·(ox,oy); only normals unitize the orbit direction so non-circular orbits keep their scale.