### PR TITLE
Add surface drag for sub-objects in 3D edit mode

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -154,6 +154,10 @@ Attach another library project as a child (**Copy** = new GUID, **Link** = share
 3. Click to place: the child’s **placement normal** aligns to the hit surface normal
 4. Esc cancels; right-drag still orbits the preview
 
+**Surface drag (sub-object edit):** open **Edit** on a child, then in the 3D preview
+hover that instance (grab cursor) and drag — it slides on the root surface, staying
+aligned to the hit normal (profile-plane children convert to surface placement on drag).
+
 Also: **Twin** / **Sym** for mirrored pairs; Profile attach boxes for non-surface nudging; **Edit** loads a child large while the preview stays the full assembly.
 
 ## Shading base

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -33,6 +33,10 @@ assert.ok(hit);
 assert.ok(Math.abs(hit.point[2]) < 1e-5);
 assert.ok(hit.normal[2] > 0.9);
 
+const tagged = [{ ...parts[0], instanceGuid: "child-a" }];
+const hitTagged = raycastMeshParts([0, 0, 3], [0, 0, -1], tagged);
+assert.equal(hitTagged?.instanceGuid, "child-a");
+
 const view = {
   cam: [0, 0, 4],
   target: [0, 0, 0],

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -239,6 +239,29 @@ function onPlaceCommit(hit) {
   tessellate();
 }
 
+const surfaceDragContentGuid = computed(() =>
+  isEditingChild() ? state.editTarget : null,
+);
+
+function onSurfaceDrag({ instanceGuid, point, normal }) {
+  if (!instanceGuid || !point || !normal) return;
+  updateChildTransform(instanceGuid, {
+    surface: true,
+    x: point[0],
+    y: point[1],
+    z: point[2],
+    nx: normal[0],
+    ny: normal[1],
+    nz: normal[2],
+  });
+  tessellate();
+}
+
+function onSurfaceDragEnd() {
+  endGesture();
+  tessellate();
+}
+
 onMounted(() => {
   tessellate();
   window.addEventListener("keydown", onKeyDown);
@@ -466,8 +489,13 @@ onBeforeUnmount(() => {
           :material-mode="state.materialMode"
           :placement-normal="state.placementNormal"
           :place-mode="!!placePending"
+          :surface-drag-content-guid="surfaceDragContentGuid"
+          :children="state.children"
           @place-commit="onPlaceCommit"
           @place-cancel="onCancelPlace"
+          @surface-drag="onSurfaceDrag"
+          @surface-drag-end="onSurfaceDragEnd"
+          @select-child="selectChild"
         />
         <ChildrenPanel
           :children="state.children"

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/ChildrenPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/ChildrenPanel.vue
@@ -152,7 +152,8 @@ function onAttach(slug, mode, symmetric) {
       <h3>Attach from library</h3>
       <p class="hint">
         Pick Copy / Link, then click the root surface in the 3D preview. The sub-object’s placement
-        normal aligns to the hit normal.
+        normal aligns to the hit normal. While editing a sub-object, drag it in 3D along that
+        surface.
       </p>
       <p v-if="placeMode" class="placing">
         Placing {{ placeLabel }}…

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
@@ -17,17 +17,37 @@ const props = defineProps({
     default: () => ({ start: { x: 0, y: -1 }, end: { x: 0, y: 1 } }),
   },
   placeMode: { type: Boolean, default: false },
+  /** When set (editing a sub-object), hover+drag that content’s instances on the root surface. */
+  surfaceDragContentGuid: { type: String, default: null },
+  children: { type: Array, default: () => [] },
 });
 
-const emit = defineEmits(["place-hover", "place-commit", "place-cancel"]);
+const emit = defineEmits([
+  "place-hover",
+  "place-commit",
+  "place-cancel",
+  "surface-drag",
+  "surface-drag-end",
+  "select-child",
+]);
 
 const canvasRef = ref(null);
 const wrapRef = ref(null);
 const backendLabel = ref("…");
 const hoverHit = ref(null);
+const hoverChildGuid = ref(null);
 let session = null;
 let draggingOrbit = false;
 let downPos = null;
+let surfaceDragging = false;
+let dragGuid = null;
+let blockHostOrbit = false;
+let dragRaf = 0;
+let pendingDragHit = null;
+
+const surfaceDragActive = computed(
+  () => !!props.surfaceDragContentGuid && !props.placeMode,
+);
 
 const displayMesh = computed(() =>
   orientMeshToPlacementNormal(props.mesh, props.placementNormal),
@@ -49,9 +69,8 @@ function getView() {
   return session?.getView?.() || null;
 }
 
-function pickAt(sx, sy) {
+function pickParts(sx, sy, parts) {
   const view = getView();
-  const parts = props.rootMesh?.parts;
   if (!view || !parts?.length) return null;
   return pickRootSurface(
     sx,
@@ -64,60 +83,166 @@ function pickAt(sx, sy) {
   );
 }
 
+function pickRoot(sx, sy) {
+  return pickParts(sx, sy, props.rootMesh?.parts);
+}
+
+function contentGuidForInstance(instanceGuid) {
+  const ch = props.children.find((c) => c.instanceGuid === instanceGuid);
+  return ch?.contentGuid || null;
+}
+
+function pickEditableChild(sx, sy) {
+  if (!surfaceDragActive.value) return null;
+  const hit = pickParts(sx, sy, props.mesh?.parts);
+  if (!hit?.instanceGuid) return null;
+  if (contentGuidForInstance(hit.instanceGuid) !== props.surfaceDragContentGuid) {
+    return null;
+  }
+  return hit;
+}
+
+function syncCursor() {
+  const el = canvasRef.value;
+  if (!el) return;
+  if (props.placeMode) el.style.cursor = "copy";
+  else if (surfaceDragging) el.style.cursor = "grabbing";
+  else if (hoverChildGuid.value) el.style.cursor = "grab";
+  else el.style.cursor = "crosshair";
+}
+
+function flushSurfaceDrag() {
+  dragRaf = 0;
+  const hit = pendingDragHit;
+  pendingDragHit = null;
+  if (!hit || !dragGuid) return;
+  emit("surface-drag", {
+    instanceGuid: dragGuid,
+    point: hit.point,
+    normal: hit.normal,
+  });
+}
+
+function queueSurfaceDrag(hit) {
+  pendingDragHit = hit;
+  if (dragRaf) return;
+  dragRaf = requestAnimationFrame(flushSurfaceDrag);
+}
+
 function onPointerDown(e) {
-  if (!props.placeMode) return;
-  if (e.button === 2 || e.button === 1) {
-    draggingOrbit = true;
-    session?.host?.pointerDown?.(e.offsetX, e.offsetY, e.button);
+  if (props.placeMode) {
+    if (e.button === 2 || e.button === 1) {
+      draggingOrbit = true;
+      blockHostOrbit = false;
+      session?.host?.pointerDown?.(e.offsetX, e.offsetY, e.button);
+      return;
+    }
+    if (e.button !== 0) return;
+    downPos = { x: e.offsetX, y: e.offsetY };
+    e.stopPropagation();
     return;
   }
-  if (e.button !== 0) return;
-  downPos = { x: e.offsetX, y: e.offsetY };
-  // Don't start orbit on left in place mode
-  e.stopPropagation();
+
+  if (surfaceDragActive.value && e.button === 0) {
+    const childHit = pickEditableChild(e.offsetX, e.offsetY);
+    if (childHit?.instanceGuid) {
+      surfaceDragging = true;
+      dragGuid = childHit.instanceGuid;
+      blockHostOrbit = true;
+      hoverChildGuid.value = dragGuid;
+      session?.setAutoRotate?.(false);
+      emit("select-child", dragGuid);
+      // Snap immediately if root is under the cursor
+      const rootHit = pickRoot(e.offsetX, e.offsetY);
+      if (rootHit) queueSurfaceDrag(rootHit);
+      try {
+        canvasRef.value?.setPointerCapture?.(e.pointerId);
+      } catch {
+        /* ignore */
+      }
+      e.stopPropagation();
+      syncCursor();
+      return;
+    }
+  }
 }
 
 function onPointerMove(e) {
-  if (!props.placeMode) return;
-  if (draggingOrbit) {
-    session?.host?.pointerMove?.(e.offsetX, e.offsetY);
+  if (props.placeMode) {
+    if (draggingOrbit) {
+      session?.host?.pointerMove?.(e.offsetX, e.offsetY);
+      return;
+    }
+    const hit = pickRoot(e.offsetX, e.offsetY);
+    hoverHit.value = hit;
+    emit("place-hover", hit);
     return;
   }
-  const hit = pickAt(e.offsetX, e.offsetY);
-  hoverHit.value = hit;
-  emit("place-hover", hit);
+
+  if (surfaceDragging && dragGuid) {
+    const rootHit = pickRoot(e.offsetX, e.offsetY);
+    if (rootHit) queueSurfaceDrag(rootHit);
+    return;
+  }
+
+  if (surfaceDragActive.value) {
+    const childHit = pickEditableChild(e.offsetX, e.offsetY);
+    hoverChildGuid.value = childHit?.instanceGuid || null;
+    syncCursor();
+  }
 }
 
 function onPointerUp(e) {
-  if (!props.placeMode) return;
-  if (draggingOrbit) {
-    session?.host?.pointerUp?.();
-    draggingOrbit = false;
+  if (props.placeMode) {
+    if (draggingOrbit) {
+      session?.host?.pointerUp?.();
+      draggingOrbit = false;
+      return;
+    }
+    if (e.button !== 0 || !downPos) return;
+    const dist = Math.hypot(e.offsetX - downPos.x, e.offsetY - downPos.y);
+    downPos = null;
+    if (dist > 6) return;
+    const hit = pickRoot(e.offsetX, e.offsetY);
+    if (hit) emit("place-commit", hit);
     return;
   }
-  if (e.button !== 0 || !downPos) return;
-  const dist = Math.hypot(e.offsetX - downPos.x, e.offsetY - downPos.y);
-  downPos = null;
-  if (dist > 6) return;
-  const hit = pickAt(e.offsetX, e.offsetY);
-  if (hit) emit("place-commit", hit);
+
+  if (surfaceDragging) {
+    if (dragRaf) {
+      cancelAnimationFrame(dragRaf);
+      dragRaf = 0;
+    }
+    flushSurfaceDrag();
+    surfaceDragging = false;
+    dragGuid = null;
+    blockHostOrbit = false;
+    session?.setAutoRotate?.(!props.placeMode);
+    emit("surface-drag-end");
+    syncCursor();
+  }
 }
 
 function onKeyDown(e) {
-  if (!props.placeMode) return;
-  if (e.key === "Escape") {
+  if (props.placeMode && e.key === "Escape") {
     emit("place-cancel");
   }
 }
 
 function onContextMenu(e) {
-  if (props.placeMode) e.preventDefault();
+  if (props.placeMode || surfaceDragging) e.preventDefault();
+}
+
+function onPointerLeave() {
+  if (surfaceDragging) return;
+  hoverChildGuid.value = null;
+  syncCursor();
 }
 
 onMounted(async () => {
   try {
     session = await createPreviewSession(canvasRef.value, 420, {
-      placeModeGetter: () => props.placeMode,
+      placeModeGetter: () => props.placeMode || blockHostOrbit,
     });
     backendLabel.value = session.useGL ? "Ranger Three · WebGL" : "Ranger Three · software";
     pushDisplay();
@@ -132,6 +257,7 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   window.removeEventListener("keydown", onKeyDown);
+  if (dragRaf) cancelAnimationFrame(dragRaf);
   session?.dispose();
   session = null;
 });
@@ -148,17 +274,34 @@ watch(
 watch(
   () => props.placeMode,
   (on) => {
-    session?.setAutoRotate?.(!on);
+    session?.setAutoRotate?.(!on && !surfaceDragging);
     hoverHit.value = null;
-    if (canvasRef.value) {
-      canvasRef.value.style.cursor = on ? "copy" : "crosshair";
+    hoverChildGuid.value = null;
+    syncCursor();
+  },
+);
+
+watch(
+  () => props.surfaceDragContentGuid,
+  () => {
+    hoverChildGuid.value = null;
+    if (surfaceDragging) {
+      surfaceDragging = false;
+      dragGuid = null;
+      blockHostOrbit = false;
+      emit("surface-drag-end");
     }
+    syncCursor();
   },
 );
 </script>
 
 <template>
-  <div ref="wrapRef" class="preview" :class="{ placing: placeMode }">
+  <div
+    ref="wrapRef"
+    class="preview"
+    :class="{ placing: placeMode, 'surface-drag': surfaceDragActive }"
+  >
     <header>
       <h2>3D preview</h2>
       <span>{{ backendLabel }}</span>
@@ -167,25 +310,25 @@ watch(
       <canvas
         ref="canvasRef"
         class="view"
-        :class="{ place: placeMode }"
+        :class="{ place: placeMode, grab: !!hoverChildGuid || surfaceDragging }"
         @pointerdown.capture="onPointerDown"
         @pointermove.capture="onPointerMove"
         @pointerup.capture="onPointerUp"
+        @pointerleave="onPointerLeave"
         @contextmenu="onContextMenu"
       />
       <div v-if="placeMode" class="place-banner">
         Place on surface · hover (+) · click to attach · Esc cancel · right-drag orbit
       </div>
-      <div
-        v-if="placeMode && hoverHit"
-        class="hit-dot"
-        :style="{
-          // approximate marker — banner is enough; keep simple center cue
-        }"
-      />
+      <div v-else-if="surfaceDragActive" class="place-banner drag">
+        Sub edit · hover sub-object · drag along surface · right-drag orbit
+      </div>
     </div>
     <p class="hint">
       <template v-if="placeMode">Aim at the root surface — sub-object aligns to the normal</template>
+      <template v-else-if="surfaceDragActive">
+        Drag the sub-object on the root surface (follows normals)
+      </template>
       <template v-else>Drag to orbit · wheel to zoom · view aligned so placement normal points up</template>
     </p>
   </div>
@@ -205,6 +348,10 @@ watch(
 .preview.placing {
   border-color: rgba(59, 130, 246, 0.55);
   box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.25);
+}
+.preview.surface-drag {
+  border-color: rgba(52, 211, 153, 0.45);
+  box-shadow: 0 0 0 1px rgba(52, 211, 153, 0.2);
 }
 
 header {
@@ -246,6 +393,9 @@ span {
 .view.place {
   cursor: copy;
 }
+.view.grab {
+  cursor: grab;
+}
 
 .place-banner {
   position: absolute;
@@ -259,6 +409,9 @@ span {
   font-size: 0.68rem;
   pointer-events: none;
   text-align: center;
+}
+.place-banner.drag {
+  color: #a7f3d0;
 }
 
 .hint {

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -859,7 +859,7 @@ export function useSplineEditor() {
     };
   }
 
-  function pushTransformedParts(parts, childParts, xf, mirrorX, body) {
+  function pushTransformedParts(parts, childParts, xf, mirrorX, body, instanceGuid) {
     const pn = normalizePlacementNormal(body?.placementNormal);
     const up = placementNormalDirection3(pn);
     const pivot = [pn.start.x, pn.start.y, 0];
@@ -887,7 +887,9 @@ export function useSplineEditor() {
           mirrorX,
         };
     const placed = transformParts(childParts, surfaceXf, xf.surface ? pivot : undefined);
-    for (const p of placed) parts.push(p);
+    for (const p of placed) {
+      parts.push(instanceGuid ? { ...p, instanceGuid } : p);
+    }
   }
 
   function tessellate() {
@@ -904,12 +906,12 @@ export function useSplineEditor() {
       if (!body || body.knots.length < 2 || body.orbitKnots.length < 3) continue;
       const child = tessellateBody(body);
       const xf = ch.transform || defaultChildTransform();
-      pushTransformedParts(parts, child.parts, xf, false, body);
+      pushTransformedParts(parts, child.parts, xf, false, body, ch.instanceGuid);
       totalV += child.verts;
       totalT += child.tris;
       // Symmetry: same content, mirrored placement (linked eyes without a second instance).
       if (xf.useSymmetry && !xf.snapCenterline && !xf.surface && Math.abs(xf.x) > 0.001) {
-        pushTransformedParts(parts, child.parts, xf, true, body);
+        pushTransformedParts(parts, child.parts, xf, true, body, ch.instanceGuid);
         totalV += child.verts;
         totalT += child.tris;
       }
@@ -959,12 +961,23 @@ export function useSplineEditor() {
   function updateChildTransform(instanceGuid, patch) {
     const ch = state.children.find((c) => c.instanceGuid === instanceGuid);
     if (!ch) return;
-    const moving = patch.x != null || patch.y != null;
+    const moving =
+      patch.x != null ||
+      patch.y != null ||
+      patch.z != null ||
+      patch.nx != null ||
+      patch.ny != null ||
+      patch.nz != null ||
+      patch.surface != null;
     if (moving) beginGesture("move-child");
     else commitToHistory("child-transform");
     Object.assign(ch.transform, patch);
     if (patch.snapCenterline) {
       ch.transform.x = 0;
+      ch.transform.useSymmetry = false;
+    }
+    if (patch.surface) {
+      ch.transform.snapCenterline = false;
       ch.transform.useSymmetry = false;
     }
   }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/meshPick.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/meshPick.js
@@ -116,7 +116,7 @@ export function intersectTriangle(origin, dir, v0, v1, v2) {
 
 /**
  * Raycast mesh parts in the same space as the ray.
- * @returns {{ point:[number,number,number], normal:[number,number,number], t:number } | null}
+ * @returns {{ point:[number,number,number], normal:[number,number,number], t:number, instanceGuid?:string } | null}
  */
 export function raycastMeshParts(origin, dir, parts) {
   let bestT = Infinity;
@@ -147,6 +147,7 @@ export function raycastMeshParts(origin, dir, parts) {
         point: add3(origin, mul3(dir, t)),
         normal: n,
         t,
+        instanceGuid: part.instanceGuid || undefined,
       };
     }
   }

--- a/gallery/game_engine/v2/mesh_editor/library/README.md
+++ b/gallery/game_engine/v2/mesh_editor/library/README.md
@@ -43,7 +43,7 @@ copy or symlink selected folders into a tracked tree, or temporarily force-add.
 - v7 adds `editor.tessellationMode`: `rotation` (classic lathe) or `torus` (profile
   swept along orbit as a unit-sized ring)
 - v8 extends child `transform` with optional surface placement (`z`, `nx/ny/nz`,
-  `surface`) for 3D preview raycast attach
+  `surface`) for 3D preview raycast attach and surface-drag while editing a child
 
 When you change the document shape, bump the version and add a step; old folders
 keep working.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
While editing a sub-object, you can now drag it along the root surface in the 3D preview.

### Behavior
- Enter **Edit** on a child (sub-object edit mode)
- In the 3D preview, hover that instance (grab cursor)
- Left-drag: raycast the **root** mesh and update the child’s surface transform (`x,y,z` + `nx,ny,nz`, `surface: true`) so it slides on the surface and stays aligned to the hit normal
- Profile-plane children convert to surface placement on first drag
- Undo uses the existing move-child gesture; right-drag still orbits; place mode unchanged

### Implementation notes
- Tessellated child parts are tagged with `instanceGuid` for hover hit-testing
- `Preview3D` owns the drag gesture; `App` applies `updateChildTransform` + `tessellate`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

