### PR TITLE
Add 3D surface place for sub-objects via raycast

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -145,15 +145,16 @@ Edits push immutable shape snapshots into an in-memory buffer (no Zustand depend
 Toolbar **Bulk colour** → *Whole object* paints every knot/segment (+ object material) on the
 active edit target; *Selection* paints only the multi-selected points.
 
-### Sub-objects (schema v3)
+### Sub-objects (schema v3+)
 
-- Attach another library project as a **copy** (new `assetGuid`, independent of later Saves of the source) or **link** (shared `assetGuid`)
-- **Copy×2** / **Twin** / **Sym** for mirrored pairs that share content (e.g. two eyes)
-- Placement: `(x,y)` on the profile plane, Y-rotation, **bbox scale**, **Center** on the axis
-- **Edit** a sub-object to load it large in the canvas; the 3D preview always shows the **full assembly**
-- Instance GUID ≠ content GUID: instances can differ in transform while linked content stays in sync
+Attach another library project as a child (**Copy** = new GUID, **Link** = shared GUID).
 
-Profile list is **top → bottom**. Orbit list follows knot order around the loop.
+1. Click **Copy** / **Copy×2** / **Link** in Sub-objects
+2. Move over the **3D preview** (cursor = copy/+) — raycast hits the **root** surface
+3. Click to place: the child’s **placement normal** aligns to the hit surface normal
+4. Esc cancels; right-drag still orbits the preview
+
+Also: **Twin** / **Sym** for mirrored pairs; Profile attach boxes for non-surface nudging; **Edit** loads a child large while the preview stays the full assembly.
 
 ## Shading base
 

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import {
+  rayFromCanvas,
+  intersectTriangle,
+  raycastMeshParts,
+  applyPreviewEuler,
+  applyPreviewEulerInv,
+} from "../src/lib/meshPick.js";
+import { migrateProject } from "../src/library/migrations.js";
+import { CURRENT_SCHEMA_VERSION } from "../src/library/schema.js";
+
+// Unit square in XY at z=0, facing +Z
+const parts = [
+  {
+    positions: [-1, -1, 0, 1, -1, 0, 1, 1, 0, -1, 1, 0],
+    normals: [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1],
+    indices: [0, 1, 2, 0, 2, 3],
+  },
+];
+
+const t = intersectTriangle(
+  [0, 0, 2],
+  [0, 0, -1],
+  [-1, -1, 0],
+  [1, -1, 0],
+  [1, 1, 0],
+);
+assert.ok(t != null && Math.abs(t - 2) < 1e-6);
+
+const hit = raycastMeshParts([0, 0, 3], [0, 0, -1], parts);
+assert.ok(hit);
+assert.ok(Math.abs(hit.point[2]) < 1e-5);
+assert.ok(hit.normal[2] > 0.9);
+
+const view = {
+  cam: [0, 0, 4],
+  target: [0, 0, 0],
+  fovDeg: 45,
+  width: 400,
+  height: 400,
+};
+const { origin, dir } = rayFromCanvas(200, 200, view);
+assert.ok(dir[2] < -0.5);
+
+const p = [1, 0, 0];
+const e = applyPreviewEuler(p, 0.12, 0.5);
+const back = applyPreviewEulerInv(e, 0.12, 0.5);
+assert.ok(Math.hypot(back[0] - 1, back[1], back[2]) < 1e-6);
+
+const v7 = {
+  kind: "ranger.splineProject",
+  schemaVersion: 7,
+  id: "t",
+  assetGuid: "g",
+  slug: "p",
+  name: "P",
+  description: "",
+  tags: [],
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  editor: {
+    curveType: 0,
+    pathSegments: 12,
+    angularSteps: 24,
+    revolutionDeg: 360,
+    materialMode: 3,
+    symmetry: true,
+    viewMode: "profile",
+    spineSource: "profile",
+    tessellationMode: "rotation",
+  },
+  objectMaterial: { color: null, roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient" },
+  placementNormal: { start: { x: 0, y: -1 }, end: { x: 0, y: 1 } },
+  profile: {
+    knots: [
+      { id: "a", x: 0, y: -1, hx: 0, hy: 0, color: "#fff" },
+      { id: "b", x: 0.4, y: 1, hx: 0, hy: 0, color: "#fff" },
+    ],
+    segments: [
+      {
+        fromId: "a",
+        toId: "b",
+        pathType: "line",
+        roughness: 0.4,
+        metalness: 0,
+        opacity: 1,
+        texture: "gradient",
+        color: null,
+      },
+    ],
+  },
+  orbit: {
+    knots: [
+      { id: "o0", x: 1, y: 0, hx: 0, hy: 0.55, color: "#fff" },
+      { id: "o1", x: 0, y: 1, hx: -0.55, hy: 0, color: "#fff" },
+      { id: "o2", x: -1, y: 0, hx: 0, hy: -0.55, color: "#fff" },
+      { id: "o3", x: 0, y: -1, hx: 0.55, hy: 0, color: "#fff" },
+    ],
+    segments: [
+      { fromId: "o0", toId: "o1", pathType: "bezier", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+      { fromId: "o1", toId: "o2", pathType: "bezier", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+      { fromId: "o2", toId: "o3", pathType: "bezier", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+      { fromId: "o3", toId: "o0", pathType: "bezier", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+    ],
+  },
+  spineProfile: {
+    knots: [
+      { id: "s0", x: 0, y: -1, hx: 0, hy: 0, color: "#fff" },
+      { id: "s1", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+    ],
+    segments: [
+      { fromId: "s0", toId: "s1", pathType: "line", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+    ],
+  },
+  spineOrbit: {
+    knots: [
+      { id: "t0", x: 0, y: -1, hx: 0, hy: 0, color: "#fff" },
+      { id: "t1", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+    ],
+    segments: [
+      { fromId: "t0", toId: "t1", pathType: "line", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+    ],
+  },
+  embeddedAssets: {},
+  children: [
+    {
+      instanceGuid: "i1",
+      contentGuid: "c1",
+      mode: "copy",
+      name: "Eye",
+      transform: { x: 0.4, y: 0.2, rotationYDeg: 0, scale: 0.2, useSymmetry: false, snapCenterline: false },
+      visible: true,
+    },
+  ],
+};
+
+const mig = migrateProject(v7);
+assert.equal(mig.ok, true, mig.errors?.join("; "));
+assert.equal(CURRENT_SCHEMA_VERSION, 8);
+assert.equal(mig.doc.schemaVersion, 8);
+assert.equal(mig.doc.children[0].transform.surface, false);
+assert.equal(mig.doc.children[0].transform.z, 0);
+
+console.log("smoke-mesh-pick: ok");

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-placement-normal.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-placement-normal.mjs
@@ -121,7 +121,7 @@ const v5 = {
 const mig = migrateProject(v5);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
 assert.equal(mig.doc.schemaVersion, CURRENT_SCHEMA_VERSION);
-assert.equal(CURRENT_SCHEMA_VERSION, 7);
+assert.equal(CURRENT_SCHEMA_VERSION, 8);
 assert.deepEqual(mig.doc.placementNormal.start, { x: 0, y: -1 });
 assert.deepEqual(mig.doc.placementNormal.end, { x: 0, y: 1 });
 assert.equal(mig.doc.editor.tessellationMode, "rotation");

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
@@ -156,7 +156,7 @@ const v6 = {
 const mig = migrateProject(v6);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
 assert.equal(mig.doc.schemaVersion, CURRENT_SCHEMA_VERSION);
-assert.equal(CURRENT_SCHEMA_VERSION, 7);
+assert.equal(CURRENT_SCHEMA_VERSION, 8);
 assert.equal(mig.doc.editor.tessellationMode, "rotation");
 const errs = validateProject(mig.doc);
 assert.equal(errs.length, 0, errs.join("; "));

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, onBeforeUnmount } from "vue";
+import { computed, onMounted, onBeforeUnmount, ref } from "vue";
 import SplineCanvas from "./components/SplineCanvas.vue";
 import PointEditor from "./components/PointEditor.vue";
 import Preview3D from "./components/Preview3D.vue";
@@ -193,14 +193,50 @@ function onKeyDown(e) {
   }
 }
 
-async function onAttach({ slug, mode, symmetric }) {
+const placePending = ref(null); // { slug, mode, symmetric, doc }
+
+const placeLabel = computed(() => {
+  if (!placePending.value) return "";
+  const p = placePending.value;
+  return `${p.doc?.name || p.slug} (${p.mode}${p.symmetric ? " ×2" : ""})`;
+});
+
+async function onBeginPlace({ slug, mode, symmetric }) {
   try {
     const doc = await api.loadProject(slug);
-    attachFromProject(doc, { mode, symmetric });
-    tessellate();
+    placePending.value = { slug, mode, symmetric, doc };
+    state.status = `Place mode — click the root surface in 3D to attach “${doc.name || slug}”.`;
+    if (!state.rootMesh) tessellate();
   } catch (err) {
     state.status = "Attach failed: " + (err.message || err);
   }
+}
+
+function onCancelPlace() {
+  placePending.value = null;
+  state.status = "Place cancelled.";
+}
+
+function onPlaceCommit(hit) {
+  const pending = placePending.value;
+  if (!pending?.doc || !hit) return;
+  attachFromProject(pending.doc, {
+    mode: pending.mode,
+    symmetric: pending.symmetric,
+    transform: {
+      surface: true,
+      x: hit.point[0],
+      y: hit.point[1],
+      z: hit.point[2],
+      nx: hit.normal[0],
+      ny: hit.normal[1],
+      nz: hit.normal[2],
+      scale: 0.28,
+      rotationYDeg: 0,
+    },
+  });
+  placePending.value = null;
+  tessellate();
 }
 
 onMounted(() => {
@@ -426,8 +462,12 @@ onBeforeUnmount(() => {
       <div class="side-stack">
         <Preview3D
           :mesh="state.mesh"
+          :root-mesh="state.rootMesh"
           :material-mode="state.materialMode"
           :placement-normal="state.placementNormal"
+          :place-mode="!!placePending"
+          @place-commit="onPlaceCommit"
+          @place-cancel="onCancelPlace"
         />
         <ChildrenPanel
           :children="state.children"
@@ -436,6 +476,8 @@ onBeforeUnmount(() => {
           :edit-target="state.editTarget"
           :projects="lib.projects"
           :asset-guid="state.assetGuid"
+          :place-mode="!!placePending"
+          :place-label="placeLabel"
           @select-child="selectChild"
           @edit-child="
             (g) => {
@@ -474,7 +516,8 @@ onBeforeUnmount(() => {
               tessellate();
             }
           "
-          @attach="onAttach"
+          @begin-place="onBeginPlace"
+          @cancel-place="onCancelPlace"
           @tessellate="onTessellate"
         />
       </div>

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/ChildrenPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/ChildrenPanel.vue
@@ -8,6 +8,8 @@ const props = defineProps({
   editTarget: { type: String, default: "root" },
   projects: { type: Array, default: () => [] },
   assetGuid: { type: String, default: "" },
+  placeMode: { type: Boolean, default: false },
+  placeLabel: { type: String, default: "" },
 });
 
 const emit = defineEmits([
@@ -19,7 +21,8 @@ const emit = defineEmits([
   "center",
   "toggle-symmetry",
   "add-twin",
-  "attach",
+  "begin-place",
+  "cancel-place",
   "tessellate",
 ]);
 
@@ -32,7 +35,8 @@ function shortGuid(g) {
 }
 
 function onAttach(slug, mode, symmetric) {
-  emit("attach", { slug, mode, symmetric });
+  // Enter 3D surface-place mode (Copy / Link); panel no longer dumps at default (0.45,0.35).
+  emit("begin-place", { slug, mode, symmetric });
 }
 </script>
 
@@ -146,12 +150,26 @@ function onAttach(slug, mode, symmetric) {
 
     <div class="attach">
       <h3>Attach from library</h3>
+      <p class="hint">
+        Pick Copy / Link, then click the root surface in the 3D preview. The sub-object’s placement
+        normal aligns to the hit normal.
+      </p>
+      <p v-if="placeMode" class="placing">
+        Placing {{ placeLabel }}…
+        <button type="button" @click="emit('cancel-place')">Cancel</button>
+      </p>
       <p v-if="!projects.length" class="hint">Save another spline first, then attach it here.</p>
       <div v-for="p in projects" :key="p.slug" class="proj">
         <span>{{ p.name || p.slug }}</span>
-        <button type="button" @click="onAttach(p.slug, 'copy', false)">Copy</button>
-        <button type="button" @click="onAttach(p.slug, 'copy', true)">Copy×2</button>
-        <button type="button" @click="onAttach(p.slug, 'link', false)">Link</button>
+        <button type="button" :disabled="placeMode" @click="onAttach(p.slug, 'copy', false)">
+          Copy
+        </button>
+        <button type="button" :disabled="placeMode" @click="onAttach(p.slug, 'copy', true)">
+          Copy×2
+        </button>
+        <button type="button" :disabled="placeMode" @click="onAttach(p.slug, 'link', false)">
+          Link
+        </button>
       </div>
     </div>
   </aside>
@@ -280,5 +298,13 @@ code {
 }
 button.active {
   border-color: rgba(126, 207, 106, 0.6);
+}
+.placing {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  color: #93c5fd;
+  font-size: 0.72rem;
 }
 </style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
@@ -1,43 +1,137 @@
 <script setup>
 import { onMounted, onBeforeUnmount, ref, watch, computed } from "vue";
 import { createPreviewSession } from "../lib/rangerPreview.js";
-import { orientMeshToPlacementNormal } from "../lib/placementNormal.js";
+import {
+  orientMeshToPlacementNormal,
+  placementNormalDirection3,
+  rotationAligning,
+} from "../lib/placementNormal.js";
+import { pickRootSurface, transposeMat3 } from "../lib/meshPick.js";
 
 const props = defineProps({
   mesh: { type: Object, default: null },
+  rootMesh: { type: Object, default: null },
   materialMode: { type: Number, default: 3 },
   placementNormal: {
     type: Object,
     default: () => ({ start: { x: 0, y: -1 }, end: { x: 0, y: 1 } }),
   },
+  placeMode: { type: Boolean, default: false },
 });
 
+const emit = defineEmits(["place-hover", "place-commit", "place-cancel"]);
+
 const canvasRef = ref(null);
+const wrapRef = ref(null);
 const backendLabel = ref("…");
+const hoverHit = ref(null);
 let session = null;
+let draggingOrbit = false;
+let downPos = null;
 
 const displayMesh = computed(() =>
   orientMeshToPlacementNormal(props.mesh, props.placementNormal),
 );
+
+const orientInv = computed(() => {
+  const dir = placementNormalDirection3(props.placementNormal);
+  // Display = R * authoring, so inv = R^T where R maps dir → +Y
+  const R = rotationAligning(dir, { x: 0, y: 1, z: 0 });
+  return transposeMat3(R);
+});
 
 function pushDisplay() {
   if (!session) return;
   if (displayMesh.value) session.setMesh(displayMesh.value);
 }
 
+function getView() {
+  return session?.getView?.() || null;
+}
+
+function pickAt(sx, sy) {
+  const view = getView();
+  const parts = props.rootMesh?.parts;
+  if (!view || !parts?.length) return null;
+  return pickRootSurface(
+    sx,
+    sy,
+    view,
+    parts,
+    view.meshTilt,
+    view.meshAngle,
+    orientInv.value,
+  );
+}
+
+function onPointerDown(e) {
+  if (!props.placeMode) return;
+  if (e.button === 2 || e.button === 1) {
+    draggingOrbit = true;
+    session?.host?.pointerDown?.(e.offsetX, e.offsetY, e.button);
+    return;
+  }
+  if (e.button !== 0) return;
+  downPos = { x: e.offsetX, y: e.offsetY };
+  // Don't start orbit on left in place mode
+  e.stopPropagation();
+}
+
+function onPointerMove(e) {
+  if (!props.placeMode) return;
+  if (draggingOrbit) {
+    session?.host?.pointerMove?.(e.offsetX, e.offsetY);
+    return;
+  }
+  const hit = pickAt(e.offsetX, e.offsetY);
+  hoverHit.value = hit;
+  emit("place-hover", hit);
+}
+
+function onPointerUp(e) {
+  if (!props.placeMode) return;
+  if (draggingOrbit) {
+    session?.host?.pointerUp?.();
+    draggingOrbit = false;
+    return;
+  }
+  if (e.button !== 0 || !downPos) return;
+  const dist = Math.hypot(e.offsetX - downPos.x, e.offsetY - downPos.y);
+  downPos = null;
+  if (dist > 6) return;
+  const hit = pickAt(e.offsetX, e.offsetY);
+  if (hit) emit("place-commit", hit);
+}
+
+function onKeyDown(e) {
+  if (!props.placeMode) return;
+  if (e.key === "Escape") {
+    emit("place-cancel");
+  }
+}
+
+function onContextMenu(e) {
+  if (props.placeMode) e.preventDefault();
+}
+
 onMounted(async () => {
   try {
-    session = await createPreviewSession(canvasRef.value, 420);
+    session = await createPreviewSession(canvasRef.value, 420, {
+      placeModeGetter: () => props.placeMode,
+    });
     backendLabel.value = session.useGL ? "Ranger Three · WebGL" : "Ranger Three · software";
     pushDisplay();
     session.setMaterialMode(props.materialMode);
+    session.setAutoRotate?.(true);
   } catch (err) {
     backendLabel.value = "preview failed";
     console.error(err);
   }
+  window.addEventListener("keydown", onKeyDown);
 });
 
 onBeforeUnmount(() => {
+  window.removeEventListener("keydown", onKeyDown);
   session?.dispose();
   session = null;
 });
@@ -50,17 +144,49 @@ watch(
     if (session) session.setMaterialMode(mode);
   },
 );
+
+watch(
+  () => props.placeMode,
+  (on) => {
+    session?.setAutoRotate?.(!on);
+    hoverHit.value = null;
+    if (canvasRef.value) {
+      canvasRef.value.style.cursor = on ? "copy" : "crosshair";
+    }
+  },
+);
 </script>
 
 <template>
-  <div class="preview">
+  <div ref="wrapRef" class="preview" :class="{ placing: placeMode }">
     <header>
       <h2>3D preview</h2>
       <span>{{ backendLabel }}</span>
     </header>
-    <canvas ref="canvasRef" class="view" />
+    <div class="view-wrap">
+      <canvas
+        ref="canvasRef"
+        class="view"
+        :class="{ place: placeMode }"
+        @pointerdown.capture="onPointerDown"
+        @pointermove.capture="onPointerMove"
+        @pointerup.capture="onPointerUp"
+        @contextmenu="onContextMenu"
+      />
+      <div v-if="placeMode" class="place-banner">
+        Place on surface · hover (+) · click to attach · Esc cancel · right-drag orbit
+      </div>
+      <div
+        v-if="placeMode && hoverHit"
+        class="hit-dot"
+        :style="{
+          // approximate marker — banner is enough; keep simple center cue
+        }"
+      />
+    </div>
     <p class="hint">
-      Drag to orbit · wheel to zoom · view aligned so placement normal points up
+      <template v-if="placeMode">Aim at the root surface — sub-object aligns to the normal</template>
+      <template v-else>Drag to orbit · wheel to zoom · view aligned so placement normal points up</template>
     </p>
   </div>
 </template>
@@ -75,6 +201,10 @@ watch(
   border-radius: var(--radius);
   padding: 0.85rem;
   min-height: 0;
+}
+.preview.placing {
+  border-color: rgba(59, 130, 246, 0.55);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.25);
 }
 
 header {
@@ -96,15 +226,39 @@ span {
   color: var(--ink-dim);
 }
 
-.view {
+.view-wrap {
+  position: relative;
+  justify-self: center;
   width: 100%;
   max-width: 420px;
+}
+
+.view {
+  width: 100%;
   aspect-ratio: 1;
   border-radius: 12px;
   border: 1px solid var(--line);
   background: #0a0e0c;
-  justify-self: center;
   touch-action: none;
+  cursor: crosshair;
+  display: block;
+}
+.view.place {
+  cursor: copy;
+}
+
+.place-banner {
+  position: absolute;
+  left: 0.5rem;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.82);
+  color: #bfdbfe;
+  font-size: 0.68rem;
+  pointer-events: none;
+  text-align: center;
 }
 
 .hint {

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -13,6 +13,7 @@ import { defaultSpineKnots, defaultSpineSegments } from "../lib/spineLathe.js";
 import {
   defaultPlacementNormal,
   normalizePlacementNormal,
+  placementNormalDirection3,
 } from "../lib/placementNormal.js";
 
 /** @typedef {{ id: string, x: number, y: number, hx: number, hy: number, color: string }} Knot */
@@ -86,6 +87,7 @@ function projectDocToBody(doc, { newGuidForCopy = true } = {}) {
       orbit: doc.orbit,
       spineProfile: doc.spineProfile,
       spineOrbit: doc.spineOrbit,
+      placementNormal: doc.placementNormal,
       editor: doc.editor,
       objectMaterial: doc.objectMaterial,
       knots: doc.profile?.knots,
@@ -172,6 +174,8 @@ export function useSplineEditor() {
     editTarget: "root",
     bulkColor: "#7ecf6a",
     mesh: null,
+    /** Root-only mesh parts for surface raycasting (no children). */
+    rootMesh: null,
     stats: { verts: 0, tris: 0, profile: 0, parts: 0 },
     status: "Edit mode — drag points. Sub-objects attach in Profile view.",
     history: { canUndo: false, canRedo: false, past: 0, future: 0 },
@@ -855,21 +859,41 @@ export function useSplineEditor() {
     };
   }
 
-  function pushTransformedParts(parts, childParts, xf, mirrorX) {
-    const placed = transformParts(childParts, {
-      x: xf.x,
-      y: xf.y,
-      rotationYDeg: xf.rotationYDeg,
-      scale: xf.scale,
-      snapCenterline: xf.snapCenterline,
-      mirrorX,
-    });
+  function pushTransformedParts(parts, childParts, xf, mirrorX, body) {
+    const pn = normalizePlacementNormal(body?.placementNormal);
+    const up = placementNormalDirection3(pn);
+    const pivot = [pn.start.x, pn.start.y, 0];
+    const surfaceXf = xf.surface
+      ? {
+          ...xf,
+          x: mirrorX ? -xf.x : xf.x,
+          nx: mirrorX ? -xf.nx : xf.nx,
+          ny: xf.ny,
+          nz: xf.nz,
+          mirrorX: false,
+          childUpX: up.x,
+          childUpY: up.y,
+          childUpZ: up.z,
+          pivotX: pivot[0],
+          pivotY: pivot[1],
+          pivotZ: pivot[2],
+        }
+      : {
+          x: xf.x,
+          y: xf.y,
+          rotationYDeg: xf.rotationYDeg,
+          scale: xf.scale,
+          snapCenterline: xf.snapCenterline,
+          mirrorX,
+        };
+    const placed = transformParts(childParts, surfaceXf, xf.surface ? pivot : undefined);
     for (const p of placed) parts.push(p);
   }
 
   function tessellate() {
     // Always assemble from ROOT + children (preview shows full object even when editing a child).
     const root = tessellateBody(rootBodySnapshot());
+    state.rootMesh = { parts: root.parts.slice() };
     const parts = root.parts.slice();
     let totalV = root.verts;
     let totalT = root.tris;
@@ -880,12 +904,12 @@ export function useSplineEditor() {
       if (!body || body.knots.length < 2 || body.orbitKnots.length < 3) continue;
       const child = tessellateBody(body);
       const xf = ch.transform || defaultChildTransform();
-      pushTransformedParts(parts, child.parts, xf, false);
+      pushTransformedParts(parts, child.parts, xf, false, body);
       totalV += child.verts;
       totalT += child.tris;
       // Symmetry: same content, mirrored placement (linked eyes without a second instance).
-      if (xf.useSymmetry && !xf.snapCenterline && Math.abs(xf.x) > 0.001) {
-        pushTransformedParts(parts, child.parts, xf, true);
+      if (xf.useSymmetry && !xf.snapCenterline && !xf.surface && Math.abs(xf.x) > 0.001) {
+        pushTransformedParts(parts, child.parts, xf, true, body);
         totalV += child.verts;
         totalT += child.tris;
       }
@@ -975,7 +999,7 @@ export function useSplineEditor() {
    * mode 'link' → keep source assetGuid so edits stay linked.
    * symmetric → also add a mirrored instance sharing the same contentGuid.
    */
-  function attachFromProject(doc, { mode = "copy", symmetric = false, name } = {}) {
+  function attachFromProject(doc, { mode = "copy", symmetric = false, name, transform } = {}) {
     if (!doc?.profile?.knots || !doc?.orbit?.knots) {
       state.status = "Project needs profile + orbit to attach.";
       return null;
@@ -992,6 +1016,7 @@ export function useSplineEditor() {
       const body = projectDocToBody(doc, { newGuidForCopy: asCopy });
       if (!asCopy && doc.assetGuid) body.assetGuid = doc.assetGuid;
       body.name = bodyName;
+      body.placementNormal = normalizePlacementNormal(doc.placementNormal);
       state.embeddedAssets[body.assetGuid] = body;
       contentGuid = body.assetGuid;
     }
@@ -1007,18 +1032,43 @@ export function useSplineEditor() {
       visible: true,
     });
 
+    const baseXf = transform?.surface
+      ? {
+          x: transform.x,
+          y: transform.y,
+          z: transform.z ?? 0,
+          nx: transform.nx ?? 0,
+          ny: transform.ny ?? 1,
+          nz: transform.nz ?? 0,
+          surface: true,
+          scale: transform.scale ?? 0.28,
+          rotationYDeg: transform.rotationYDeg ?? 0,
+          useSymmetry: false,
+          snapCenterline: false,
+        }
+      : { x: 0.45, y: 0.35, useSymmetry: false };
+
     const primary = makeInst(
-      { x: 0.45, y: 0.35, useSymmetry: false },
+      baseXf,
       bodyName + (symmetric ? " (R)" : ""),
     );
     state.children.push(primary);
     if (symmetric) {
-      state.children.push(
-        makeInst(
-          { x: -0.45, y: 0.35, rotationYDeg: 0, useSymmetry: false },
-          bodyName + " (L)",
-        ),
-      );
+      if (transform?.surface) {
+        state.children.push(
+          makeInst(
+            { ...baseXf, x: -baseXf.x, nx: -baseXf.nx },
+            bodyName + " (L)",
+          ),
+        );
+      } else {
+        state.children.push(
+          makeInst(
+            { x: -0.45, y: 0.35, rotationYDeg: 0, useSymmetry: false },
+            bodyName + " (L)",
+          ),
+        );
+      }
     }
 
     state.selectedChildGuid = primary.instanceGuid;

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/assetClone.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/assetClone.js
@@ -3,6 +3,7 @@
 // ============================================================================
 
 import { defaultSpineKnots, defaultSpineSegments } from "./spineLathe.js";
+import { normalizePlacementNormal } from "./placementNormal.js";
 
 export function newGuid() {
   if (typeof crypto !== "undefined" && crypto.randomUUID) return crypto.randomUUID();
@@ -98,6 +99,7 @@ export function cloneBodyContent(src, { preserveGuid = false, name = "Sub-object
     spineProfileSegments,
     spineOrbitKnots,
     spineOrbitSegments,
+    placementNormal: normalizePlacementNormal(src.placementNormal),
   };
 }
 
@@ -173,6 +175,11 @@ export function defaultChildTransform(overrides = {}) {
   return {
     x: 0.45,
     y: 0.35,
+    z: 0,
+    nx: 0,
+    ny: 1,
+    nz: 0,
+    surface: false,
     rotationYDeg: 0,
     scale: 0.28,
     useSymmetry: false,

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/meshPick.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/meshPick.js
@@ -1,0 +1,186 @@
+// ============================================================================
+// meshPick.js — CPU raycast against lathe mesh parts (authoring or display space).
+// ============================================================================
+
+/**
+ * @param {number} sx canvas X
+ * @param {number} sy canvas Y
+ * @param {{ cam:[number,number,number], target:[number,number,number], fovDeg:number, width:number, height:number }} view
+ * @returns {{ origin:[number,number,number], dir:[number,number,number] }}
+ */
+export function rayFromCanvas(sx, sy, view) {
+  const w = view.width || 1;
+  const h = view.height || 1;
+  const ndcX = (sx / w) * 2 - 1;
+  const ndcY = 1 - (sy / h) * 2;
+  const fov = ((view.fovDeg || 45) * Math.PI) / 180;
+  const aspect = w / h;
+  const tan = Math.tan(fov / 2);
+
+  const eye = view.cam;
+  const target = view.target;
+  const forward = normalize3([
+    target[0] - eye[0],
+    target[1] - eye[1],
+    target[2] - eye[2],
+  ]);
+  // world up
+  let right = cross3(forward, [0, 1, 0]);
+  if (len3(right) < 1e-8) right = cross3(forward, [1, 0, 0]);
+  right = normalize3(right);
+  const up = normalize3(cross3(right, forward));
+
+  const dir = normalize3([
+    forward[0] + right[0] * ndcX * tan * aspect + up[0] * ndcY * tan,
+    forward[1] + right[1] * ndcX * tan * aspect + up[1] * ndcY * tan,
+    forward[2] + right[2] * ndcX * tan * aspect + up[2] * ndcY * tan,
+  ]);
+  return { origin: [...eye], dir };
+}
+
+function len3(a) {
+  return Math.hypot(a[0], a[1], a[2]);
+}
+function normalize3(a) {
+  const L = len3(a) || 1;
+  return [a[0] / L, a[1] / L, a[2] / L];
+}
+function cross3(a, b) {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+function sub3(a, b) {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+function dot3(a, b) {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+function add3(a, b) {
+  return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+function mul3(a, s) {
+  return [a[0] * s, a[1] * s, a[2] * s];
+}
+
+/** Rotate point by euler (rx, ry, 0) — matches preview entityTransform. */
+export function applyPreviewEuler(p, rx, ry) {
+  const cx = Math.cos(rx);
+  const sx = Math.sin(rx);
+  const cy = Math.cos(ry);
+  const sy = Math.sin(ry);
+  // X then Y (XYZ euler with z=0)
+  let x = p[0];
+  let y = p[1] * cx - p[2] * sx;
+  let z = p[1] * sx + p[2] * cx;
+  const x2 = x * cy + z * sy;
+  const z2 = -x * sy + z * cy;
+  return [x2, y, z2];
+}
+
+export function applyPreviewEulerInv(p, rx, ry) {
+  const cx = Math.cos(rx);
+  const sx = Math.sin(rx);
+  const cy = Math.cos(ry);
+  const sy = Math.sin(ry);
+  // inverse Y then inverse X
+  let x = p[0] * cy - p[2] * sy;
+  let y = p[1];
+  let z = p[0] * sy + p[2] * cy;
+  const y2 = y * cx + z * sx;
+  const z2 = -y * sx + z * cx;
+  return [x, y2, z2];
+}
+
+/** Möller–Trumbore; returns t or null. */
+export function intersectTriangle(origin, dir, v0, v1, v2) {
+  const eps = 1e-8;
+  const e1 = sub3(v1, v0);
+  const e2 = sub3(v2, v0);
+  const pvec = cross3(dir, e2);
+  const det = dot3(e1, pvec);
+  if (Math.abs(det) < eps) return null;
+  const invDet = 1 / det;
+  const tvec = sub3(origin, v0);
+  const u = dot3(tvec, pvec) * invDet;
+  if (u < 0 || u > 1) return null;
+  const qvec = cross3(tvec, e1);
+  const v = dot3(dir, qvec) * invDet;
+  if (v < 0 || u + v > 1) return null;
+  const t = dot3(e2, qvec) * invDet;
+  if (t < eps) return null;
+  return t;
+}
+
+/**
+ * Raycast mesh parts in the same space as the ray.
+ * @returns {{ point:[number,number,number], normal:[number,number,number], t:number } | null}
+ */
+export function raycastMeshParts(origin, dir, parts) {
+  let bestT = Infinity;
+  let best = null;
+  for (const part of parts || []) {
+    const pos = part.positions;
+    const idx = part.indices;
+    const nrm = part.normals;
+    if (!pos?.length || !idx?.length) continue;
+    for (let i = 0; i + 2 < idx.length; i += 3) {
+      const i0 = idx[i] * 3;
+      const i1 = idx[i + 1] * 3;
+      const i2 = idx[i + 2] * 3;
+      const v0 = [pos[i0], pos[i0 + 1], pos[i0 + 2]];
+      const v1 = [pos[i1], pos[i1 + 1], pos[i1 + 2]];
+      const v2 = [pos[i2], pos[i2 + 1], pos[i2 + 2]];
+      const t = intersectTriangle(origin, dir, v0, v1, v2);
+      if (t == null || t >= bestT) continue;
+      bestT = t;
+      let n = cross3(sub3(v1, v0), sub3(v2, v0));
+      if (len3(n) < 1e-12 && nrm) {
+        n = [nrm[i0], nrm[i0 + 1], nrm[i0 + 2]];
+      }
+      n = normalize3(n);
+      // Face toward the ray
+      if (dot3(n, dir) > 0) n = mul3(n, -1);
+      best = {
+        point: add3(origin, mul3(dir, t)),
+        normal: n,
+        t,
+      };
+    }
+  }
+  return best;
+}
+
+/**
+ * Full pick: canvas → world ray → inverse preview euler → authoring ray → hit.
+ * `orientInv` maps display(oriented) → authoring (3×3 row-major or null).
+ */
+export function pickRootSurface(sx, sy, view, rootParts, meshTilt, meshAngle, orientInvMat) {
+  const { origin, dir } = rayFromCanvas(sx, sy, view);
+  // World (after euler) → pre-euler oriented space
+  const o1 = applyPreviewEulerInv(origin, meshTilt, meshAngle);
+  const d1p = applyPreviewEulerInv(add3(origin, dir), meshTilt, meshAngle);
+  let oA = o1;
+  let dA = normalize3(sub3(d1p, o1));
+  if (orientInvMat) {
+    oA = mulMat3(orientInvMat, o1);
+    const tip = mulMat3(orientInvMat, add3(o1, dA));
+    dA = normalize3(sub3(tip, oA));
+  }
+  return raycastMeshParts(oA, dA, rootParts);
+}
+
+function mulMat3(m, v) {
+  return [
+    m[0] * v[0] + m[1] * v[1] + m[2] * v[2],
+    m[3] * v[0] + m[4] * v[1] + m[5] * v[2],
+    m[6] * v[0] + m[7] * v[1] + m[8] * v[2],
+  ];
+}
+
+/** Transpose of row-major 3×3 (= inverse for pure rotation). */
+export function transposeMat3(m) {
+  return [m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]];
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/meshTransform.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/meshTransform.js
@@ -2,6 +2,8 @@
 // meshTransform.js — place / scale / mirror lathe part buffers in parent space.
 // ============================================================================
 
+import { rotationAligning } from "./placementNormal.js";
+
 /**
  * @param {number[]} positions flat xyz
  * @returns {{ min:[number,number,number], max:[number,number,number], center:[number,number,number], size:[number,number,number], maxExtent:number }}
@@ -63,11 +65,28 @@ function reverseWinding(indices) {
   return out;
 }
 
+function mulMat3Vec(m, x, y, z) {
+  return {
+    x: m[0] * x + m[1] * y + m[2] * z,
+    y: m[3] * x + m[4] * y + m[5] * z,
+    z: m[6] * x + m[7] * y + m[8] * z,
+  };
+}
+
+function unit3(x, y, z, fallback) {
+  const L = Math.hypot(x, y, z);
+  if (!Number.isFinite(L) || L < 1e-9) return fallback;
+  return { x: x / L, y: y / L, z: z / L };
+}
+
 /**
- * Bake TRS into one part using a SHARED object-space center (not this part's bbox).
- * Centering each profile×orbit wedge on its own AABB tears the child mesh apart.
+ * Profile stamp (default): (x,y,0) + Y-rotation + optional mirrorX.
+ * Surface place (xf.surface): align child up → hit normal, pivot, translate to (x,y,z).
  */
-export function transformPart(part, xf, sharedCenter) {
+export function transformPart(part, xf, sharedCenter, pivot) {
+  if (xf?.surface) {
+    return transformPartSurface(part, xf, pivot || sharedCenter);
+  }
   const positions = part.positions.slice();
   const normals = part.normals ? part.normals.slice() : null;
   const indices = part.indices ? part.indices.slice() : [];
@@ -94,7 +113,6 @@ export function transformPart(part, xf, sharedCenter) {
 
     if (mirror) x = -x;
 
-    // Place at ±attach: mirrored copies go to the opposite side of the axis.
     positions[i] = x + (mirror ? -ax : ax);
     positions[i + 1] = y + ay;
     positions[i + 2] = z;
@@ -121,9 +139,83 @@ export function transformPart(part, xf, sharedCenter) {
     ...part,
     positions,
     normals: normals || part.normals,
-    // Mirroring flips triangle winding — reverse so fronts stay outward.
     indices: mirror ? reverseWinding(indices) : indices,
-    // Defensive copies so mirrored pass never shares buffers with the primary.
+    uvs: part.uvs ? part.uvs.slice() : part.uvs,
+    mapRgba: part.mapRgba ? part.mapRgba.slice() : part.mapRgba,
+  };
+}
+
+function transformPartSurface(part, xf, pivot) {
+  const positions = part.positions.slice();
+  const normals = part.normals ? part.normals.slice() : null;
+  const indices = part.indices ? part.indices.slice() : [];
+  const s = Math.max(0.001, xf.scale ?? 1);
+  const ppx = Number(pivot?.[0]) || 0;
+  const ppy = Number(pivot?.[1]) || 0;
+  const ppz = Number(pivot?.[2]) || 0;
+  const ax = Number(xf.x) || 0;
+  const ay = Number(xf.y) || 0;
+  const az = Number(xf.z) || 0;
+  const hitN = unit3(Number(xf.nx), Number(xf.ny), Number(xf.nz), { x: 0, y: 1, z: 0 });
+  const childUp = unit3(
+    Number(xf.childUpX),
+    Number(xf.childUpY),
+    Number(xf.childUpZ),
+    { x: 0, y: 1, z: 0 },
+  );
+  const R = rotationAligning(childUp, hitN);
+  const twist = ((Number(xf.rotationYDeg) || 0) * Math.PI) / 180;
+  const ct = Math.cos(twist);
+  const st = Math.sin(twist);
+  const { x: nx, y: ny, z: nz } = hitN;
+
+  for (let i = 0; i < positions.length; i += 3) {
+    let x = (positions[i] - ppx) * s;
+    let y = (positions[i + 1] - ppy) * s;
+    let z = (positions[i + 2] - ppz) * s;
+    let p = mulMat3Vec(R, x, y, z);
+    if (Math.abs(twist) > 1e-8) {
+      const d = p.x * nx + p.y * ny + p.z * nz;
+      const cx = ny * p.z - nz * p.y;
+      const cy = nz * p.x - nx * p.z;
+      const cz = nx * p.y - ny * p.x;
+      p = {
+        x: p.x * ct + cx * st + nx * d * (1 - ct),
+        y: p.y * ct + cy * st + ny * d * (1 - ct),
+        z: p.z * ct + cz * st + nz * d * (1 - ct),
+      };
+    }
+    positions[i] = p.x + ax;
+    positions[i + 1] = p.y + ay;
+    positions[i + 2] = p.z + az;
+  }
+
+  if (normals) {
+    for (let i = 0; i < normals.length; i += 3) {
+      let p = mulMat3Vec(R, normals[i], normals[i + 1], normals[i + 2]);
+      if (Math.abs(twist) > 1e-8) {
+        const d = p.x * nx + p.y * ny + p.z * nz;
+        const cx = ny * p.z - nz * p.y;
+        const cy = nz * p.x - nx * p.z;
+        const cz = nx * p.y - ny * p.x;
+        p = {
+          x: p.x * ct + cx * st + nx * d * (1 - ct),
+          y: p.y * ct + cy * st + ny * d * (1 - ct),
+          z: p.z * ct + cz * st + nz * d * (1 - ct),
+        };
+      }
+      const len = Math.hypot(p.x, p.y, p.z) || 1;
+      normals[i] = p.x / len;
+      normals[i + 1] = p.y / len;
+      normals[i + 2] = p.z / len;
+    }
+  }
+
+  return {
+    ...part,
+    positions,
+    normals: normals || part.normals,
+    indices,
     uvs: part.uvs ? part.uvs.slice() : part.uvs,
     mapRgba: part.mapRgba ? part.mapRgba.slice() : part.mapRgba,
   };
@@ -132,9 +224,17 @@ export function transformPart(part, xf, sharedCenter) {
 /**
  * Transform every part of a child mesh with one shared bbox center so wedges
  * stay welded. Returns new part objects (never mutates inputs).
+ * For surface placement, pass xf.surface and optional pivot [x,y,z].
  */
-export function transformParts(parts, xf) {
+export function transformParts(parts, xf, pivot) {
   if (!parts?.length) return [];
   const bbox = partsBBox(parts);
-  return parts.map((p) => transformPart(p, xf, bbox.center));
+  const usePivot = xf?.surface
+    ? pivot || [
+        Number(xf.pivotX) || bbox.center[0],
+        Number(xf.pivotY) || bbox.min[1],
+        Number(xf.pivotZ) || bbox.center[2],
+      ]
+    : bbox.center;
+  return parts.map((p) => transformPart(p, xf, bbox.center, usePivot));
 }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/rangerPreview.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/rangerPreview.js
@@ -1,6 +1,6 @@
 /** Boot / drive WebMeshEditorHost for the 3D preview canvas. */
 
-export async function createPreviewSession(canvas, size = 420) {
+export async function createPreviewSession(canvas, size = 420, opts = {}) {
   const bundleSource = await fetch("/ranger/mesh_editor.bundle.js").then((r) => r.text());
   const vfs = new window.RangerVFS();
   const engine = window.RangerEngineHost.createEngine(bundleSource, vfs, {});
@@ -27,6 +27,7 @@ export async function createPreviewSession(canvas, size = 420) {
   let running = false;
   let lastMesh = null;
   let lastMode = 3;
+  const placeModeGetter = opts.placeModeGetter || (() => false);
 
   function blit() {
     if (useGL || !ctx || !image) return;
@@ -66,7 +67,6 @@ export async function createPreviewSession(canvas, size = 420) {
   function pushMesh(mesh) {
     if (!mesh) return;
     host.setMaterialMode(lastMode | 0);
-    // New multi-part format
     if (mesh.parts && mesh.parts.length) {
       host.beginParts();
       for (const part of mesh.parts) {
@@ -89,7 +89,6 @@ export async function createPreviewSession(canvas, size = 420) {
       blit();
       return;
     }
-    // Legacy single mesh
     if (mesh.positions) {
       host.setMesh(mesh.positions, mesh.normals, mesh.uvs, mesh.indices);
       host.frame(0);
@@ -112,12 +111,37 @@ export async function createPreviewSession(canvas, size = 420) {
     }
   }
 
+  function setAutoRotate(on) {
+    host.setAutoRotate?.(!!on);
+  }
+
+  function getView() {
+    try {
+      return {
+        cam: [host.viewCamX(), host.viewCamY(), host.viewCamZ()],
+        target: [host.viewTargetX(), host.viewTargetY(), host.viewTargetZ()],
+        fovDeg: host.viewFov(),
+        width: host.viewWidth(),
+        height: host.viewHeight(),
+        meshAngle: host.viewMeshAngle(),
+        meshTilt: host.viewMeshTilt(),
+      };
+    } catch {
+      return null;
+    }
+  }
+
   function wirePointer() {
     const onDown = (e) => {
+      // In place mode, Preview3D capture handlers own left-click; still allow right orbit via host.
+      if (placeModeGetter() && e.button === 0) return;
       canvas.setPointerCapture(e.pointerId);
       host.pointerDown(e.offsetX, e.offsetY, e.button);
     };
-    const onMove = (e) => host.pointerMove(e.offsetX, e.offsetY);
+    const onMove = (e) => {
+      if (placeModeGetter() && e.buttons === 1) return;
+      host.pointerMove(e.offsetX, e.offsetY);
+    };
     const onUp = () => host.pointerUp();
     const onWheel = (e) => {
       e.preventDefault();
@@ -143,6 +167,8 @@ export async function createPreviewSession(canvas, size = 420) {
     useGL,
     setMesh,
     setMaterialMode,
+    setAutoRotate,
+    getView,
     start,
     stop,
     dispose() {

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -356,6 +356,32 @@ function normalizeV7(doc) {
   return v6;
 }
 
+function normalizeChildTransformV8(t) {
+  return {
+    x: Number(t?.x ?? 0.45),
+    y: Number(t?.y ?? 0.35),
+    z: Number(t?.z ?? 0),
+    nx: Number.isFinite(Number(t?.nx)) ? Number(t.nx) : 0,
+    ny: Number.isFinite(Number(t?.ny)) ? Number(t.ny) : 1,
+    nz: Number.isFinite(Number(t?.nz)) ? Number(t.nz) : 0,
+    surface: !!t?.surface,
+    rotationYDeg: Number(t?.rotationYDeg ?? 0),
+    scale: Number(t?.scale ?? 0.28),
+    useSymmetry: !!t?.useSymmetry,
+    snapCenterline: !!t?.snapCenterline,
+  };
+}
+
+function normalizeV8(doc) {
+  const v7 = normalizeV7(doc);
+  v7.schemaVersion = 8;
+  v7.children = (v7.children || []).map((ch) => ({
+    ...ch,
+    transform: normalizeChildTransformV8(ch.transform),
+  }));
+  return v7;
+}
+
 /** @type {Record<number, (doc: any) => any>} */
 const STEPS = {
   1(doc) {
@@ -382,6 +408,10 @@ const STEPS = {
   // 6 → 7: tessellationMode rotation | torus
   7(doc) {
     return normalizeV7(doc);
+  },
+  // 7 → 8: child surface placement (z + normal + surface flag)
+  8(doc) {
+    return normalizeV8(doc);
   },
 };
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -2,7 +2,7 @@
 // schema.js — semantic spline-project document + versioned migrations.
 // ============================================================================
 
-export const CURRENT_SCHEMA_VERSION = 7;
+export const CURRENT_SCHEMA_VERSION = 8;
 
 export const SCHEMA_KIND = "ranger.splineProject";
 
@@ -117,6 +117,11 @@ function serializeChild(ch) {
     transform: {
       x: Number(ch.transform?.x ?? 0.45),
       y: Number(ch.transform?.y ?? 0.35),
+      z: Number(ch.transform?.z ?? 0),
+      nx: Number(ch.transform?.nx ?? 0),
+      ny: Number(ch.transform?.ny ?? 1),
+      nz: Number(ch.transform?.nz ?? 0),
+      surface: !!ch.transform?.surface,
       rotationYDeg: Number(ch.transform?.rotationYDeg ?? 0),
       scale: Number(ch.transform?.scale ?? 0.28),
       useSymmetry: !!ch.transform?.useSymmetry,

--- a/gallery/game_engine/v2/mesh_editor/host/web_mesh_editor_host.rgr
+++ b/gallery/game_engine/v2/mesh_editor/host/web_mesh_editor_host.rgr
@@ -186,6 +186,41 @@ class WebMeshEditorHost {
         autoRotate = on
     }
 
+    ; View state for JS surface picking (camera + mesh yaw/tilt).
+    fn viewCamX:double () {
+        return (controls.camX())
+    }
+    fn viewCamY:double () {
+        return (controls.camY())
+    }
+    fn viewCamZ:double () {
+        return (controls.camZ())
+    }
+    fn viewTargetX:double () {
+        return (controls.getTargetX())
+    }
+    fn viewTargetY:double () {
+        return (controls.getTargetY())
+    }
+    fn viewTargetZ:double () {
+        return (controls.getTargetZ())
+    }
+    fn viewFov:double () {
+        return (controls.getFov())
+    }
+    fn viewMeshAngle:double () {
+        return angle
+    }
+    fn viewMeshTilt:double () {
+        return 0.12
+    }
+    fn viewWidth:double () {
+        return (to_double w)
+    }
+    fn viewHeight:double () {
+        return (to_double h)
+    }
+
     fn pointerDown:void (x:double y:double button:int) {
         controls.pointerDown(x y button)
         autoRotate = false

--- a/gallery/game_engine/v2/mesh_editor/library/README.md
+++ b/gallery/game_engine/v2/mesh_editor/library/README.md
@@ -42,6 +42,8 @@ copy or symlink selected folders into a tracked tree, or temporarily force-add.
   preview orientation and future assembly (default `(0,-1)→(0,1)`)
 - v7 adds `editor.tessellationMode`: `rotation` (classic lathe) or `torus` (profile
   swept along orbit as a unit-sized ring)
+- v8 extends child `transform` with optional surface placement (`z`, `nx/ny/nz`,
+  `surface`) for 3D preview raycast attach
 
 When you change the document shape, bump the version and add a step; old folders
 keep working.

--- a/gallery/game_engine/v2/three/port/src/three_orbit_controls.rgr
+++ b/gallery/game_engine/v2/three/port/src/three_orbit_controls.rgr
@@ -113,6 +113,34 @@ class ThreeOrbitControls {
         camera.lookAt(targetX targetY targetZ)
     }
 
+    ; Readouts for JS raycasting (camera at target + spherical offset).
+    fn camX:double () {
+        def sp:double (sin phi)
+        return (targetX + ((radius * sp) * (sin theta)))
+    }
+    fn camY:double () {
+        return (targetY + (radius * (cos phi)))
+    }
+    fn camZ:double () {
+        def sp:double (sin phi)
+        return (targetZ + ((radius * sp) * (cos theta)))
+    }
+    fn getTargetX:double () {
+        return targetX
+    }
+    fn getTargetY:double () {
+        return targetY
+    }
+    fn getTargetZ:double () {
+        return targetZ
+    }
+    fn getFov:double () {
+        if (hasCamera == false) {
+            return 45.0
+        }
+        return camera.fov
+    }
+
     fn pointerDown:void (x:double y:double button:int) {
         dragging = true
         if (button == 2) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sub-object attach is now a **3D surface place** flow:

1. Choose **Copy** / **Copy×2** / **Link** in Sub-objects  
2. Hover the **3D preview** (cursor = `copy` / +) — CPU raycast against the **root** mesh  
3. Click to attach: child’s **placement normal** is aligned to the hit surface normal  
4. Esc cancels; right-drag still orbits  

### Technical
- Schema **v8**: child `transform` adds `z`, `nx/ny/nz`, `surface`
- `meshPick.js` — canvas ray + Möller–Trumbore; inverts preview euler + placement orient
- Host exposes camera / mesh yaw for picking (`viewCam*`, `viewMeshAngle`, …)
- `meshTransform` surface bake: pivot at placement-normal start, align up → hit normal

## Test plan

- [ ] Copy from library → preview cursor becomes + → click root surface → child sticks on and points out along the normal
- [ ] Esc cancels place mode without attaching
- [ ] Right-drag still orbits while in place mode
- [ ] Linked attach shares content GUID; Copy×2 mirrors across X
- [ ] `node scripts/smoke-mesh-pick.mjs` passes
- [ ] Rebuild host (`node build-host.mjs`) before `npm run dev` if preview getters missing

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

