### PR TITLE
Add torus tessellation mode alongside rotation lathe

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -58,11 +58,18 @@ mesh_editor/
 
 ## Tessellate
 
+Two modes (`editor.tessellationMode`):
+
+| Mode | Behaviour |
+|------|-----------|
+| **Rotation** (default) | Classic lathe: profile revolved using orbit as direction scales `(r·ox, y, r·oy)`, optionally along a spine centerline |
+| **Torus** | Profile is swept as a tube cross-section along the **orbit path** (major ring). The ring is **unit-sized**: profile + major radius are scaled so outer ≈ 1. Spine modulates major radius (profile-spine X) and lifts the ring (orbit-spine X → Y) |
+
+Shared steps:
+
 1. Sample the **profile** curve (Bezier default, or Catmull-Rom)
-2. Sample the closed **orbit** path; each sample `(ox, oy)` replaces `(cos θ, sin θ)`
-3. Sample **spineProfile** + **spineOrbit** along profile height `u`; center
-   `(spineX, spineY, spineZ)` with frames → place `radius · orbit` in the local N/B plane
-   (straight spines ⇒ classic `(r·ox, y, r·oy)`)
+2. Sample the closed **orbit** path
+3. Apply the active mode kernel (rotation lathe or torus sweep), with optional spines
 4. **Orbit samples N** is distributed across orbit spans (`≈ N / orbitKnots`)
 5. **360° closed**: faces wrap the last orbit column to the first
 6. **180°**: use the first half of the orbit samples; faces do **not** wrap

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
@@ -1,61 +1,95 @@
 #!/usr/bin/env node
-// Smoke: placement normal defaults, alignment rotation, migration v5→v6.
+// Smoke: torus unit-fit, ring topology, spine radius mod, v6→v7 migration.
 import assert from "node:assert/strict";
 import {
-  defaultPlacementNormal,
-  normalizePlacementNormal,
-  placementNormalDirection3,
-  rotationAligning,
-  orientMeshToPlacementNormal,
-  rotateFlatXyz,
-} from "../src/lib/placementNormal.js";
+  latheProfileAsTorusOnSpine,
+  torusUnitFitScale,
+  defaultSpineKnots,
+  defaultSpineSegments,
+} from "../src/lib/spineLathe.js";
 import { migrateProject } from "../src/library/migrations.js";
 import { CURRENT_SCHEMA_VERSION, validateProject } from "../src/library/schema.js";
 
-const d = defaultPlacementNormal();
-assert.deepEqual(d.start, { x: 0, y: -1 });
-assert.deepEqual(d.end, { x: 0, y: 1 });
-const dir = placementNormalDirection3(d);
-assert.ok(Math.abs(dir.x) < 1e-9 && dir.y > 0.99 && Math.abs(dir.z) < 1e-9);
+function discProfile() {
+  return [
+    { x: 0, y: -0.4, tx: 0, ty: 1, segmentIndex: 0 },
+    { x: 0.35, y: 0, tx: 1, ty: 0, segmentIndex: 0 },
+    { x: 0, y: 0.4, tx: 0, ty: 1, segmentIndex: 0 },
+  ];
+}
 
-// Align +X → +Y
-const m = rotationAligning({ x: 1, y: 0, z: 0 }, { x: 0, y: 1, z: 0 });
-const p = rotateFlatXyz([1, 0, 0], m);
-assert.ok(Math.abs(p[0]) < 1e-6 && Math.abs(p[1] - 1) < 1e-6 && Math.abs(p[2]) < 1e-6);
+function unitOrbit(n = 16) {
+  const pts = [];
+  for (let i = 0; i < n; i++) {
+    const t = (i / n) * Math.PI * 2;
+    pts.push({
+      x: Math.cos(t),
+      y: Math.sin(t),
+      tx: -Math.sin(t),
+      ty: Math.cos(t),
+      segmentIndex: 0,
+    });
+  }
+  return pts;
+}
 
