### PR TITLE
Fix child surface transforms stripped on save/migrate

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -146,4 +146,39 @@ assert.equal(mig.doc.schemaVersion, 8);
 assert.equal(mig.doc.children[0].transform.surface, false);
 assert.equal(mig.doc.children[0].transform.z, 0);
 
+// Save path re-runs migrate on an already-v8 doc — surface pose must survive.
+const v8Surface = {
+  ...mig.doc,
+  schemaVersion: 8,
+  children: [
+    {
+      ...mig.doc.children[0],
+      transform: {
+        x: 0.12,
+        y: -0.34,
+        z: 0.56,
+        nx: 0.1,
+        ny: 0.9,
+        nz: 0.2,
+        surface: true,
+        rotationYDeg: 15,
+        scale: 0.22,
+        useSymmetry: false,
+        snapCenterline: false,
+      },
+    },
+  ],
+};
+const roundTrip = migrateProject(v8Surface);
+assert.equal(roundTrip.ok, true, roundTrip.errors?.join("; "));
+const xf = roundTrip.doc.children[0].transform;
+assert.equal(xf.surface, true);
+assert.ok(Math.abs(xf.x - 0.12) < 1e-9);
+assert.ok(Math.abs(xf.y - -0.34) < 1e-9);
+assert.ok(Math.abs(xf.z - 0.56) < 1e-9);
+assert.ok(Math.abs(xf.nx - 0.1) < 1e-9);
+assert.ok(Math.abs(xf.ny - 0.9) < 1e-9);
+assert.ok(Math.abs(xf.nz - 0.2) < 1e-9);
+assert.ok(Math.abs(xf.scale - 0.22) < 1e-9);
+
 console.log("smoke-mesh-pick: ok");

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -176,6 +176,13 @@ function normalizeV3(doc) {
     transform: {
       x: Number(ch.transform?.x ?? 0.45),
       y: Number(ch.transform?.y ?? 0.35),
+      // Forward-compat: v8 surface fields must survive the v3 whitelist when
+      // migrateProject re-runs STEPS[CURRENT] on an already-current document.
+      z: Number(ch.transform?.z ?? 0),
+      nx: Number.isFinite(Number(ch.transform?.nx)) ? Number(ch.transform.nx) : 0,
+      ny: Number.isFinite(Number(ch.transform?.ny)) ? Number(ch.transform.ny) : 1,
+      nz: Number.isFinite(Number(ch.transform?.nz)) ? Number(ch.transform.nz) : 0,
+      surface: !!ch.transform?.surface,
       rotationYDeg: Number(ch.transform?.rotationYDeg ?? 0),
       scale: Number(ch.transform?.scale ?? 0.28),
       useSymmetry: !!ch.transform?.useSymmetry,
@@ -375,9 +382,20 @@ function normalizeChildTransformV8(t) {
 function normalizeV8(doc) {
   const v7 = normalizeV7(doc);
   v7.schemaVersion = 8;
+  // normalizeV7→V3 historically rebuilt child transforms without surface fields.
+  // Prefer the input document's transforms (by instanceGuid) so save/load keeps
+  // surface placement (x,y,z + normal) instead of resetting to profile-plane defaults.
+  const origXf = new Map(
+    (doc.children || [])
+      .filter((ch) => ch?.instanceGuid)
+      .map((ch) => [ch.instanceGuid, ch.transform || {}]),
+  );
   v7.children = (v7.children || []).map((ch) => ({
     ...ch,
-    transform: normalizeChildTransformV8(ch.transform),
+    transform: normalizeChildTransformV8({
+      ...ch.transform,
+      ...(origXf.get(ch.instanceGuid) || {}),
+    }),
   }));
   return v7;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Surface-placed sub-objects lost their 3D pose on save/load and jumped back to profile-plane placement.

### Cause
`migrateProject` always re-runs `STEPS[CURRENT]` (`normalizeV8`). That chained through `normalizeV3`, which rebuilt child `transform` **without** `z` / `nx` / `ny` / `nz` / `surface`. The final v8 normalize then defaulted those fields, so `surface` became `false` even though `x`/`y` were kept.

### Fix
- Preserve surface fields through the v3 transform whitelist (forward-compat)
- In `normalizeV8`, merge transforms from the **input** document by `instanceGuid` before normalizing
- Smoke: round-trip an already-v8 doc with a surface pose through `migrateProject`

Already-saved projects that were wiped need to be re-placed once after this lands (the bad save already dropped the fields on disk).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

