### PR TITLE
Fix child spine save/load and re-seat surface children on spine edits

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -158,6 +158,10 @@ Attach another library project as a child (**Copy** = new GUID, **Link** = share
 hover that instance (grab cursor) and drag — it slides on the root surface, staying
 aligned to the hit normal (profile-plane children convert to surface placement on drag).
 
+Editing the root **spine** (or profile) re-seats surface-placed children on the updated
+root mesh along their stored parent normal. Child spines and placement normals are
+stored on the embedded asset and survive save/load.
+
 Also: **Twin** / **Sym** for mirrored pairs; Profile attach boxes for non-surface nudging; **Edit** loads a child large while the preview stays the full assembly.
 
 ## Shading base

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-spine.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-spine.mjs
@@ -195,9 +195,93 @@ assert.ok(mig.doc.spineProfile.knots.every((k) => Math.abs(k.x) < 1e-9));
 const errs = validateProject(mig.doc);
 assert.equal(errs.length, 0, errs.join("; "));
 
+// Embedded child spines must survive save re-migrate (not reset to y=-1…1).
+const shortSpine = [
+  { id: "sp0", x: 0, y: -0.2, hx: 0, hy: 0, color: "#fff" },
+  { id: "sp1", x: 0, y: 0, hx: 0, hy: 0, color: "#fff" },
+  { id: "sp2", x: 0, y: 0.25, hx: 0, hy: 0, color: "#fff" },
+];
+const shortSegs = [
+  {
+    fromId: "sp0",
+    toId: "sp1",
+    pathType: "line",
+    roughness: 0.4,
+    metalness: 0,
+    opacity: 1,
+    texture: "gradient",
+    color: null,
+  },
+  {
+    fromId: "sp1",
+    toId: "sp2",
+    pathType: "line",
+    roughness: 0.4,
+    metalness: 0,
+    opacity: 1,
+    texture: "gradient",
+    color: null,
+  },
+];
+const v8Child = {
+  ...mig.doc,
+  schemaVersion: 8,
+  embeddedAssets: {
+    c1: {
+      assetGuid: "c1",
+      name: "Eye",
+      curveType: 0,
+      pathSegments: 12,
+      angularSteps: 24,
+      revolutionDeg: 360,
+      tessellationMode: "rotation",
+      objectMaterial: mig.doc.objectMaterial,
+      knots: mig.doc.profile.knots,
+      segments: mig.doc.profile.segments,
+      orbitKnots: mig.doc.orbit.knots,
+      orbitSegments: mig.doc.orbit.segments,
+      spineProfileKnots: shortSpine,
+      spineProfileSegments: shortSegs,
+      spineOrbitKnots: shortSpine,
+      spineOrbitSegments: shortSegs,
+      placementNormal: { start: { x: 0, y: -0.2 }, end: { x: 0, y: 0.25 } },
+    },
+  },
+  children: [
+    {
+      instanceGuid: "i1",
+      contentGuid: "c1",
+      mode: "copy",
+      name: "Eye",
+      transform: {
+        x: 0.1,
+        y: 0.2,
+        z: 0.3,
+        nx: 0,
+        ny: 1,
+        nz: 0,
+        surface: true,
+        scale: 0.2,
+        rotationYDeg: 0,
+        useSymmetry: false,
+        snapCenterline: false,
+      },
+      visible: true,
+    },
+  ],
+};
+const childRound = migrateProject(v8Child);
+assert.equal(childRound.ok, true, childRound.errors?.join("; "));
+const emb = childRound.doc.embeddedAssets.c1;
+assert.ok(emb, "embedded asset kept");
+assert.ok(Math.abs(emb.spineProfileKnots[0].y - -0.2) < 1e-9, "short spine start kept");
+assert.ok(Math.abs(emb.spineProfileKnots[2].y - 0.25) < 1e-9, "short spine end kept");
+assert.ok(Math.abs(emb.placementNormal.start.y - -0.2) < 1e-9, "child placementNormal kept");
+
 console.log("smoke-spine: ok", {
   maxDiffStraight: maxDiff,
   scaledOrbitDiff: scaledDiff,
   bentMoved: moved,
   schema: mig.doc.schemaVersion,
+  childSpineY: [emb.spineProfileKnots[0].y, emb.spineProfileKnots[2].y],
 });

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -46,6 +46,7 @@ const {
   redo,
   endGesture,
   isEditingChild,
+  activePlacementNormal,
 } = useSplineEditor();
 
 const { lib, refresh, load, save, saveAs, remove, exportJson, importJsonFile } = useLibrary({
@@ -109,6 +110,7 @@ function onNormalNum(which, axis, ev) {
 
 const knots = computed(() => activeKnots());
 const segments = computed(() => activeSegments());
+const placementNormal = computed(() => activePlacementNormal());
 const editingLabel = computed(() =>
   isEditingChild()
     ? state.embeddedAssets[state.editTarget]?.name || "sub-object"
@@ -404,13 +406,13 @@ onBeforeUnmount(() => {
             <input
               type="number"
               step="0.05"
-              :value="state.placementNormal.start.x"
+              :value="placementNormal.start.x"
               @change="onNormalNum('start', 'x', $event)"
             />
             <input
               type="number"
               step="0.05"
-              :value="state.placementNormal.start.y"
+              :value="placementNormal.start.y"
               @change="onNormalNum('start', 'y', $event)"
             />
           </label>
@@ -419,13 +421,13 @@ onBeforeUnmount(() => {
             <input
               type="number"
               step="0.05"
-              :value="state.placementNormal.end.x"
+              :value="placementNormal.end.x"
               @change="onNormalNum('end', 'x', $event)"
             />
             <input
               type="number"
               step="0.05"
-              :value="state.placementNormal.end.y"
+              :value="placementNormal.end.y"
               @change="onNormalNum('end', 'y', $event)"
             />
           </label>
@@ -455,7 +457,7 @@ onBeforeUnmount(() => {
         :selected-child-guid="state.selectedChildGuid"
         :edit-target="state.editTarget"
         :viewport="state.viewport"
-        :placement-normal="state.placementNormal"
+        :placement-normal="placementNormal"
         :sample-curve-points="sampleCurvePoints"
         :find-closest-on-curve="findClosestOnCurve"
         @select="onSelect"

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -15,6 +15,7 @@ import {
   normalizePlacementNormal,
   placementNormalDirection3,
 } from "../lib/placementNormal.js";
+import { raycastMeshParts } from "../lib/meshPick.js";
 
 /** @typedef {{ id: string, x: number, y: number, hx: number, hy: number, color: string }} Knot */
 /** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureData: any, textureAsset?: string|null, pathType?: string, arcBulge?: number|null }} Segment */
@@ -262,6 +263,7 @@ export function useSplineEditor() {
         spineProfileSegments: bsp.segments,
         spineOrbitKnots: bso.knots,
         spineOrbitSegments: bso.segments,
+        placementNormal: normalizePlacementNormal(body.placementNormal),
         objectMaterial: { ...defaultObjectMaterial(), ...(body.objectMaterial || {}) },
       };
     }
@@ -619,6 +621,12 @@ export function useSplineEditor() {
     Object.assign(s, patch);
   }
 
+  function activePlacementNormal() {
+    const b = bodyRef();
+    if (b) return normalizePlacementNormal(b.placementNormal);
+    return normalizePlacementNormal(state.placementNormal);
+  }
+
   function updatePlacementNormal(patch) {
     const moving =
       patch?.start != null ||
@@ -629,7 +637,10 @@ export function useSplineEditor() {
       patch?.endY != null;
     if (moving) beginGesture("move-normal");
     else commitToHistory("placement-normal");
-    const cur = normalizePlacementNormal(state.placementNormal);
+    const target = bodyRef();
+    const cur = normalizePlacementNormal(
+      target ? target.placementNormal : state.placementNormal,
+    );
     const next = {
       start: { ...cur.start, ...(patch.start || {}) },
       end: { ...cur.end, ...(patch.end || {}) },
@@ -642,12 +653,15 @@ export function useSplineEditor() {
     if (Math.hypot(next.end.x - next.start.x, next.end.y - next.start.y) < 1e-6) {
       next.end.y = next.start.y + 0.01;
     }
-    state.placementNormal = next;
+    if (target) target.placementNormal = next;
+    else state.placementNormal = next;
   }
 
   function resetPlacementNormal() {
     commitToHistory("reset-normal");
-    state.placementNormal = defaultPlacementNormal();
+    const target = bodyRef();
+    if (target) target.placementNormal = defaultPlacementNormal();
+    else state.placementNormal = defaultPlacementNormal();
     state.status = "Placement normal reset to bottom→top (0,-1)→(0,1).";
   }
 
@@ -892,10 +906,49 @@ export function useSplineEditor() {
     }
   }
 
+  /**
+   * Keep surface-placed children seated on the root: raycast along the stored
+   * parent normal through the attach point and refresh point + normal.
+   * Called after root (re)tessellation so spine/profile edits re-align subs.
+   */
+  function resnapSurfaceChildren(rootParts) {
+    if (!rootParts?.length) return;
+    for (const ch of state.children) {
+      const xf = ch.transform;
+      if (!xf?.surface) continue;
+      const nx = Number(xf.nx) || 0;
+      const ny = Number(xf.ny) || 1;
+      const nz = Number(xf.nz) || 0;
+      const L = Math.hypot(nx, ny, nz) || 1;
+      const n = [nx / L, ny / L, nz / L];
+      const px = Number(xf.x) || 0;
+      const py = Number(xf.y) || 0;
+      const pz = Number(xf.z) || 0;
+      const origin = [px + n[0] * 0.75, py + n[1] * 0.75, pz + n[2] * 0.75];
+      let hit = raycastMeshParts(origin, [-n[0], -n[1], -n[2]], rootParts);
+      if (!hit) {
+        hit = raycastMeshParts(
+          [px - n[0] * 0.75, py - n[1] * 0.75, pz - n[2] * 0.75],
+          n,
+          rootParts,
+        );
+      }
+      if (!hit) continue;
+      xf.x = hit.point[0];
+      xf.y = hit.point[1];
+      xf.z = hit.point[2];
+      xf.nx = hit.normal[0];
+      xf.ny = hit.normal[1];
+      xf.nz = hit.normal[2];
+    }
+  }
+
   function tessellate() {
     // Always assemble from ROOT + children (preview shows full object even when editing a child).
     const root = tessellateBody(rootBodySnapshot());
     state.rootMesh = { parts: root.parts.slice() };
+    // Spine / profile edits move the root surface — re-seat surface children on it.
+    resnapSurfaceChildren(state.rootMesh.parts);
     const parts = root.parts.slice();
     let totalV = root.verts;
     let totalT = root.tris;
@@ -950,6 +1003,7 @@ export function useSplineEditor() {
       state.status = "Missing embedded content for this sub-object.";
       return;
     }
+    if (!body.placementNormal) body.placementNormal = defaultPlacementNormal();
     state.selectedChildGuid = instanceGuid;
     state.editTarget = ch.contentGuid;
     state.viewMode = "profile";
@@ -1200,6 +1254,7 @@ export function useSplineEditor() {
         spineProfileSegments: bsp.segments,
         spineOrbitKnots: bso.knots,
         spineOrbitSegments: bso.segments,
+        placementNormal: normalizePlacementNormal(body.placementNormal),
         objectMaterial: { ...defaultObjectMaterial(), ...(body.objectMaterial || {}) },
       };
     }
@@ -1240,6 +1295,7 @@ export function useSplineEditor() {
         spineProfileSegments: (body.spineProfileSegments || []).map(mapSegSnapshot),
         spineOrbitKnots: (body.spineOrbitKnots || []).map((k) => ({ ...k })),
         spineOrbitSegments: (body.spineOrbitSegments || []).map(mapSegSnapshot),
+        placementNormal: normalizePlacementNormal(body.placementNormal),
       };
     }
     return {
@@ -1303,6 +1359,7 @@ export function useSplineEditor() {
     activeSegments,
     activeObjectMaterial,
     activeCurveType,
+    activePlacementNormal,
     setActiveCurveType,
     isEditingChild,
     setViewMode,

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/assetClone.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/assetClone.js
@@ -168,6 +168,7 @@ export function snapshotRootAsBody(state) {
       pathType: s.pathType || "line",
       arcBulge: s.arcBulge ?? null,
     })),
+    placementNormal: normalizePlacementNormal(state.placementNormal),
   };
 }
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -137,6 +137,10 @@ function normalizeEmbeddedBody(body, fallbackGuid) {
   const knots = mapKnots(body.knots);
   const orbitKnots = mapKnots(body.orbitKnots || body.orbit?.knots);
   if (orbitKnots.length < 3) return null;
+  // Forward-compat: keep spine + placementNormal through the v3 whitelist so
+  // migrateProject's final STEPS[CURRENT] re-normalize does not wipe them.
+  const spineProfileKnots = mapKnots(body.spineProfileKnots);
+  const spineOrbitKnots = mapKnots(body.spineOrbitKnots);
   return {
     assetGuid: body.assetGuid || fallbackGuid || newId(),
     name: body.name || "Sub-object",
@@ -155,6 +159,26 @@ function normalizeEmbeddedBody(body, fallbackGuid) {
     segments: mapSegments(body.segments, knots, false),
     orbitKnots,
     orbitSegments: mapSegments(body.orbitSegments || body.orbit?.segments, orbitKnots, true),
+    spineProfileKnots,
+    spineProfileSegments: spineProfileKnots.length
+      ? mapSegments(body.spineProfileSegments, spineProfileKnots, false)
+      : [],
+    spineOrbitKnots,
+    spineOrbitSegments: spineOrbitKnots.length
+      ? mapSegments(body.spineOrbitSegments, spineOrbitKnots, false)
+      : [],
+    placementNormal: body.placementNormal
+      ? {
+          start: {
+            x: Number(body.placementNormal.start?.x) || 0,
+            y: Number(body.placementNormal.start?.y) || 0,
+          },
+          end: {
+            x: Number(body.placementNormal.end?.x) || 0,
+            y: Number(body.placementNormal.end?.y) || 0,
+          },
+        }
+      : undefined,
   };
 }
 
@@ -299,21 +323,43 @@ function normalizeV5(doc) {
   v4.spineProfile = normalizeSpineBlock(doc.spineProfile, "spp");
   v4.spineOrbit = normalizeSpineBlock(doc.spineOrbit, "spo");
   const emb = {};
+  // Prefer spines from the *input* doc — normalizeV3 historically rebuilt
+  // embedded bodies without spine fields, which reset shortened child spines
+  // to the default full-length (-1…1) centerline on every save/migrate.
+  const origEmb = doc.embeddedAssets || {};
   for (const [guid, body] of Object.entries(v4.embeddedAssets || {})) {
+    const src =
+      origEmb[guid] ||
+      origEmb[body.assetGuid] ||
+      Object.values(origEmb).find((b) => b?.assetGuid === body.assetGuid) ||
+      body;
     const sp = normalizeSpineBlock(
-      { knots: body.spineProfileKnots, segments: body.spineProfileSegments },
+      { knots: src.spineProfileKnots, segments: src.spineProfileSegments },
       "spp",
     );
     const so = normalizeSpineBlock(
-      { knots: body.spineOrbitKnots, segments: body.spineOrbitSegments },
+      { knots: src.spineOrbitKnots, segments: src.spineOrbitSegments },
       "spo",
     );
+    const pnSrc = src.placementNormal || body.placementNormal;
     emb[guid] = {
       ...body,
       spineProfileKnots: sp.knots,
       spineProfileSegments: sp.segments,
       spineOrbitKnots: so.knots,
       spineOrbitSegments: so.segments,
+      placementNormal: pnSrc
+        ? {
+            start: {
+              x: Number(pnSrc.start?.x) || 0,
+              y: Number(pnSrc.start?.y) || 0,
+            },
+            end: {
+              x: Number(pnSrc.end?.x) || 0,
+              y: Number(pnSrc.end?.y) || 0,
+            },
+          }
+        : body.placementNormal,
     };
   }
   v4.embeddedAssets = emb;

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -103,6 +103,7 @@ function serializeBodyContent(body) {
     spineProfileSegments: (body.spineProfileSegments || []).map(serializeSegment),
     spineOrbitKnots: (body.spineOrbitKnots || []).map(serializeKnot),
     spineOrbitSegments: (body.spineOrbitSegments || []).map(serializeSegment),
+    placementNormal: serializePlacementNormal(body.placementNormal),
   };
 }
 

--- a/gallery/game_engine/v2/mesh_editor/library/README.md
+++ b/gallery/game_engine/v2/mesh_editor/library/README.md
@@ -43,7 +43,9 @@ copy or symlink selected folders into a tracked tree, or temporarily force-add.
 - v7 adds `editor.tessellationMode`: `rotation` (classic lathe) or `torus` (profile
   swept along orbit as a unit-sized ring)
 - v8 extends child `transform` with optional surface placement (`z`, `nx/ny/nz`,
-  `surface`) for 3D preview raycast attach and surface-drag while editing a child
+  `surface`) for 3D preview raycast attach and surface-drag while editing a child.
+  Embedded assets also persist `spineProfileKnots` / `spineOrbitKnots` and
+  `placementNormal` (shortened child spines must not reset on save).
 
 When you change the document shape, bump the version and add a step; old folders
 keep working.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Child spine reset on save (bug)
Saving re-ran `migrateProject` → `normalizeV8` → … → `normalizeV3`, which rebuilt embedded assets **without** spine fields. `normalizeV5` then filled the default full-length centerline (`y = -1…1`), so shortened child spines “grew” back to max length after load.

**Fix:** keep spine (+ `placementNormal`) through the embedded-body whitelist, and in `normalizeV5` prefer spines from the input document. Also serialize embedded `placementNormal` on save.

### Re-align sub-objects when spine changes
After root retessellation, surface-placed children are re-raycast along their stored parent normal so they stay seated/aligned when the root spine (or profile) moves. While editing a child, the placement-normal UI/canvas edits that child’s own normal (used for surface alignment).

### Test
`smoke-spine.mjs` now round-trips a v8 project with a shortened embedded spine through `migrateProject`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