-// Mesh with point on +X should flip to +Y when normal is +X
-const mesh = {
-  parts: [
-    {
-      positions: [0.5, 0, 0, 0.5, 0, 0.1],
-      normals: [1, 0, 0, 1, 0, 0],
-      uvs: [],
-      indices: [0, 1, 0],
-    },
-  ],
-};
-const oriented = orientMeshToPlacementNormal(mesh, {
-  start: { x: 0, y: 0 },
-  end: { x: 1, y: 0 },
-});
-assert.ok(Math.abs(oriented.parts[0].positions[0]) < 1e-6);
-assert.ok(Math.abs(oriented.parts[0].positions[1] - 0.5) < 1e-6);
+const profile = discProfile();
+const orbit = unitOrbit(24);
+const { scale, majorR, tubeR } = torusUnitFitScale(profile, orbit);
+assert.ok(Math.abs(majorR - 1) < 1e-6);
+assert.ok(tubeR > 0.3);
+assert.ok(Math.abs(scale * (majorR + tubeR) - 1) < 1e-6);
 
-// Default normal → identity (same positions)
-const same = orientMeshToPlacementNormal(mesh, defaultPlacementNormal());
-assert.equal(same.parts[0].positions[0], 0.5);
+const straightK = defaultSpineKnots(() => "t" + Math.random().toString(36).slice(2, 6));
+const straightS = defaultSpineSegments(straightK);
+const mesh = latheProfileAsTorusOnSpine(
+  profile,
+  orbit,
+  true,
+  { knots: straightK, segments: straightS },
+  { knots: straightK, segments: straightS },
+);
 
-const n = normalizePlacementNormal({ start: { x: "nope" }, end: {} });
-assert.equal(n.start.y, -1);
-assert.equal(n.end.y, 1);
+assert.equal(mesh.rows, profile.length);
+assert.equal(mesh.steps, orbit.length);
+assert.equal(mesh.positions.length, profile.length * orbit.length * 3);
 
-const v5 = {
+// Outer radius should be ~1 (unit torus)
+let maxR = 0;
+for (let i = 0; i < mesh.positions.length; i += 3) {
+  maxR = Math.max(
+    maxR,
+    Math.hypot(mesh.positions[i], mesh.positions[i + 1], mesh.positions[i + 2]),
+  );
+}
+assert.ok(maxR > 0.85 && maxR < 1.15, `unit outer radius expected ~1, got ${maxR}`);
+
+// Bent profile-spine should change major radius
+const bentK = [
+  { id: "b0", x: 0, y: -1, hx: 0, hy: 0, color: "#fff" },
+  { id: "b1", x: 0.4, y: 0, hx: 0, hy: 0, color: "#fff" },
+  { id: "b2", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+];
+const bent = latheProfileAsTorusOnSpine(
+  profile,
+  orbit,
+  true,
+  { knots: bentK, segments: defaultSpineSegments(bentK) },
+  { knots: straightK, segments: straightS },
+);
+let moved = 0;
+for (let i = 0; i < mesh.positions.length; i++) {
+  moved = Math.max(moved, Math.abs(bent.positions[i] - mesh.positions[i]));
+}
+assert.ok(moved > 0.02, `spine should modulate torus (moved=${moved})`);
+
+const v6 = {
   kind: "ranger.splineProject",
-  schemaVersion: 5,
+  schemaVersion: 6,
   id: "t1",
   assetGuid: "g1",
-  slug: "smoke-normal",
-  name: "Smoke normal",
+  slug: "smoke-torus",
+  name: "Smoke torus",
   description: "",
   tags: [],
   createdAt: "2026-01-01T00:00:00.000Z",
@@ -71,6 +105,7 @@ const v5 = {
     spineSource: "profile",
   },
   objectMaterial: { color: null, roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient" },
+  placementNormal: { start: { x: 0, y: -1 }, end: { x: 0, y: 1 } },
   profile: {
     knots: [
       { id: "p0", x: 0, y: -1, hx: 0, hy: 0, color: "#7ecf6a" },
@@ -118,14 +153,12 @@ const v5 = {
   children: [],
 };
 
-const mig = migrateProject(v5);
+const mig = migrateProject(v6);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
 assert.equal(mig.doc.schemaVersion, CURRENT_SCHEMA_VERSION);
 assert.equal(CURRENT_SCHEMA_VERSION, 7);
-assert.deepEqual(mig.doc.placementNormal.start, { x: 0, y: -1 });
-assert.deepEqual(mig.doc.placementNormal.end, { x: 0, y: 1 });
 assert.equal(mig.doc.editor.tessellationMode, "rotation");
 const errs = validateProject(mig.doc);
 assert.equal(errs.length, 0, errs.join("; "));
 
-console.log("smoke-placement-normal: ok", { schema: mig.doc.schemaVersion });
+console.log("smoke-torus: ok", { maxR, moved, schema: mig.doc.schemaVersion, scale });

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -292,6 +292,13 @@ onBeforeUnmount(() => {
         <input v-model.number="state.angularSteps" type="number" min="3" max="96" />
       </label>
       <label class="field">
+        Tessellation
+        <select v-model="state.tessellationMode" @change="onTessellate">
+          <option value="rotation">Rotation (lathe)</option>
+          <option value="torus">Torus (ring sweep)</option>
+        </select>
+      </label>
+      <label class="field">
         Revolution
         <select v-model.number="state.revolutionDeg" @change="onTessellate">
           <option :value="360">360° closed</option>

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -159,6 +159,7 @@ export function useSplineEditor() {
     pathSegments: 12,
     angularSteps: 24,
     revolutionDeg: 360,
+    tessellationMode: "rotation", // rotation | torus
     materialMode: 3,
     symmetry: true,
     viewport: { min: -1.1, max: 1.1 },
@@ -559,6 +560,7 @@ export function useSplineEditor() {
     state.spineOrbitSegments = [];
     state.spineSource = "profile";
     state.placementNormal = defaultPlacementNormal();
+    state.tessellationMode = "rotation";
     state.objectMaterial = defaultObjectMaterial();
     state.embeddedAssets = {};
     state.children = [];
@@ -840,6 +842,7 @@ export function useSplineEditor() {
       pathSegments: state.pathSegments,
       angularSteps: state.angularSteps,
       revolutionDeg: state.revolutionDeg,
+      tessellationMode: state.tessellationMode === "torus" ? "torus" : "rotation",
       objectMaterial: state.objectMaterial,
       knots: state.knots,
       segments: state.segments,
@@ -1070,6 +1073,7 @@ export function useSplineEditor() {
     state.pathSegments = ed.pathSegments || 12;
     state.angularSteps = ed.angularSteps || 24;
     state.revolutionDeg = ed.revolutionDeg || 360;
+    state.tessellationMode = ed.tessellationMode === "torus" ? "torus" : "rotation";
     state.materialMode = ed.materialMode ?? 3;
     state.symmetry = ed.symmetry !== false;
     state.viewMode =
@@ -1163,6 +1167,7 @@ export function useSplineEditor() {
         pathSegments: body.pathSegments,
         angularSteps: body.angularSteps,
         revolutionDeg: body.revolutionDeg,
+        tessellationMode: body.tessellationMode === "torus" ? "torus" : "rotation",
         objectMaterial: { ...body.objectMaterial },
         knots: body.knots.map((k) => ({ ...k })),
         segments: body.segments.map(mapSegSnapshot),
@@ -1180,6 +1185,7 @@ export function useSplineEditor() {
       pathSegments: state.pathSegments,
       angularSteps: state.angularSteps,
       revolutionDeg: state.revolutionDeg,
+      tessellationMode: state.tessellationMode === "torus" ? "torus" : "rotation",
       materialMode: state.materialMode,
       symmetry: state.symmetry,
       viewMode: state.viewMode,

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/assetClone.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/assetClone.js
@@ -86,6 +86,7 @@ export function cloneBodyContent(src, { preserveGuid = false, name = "Sub-object
     pathSegments: ed.pathSegments || 12,
     angularSteps: ed.angularSteps || 24,
     revolutionDeg: ed.revolutionDeg || 360,
+    tessellationMode: ed.tessellationMode === "torus" || src.tessellationMode === "torus" ? "torus" : "rotation",
     objectMaterial: src.objectMaterial
       ? { ...src.objectMaterial }
       : { color: null, roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient" },
@@ -109,6 +110,7 @@ export function snapshotRootAsBody(state) {
     pathSegments: state.pathSegments,
     angularSteps: state.angularSteps,
     revolutionDeg: state.revolutionDeg,
+    tessellationMode: state.tessellationMode === "torus" ? "torus" : "rotation",
     objectMaterial: { ...state.objectMaterial },
     knots: state.knots.map((k) => ({ ...k })),
     segments: state.segments.map((s) => ({

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/latheTessellate.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/latheTessellate.js
@@ -8,7 +8,7 @@ import {
   sampleClosedPath,
   splitLatheBySegments,
 } from "./pathSample.js";
-import { latheProfileWithOrbitOnSpine } from "./spineLathe.js";
+import { latheProfileWithOrbitOnSpine, latheProfileAsTorusOnSpine } from "./spineLathe.js";
 
 function hexToRgb(hex) {
   const h = String(hex || "#ffffff").replace("#", "");
@@ -223,13 +223,13 @@ export function tessellateBody(body) {
     segments: body.spineOrbitSegments || [],
   };
   // Fall back to straight vertical if spines missing
-  const mesh = latheProfileWithOrbitOnSpine(
-    profilePts,
-    orbitPts,
-    closed,
-    spineProfile.knots.length >= 2 ? spineProfile : null,
-    spineOrbit.knots.length >= 2 ? spineOrbit : null,
-  );
+  const mode = body.tessellationMode === "torus" ? "torus" : "rotation";
+  const spIn = spineProfile.knots.length >= 2 ? spineProfile : null;
+  const soIn = spineOrbit.knots.length >= 2 ? spineOrbit : null;
+  const mesh =
+    mode === "torus"
+      ? latheProfileAsTorusOnSpine(profilePts, orbitPts, closed, spIn, soIn)
+      : latheProfileWithOrbitOnSpine(profilePts, orbitPts, closed, spIn, soIn);
   const pieces = splitLatheBySegments(
     mesh,
     Math.max(0, body.knots.length - 1),

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/spineLathe.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/spineLathe.js
@@ -239,3 +239,137 @@ export function latheProfileWithOrbitOnSpine(profilePts, orbitPts, closed, spine
 
   return { positions, normals, uvs, indices, rowSeg, colSeg, rows, steps };
 }
+
+/**
+ * Unit-fit scale so major orbit radius R plus profile extent r fits in ~unit ball:
+ * s = 1 / (R + r).
+ */
+export function torusUnitFitScale(profilePts, orbitPts) {
+  let R = 0;
+  let n = 0;
+  for (const o of orbitPts || []) {
+    const L = Math.hypot(o.x, o.y);
+    if (L > 1e-9) {
+      R += L;
+      n++;
+    }
+  }
+  R = n ? R / n : 1;
+  let r = 0;
+  for (const p of profilePts || []) {
+    r = Math.max(r, Math.hypot(Math.max(0, p.x), p.y));
+  }
+  if (r < 1e-9) r = 0.25;
+  return { scale: 1 / (R + r), majorR: R, tubeR: r };
+}
+
+/**
+ * Torus / tube-sweep mode: profile travels along the orbit path as a ring.
+ * Orbit = major path (XZ). Profile = tube cross-section in the path normal plane (N,B).
+ * Everything is scaled so R_major + r_profile ≈ 1 (unit torus).
+ * Spine modulates major radius (profile-spine.x) and lifts the ring (orbit-spine.x → Y).
+ */
+export function latheProfileAsTorusOnSpine(
+  profilePts,
+  orbitPts,
+  closed,
+  spineProfile,
+  spineOrbit,
+) {
+  const rows = profilePts.length;
+  const steps = orbitPts.length;
+  const positions = [];
+  const normals = [];
+  const uvs = [];
+  const indices = [];
+  const rowSeg = profilePts.map((p) => p.segmentIndex | 0);
+  const colSeg = orbitPts.map((p) => p.segmentIndex | 0);
+
+  const { scale: fit } = torusUnitFitScale(profilePts, orbitPts);
+  const pk = spineProfile?.knots || [];
+  const ps = spineProfile?.segments || [];
+  const ok = spineOrbit?.knots || [];
+  const os = spineOrbit?.segments || [];
+  const hasSp = pk.length >= 2;
+  const hasSo = ok.length >= 2;
+
+  // Major-path centers in XZ, unit-fit scaled; spine adjusts radius + lift.
+  const centers = [];
+  for (let col = 0; col < steps; col++) {
+    const o = orbitPts[col];
+    const u = steps <= 1 ? 0 : col / (steps - 1);
+    let radialMul = 1;
+    let liftY = 0;
+    if (hasSp) {
+      const sp = sampleSpineAt(pk, ps, u);
+      radialMul = 1 + sp.x;
+      if (radialMul < 0.05) radialMul = 0.05;
+    }
+    if (hasSo) {
+      const so = sampleSpineAt(ok, os, u);
+      liftY = so.x * fit;
+    }
+    centers.push({
+      x: o.x * fit * radialMul,
+      y: liftY,
+      z: o.y * fit * radialMul,
+    });
+  }
+  const frames = buildSpineFrames(centers);
+
+  for (let row = 0; row < rows; row++) {
+    const pr = profilePts[row];
+    const px = Math.max(0, pr.x) * fit;
+    const py = pr.y * fit;
+    // Profile normal in the N–B plane (same 2D construction as lathe silhouette).
+    let pnx = pr.ty;
+    let pny = -pr.tx;
+    let pnl = Math.hypot(pnx, pny);
+    if (pnl < 1e-9) {
+      pnx = 1;
+      pny = 0;
+      pnl = 1;
+    }
+    pnx /= pnl;
+    pny /= pnl;
+    if (pnx < 0) {
+      pnx = -pnx;
+      pny = -pny;
+    }
+
+    for (let col = 0; col < steps; col++) {
+      const fr = frames[col] || {
+        C: centers[col] || { x: 0, y: 0, z: 0 },
+        T: { x: 0, y: 0, z: 1 },
+        N: { x: 1, y: 0, z: 0 },
+        B: { x: 0, y: 1, z: 0 },
+      };
+      // Tube cross-section: N·px + B·py (travels along T / orbit).
+      const ox = fr.N.x * px + fr.B.x * py;
+      const oy = fr.N.y * px + fr.B.y * py;
+      const oz = fr.N.z * px + fr.B.z * py;
+      positions.push(fr.C.x + ox, fr.C.y + oy, fr.C.z + oz);
+
+      const nx = fr.N.x * pnx + fr.B.x * pny;
+      const ny = fr.N.y * pnx + fr.B.y * pny;
+      const nz = fr.N.z * pnx + fr.B.z * pny;
+      const nl = Math.hypot(nx, ny, nz) || 1;
+      normals.push(nx / nl, ny / nl, nz / nl);
+      uvs.push(col / steps, rows <= 1 ? 0 : row / (rows - 1));
+    }
+  }
+
+  for (let r = 0; r < rows - 1; r++) {
+    const colMax = closed ? steps : steps - 1;
+    for (let c = 0; c < colMax; c++) {
+      const cNext = c + 1 >= steps ? 0 : c + 1;
+      const a = r * steps + c;
+      const b = r * steps + cNext;
+      const cc = (r + 1) * steps + cNext;
+      const d = (r + 1) * steps + c;
+      indices.push(a, d, b, b, d, cc);
+    }
+  }
+
+  return { positions, normals, uvs, indices, rowSeg, colSeg, rows, steps };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -337,6 +337,25 @@ function normalizeV6(doc) {
   return v5;
 }
 
+function normalizeV7(doc) {
+  const v6 = normalizeV6(doc);
+  v6.schemaVersion = 7;
+  const mode =
+    doc.editor?.tessellationMode === "torus" || v6.editor?.tessellationMode === "torus"
+      ? "torus"
+      : "rotation";
+  v6.editor = { ...v6.editor, tessellationMode: mode };
+  const emb = {};
+  for (const [guid, body] of Object.entries(v6.embeddedAssets || {})) {
+    emb[guid] = {
+      ...body,
+      tessellationMode: body.tessellationMode === "torus" ? "torus" : "rotation",
+    };
+  }
+  v6.embeddedAssets = emb;
+  return v6;
+}
+
 /** @type {Record<number, (doc: any) => any>} */
 const STEPS = {
   1(doc) {
@@ -359,6 +378,10 @@ const STEPS = {
   // 5 → 6: placementNormal (object “up” segment for preview / assembly)
   6(doc) {
     return normalizeV6(doc);
+  },
+  // 6 → 7: tessellationMode rotation | torus
+  7(doc) {
+    return normalizeV7(doc);
   },
 };
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -2,7 +2,7 @@
 // schema.js — semantic spline-project document + versioned migrations.
 // ============================================================================
 
-export const CURRENT_SCHEMA_VERSION = 6;
+export const CURRENT_SCHEMA_VERSION = 7;
 
 export const SCHEMA_KIND = "ranger.splineProject";
 
@@ -87,6 +87,7 @@ function serializeBodyContent(body) {
     pathSegments: body.pathSegments | 0,
     angularSteps: body.angularSteps | 0,
     revolutionDeg: body.revolutionDeg | 0,
+    tessellationMode: body.tessellationMode === "torus" ? "torus" : "rotation",
     objectMaterial: {
       color: body.objectMaterial?.color ?? null,
       roughness: Number(body.objectMaterial?.roughness ?? 0.4),
@@ -152,6 +153,7 @@ export function buildProjectDocument(opts) {
       pathSegments: st.pathSegments | 0,
       angularSteps: st.angularSteps | 0,
       revolutionDeg: st.revolutionDeg | 0,
+      tessellationMode: st.tessellationMode === "torus" ? "torus" : "rotation",
       materialMode: st.materialMode | 0,
       symmetry: !!st.symmetry,
       viewMode:
@@ -236,6 +238,12 @@ export function validateProject(doc) {
       } else if (Math.hypot(ex - sx, ey - sy) < 1e-9) {
         errors.push("placementNormal start and end must differ");
       }
+    }
+  }
+  if (doc.schemaVersion >= 7) {
+    const m = doc.editor?.tessellationMode;
+    if (m != null && m !== "rotation" && m !== "torus") {
+      errors.push('editor.tessellationMode must be "rotation" or "torus"');
     }
   }
   return errors;

--- a/gallery/game_engine/v2/mesh_editor/library/README.md
+++ b/gallery/game_engine/v2/mesh_editor/library/README.md
@@ -40,6 +40,8 @@ copy or symlink selected folders into a tracked tree, or temporarily force-add.
   curve the lathe centerline; default is a straight vertical line (`pathType: line`)
 - v6 adds `placementNormal` `{ start:{x,y}, end:{x,y} }` — object “up” segment for
   preview orientation and future assembly (default `(0,-1)→(0,1)`)
+- v7 adds `editor.tessellationMode`: `rotation` (classic lathe) or `torus` (profile
+  swept along orbit as a unit-sized ring)
 
 When you change the document shape, bump the version and add a step; old folders
 keep working.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an optional **torus** tessellation mode next to the existing **rotation** (lathe) mode.

| Mode | Meaning |
|------|---------|
| **Rotation** | Profile revolved in place; orbit = direction scales (unchanged) |
| **Torus** | Profile swept as a tube cross-section along the **orbit path** (major ring) |

In torus mode:
- Orbit describes the path the ring travels
- Profile + major radius are **unit-fit scaled** so outer radius ≈ 1 (`s = 1/(R+r)`)
- Spine modulates major radius (profile-spine X) and lifts the ring (orbit-spine X → Y)
- Same topology / segment colouring as the lathe

Schema **v7**: `editor.tessellationMode`: `"rotation"` \| `"torus"` (default rotation). Toolbar select retessellates on change.

## Test plan

- [ ] Default mode Rotation matches previous mesh
- [ ] Switch to Torus → ring along unit orbit; outer extent ~ unit
- [ ] Bend profile-spine X → major radius changes along the ring
- [ ] Bend orbit-spine X → ring lifts in Y
- [ ] Save / reload preserves mode
- [ ] `node scripts/smoke-torus.mjs` from `app/` passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

