### PR TITLE
Add texture sector with reusable path editor and eye layers

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -3,7 +3,8 @@
 Vite + Vue editor under `gallery/game_engine/v2/mesh_editor` for building
 **symmetrical spline silhouettes** plus an editable **orbit path** (Bezier
 replacement for cos/sin), lathe-tessellated into 3D meshes rendered with
-**Ranger Three**.
+**Ranger Three**. Includes a **Texture** sector (eye editor first) that reuses
+the shared Bezier path editor and stores **params only** (runtime raster).
 
 ## Layout
 
@@ -163,6 +164,25 @@ root mesh along their stored parent normal. Child spines and placement normals a
 stored on the embedded asset and survive save/load.
 
 Also: **Twin** / **Sym** for mirrored pairs; Profile attach boxes for non-surface nudging; **Edit** loads a child large while the preview stays the full assembly.
+
+### Texture editor (schema v9)
+
+Top toggle **Mesh | Texture**. Shared path kit: `lib/pathModel.js`, `usePathEditor`,
+`SplineCanvas` feature flags (lathe guides off in texture mode).
+
+**Eye texture** (`textureAssets[*].kind: "eye"`):
+
+| Layer | Role |
+|-------|------|
+| Eyeball | Closed Bezier silhouette (shape editor) |
+| Iris | Closed path, constrained inside eyeball |
+| Pupil | Closed path, constrained inside iris |
+| Reflection | Shine spot, constrained inside eyeball |
+| Eyelid | Open Bezier + filled clip region, drawn on top (clipped to eyeball) |
+
+Layers can be named, reordered, enabled/disabled. Only **params** are saved
+(`knots` / `segments` / colours) — `renderEyeTexture` rebuilds pixels at runtime
+(animatable). Mesh UV projection / vertex-colour background assign is next.
 
 ## Shading base
 

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import {
+  createDefaultEyeTexture,
+  serializeEyeTexture,
+  normalizeEyeTexture,
+  constrainAllEyeLayers,
+  findLayer,
+  layerPolygon,
+} from "../src/lib/texture/eyeTexture.js";
+import { pointInPolygon, pathCentroid } from "../src/lib/pathModel.js";
+import { migrateProject } from "../src/library/migrations.js";
+import { CURRENT_SCHEMA_VERSION, buildProjectDocument } from "../src/library/schema.js";
+
+const eye = createDefaultEyeTexture({ name: "TestEye" });
+assert.equal(eye.kind, "eye");
+assert.ok(eye.layers.some((L) => L.type === "eyeball"));
+assert.ok(eye.layers.some((L) => L.type === "iris"));
+assert.ok(eye.layers.some((L) => L.type === "pupil"));
+
+// Move iris far outside, then constrain — centroid should land inside eyeball
+const iris = findLayer(eye, "iris");
+for (const k of iris.knots) {
+  k.x += 5;
+  k.y += 5;
+}
+constrainAllEyeLayers(eye);
+const eyePoly = layerPolygon(findLayer(eye, "eyeball"));
+const c = pathCentroid(iris.knots);
+assert.ok(pointInPolygon(c.x, c.y, eyePoly), "iris centroid inside eyeball after constrain");
+
+const pupil = findLayer(eye, "pupil");
+for (const k of pupil.knots) {
+  k.x = iris.knots[0].x + 3;
+  k.y = iris.knots[0].y + 3;
+}
+constrainAllEyeLayers(eye);
+const irisPoly = layerPolygon(findLayer(eye, "iris"));
+const pc = pathCentroid(pupil.knots);
+assert.ok(pointInPolygon(pc.x, pc.y, irisPoly), "pupil centroid inside iris after constrain");
+
+const ser = serializeEyeTexture(eye);
+const again = normalizeEyeTexture(ser);
+assert.equal(again.name, "TestEye");
+assert.equal(again.layers.length, eye.layers.length);
+
+// Schema v9 migrate round-trip
+const doc = buildProjectDocument({
+  state: {
+    assetGuid: "root-g",
+    curveType: 0,
+    pathSegments: 12,
+    angularSteps: 24,
+    revolutionDeg: 360,
+    tessellationMode: "rotation",
+    materialMode: 3,
+    symmetry: true,
+    viewMode: "profile",
+    spineSource: "profile",
+    objectMaterial: { color: null, roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient" },
+    knots: [
+      { id: "a", x: 0, y: -1, hx: 0, hy: 0, color: "#fff" },
+      { id: "b", x: 0.4, y: 1, hx: 0, hy: 0, color: "#fff" },
+    ],
+    segments: [
+      {
+        fromId: "a",
+        toId: "b",
+        pathType: "line",
+        roughness: 0.4,
+        metalness: 0,
+        opacity: 1,
+        texture: "gradient",
+        color: null,
+      },
+    ],
+    orbitKnots: [
+      { id: "o0", x: 1, y: 0, hx: 0, hy: 0.55, color: "#fff" },
+      { id: "o1", x: 0, y: 1, hx: -0.55, hy: 0, color: "#fff" },
+      { id: "o2", x: -1, y: 0, hx: 0, hy: -0.55, color: "#fff" },
+      { id: "o3", x: 0, y: -1, hx: 0.55, hy: 0, color: "#fff" },
+    ],
+    orbitSegments: [
+      { fromId: "o0", toId: "o1", pathType: "bezier", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+      { fromId: "o1", toId: "o2", pathType: "bezier", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+      { fromId: "o2", toId: "o3", pathType: "bezier", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+      { fromId: "o3", toId: "o0", pathType: "bezier", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+    ],
+    spineProfileKnots: [
+      { id: "s0", x: 0, y: -1, hx: 0, hy: 0, color: "#fff" },
+      { id: "s1", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+    ],
+    spineProfileSegments: [
+      { fromId: "s0", toId: "s1", pathType: "line", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+    ],
+    spineOrbitKnots: [
+      { id: "t0", x: 0, y: -1, hx: 0, hy: 0, color: "#fff" },
+      { id: "t1", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+    ],
+    spineOrbitSegments: [
+      { fromId: "t0", toId: "t1", pathType: "line", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+    ],
+    placementNormal: { start: { x: 0, y: -1 }, end: { x: 0, y: 1 } },
+    embeddedAssets: {},
+    children: [],
+    textureAssets: { [ser.assetGuid]: ser },
+  },
+  name: "With eye texture",
+  slug: "with-eye",
+});
+assert.equal(doc.schemaVersion, 9);
+assert.ok(doc.textureAssets[ser.assetGuid]);
+
+const mig = migrateProject(doc);
+assert.equal(mig.ok, true, mig.errors?.join("; "));
+assert.equal(CURRENT_SCHEMA_VERSION, 9);
+assert.equal(mig.doc.schemaVersion, 9);
+assert.ok(mig.doc.textureAssets[ser.assetGuid].layers.length >= 4);
+
+console.log("smoke-eye-texture: ok", {
+  schema: mig.doc.schemaVersion,
+  layers: mig.doc.textureAssets[ser.assetGuid].layers.map((L) => L.type),
+});

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -141,8 +141,8 @@ const v7 = {
 
 const mig = migrateProject(v7);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
-assert.equal(CURRENT_SCHEMA_VERSION, 8);
-assert.equal(mig.doc.schemaVersion, 8);
+assert.equal(CURRENT_SCHEMA_VERSION, 9);
+assert.equal(mig.doc.schemaVersion, 9);
 assert.equal(mig.doc.children[0].transform.surface, false);
 assert.equal(mig.doc.children[0].transform.z, 0);
 

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-placement-normal.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-placement-normal.mjs
@@ -121,7 +121,7 @@ const v5 = {
 const mig = migrateProject(v5);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
 assert.equal(mig.doc.schemaVersion, CURRENT_SCHEMA_VERSION);
-assert.equal(CURRENT_SCHEMA_VERSION, 8);
+assert.equal(CURRENT_SCHEMA_VERSION, 9);
 assert.deepEqual(mig.doc.placementNormal.start, { x: 0, y: -1 });
 assert.deepEqual(mig.doc.placementNormal.end, { x: 0, y: 1 });
 assert.equal(mig.doc.editor.tessellationMode, "rotation");

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
@@ -156,7 +156,7 @@ const v6 = {
 const mig = migrateProject(v6);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
 assert.equal(mig.doc.schemaVersion, CURRENT_SCHEMA_VERSION);
-assert.equal(CURRENT_SCHEMA_VERSION, 8);
+assert.equal(CURRENT_SCHEMA_VERSION, 9);
 assert.equal(mig.doc.editor.tessellationMode, "rotation");
 const errs = validateProject(mig.doc);
 assert.equal(errs.length, 0, errs.join("; "));

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -5,7 +5,10 @@ import PointEditor from "./components/PointEditor.vue";
 import Preview3D from "./components/Preview3D.vue";
 import LibraryPanel from "./components/LibraryPanel.vue";
 import ChildrenPanel from "./components/ChildrenPanel.vue";
+import TextureLayerPanel from "./components/TextureLayerPanel.vue";
+import TexturePreview from "./components/TexturePreview.vue";
 import { useSplineEditor } from "./composables/useSplineEditor.js";
+import { useTextureEditor } from "./composables/useTextureEditor.js";
 import { useLibrary } from "./composables/useLibrary.js";
 import * as api from "./library/api.js";
 
@@ -31,8 +34,8 @@ const {
   findClosestOnCurve,
   insertKnotOnCurve,
   tessellate,
-  applyProject,
-  snapshotState,
+  applyProject: applyMeshProject,
+  snapshotState: snapshotMeshState,
   attachFromProject,
   selectChild,
   editRoot,
@@ -48,6 +51,31 @@ const {
   isEditingChild,
   activePlacementNormal,
 } = useSplineEditor();
+
+const tex = useTextureEditor();
+const texState = tex.state;
+const texPath = tex.path;
+const texLayers = tex.layers;
+const texSelected = tex.selectedTexture;
+const texPathClosed = tex.pathClosed;
+
+const workspace = ref("mesh"); // mesh | texture
+
+function snapshotState() {
+  return {
+    ...snapshotMeshState(),
+    textureAssets: tex.snapshotTextures(),
+  };
+}
+
+function applyProject(doc) {
+  applyMeshProject(doc);
+  tex.loadTextures(doc?.textureAssets || {});
+}
+
+if (!Object.keys(texState.textures).length) {
+  tex.createEye("Eye");
+}
 
 const { lib, refresh, load, save, saveAs, remove, exportJson, importJsonFile } = useLibrary({
   snapshotState,
@@ -188,10 +216,12 @@ function onKeyDown(e) {
   const key = e.key.toLowerCase();
   if (key === "z" && !e.shiftKey) {
     e.preventDefault();
-    onUndo();
+    if (workspace.value === "texture") texPath.undo();
+    else onUndo();
   } else if ((key === "z" && e.shiftKey) || key === "y") {
     e.preventDefault();
-    onRedo();
+    if (workspace.value === "texture") texPath.redo();
+    else onRedo();
   }
 }
 
@@ -281,13 +311,35 @@ onBeforeUnmount(() => {
         <p class="eyebrow">Ranger · gallery/game_engine/v2</p>
         <h1>Spline Mesh Editor</h1>
         <p class="lede">
-          Profile + orbit lathe with an optional curved
-          <strong>spine</strong> centerline, bulk colouring, and sub-objects — editing
-          <strong>{{ editingLabel }}</strong>.
+          <template v-if="workspace === 'mesh'">
+            Profile + orbit lathe with an optional curved
+            <strong>spine</strong> centerline, bulk colouring, and sub-objects — editing
+            <strong>{{ editingLabel }}</strong>.
+          </template>
+          <template v-else>
+            <strong>Texture editor</strong> — procedural eye layers (params only, runtime
+            raster). Shared Bezier path editor · iris/pupil clipped inside the eyeball.
+          </template>
         </p>
       </div>
       <div class="actions">
-        <div class="tool-row">
+        <div class="tool-row sector">
+          <button
+            type="button"
+            :class="{ active: workspace === 'mesh', primary: workspace === 'mesh' }"
+            @click="workspace = 'mesh'"
+          >
+            Mesh
+          </button>
+          <button
+            type="button"
+            :class="{ active: workspace === 'texture', primary: workspace === 'texture' }"
+            @click="workspace = 'texture'"
+          >
+            Texture
+          </button>
+        </div>
+        <div v-if="workspace === 'mesh'" class="tool-row">
           <button
             v-for="v in views"
             :key="v.id"
@@ -297,46 +349,96 @@ onBeforeUnmount(() => {
             {{ v.label }}
           </button>
         </div>
-        <p v-if="state.viewMode === 'spine'" class="spine-hint">
+        <div v-else class="tool-row">
+          <button type="button" class="primary" @click="tex.createEye()">New eye</button>
+          <button
+            type="button"
+            :disabled="!texState.selectedGuid"
+            @click="tex.removeSelectedTexture()"
+          >
+            Delete texture
+          </button>
+        </div>
+        <p v-if="workspace === 'mesh' && state.viewMode === 'spine'" class="spine-hint">
           Editing {{ spinePlaneLabel }} · pick Profile/Orbit first to choose which bend
         </p>
         <div class="tool-row">
           <button
             v-for="t in tools"
             :key="t.id"
-            :class="{ active: state.toolMode === t.id, primary: state.toolMode === t.id }"
-            @click="setToolMode(t.id)"
+            :class="{
+              active:
+                workspace === 'mesh'
+                  ? state.toolMode === t.id
+                  : texPath.state.toolMode === t.id,
+              primary:
+                workspace === 'mesh'
+                  ? state.toolMode === t.id
+                  : texPath.state.toolMode === t.id,
+            }"
+            @click="
+              workspace === 'mesh' ? setToolMode(t.id) : texPath.setToolMode(t.id)
+            "
           >
             {{ t.label }}
           </button>
         </div>
-        <button @click="resetDefaults">Reset</button>
-        <button
-          v-if="state.viewMode === 'spine'"
-          type="button"
-          title="Straighten the active spine plane"
-          @click="onResetSpine"
-        >
-          Reset spine
-        </button>
-        <button
-          v-if="state.viewMode === 'spine'"
-          type="button"
-          title="Straighten both spine planes"
-          @click="onResetSpineBoth"
-        >
-          Reset both spines
-        </button>
-        <button @click="onUndo" :disabled="!state.history.canUndo" title="Ctrl+Z">Undo</button>
-        <button @click="onRedo" :disabled="!state.history.canRedo" title="Ctrl+Shift+Z">
-          Redo
-        </button>
-        <button @click="removeSelected" :disabled="!state.selectedId">Remove</button>
-        <button class="primary" @click="onTessellate">Tessellate</button>
+        <template v-if="workspace === 'mesh'">
+          <button @click="resetDefaults">Reset</button>
+          <button
+            v-if="state.viewMode === 'spine'"
+            type="button"
+            title="Straighten the active spine plane"
+            @click="onResetSpine"
+          >
+            Reset spine
+          </button>
+          <button
+            v-if="state.viewMode === 'spine'"
+            type="button"
+            title="Straighten both spine planes"
+            @click="onResetSpineBoth"
+          >
+            Reset both spines
+          </button>
+          <button @click="onUndo" :disabled="!state.history.canUndo" title="Ctrl+Z">Undo</button>
+          <button @click="onRedo" :disabled="!state.history.canRedo" title="Ctrl+Shift+Z">
+            Redo
+          </button>
+          <button @click="removeSelected" :disabled="!state.selectedId">Remove</button>
+          <button class="primary" @click="onTessellate">Tessellate</button>
+        </template>
+        <template v-else>
+          <button
+            @click="texPath.undo()"
+            :disabled="!texPath.state.history.canUndo"
+            title="Ctrl+Z"
+          >
+            Undo
+          </button>
+          <button
+            @click="texPath.redo()"
+            :disabled="!texPath.state.history.canRedo"
+            title="Ctrl+Shift+Z"
+          >
+            Redo
+          </button>
+          <button
+            @click="
+              () => {
+                texPath.removeSelected();
+                tex.pushPathToLayer();
+              }
+            "
+            :disabled="!texPath.state.selectedId"
+          >
+            Remove
+          </button>
+        </template>
       </div>
     </header>
 
-    <section class="toolbar">
+    <section v-if="workspace === 'mesh'" class="toolbar">
       <label class="field">
         Curve
         <select v-model.number="state.curveType">
@@ -442,7 +544,7 @@ onBeforeUnmount(() => {
       </p>
     </section>
 
-    <main class="workspace">
+    <main v-if="workspace === 'mesh'" class="workspace">
       <SplineCanvas
         :knots="knots"
         :segments="segments"
@@ -550,6 +652,79 @@ onBeforeUnmount(() => {
           @cancel-place="onCancelPlace"
           @tessellate="onTessellate"
         />
+      </div>
+      <LibraryPanel
+        :lib="lib"
+        @refresh="refresh"
+        @load="load"
+        @save="save"
+        @save-as="saveAs"
+        @remove="remove"
+        @export="exportJson"
+        @import-file="importJsonFile"
+      />
+    </main>
+
+    <main v-else class="workspace texture-workspace">
+      <SplineCanvas
+        :knots="texPath.state.knots"
+        :segments="texPath.state.segments"
+        :selected-id="texPath.state.selectedId"
+        :selected-ids="texPath.state.selectedIds"
+        :selected-segment-index="texPath.state.selectedSegmentIndex"
+        :curve-type="texPath.state.curveType"
+        :symmetry="false"
+        :tool-mode="texPath.state.toolMode"
+        view-mode="profile"
+        :path-closed="texPathClosed"
+        :show-unit-circle="false"
+        :show-placement-normal-prop="false"
+        :show-attachments-prop="false"
+        :show-mirror="false"
+        :show-lathe-guides="false"
+        :clamp-non-negative-x="false"
+        :children="[]"
+        :viewport="texPath.state.viewport"
+        :sample-curve-points="texPath.sampleCurvePoints"
+        :find-closest-on-curve="texPath.findClosestOnCurve"
+        @select="(id, opts) => texPath.select(id, opts || {})"
+        @select-segment="texPath.selectSegment"
+        @update-knot="tex.onPathKnotUpdate"
+        @add-on-curve="tex.onPathAdd"
+        @drag-end="tex.onPathDragEnd"
+      />
+      <TextureLayerPanel
+        :layers="texLayers"
+        :selected-layer-id="texState.selectedLayerId"
+        :texture-kind="texSelected?.kind || 'eye'"
+        @select-layer="tex.selectLayer"
+        @rename-layer="tex.renameLayer"
+        @toggle-layer="tex.setLayerEnabled"
+        @move-layer="tex.moveLayer"
+        @add-layer="tex.addLayer"
+        @remove-layer="tex.removeLayer"
+        @set-color="tex.setLayerColor"
+      />
+      <div class="side-stack">
+        <TexturePreview :texture="texSelected" />
+        <section class="tex-list panel-ish">
+          <h2>Textures</h2>
+          <p class="hint">{{ texState.status }}</p>
+          <ul>
+            <li
+              v-for="t in Object.values(texState.textures)"
+              :key="t.assetGuid"
+              :class="{ active: t.assetGuid === texState.selectedGuid }"
+              @click="tex.selectTexture(t.assetGuid)"
+            >
+              {{ t.name }} · {{ t.kind }}
+            </li>
+          </ul>
+          <p v-if="!Object.keys(texState.textures).length" class="hint">
+            Click <strong>New eye</strong> to start. Layers: eyeball, iris, pupil, shine,
+            optional eyelid.
+          </p>
+        </section>
       </div>
       <LibraryPanel
         :lib="lib"
@@ -737,6 +912,47 @@ h1 {
   flex-direction: column;
   gap: 0.75rem;
   min-height: 0;
+}
+
+.tex-list {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 0.85rem;
+}
+.tex-list h2 {
+  margin: 0 0 0.4rem;
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+  font-weight: 400;
+}
+.tex-list .hint {
+  margin: 0 0 0.5rem;
+  font-size: 0.72rem;
+  color: var(--ink-dim);
+}
+.tex-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.3rem;
+}
+.tex-list li {
+  padding: 0.4rem 0.5rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+.tex-list li.active {
+  border-color: rgba(126, 207, 106, 0.45);
+  background: rgba(126, 207, 106, 0.08);
+}
+.tool-row.sector {
+  padding: 0.15rem;
+  border-radius: 10px;
+  border: 1px solid var(--line);
 }
 
 @media (max-width: 1200px) {

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
@@ -21,6 +21,15 @@ const props = defineProps({
     type: Object,
     default: () => ({ start: { x: 0, y: -1 }, end: { x: 0, y: 1 } }),
   },
+  /** Override closed-path behaviour (null = infer from viewMode === 'orbit'). */
+  pathClosed: { type: Boolean, default: null },
+  showUnitCircle: { type: Boolean, default: null },
+  showPlacementNormalProp: { type: Boolean, default: null },
+  showAttachmentsProp: { type: Boolean, default: null },
+  clampNonNegativeX: { type: Boolean, default: null },
+  showMirror: { type: Boolean, default: null },
+  /** When false, skip lathe axes / unit-circle / spine guides (texture editor). */
+  showLatheGuides: { type: Boolean, default: true },
 });
 
 const emit = defineEmits([
@@ -42,13 +51,38 @@ let draggingNormal = null; // 'start' | 'end'
 let raf = 0;
 const hoverAdd = ref(null);
 
-const isOrbit = computed(() => props.viewMode === "orbit");
-const isSpine = computed(() => props.viewMode === "spine");
-const allowSignedX = computed(() => isOrbit.value || isSpine.value);
-const showPlacementNormal = computed(() => props.viewMode === "profile" || props.viewMode === "orbit");
-const showAttachments = computed(
-  () => !isOrbit.value && !isSpine.value && props.editTarget === "root" && props.children?.length,
+/** Orbit chrome (axes / unit circle) — mesh orbit view only. */
+const isOrbitView = computed(() => props.viewMode === "orbit");
+/** Closed loop path math (orbit view or texture layers). */
+const pathIsClosed = computed(() =>
+  props.pathClosed != null ? !!props.pathClosed : isOrbitView.value,
 );
+const isSpine = computed(() => props.viewMode === "spine");
+const allowSignedX = computed(() => {
+  if (props.clampNonNegativeX != null) return !props.clampNonNegativeX;
+  return isOrbitView.value || isSpine.value || pathIsClosed.value;
+});
+const showPlacementNormal = computed(() => {
+  if (props.showPlacementNormalProp != null) return !!props.showPlacementNormalProp;
+  return props.viewMode === "profile" || props.viewMode === "orbit";
+});
+const showAttachments = computed(() => {
+  if (props.showAttachmentsProp != null) return !!props.showAttachmentsProp;
+  return (
+    !isOrbitView.value &&
+    !isSpine.value &&
+    props.editTarget === "root" &&
+    props.children?.length
+  );
+});
+const showUnitCircleGuide = computed(() => {
+  if (props.showUnitCircle != null) return !!props.showUnitCircle;
+  return isOrbitView.value;
+});
+const showMirrorGuide = computed(() => {
+  if (props.showMirror != null) return !!props.showMirror;
+  return props.symmetry && !isOrbitView.value && !isSpine.value;
+});
 const curvePts = computed(() => props.sampleCurvePoints(28));
 
 function clampWorldX(wx) {
@@ -84,14 +118,14 @@ function segmentColor(segIndex) {
   const seg = props.segments[segIndex];
   if (seg?.color) return seg.color;
   const a = props.knots[segIndex];
-  const b = props.knots[isOrbit.value ? (segIndex + 1) % props.knots.length : segIndex + 1];
+  const b = props.knots[pathIsClosed.value ? (segIndex + 1) % props.knots.length : segIndex + 1];
   return a?.color || "#6ec8ff";
 }
 
 function knotUsesBezierHandles(knotIndex) {
   // Show handles if any adjacent segment is bezier (SVG-style mix).
   const segs = props.segments || [];
-  if (isOrbit.value) {
+  if (pathIsClosed.value) {
     const n = props.knots.length;
     const prev = segs[(knotIndex - 1 + n) % n];
     const next = segs[knotIndex];
@@ -225,47 +259,49 @@ function draw() {
     ctx.stroke();
   }
 
-  if (isOrbit.value) {
-    // XZ plane: canvas x → world X, canvas y → world Z
-    const [ax0, ay0] = worldToScreen(-1, 0, w, h);
-    const [ax1, ay1] = worldToScreen(1, 0, w, h);
-    const [az0, az1y] = worldToScreen(0, -1, w, h);
-    const [az1, az0y] = worldToScreen(0, 1, w, h);
-    ctx.strokeStyle = "rgba(200,232,122,0.45)";
-    ctx.lineWidth = 1.25;
-    ctx.beginPath();
-    ctx.moveTo(ax0, ay0);
-    ctx.lineTo(ax1, ay1);
-    ctx.moveTo(az0, az0y);
-    ctx.lineTo(az1, az1y);
-    ctx.stroke();
-    drawUnitCircle(ctx, w, h);
-  } else if (isSpine.value) {
-    // Straight-centerline guide (reset target); editable spine may bend away.
-    const [ax0, ay0] = worldToScreen(0, -1, w, h);
-    const [ax1, ay1] = worldToScreen(0, 1, w, h);
-    ctx.strokeStyle = "rgba(200,232,122,0.35)";
-    ctx.lineWidth = 1.25;
-    ctx.setLineDash([5, 5]);
-    ctx.beginPath();
-    ctx.moveTo(ax0, ay0);
-    ctx.lineTo(ax1, ay1);
-    ctx.stroke();
-    ctx.setLineDash([]);
-  } else {
-    const [ax0, ay0] = worldToScreen(0, -1, w, h);
-    const [ax1, ay1] = worldToScreen(0, 1, w, h);
-    ctx.strokeStyle = "rgba(200,232,122,0.55)";
-    ctx.lineWidth = 1.5;
-    ctx.beginPath();
-    ctx.moveTo(ax0, ay0);
-    ctx.lineTo(ax1, ay1);
-    ctx.stroke();
+  if (props.showLatheGuides) {
+    if (isOrbitView.value) {
+      // XZ plane: canvas x → world X, canvas y → world Z
+      const [ax0, ay0] = worldToScreen(-1, 0, w, h);
+      const [ax1, ay1] = worldToScreen(1, 0, w, h);
+      const [az0, az1y] = worldToScreen(0, -1, w, h);
+      const [az1, az0y] = worldToScreen(0, 1, w, h);
+      ctx.strokeStyle = "rgba(200,232,122,0.45)";
+      ctx.lineWidth = 1.25;
+      ctx.beginPath();
+      ctx.moveTo(ax0, ay0);
+      ctx.lineTo(ax1, ay1);
+      ctx.moveTo(az0, az0y);
+      ctx.lineTo(az1, az1y);
+      ctx.stroke();
+      if (showUnitCircleGuide.value) drawUnitCircle(ctx, w, h);
+    } else if (isSpine.value) {
+      // Straight-centerline guide (reset target); editable spine may bend away.
+      const [ax0, ay0] = worldToScreen(0, -1, w, h);
+      const [ax1, ay1] = worldToScreen(0, 1, w, h);
+      ctx.strokeStyle = "rgba(200,232,122,0.35)";
+      ctx.lineWidth = 1.25;
+      ctx.setLineDash([5, 5]);
+      ctx.beginPath();
+      ctx.moveTo(ax0, ay0);
+      ctx.lineTo(ax1, ay1);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    } else {
+      const [ax0, ay0] = worldToScreen(0, -1, w, h);
+      const [ax1, ay1] = worldToScreen(0, 1, w, h);
+      ctx.strokeStyle = "rgba(200,232,122,0.55)";
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(ax0, ay0);
+      ctx.lineTo(ax1, ay1);
+      ctx.stroke();
+    }
   }
 
   const pts = curvePts.value;
 
-  if (!isOrbit.value && !isSpine.value && props.symmetry && pts.length > 1) {
+  if (showMirrorGuide.value && pts.length > 1) {
     ctx.lineWidth = 2;
     drawGradientStroke(
       ctx,
@@ -294,7 +330,7 @@ function draw() {
     );
   }
 
-  const segCount = isOrbit.value ? props.knots.length : props.knots.length - 1;
+  const segCount = pathIsClosed.value ? props.knots.length : props.knots.length - 1;
   if (props.toolMode === "color") {
     for (let i = 0; i < segCount; i++) {
       const mid = evalMid(i);
@@ -331,7 +367,7 @@ function draw() {
     const multi = props.selectedIds?.includes(k.id);
     drawPoint(ctx, sx, sy, k.id === props.selectedId || multi, k.color, multi);
 
-    if (!isOrbit.value && !isSpine.value && props.symmetry && k.x > 0.001) {
+    if (showMirrorGuide.value && k.x > 0.001) {
       const [mx, my] = worldToScreen(-k.x, k.y, w, h);
       ctx.fillStyle = "rgba(110,200,255,0.35)";
       ctx.beginPath();
@@ -423,7 +459,7 @@ function hitTestPoint(sx, sy) {
 
 function hitTestSegment(sx, sy) {
   const thresh = 12;
-  const segCount = isOrbit.value ? props.knots.length : props.knots.length - 1;
+  const segCount = pathIsClosed.value ? props.knots.length : props.knots.length - 1;
   for (let i = 0; i < segCount; i++) {
     const mid = evalMid(i);
     if (!mid) continue;

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/TextureLayerPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/TextureLayerPanel.vue
@@ -1,0 +1,182 @@
+<script setup>
+const props = defineProps({
+  layers: { type: Array, default: () => [] },
+  selectedLayerId: { type: String, default: null },
+  textureKind: { type: String, default: "eye" },
+});
+
+const emit = defineEmits([
+  "select-layer",
+  "rename-layer",
+  "toggle-layer",
+  "move-layer",
+  "add-layer",
+  "remove-layer",
+  "set-color",
+]);
+
+const addTypes = [
+  { id: "iris", label: "+ Iris" },
+  { id: "pupil", label: "+ Pupil" },
+  { id: "reflection", label: "+ Shine" },
+  { id: "eyelid", label: "+ Eyelid" },
+];
+</script>
+
+<template>
+  <section class="panel">
+    <header>
+      <h2>Layers</h2>
+      <span>{{ layers.length }}</span>
+    </header>
+    <p class="hint">
+      Named parts · enable/disable · reorder. Iris stays in the eyeball, pupil in the iris,
+      reflection in the eye; eyelid draws on top (clipped).
+    </p>
+    <ul class="list">
+      <li
+        v-for="L in layers"
+        :key="L.id"
+        :class="{ active: L.id === selectedLayerId, off: L.enabled === false }"
+        @click="emit('select-layer', L.id)"
+      >
+        <label class="en" @click.stop>
+          <input
+            type="checkbox"
+            :checked="L.enabled !== false"
+            @change="emit('toggle-layer', L.id, $event.target.checked)"
+          />
+        </label>
+        <input
+          class="name"
+          :value="L.name"
+          @click.stop
+          @change="emit('rename-layer', L.id, $event.target.value)"
+        />
+        <span class="type">{{ L.type }}</span>
+        <input
+          class="swatch"
+          type="color"
+          :value="L.color || '#ffffff'"
+          @click.stop
+          @input="emit('set-color', L.id, $event.target.value)"
+        />
+        <button type="button" title="Move up" @click.stop="emit('move-layer', L.id, -1)">↑</button>
+        <button type="button" title="Move down" @click.stop="emit('move-layer', L.id, 1)">↓</button>
+        <button
+          type="button"
+          class="danger"
+          :disabled="L.type === 'eyeball'"
+          title="Remove"
+          @click.stop="emit('remove-layer', L.id)"
+        >
+          ×
+        </button>
+      </li>
+    </ul>
+    <div v-if="textureKind === 'eye'" class="add-row">
+      <button v-for="t in addTypes" :key="t.id" type="button" @click="emit('add-layer', t.id)">
+        {{ t.label }}
+      </button>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.panel {
+  display: grid;
+  gap: 0.55rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 0.85rem;
+  min-height: 0;
+  align-content: start;
+}
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+  font-weight: 400;
+}
+span {
+  font-size: 0.72rem;
+  color: var(--ink-dim);
+}
+.hint {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--ink-dim);
+  line-height: 1.35;
+}
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+  max-height: 280px;
+  overflow: auto;
+}
+li {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto auto auto auto;
+  gap: 0.3rem;
+  align-items: center;
+  padding: 0.35rem 0.4rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+li.active {
+  border-color: rgba(126, 207, 106, 0.45);
+  background: rgba(126, 207, 106, 0.08);
+}
+li.off {
+  opacity: 0.45;
+}
+.name {
+  min-width: 0;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.78rem;
+}
+.type {
+  font-size: 0.65rem;
+  color: var(--ink-dim);
+  text-transform: uppercase;
+}
+.swatch {
+  width: 1.6rem;
+  height: 1.4rem;
+  padding: 0;
+  border: none;
+  background: none;
+}
+button {
+  padding: 0.2rem 0.4rem;
+  font-size: 0.75rem;
+}
+button.danger:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+.add-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+.add-row button {
+  font-size: 0.72rem;
+}
+.en {
+  display: flex;
+}
+</style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/TexturePreview.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/TexturePreview.vue
@@ -1,0 +1,100 @@
+<script setup>
+import { onMounted, onBeforeUnmount, ref, watch } from "vue";
+import { renderEyeTexture } from "../lib/texture/eyeTexture.js";
+
+const props = defineProps({
+  texture: { type: Object, default: null },
+  size: { type: Number, default: 256 },
+});
+
+const canvasRef = ref(null);
+
+function paint() {
+  const c = canvasRef.value;
+  if (!c) return;
+  const ctx = c.getContext("2d");
+  if (!props.texture) {
+    ctx.clearRect(0, 0, c.width, c.height);
+    ctx.fillStyle = "#1a221c";
+    ctx.fillRect(0, 0, c.width, c.height);
+    ctx.fillStyle = "#9aab9c";
+    ctx.font = "12px sans-serif";
+    ctx.fillText("No texture", 16, 28);
+    return;
+  }
+  if (props.texture.kind === "eye") {
+    renderEyeTexture(ctx, props.texture);
+  }
+}
+
+onMounted(paint);
+watch(() => props.texture, paint, { deep: true });
+watch(
+  () => props.size,
+  (s) => {
+    if (canvasRef.value) {
+      canvasRef.value.width = s;
+      canvasRef.value.height = s;
+      paint();
+    }
+  },
+);
+
+onBeforeUnmount(() => {});
+</script>
+
+<template>
+  <section class="panel">
+    <header>
+      <h2>Texture preview</h2>
+      <span>dynamic · params only</span>
+    </header>
+    <canvas ref="canvasRef" class="view" :width="size" :height="size" />
+    <p class="hint">
+      Rasterized at runtime from layer params (animatable). Mesh assign / UV projection comes later —
+      background from vertex colours when applied.
+    </p>
+  </section>
+</template>
+
+<style scoped>
+.panel {
+  display: grid;
+  gap: 0.55rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 0.85rem;
+  justify-items: center;
+}
+header {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  align-items: baseline;
+}
+h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+  font-weight: 400;
+}
+span {
+  font-size: 0.72rem;
+  color: var(--ink-dim);
+}
+.view {
+  width: min(100%, 280px);
+  aspect-ratio: 1;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: #0a0e0c;
+  display: block;
+}
+.hint {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--ink-dim);
+  text-align: center;
+}
+</style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/usePathEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/usePathEditor.js
@@ -1,0 +1,270 @@
+// ============================================================================
+// usePathEditor.js — reusable single-path Bezier editor (texture layers, etc.).
+// ============================================================================
+
+import { reactive, computed, watch } from "vue";
+import {
+  knotUid,
+  defaultSegment,
+  syncOpenSegments,
+  syncClosedSegments,
+  samplePath,
+} from "../lib/pathModel.js";
+import { evalSpan as evalPathSpan } from "../lib/pathSample.js";
+import { createEditHistory } from "../lib/editHistory.js";
+
+/**
+ * @param {{
+ *   closed?: boolean,
+ *   clampNonNegativeX?: boolean,
+ *   defaultPathType?: string,
+ *   curveType?: number,
+ *   initialKnots?: any[],
+ *   initialSegments?: any[],
+ * }} [opts]
+ */
+export function usePathEditor(opts = {}) {
+  const clampNonNegativeX = !!opts.clampNonNegativeX;
+  const defaultPathType = opts.defaultPathType || "bezier";
+
+  const state = reactive({
+    knots: opts.initialKnots ? opts.initialKnots.map((k) => ({ ...k })) : [],
+    segments: opts.initialSegments ? opts.initialSegments.map((s) => ({ ...s })) : [],
+    curveType: opts.curveType | 0,
+    toolMode: "edit",
+    /** When true, path is a closed loop (orbit-style). */
+    closed: !!opts.closed,
+    selectedId: null,
+    selectedIds: [],
+    selectedSegmentIndex: -1,
+    viewport: opts.viewport || { min: -1.15, max: 1.15 },
+    history: { past: 0, future: 0, canUndo: false, canRedo: false },
+  });
+
+  const history = createEditHistory(48);
+
+  function refreshHistoryFlags() {
+    const info = history.info();
+    state.history.past = info.past;
+    state.history.future = info.future;
+    state.history.canUndo = info.past > 0;
+    state.history.canRedo = info.future > 0;
+  }
+
+  function snapshot() {
+    return JSON.parse(
+      JSON.stringify({
+        knots: state.knots,
+        segments: state.segments,
+        selectedId: state.selectedId,
+        selectedIds: state.selectedIds,
+        selectedSegmentIndex: state.selectedSegmentIndex,
+      }),
+    );
+  }
+
+  function restore(snap) {
+    if (!snap) return;
+    state.knots = (snap.knots || []).map((k) => ({ ...k }));
+    state.segments = (snap.segments || []).map((s) => ({ ...s, textureData: null }));
+    state.selectedId = snap.selectedId || null;
+    state.selectedIds = snap.selectedIds || [];
+    state.selectedSegmentIndex = snap.selectedSegmentIndex ?? -1;
+    syncSegments();
+  }
+
+  let gestureOpen = false;
+  function beginGesture(label = "edit") {
+    if (gestureOpen) return;
+    history.push(snapshot(), label);
+    gestureOpen = true;
+    refreshHistoryFlags();
+  }
+  function endGesture() {
+    if (!gestureOpen) return;
+    gestureOpen = false;
+    history.baseline(snapshot());
+    refreshHistoryFlags();
+  }
+  function commit(label = "edit") {
+    history.push(snapshot(), label);
+    refreshHistoryFlags();
+  }
+
+  function syncSegments() {
+    state.segments = state.closed
+      ? syncClosedSegments(state.knots, state.segments, defaultPathType)
+      : syncOpenSegments(state.knots, state.segments, defaultPathType);
+    if (state.selectedSegmentIndex >= state.segments.length) {
+      state.selectedSegmentIndex = state.segments.length - 1;
+    }
+  }
+
+  function loadPath(knots, segments, { closed } = {}) {
+    if (closed != null) state.closed = !!closed;
+    state.knots = (knots || []).map((k) => ({ ...k }));
+    state.segments = (segments || []).map((s) => ({ ...s, textureData: null }));
+    syncSegments();
+    state.selectedId = state.knots[0]?.id || null;
+    state.selectedIds = state.selectedId ? [state.selectedId] : [];
+    state.selectedSegmentIndex = -1;
+    history.clear();
+    history.baseline(snapshot());
+    refreshHistoryFlags();
+  }
+
+  function sampleCurvePoints(n = 28) {
+    return samplePath(state.knots, state.segments, {
+      closed: state.closed,
+      samplesPerSpan: n,
+      curveType: state.curveType,
+    });
+  }
+
+  function findClosestOnCurve(x, y, maxDist = 0.2) {
+    const pts = sampleCurvePoints(36);
+    let best = null;
+    let bestD = maxDist;
+    for (const p of pts) {
+      const d = Math.hypot(p.x - x, p.y - y);
+      if (d < bestD) {
+        bestD = d;
+        best = p;
+      }
+    }
+    return best;
+  }
+
+  function select(id, { additive = false } = {}) {
+    if (!id) {
+      state.selectedId = null;
+      state.selectedIds = [];
+      return;
+    }
+    if (additive) {
+      const set = new Set(state.selectedIds);
+      if (set.has(id)) set.delete(id);
+      else set.add(id);
+      state.selectedIds = [...set];
+      state.selectedId = id;
+    } else {
+      state.selectedId = id;
+      state.selectedIds = [id];
+    }
+    state.selectedSegmentIndex = -1;
+  }
+
+  function selectSegment(index) {
+    state.selectedSegmentIndex = index;
+    state.selectedId = null;
+    state.selectedIds = [];
+  }
+
+  function updateKnot(id, patch) {
+    const moving = patch.x != null || patch.y != null || patch.hx != null || patch.hy != null;
+    if (moving) beginGesture("move-knot");
+    else commit("knot");
+    const k = state.knots.find((n) => n.id === id);
+    if (!k) return;
+    Object.assign(k, patch);
+    if (clampNonNegativeX && typeof patch.x === "number") k.x = Math.max(0, k.x);
+  }
+
+  function updateSegment(index, patch) {
+    commit("segment");
+    const s = state.segments[index];
+    if (!s) return;
+    Object.assign(s, patch);
+  }
+
+  function insertKnotOnCurve(x, y) {
+    const hit = findClosestOnCurve(x, y, 0.25);
+    if (!hit) return false;
+    commit("add-knot");
+    const span = hit.segmentIndex ?? 0;
+    const a = state.knots[span];
+    const b = state.knots[state.closed ? (span + 1) % state.knots.length : span + 1];
+    if (!a || !b) return false;
+    const seg = state.segments[span];
+    const mid = evalPathSpan(a, b, hit.t ?? 0.5, {
+      pathType: seg?.pathType || defaultPathType,
+      curveType: state.curveType,
+      arcBulge: seg?.arcBulge ?? null,
+    });
+    const nk = {
+      id: knotUid(),
+      x: mid?.p?.x ?? x,
+      y: mid?.p?.y ?? y,
+      hx: 0,
+      hy: 0,
+      color: a.color || "#cccccc",
+    };
+    state.knots.splice(span + 1, 0, nk);
+    syncSegments();
+    select(nk.id);
+    return true;
+  }
+
+  function removeSelected() {
+    if (!state.selectedId) return;
+    const minKnots = state.closed ? 3 : 2;
+    if (state.knots.length <= minKnots) return;
+    commit("remove-knot");
+    state.knots = state.knots.filter((k) => k.id !== state.selectedId);
+    syncSegments();
+    state.selectedId = state.knots[0]?.id || null;
+    state.selectedIds = state.selectedId ? [state.selectedId] : [];
+  }
+
+  function undo() {
+    const prev = history.undo(snapshot());
+    if (!prev) return false;
+    restore(prev);
+    refreshHistoryFlags();
+    return true;
+  }
+
+  function redo() {
+    const next = history.redo(snapshot());
+    if (!next) return false;
+    restore(next);
+    refreshHistoryFlags();
+    return true;
+  }
+
+  if (state.knots.length) {
+    syncSegments();
+    history.baseline(snapshot());
+    refreshHistoryFlags();
+    if (!state.selectedId) state.selectedId = state.knots[0].id;
+  }
+
+  watch(
+    () => state.knots.map((k) => k.id).join(","),
+    () => syncSegments(),
+  );
+
+  return {
+    state,
+    get closed() {
+      return state.closed;
+    },
+    loadPath,
+    syncSegments,
+    sampleCurvePoints,
+    findClosestOnCurve,
+    select,
+    selectSegment,
+    updateKnot,
+    updateSegment,
+    insertKnotOnCurve,
+    removeSelected,
+    beginGesture,
+    endGesture,
+    undo,
+    redo,
+    setToolMode(mode) {
+      state.toolMode = mode;
+    },
+  };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -16,6 +16,12 @@ import {
   placementNormalDirection3,
 } from "../lib/placementNormal.js";
 import { raycastMeshParts } from "../lib/meshPick.js";
+import {
+  defaultSegment,
+  cloneSeg,
+  syncOpenSegments as syncOpenSegmentsOn,
+  syncClosedSegments as syncOrbitSegmentsOn,
+} from "../lib/pathModel.js";
 
 /** @typedef {{ id: string, x: number, y: number, hx: number, hy: number, color: string }} Knot */
 /** @typedef {{ fromId: string, toId: string, color: string|null, roughness: number, metalness: number, opacity: number, texture: string, textureData: any, textureAsset?: string|null, pathType?: string, arcBulge?: number|null }} Segment */
@@ -48,35 +54,8 @@ function defaultOrbitKnots() {
   }));
 }
 
-function defaultSegment(fromId, toId, pathType = "bezier") {
-  return {
-    fromId,
-    toId,
-    color: null,
-    roughness: 0.4,
-    metalness: 0,
-    opacity: 1,
-    texture: "gradient",
-    textureData: null,
-    textureAsset: null,
-    pathType: pathType === "line" || pathType === "arc" ? pathType : "bezier",
-    arcBulge: null,
-  };
-}
-
 function defaultObjectMaterial() {
   return { color: null, roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient" };
-}
-
-function cloneSeg(s, fromId, toId) {
-  return {
-    ...s,
-    fromId,
-    toId,
-    textureData: s.textureData || null,
-    pathType: s.pathType === "line" || s.pathType === "arc" ? s.pathType : "bezier",
-    arcBulge: s.arcBulge ?? null,
-  };
 }
 
 function projectDocToBody(doc, { newGuidForCopy = true } = {}) {
@@ -378,35 +357,6 @@ export function useSplineEditor() {
     const b = bodyRef();
     if (b) b.curveType = v;
     else state.curveType = v;
-  }
-
-  function syncOpenSegmentsOn(knots, segments, defaultPathType = "bezier") {
-    const byPair = new Map();
-    for (const s of segments) byPair.set(s.fromId + ">" + s.toId, s);
-    const next = [];
-    for (let i = 0; i < knots.length - 1; i++) {
-      const fromId = knots[i].id;
-      const toId = knots[i + 1].id;
-      const exact = byPair.get(fromId + ">" + toId);
-      next.push(
-        exact ? cloneSeg(exact, fromId, toId) : defaultSegment(fromId, toId, defaultPathType),
-      );
-    }
-    return next;
-  }
-
-  function syncOrbitSegmentsOn(knots, segments) {
-    const byPair = new Map();
-    for (const s of segments) byPair.set(s.fromId + ">" + s.toId, s);
-    const next = [];
-    const n = knots.length;
-    for (let i = 0; i < n; i++) {
-      const fromId = knots[i].id;
-      const toId = knots[(i + 1) % n].id;
-      const exact = byPair.get(fromId + ">" + toId);
-      next.push(exact ? cloneSeg(exact, fromId, toId) : defaultSegment(fromId, toId));
-    }
-    return next;
   }
 
   function syncSegments() {

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
@@ -1,0 +1,239 @@
+// ============================================================================
+// useTextureEditor.js — texture asset library (params only) + eye layer editing.
+// ============================================================================
+
+import { reactive, computed, watch } from "vue";
+import {
+  createDefaultEyeTexture,
+  createEyeLayer,
+  normalizeEyeTexture,
+  serializeEyeTexture,
+  constrainEyeLayer,
+  constrainAllEyeLayers,
+  EYE_LAYER_TYPES,
+} from "../lib/texture/eyeTexture.js";
+import { usePathEditor } from "./usePathEditor.js";
+import { newGuid } from "../lib/assetClone.js";
+
+export function useTextureEditor() {
+  const state = reactive({
+    textures: /** @type {Record<string, any>} */ ({}),
+    selectedGuid: /** @type {string|null} */ (null),
+    selectedLayerId: /** @type {string|null} */ (null),
+    status: "Texture editor — params only (rasterized at runtime).",
+  });
+
+  const path = usePathEditor({
+    closed: true,
+    viewport: { min: -1.2, max: 1.2 },
+  });
+
+  const selectedTexture = computed(() =>
+    state.selectedGuid ? state.textures[state.selectedGuid] || null : null,
+  );
+
+  const selectedLayer = computed(() => {
+    const tex = selectedTexture.value;
+    if (!tex || !state.selectedLayerId) return null;
+    return tex.layers.find((L) => L.id === state.selectedLayerId) || null;
+  });
+
+  const layers = computed(() => selectedTexture.value?.layers || []);
+
+  function syncPathFromLayer() {
+    const layer = selectedLayer.value;
+    if (!layer) {
+      path.loadPath([], [], { closed: true });
+      return;
+    }
+    path.loadPath(layer.knots, layer.segments, { closed: layer.type !== "eyelid" });
+  }
+
+  function pushPathToLayer() {
+    const tex = selectedTexture.value;
+    const layer = selectedLayer.value;
+    if (!tex || !layer) return;
+    layer.knots = path.state.knots.map((k) => ({ ...k }));
+    layer.segments = path.state.segments.map((s) => ({ ...s }));
+    layer.color = layer.color || path.state.knots[0]?.color || layer.color;
+    constrainEyeLayer(tex, layer.id);
+    // If constrain moved knots, reload path editor
+    path.loadPath(layer.knots, layer.segments);
+  }
+
+  watch(
+    () => [state.selectedGuid, state.selectedLayerId],
+    () => syncPathFromLayer(),
+  );
+
+  function createEye(name = "Eye") {
+    const tex = createDefaultEyeTexture({ name });
+    state.textures[tex.assetGuid] = tex;
+    state.selectedGuid = tex.assetGuid;
+    state.selectedLayerId = tex.layers[0]?.id || null;
+    constrainAllEyeLayers(tex);
+    syncPathFromLayer();
+    state.status = `Created eye texture “${tex.name}”.`;
+    return tex;
+  }
+
+  function selectTexture(guid) {
+    state.selectedGuid = guid;
+    const tex = state.textures[guid];
+    state.selectedLayerId = tex?.layers?.[0]?.id || null;
+    syncPathFromLayer();
+  }
+
+  function selectLayer(layerId) {
+    state.selectedLayerId = layerId;
+    syncPathFromLayer();
+  }
+
+  function renameLayer(layerId, name) {
+    const tex = selectedTexture.value;
+    const L = tex?.layers.find((x) => x.id === layerId);
+    if (!L) return;
+    L.name = String(name || L.type).trim() || L.type;
+  }
+
+  function setLayerEnabled(layerId, enabled) {
+    const L = selectedTexture.value?.layers.find((x) => x.id === layerId);
+    if (!L) return;
+    L.enabled = !!enabled;
+  }
+
+  function setLayerColor(layerId, color) {
+    const L = selectedTexture.value?.layers.find((x) => x.id === layerId);
+    if (!L) return;
+    L.color = color;
+    for (const k of L.knots || []) k.color = color;
+  }
+
+  function moveLayer(layerId, dir) {
+    const tex = selectedTexture.value;
+    if (!tex) return;
+    const i = tex.layers.findIndex((L) => L.id === layerId);
+    if (i < 0) return;
+    const j = i + dir;
+    if (j < 0 || j >= tex.layers.length) return;
+    const [row] = tex.layers.splice(i, 1);
+    tex.layers.splice(j, 0, row);
+  }
+
+  function addLayer(type) {
+    const tex = selectedTexture.value;
+    if (!tex || tex.kind !== "eye") return null;
+    if (!EYE_LAYER_TYPES.includes(type)) return null;
+    // One of each core type preferred; allow extra eyelids
+    if (type !== "eyelid" && tex.layers.some((L) => L.type === type)) {
+      state.status = `Layer type “${type}” already exists — select it to edit.`;
+      const existing = tex.layers.find((L) => L.type === type);
+      if (existing) selectLayer(existing.id);
+      return existing;
+    }
+    const layer = createEyeLayer(type);
+    if (type === "eyelid") layer.enabled = true;
+    // Insert eyelid near top; others after eyeball
+    if (type === "eyelid") tex.layers.push(layer);
+    else {
+      const eyeballIdx = tex.layers.findIndex((L) => L.type === "eyeball");
+      tex.layers.splice(eyeballIdx + 1, 0, layer);
+    }
+    constrainEyeLayer(tex, layer.id);
+    selectLayer(layer.id);
+    state.status = `Added “${layer.name}”.`;
+    return layer;
+  }
+
+  function removeLayer(layerId) {
+    const tex = selectedTexture.value;
+    if (!tex) return;
+    const L = tex.layers.find((x) => x.id === layerId);
+    if (!L) return;
+    if (L.type === "eyeball") {
+      state.status = "Eyeball layer is required.";
+      return;
+    }
+    tex.layers = tex.layers.filter((x) => x.id !== layerId);
+    if (state.selectedLayerId === layerId) {
+      state.selectedLayerId = tex.layers[0]?.id || null;
+      syncPathFromLayer();
+    }
+  }
+
+  function onPathKnotUpdate(id, patch) {
+    path.updateKnot(id, patch);
+    pushPathToLayer();
+  }
+
+  function onPathDragEnd() {
+    path.endGesture();
+    pushPathToLayer();
+  }
+
+  function onPathAdd(x, y) {
+    if (path.insertKnotOnCurve(x, y)) pushPathToLayer();
+  }
+
+  function removeSelectedTexture() {
+    if (!state.selectedGuid) return;
+    delete state.textures[state.selectedGuid];
+    const keys = Object.keys(state.textures);
+    state.selectedGuid = keys[0] || null;
+    state.selectedLayerId = selectedTexture.value?.layers?.[0]?.id || null;
+    syncPathFromLayer();
+  }
+
+  function snapshotTextures() {
+    const out = {};
+    for (const [guid, tex] of Object.entries(state.textures)) {
+      out[guid] =
+        tex.kind === "eye" ? serializeEyeTexture(tex) : { ...tex, assetGuid: guid };
+    }
+    return out;
+  }
+
+  function loadTextures(map) {
+    state.textures = {};
+    for (const [guid, raw] of Object.entries(map || {})) {
+      const tex =
+        raw?.kind === "eye" || !raw?.kind
+          ? normalizeEyeTexture({ ...raw, assetGuid: raw.assetGuid || guid })
+          : { ...raw, assetGuid: raw.assetGuid || guid || newGuid() };
+      state.textures[tex.assetGuid] = tex;
+    }
+    const keys = Object.keys(state.textures);
+    state.selectedGuid = keys[0] || null;
+    state.selectedLayerId = selectedTexture.value?.layers?.[0]?.id || null;
+    syncPathFromLayer();
+  }
+
+  /** Path editor presents as closed for non-eyelid layers. */
+  const pathClosed = computed(() => selectedLayer.value?.type !== "eyelid");
+
+  return {
+    state,
+    path,
+    selectedTexture,
+    selectedLayer,
+    layers,
+    pathClosed,
+    createEye,
+    selectTexture,
+    selectLayer,
+    renameLayer,
+    setLayerEnabled,
+    setLayerColor,
+    moveLayer,
+    addLayer,
+    removeLayer,
+    onPathKnotUpdate,
+    onPathDragEnd,
+    onPathAdd,
+    removeSelectedTexture,
+    snapshotTextures,
+    loadTextures,
+    pushPathToLayer,
+    syncPathFromLayer,
+  };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/pathModel.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/pathModel.js
@@ -1,0 +1,257 @@
+// ============================================================================
+// pathModel.js — shared knot/segment helpers for mesh + texture spline editors.
+// ============================================================================
+
+import { evalSpan as evalPathSpan } from "./pathSample.js";
+import { sampleOpenPath, sampleClosedPath } from "./pathSample.js";
+
+export function knotUid() {
+  return "k" + Math.random().toString(36).slice(2, 9);
+}
+
+export function defaultSegment(fromId, toId, pathType = "bezier") {
+  return {
+    fromId,
+    toId,
+    color: null,
+    roughness: 0.4,
+    metalness: 0,
+    opacity: 1,
+    texture: "gradient",
+    textureData: null,
+    textureAsset: null,
+    pathType: pathType === "line" || pathType === "arc" ? pathType : "bezier",
+    arcBulge: null,
+  };
+}
+
+export function cloneSeg(s, fromId, toId) {
+  return {
+    ...s,
+    fromId,
+    toId,
+    textureData: s.textureData || null,
+    pathType: s.pathType === "line" || s.pathType === "arc" ? s.pathType : "bezier",
+    arcBulge: s.arcBulge ?? null,
+  };
+}
+
+export function syncOpenSegments(knots, segments, defaultPathType = "bezier") {
+  const byPair = new Map();
+  for (const s of segments || []) byPair.set(s.fromId + ">" + s.toId, s);
+  const next = [];
+  for (let i = 0; i < (knots?.length || 0) - 1; i++) {
+    const fromId = knots[i].id;
+    const toId = knots[i + 1].id;
+    const exact = byPair.get(fromId + ">" + toId);
+    next.push(exact ? cloneSeg(exact, fromId, toId) : defaultSegment(fromId, toId, defaultPathType));
+  }
+  return next;
+}
+
+export function syncClosedSegments(knots, segments, defaultPathType = "bezier") {
+  const byPair = new Map();
+  for (const s of segments || []) byPair.set(s.fromId + ">" + s.toId, s);
+  const next = [];
+  const n = knots?.length || 0;
+  for (let i = 0; i < n; i++) {
+    const fromId = knots[i].id;
+    const toId = knots[(i + 1) % n].id;
+    const exact = byPair.get(fromId + ">" + toId);
+    next.push(exact ? cloneSeg(exact, fromId, toId) : defaultSegment(fromId, toId, defaultPathType));
+  }
+  return next;
+}
+
+export function makeEllipsePath({
+  cx = 0,
+  cy = 0,
+  rx = 0.45,
+  ry = 0.55,
+  color = "#ffffff",
+  n = 8,
+} = {}) {
+  const knots = [];
+  for (let i = 0; i < n; i++) {
+    const t = (i / n) * Math.PI * 2;
+    const x = cx + Math.cos(t) * rx;
+    const y = cy + Math.sin(t) * ry;
+    // Approximate cubic handles for a circle/ellipse
+    const tang = 0.5522847498;
+    const tx = -Math.sin(t) * rx * tang;
+    const ty = Math.cos(t) * ry * tang;
+    knots.push({
+      id: knotUid(),
+      x,
+      y,
+      hx: tx / n,
+      hy: ty / n,
+      color,
+    });
+  }
+  // Better ellipse handles: adjacent Bezier control for circular arc
+  for (let i = 0; i < n; i++) {
+    const t = (i / n) * Math.PI * 2;
+    const k = 4 * Math.tan(Math.PI / n) / 3;
+    knots[i].hx = (-Math.sin(t) * rx * k) / 2;
+    knots[i].hy = (Math.cos(t) * ry * k) / 2;
+  }
+  const segments = syncClosedSegments(knots, [], "bezier");
+  for (const s of segments) s.color = color;
+  return { knots, segments };
+}
+
+export function makeOpenArcPath({
+  y = 0.15,
+  halfWidth = 0.55,
+  bulge = 0.2,
+  color = "#c8a07a",
+} = {}) {
+  const knots = [
+    { id: knotUid(), x: -halfWidth, y, hx: halfWidth * 0.25, hy: bulge, color },
+    { id: knotUid(), x: 0, y: y + bulge, hx: halfWidth * 0.3, hy: 0, color },
+    { id: knotUid(), x: halfWidth, y, hx: -halfWidth * 0.25, hy: -bulge * 0.2, color },
+  ];
+  const segments = syncOpenSegments(knots, [], "bezier");
+  for (const s of segments) s.color = color;
+  return { knots, segments };
+}
+
+/**
+ * Sample open or closed path. Open paths here allow signed X (texture eyelids);
+ * mesh profile sampling still uses pathSample.sampleOpenPath (x ≥ 0).
+ */
+export function samplePath(knots, segments, { closed = false, samplesPerSpan = 24, curveType = 0 } = {}) {
+  if (closed) return sampleClosedPath(knots, segments, samplesPerSpan, curveType);
+  const pts = [];
+  if (!knots || knots.length < 2) return pts;
+  const segN = Math.max(1, samplesPerSpan | 0);
+  for (let i = 0; i < knots.length - 1; i++) {
+    const a = knots[i];
+    const b = knots[i + 1];
+    const seg = segments?.[i];
+    const opts = {
+      pathType: seg?.pathType || "bezier",
+      curveType,
+      arcBulge: seg?.arcBulge ?? null,
+    };
+    const last = i < knots.length - 2 ? segN - 1 : segN;
+    for (let s = 0; s <= last; s++) {
+      const t = s / segN;
+      const { p, tan } = evalPathSpan(a, b, t, opts);
+      pts.push({
+        x: p.x,
+        y: p.y,
+        tx: tan.x,
+        ty: tan.y,
+        segmentIndex: i,
+        t,
+      });
+    }
+  }
+  return pts;
+}
+
+export function pathCentroid(knots) {
+  if (!knots?.length) return { x: 0, y: 0 };
+  let x = 0;
+  let y = 0;
+  for (const k of knots) {
+    x += k.x;
+    y += k.y;
+  }
+  return { x: x / knots.length, y: y / knots.length };
+}
+
+export function translatePath(knots, dx, dy) {
+  for (const k of knots) {
+    k.x += dx;
+    k.y += dy;
+  }
+}
+
+/** Point-in-polygon (ray cast). poly = [{x,y}, ...] */
+export function pointInPolygon(px, py, poly) {
+  let inside = false;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const xi = poly[i].x;
+    const yi = poly[i].y;
+    const xj = poly[j].x;
+    const yj = poly[j].y;
+    const intersect =
+      yi > py !== yj > py && px < ((xj - xi) * (py - yi)) / (yj - yi + 1e-15) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+/** Project point to nearest location on polygon edges. */
+export function projectToPolygonBoundary(px, py, poly) {
+  let best = { x: px, y: py };
+  let bestD = Infinity;
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i];
+    const b = poly[(i + 1) % poly.length];
+    const abx = b.x - a.x;
+    const aby = b.y - a.y;
+    const apx = px - a.x;
+    const apy = py - a.y;
+    const ab2 = abx * abx + aby * aby || 1;
+    let t = (apx * abx + apy * aby) / ab2;
+    t = Math.max(0, Math.min(1, t));
+    const qx = a.x + abx * t;
+    const qy = a.y + aby * t;
+    const d = (qx - px) * (qx - px) + (qy - py) * (qy - py);
+    if (d < bestD) {
+      bestD = d;
+      best = { x: qx, y: qy };
+    }
+  }
+  return best;
+}
+
+export function clampPointInPolygon(px, py, poly, inset = 0.02) {
+  if (!poly?.length) return { x: px, y: py };
+  if (pointInPolygon(px, py, poly)) return { x: px, y: py };
+  const b = projectToPolygonBoundary(px, py, poly);
+  const c = pathCentroid(poly);
+  const dx = c.x - b.x;
+  const dy = c.y - b.y;
+  const L = Math.hypot(dx, dy) || 1;
+  return { x: b.x + (dx / L) * inset, y: b.y + (dy / L) * inset };
+}
+
+/**
+ * Keep a child closed path inside a parent polygon by translating if the
+ * centroid escapes, then clamping outlier knots onto the boundary.
+ */
+export function constrainPathInside(knots, parentPoly) {
+  if (!knots?.length || !parentPoly?.length) return;
+  const c = pathCentroid(knots);
+  if (!pointInPolygon(c.x, c.y, parentPoly)) {
+    const clamped = clampPointInPolygon(c.x, c.y, parentPoly, 0.04);
+    translatePath(knots, clamped.x - c.x, clamped.y - c.y);
+  }
+  for (const k of knots) {
+    if (!pointInPolygon(k.x, k.y, parentPoly)) {
+      const p = clampPointInPolygon(k.x, k.y, parentPoly, 0.015);
+      k.x = p.x;
+      k.y = p.y;
+    }
+  }
+}
+
+export function evalSpanOnPath(knots, segments, spanIndex, t, { closed = false, curveType = 0 } = {}) {
+  const n = knots.length;
+  if (n < 2) return null;
+  const i = spanIndex;
+  const a = knots[i];
+  const b = knots[closed ? (i + 1) % n : i + 1];
+  if (!a || !b) return null;
+  const seg = segments[i];
+  return evalPathSpan(a, b, t, {
+    pathType: seg?.pathType || "bezier",
+    curveType,
+    arcBulge: seg?.arcBulge ?? null,
+  });
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -1,0 +1,356 @@
+// ============================================================================
+// eyeTexture.js — eye texture params (not pixels) + canvas renderer + constraints.
+// ============================================================================
+
+import {
+  makeEllipsePath,
+  makeOpenArcPath,
+  samplePath,
+  constrainPathInside,
+  knotUid,
+  syncClosedSegments,
+  syncOpenSegments,
+} from "../pathModel.js";
+import { newGuid } from "../assetClone.js";
+
+export const EYE_LAYER_TYPES = ["eyeball", "iris", "pupil", "reflection", "eyelid"];
+
+export const EYE_CLIP_PARENT = {
+  eyeball: null,
+  iris: "eyeball",
+  pupil: "iris",
+  reflection: "eyeball",
+  eyelid: "eyeball",
+};
+
+/** Default draw order (bottom → top). Eyelid above iris/pupil/reflection. */
+export const EYE_DEFAULT_ORDER = ["eyeball", "iris", "pupil", "reflection", "eyelid"];
+
+function layerId() {
+  return "tl_" + Math.random().toString(36).slice(2, 9);
+}
+
+export function createEyeLayer(type, overrides = {}) {
+  const defaults = {
+    eyeball: () => ({
+      name: "Eyeball",
+      color: "#f2f0ea",
+      closed: true,
+      ...makeEllipsePath({ cx: 0, cy: 0, rx: 0.72, ry: 0.55, color: "#f2f0ea", n: 8 }),
+    }),
+    iris: () => ({
+      name: "Iris",
+      color: "#3a70d0",
+      closed: true,
+      ...makeEllipsePath({ cx: 0.05, cy: 0.02, rx: 0.32, ry: 0.32, color: "#3a70d0", n: 8 }),
+    }),
+    pupil: () => ({
+      name: "Pupil",
+      color: "#0a0a0c",
+      closed: true,
+      ...makeEllipsePath({ cx: 0.05, cy: 0.02, rx: 0.14, ry: 0.14, color: "#0a0a0c", n: 6 }),
+    }),
+    reflection: () => ({
+      name: "Reflection",
+      color: "#ffffff",
+      closed: true,
+      ...makeEllipsePath({ cx: -0.02, cy: 0.1, rx: 0.05, ry: 0.07, color: "#ffffff", n: 6 }),
+    }),
+    eyelid: () => ({
+      name: "Eyelid",
+      color: "#c4a484",
+      closed: false,
+      fillSide: "above", // above | below — region clipped to eyeball
+      ...makeOpenArcPath({ y: 0.12, halfWidth: 0.7, bulge: 0.28, color: "#c4a484" }),
+    }),
+  };
+  const base = (defaults[type] || defaults.eyeball)();
+  return {
+    id: layerId(),
+    type,
+    name: overrides.name || base.name,
+    enabled: overrides.enabled !== false,
+    color: overrides.color || base.color,
+    closed: base.closed,
+    fillSide: base.fillSide || null,
+    knots: overrides.knots || base.knots,
+    segments: overrides.segments || base.segments,
+    clipTo: EYE_CLIP_PARENT[type] ?? null,
+  };
+}
+
+export function createDefaultEyeTexture({ name = "Eye" } = {}) {
+  const layers = EYE_DEFAULT_ORDER.map((t) => createEyeLayer(t));
+  // Optional eyelid starts disabled — user can enable
+  const lid = layers.find((l) => l.type === "eyelid");
+  if (lid) lid.enabled = false;
+  return {
+    assetGuid: newGuid(),
+    name,
+    kind: "eye",
+    width: 256,
+    height: 256,
+    /** Background at mesh assign time comes from vertex colors; preview uses this fallback. */
+    backgroundFrom: "vertexColors",
+    previewBackground: "#6a8f6a",
+    layers,
+  };
+}
+
+export function serializePathBlock(block) {
+  return {
+    knots: (block.knots || []).map((k) => ({
+      id: k.id || knotUid(),
+      x: Number(k.x) || 0,
+      y: Number(k.y) || 0,
+      hx: Number(k.hx) || 0,
+      hy: Number(k.hy) || 0,
+      color: k.color || "#cccccc",
+    })),
+    segments: (block.segments || []).map((s) => ({
+      fromId: s.fromId,
+      toId: s.toId,
+      color: s.color == null ? null : s.color,
+      pathType: s.pathType === "line" || s.pathType === "arc" ? s.pathType : "bezier",
+      arcBulge: s.arcBulge == null || s.arcBulge === "" ? null : Number(s.arcBulge),
+      roughness: Number(s.roughness ?? 0.4),
+      metalness: Number(s.metalness ?? 0),
+      opacity: Number(s.opacity ?? 1),
+      texture: s.texture || "none",
+      textureAsset: s.textureAsset || null,
+    })),
+  };
+}
+
+export function serializeEyeTexture(tex) {
+  return {
+    assetGuid: tex.assetGuid,
+    name: tex.name || "Eye",
+    kind: "eye",
+    width: Number(tex.width) || 256,
+    height: Number(tex.height) || 256,
+    backgroundFrom: tex.backgroundFrom === "solid" ? "solid" : "vertexColors",
+    previewBackground: tex.previewBackground || "#6a8f6a",
+    layers: (tex.layers || []).map((L) => ({
+      id: L.id,
+      type: EYE_LAYER_TYPES.includes(L.type) ? L.type : "eyeball",
+      name: L.name || L.type,
+      enabled: L.enabled !== false,
+      color: L.color || "#ffffff",
+      closed: L.closed !== false && L.type !== "eyelid",
+      fillSide: L.fillSide === "below" ? "below" : L.type === "eyelid" ? "above" : null,
+      clipTo: L.clipTo || EYE_CLIP_PARENT[L.type] || null,
+      ...serializePathBlock(L),
+    })),
+  };
+}
+
+export function normalizeEyeTexture(raw) {
+  if (!raw || typeof raw !== "object") return createDefaultEyeTexture();
+  const base = createDefaultEyeTexture({ name: raw.name || "Eye" });
+  const layersIn = Array.isArray(raw.layers) ? raw.layers : null;
+  let layers;
+  if (layersIn?.length) {
+    layers = layersIn.map((L) => {
+      const type = EYE_LAYER_TYPES.includes(L.type) ? L.type : "eyeball";
+      const def = createEyeLayer(type);
+      const path = serializePathBlock(L.knots ? L : def);
+      return {
+        ...def,
+        id: L.id || def.id,
+        type,
+        name: L.name || def.name,
+        enabled: L.enabled !== false,
+        color: L.color || def.color,
+        closed: type !== "eyelid",
+        fillSide: type === "eyelid" ? (L.fillSide === "below" ? "below" : "above") : null,
+        clipTo: L.clipTo || EYE_CLIP_PARENT[type],
+        knots: path.knots,
+        segments:
+          type === "eyelid"
+            ? syncOpenSegments(path.knots, path.segments, "bezier")
+            : syncClosedSegments(path.knots, path.segments, "bezier"),
+      };
+    });
+  } else {
+    layers = base.layers;
+  }
+  return {
+    assetGuid: raw.assetGuid || base.assetGuid,
+    name: raw.name || base.name,
+    kind: "eye",
+    width: Number(raw.width) || 256,
+    height: Number(raw.height) || 256,
+    backgroundFrom: raw.backgroundFrom === "solid" ? "solid" : "vertexColors",
+    previewBackground: raw.previewBackground || base.previewBackground,
+    layers,
+  };
+}
+
+export function findLayer(tex, typeOrId) {
+  return (tex.layers || []).find((L) => L.id === typeOrId || L.type === typeOrId) || null;
+}
+
+export function layerPolygon(layer, samplesPerSpan = 20) {
+  if (!layer?.knots?.length) return [];
+  const pts = samplePath(layer.knots, layer.segments, {
+    closed: layer.closed !== false && layer.type !== "eyelid",
+    samplesPerSpan,
+  });
+  return pts.map((p) => ({ x: p.x, y: p.y }));
+}
+
+/** Apply nesting constraints after a layer edit. */
+export function constrainEyeLayer(tex, layerId) {
+  const layer = findLayer(tex, layerId);
+  if (!layer || layer.type === "eyeball" || layer.type === "eyelid") return;
+  const parentType = layer.clipTo || EYE_CLIP_PARENT[layer.type];
+  let parent = parentType ? findLayer(tex, parentType) : null;
+  // Pupil prefers iris; if iris missing/disabled, fall back to eyeball
+  if (layer.type === "pupil" && (!parent || parent.enabled === false)) {
+    parent = findLayer(tex, "eyeball");
+  }
+  // Reflection stays inside eyeball (and ideally near pupil — soft)
+  if (!parent || !parent.enabled) parent = findLayer(tex, "eyeball");
+  if (!parent) return;
+  const poly = layerPolygon(parent);
+  constrainPathInside(layer.knots, poly);
+  if (layer.type === "pupil") {
+    // Also keep pupil inside iris when both exist
+    const iris = findLayer(tex, "iris");
+    if (iris?.enabled !== false) constrainPathInside(layer.knots, layerPolygon(iris));
+  }
+}
+
+export function constrainAllEyeLayers(tex) {
+  for (const order of ["iris", "pupil", "reflection"]) {
+    const L = findLayer(tex, order);
+    if (L) constrainEyeLayer(tex, L.id);
+  }
+}
+
+function worldToTex(x, y, w, h, pad = 0.08) {
+  // Map authoring [-1,1]² (with pad) → texture pixels
+  const min = -1 - pad;
+  const max = 1 + pad;
+  const sx = ((x - min) / (max - min)) * w;
+  const sy = ((max - y) / (max - min)) * h;
+  return [sx, sy];
+}
+
+function tracePath(ctx, pts, w, h, closed) {
+  if (pts.length < 2) return;
+  const [x0, y0] = worldToTex(pts[0].x, pts[0].y, w, h);
+  ctx.beginPath();
+  ctx.moveTo(x0, y0);
+  for (let i = 1; i < pts.length; i++) {
+    const [x, y] = worldToTex(pts[i].x, pts[i].y, w, h);
+    ctx.lineTo(x, y);
+  }
+  if (closed) ctx.closePath();
+}
+
+/**
+ * Render eye texture params into a 2D canvas context (dynamic — no bake).
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {object} tex normalizeEyeTexture result
+ * @param {{ background?: string }} [opts]
+ */
+export function renderEyeTexture(ctx, tex, opts = {}) {
+  const w = ctx.canvas.width;
+  const h = ctx.canvas.height;
+  const bg =
+    opts.background ||
+    (tex.backgroundFrom === "solid" ? tex.previewBackground : tex.previewBackground) ||
+    "#6a8f6a";
+  ctx.clearRect(0, 0, w, h);
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, w, h);
+
+  const eyeball = findLayer(tex, "eyeball");
+  const eyePoly = eyeball ? layerPolygon(eyeball) : [];
+
+  const drawOrder = [...(tex.layers || [])];
+  // Ensure eyelid after iris/pupil/reflection
+  drawOrder.sort((a, b) => {
+    const rank = (t) => {
+      const i = EYE_DEFAULT_ORDER.indexOf(t);
+      return i < 0 ? 50 : i;
+    };
+    return rank(a.type) - rank(b.type);
+  });
+
+  for (const layer of drawOrder) {
+    if (layer.enabled === false) continue;
+    const closed = layer.type !== "eyelid";
+    const pts = samplePath(layer.knots, layer.segments, {
+      closed,
+      samplesPerSpan: 28,
+    });
+    if (pts.length < 2) continue;
+
+    ctx.save();
+    if (layer.type !== "eyeball" && eyePoly.length >= 3) {
+      tracePath(ctx, eyePoly, w, h, true);
+      ctx.clip();
+    }
+
+    if (layer.type === "eyelid") {
+      // Fill region above/below curve, clipped to eyeball
+      const side = layer.fillSide === "below" ? "below" : "above";
+      const [x0, y0] = worldToTex(pts[0].x, pts[0].y, w, h);
+      ctx.beginPath();
+      ctx.moveTo(x0, y0);
+      for (let i = 1; i < pts.length; i++) {
+        const [x, y] = worldToTex(pts[i].x, pts[i].y, w, h);
+        ctx.lineTo(x, y);
+      }
+      if (side === "above") {
+        ctx.lineTo(w, worldToTex(pts[pts.length - 1].x, pts[pts.length - 1].y, w, h)[1]);
+        ctx.lineTo(w, 0);
+        ctx.lineTo(0, 0);
+        ctx.lineTo(0, y0);
+      } else {
+        ctx.lineTo(w, worldToTex(pts[pts.length - 1].x, pts[pts.length - 1].y, w, h)[1]);
+        ctx.lineTo(w, h);
+        ctx.lineTo(0, h);
+        ctx.lineTo(0, y0);
+      }
+      ctx.closePath();
+      ctx.fillStyle = layer.color || "#c4a484";
+      ctx.fill();
+    } else {
+      if (layer.type === "iris" || layer.type === "pupil") {
+        const parentType = layer.clipTo;
+        const parent = parentType ? findLayer(tex, parentType) : null;
+        if (parent?.enabled !== false && parent) {
+          const ppoly = layerPolygon(parent);
+          if (ppoly.length >= 3) {
+            tracePath(ctx, ppoly, w, h, true);
+            ctx.clip();
+          }
+        }
+      }
+      tracePath(ctx, pts, w, h, true);
+      ctx.fillStyle = layer.color || "#fff";
+      ctx.fill();
+    }
+    ctx.restore();
+  }
+}
+
+/** Offscreen render → ImageData (for tests / future mesh assign). */
+export function rasterizeEyeTexture(tex, width, height) {
+  const w = width || tex.width || 256;
+  const h = height || tex.height || 256;
+  const canvas = typeof document !== "undefined" ? document.createElement("canvas") : null;
+  if (!canvas) {
+    // Node smoke: return null; browser path uses canvas
+    return null;
+  }
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  renderEyeTexture(ctx, tex);
+  return ctx.getImageData(0, 0, w, h);
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -11,6 +11,7 @@ import {
   slugify,
   validateProject,
 } from "./schema.js";
+import { normalizeEyeTexture } from "../lib/texture/eyeTexture.js";
 
 function defaultOrbitDoc() {
   const raw = SplineLathe.defaultOrbitKnots();
@@ -446,6 +447,23 @@ function normalizeV8(doc) {
   return v7;
 }
 
+function normalizeV9(doc) {
+  const v8 = normalizeV8(doc);
+  v8.schemaVersion = 9;
+  const src = doc.textureAssets || v8.textureAssets || {};
+  const textureAssets = {};
+  for (const [guid, raw] of Object.entries(src)) {
+    const tex = normalizeEyeTexture({
+      ...raw,
+      assetGuid: raw?.assetGuid || guid,
+      kind: raw?.kind || "eye",
+    });
+    textureAssets[tex.assetGuid] = tex;
+  }
+  v8.textureAssets = textureAssets;
+  return v8;
+}
+
 /** @type {Record<number, (doc: any) => any>} */
 const STEPS = {
   1(doc) {
@@ -476,6 +494,10 @@ const STEPS = {
   // 7 → 8: child surface placement (z + normal + surface flag)
   8(doc) {
     return normalizeV8(doc);
+  },
+  // 8 → 9: textureAssets (params-only procedural textures, eye editor first)
+  9(doc) {
+    return normalizeV9(doc);
   },
 };
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -2,7 +2,7 @@
 // schema.js — semantic spline-project document + versioned migrations.
 // ============================================================================
 
-export const CURRENT_SCHEMA_VERSION = 8;
+export const CURRENT_SCHEMA_VERSION = 9;
 
 export const SCHEMA_KIND = "ranger.splineProject";
 
@@ -132,6 +132,34 @@ function serializeChild(ch) {
   };
 }
 
+/** Texture assets store editable params only (no baked pixels). */
+function serializeTextureAsset(tex) {
+  if (!tex || typeof tex !== "object") return null;
+  const kind = tex.kind === "eye" ? "eye" : String(tex.kind || "eye");
+  const layers = (tex.layers || []).map((L) => ({
+    id: L.id,
+    type: L.type || "eyeball",
+    name: L.name || L.type || "layer",
+    enabled: L.enabled !== false,
+    color: L.color || "#ffffff",
+    closed: L.closed !== false && L.type !== "eyelid",
+    fillSide: L.fillSide === "below" ? "below" : L.type === "eyelid" ? "above" : null,
+    clipTo: L.clipTo || null,
+    knots: (L.knots || []).map(serializeKnot),
+    segments: (L.segments || []).map(serializeSegment),
+  }));
+  return {
+    assetGuid: tex.assetGuid,
+    name: tex.name || "Texture",
+    kind,
+    width: Number(tex.width) || 256,
+    height: Number(tex.height) || 256,
+    backgroundFrom: tex.backgroundFrom === "solid" ? "solid" : "vertexColors",
+    previewBackground: tex.previewBackground || "#6a8f6a",
+    layers,
+  };
+}
+
 /**
  * Build a current-version project document from the live editor state.
  */
@@ -192,6 +220,14 @@ export function buildProjectDocument(opts) {
     placementNormal: serializePlacementNormal(st.placementNormal),
     embeddedAssets: embedded,
     children: (st.children || []).map(serializeChild),
+    textureAssets: (() => {
+      const out = {};
+      for (const [guid, tex] of Object.entries(st.textureAssets || {})) {
+        const s = serializeTextureAsset({ ...tex, assetGuid: tex.assetGuid || guid });
+        if (s) out[s.assetGuid] = s;
+      }
+      return out;
+    })(),
   };
 }
 
@@ -250,6 +286,19 @@ export function validateProject(doc) {
     const m = doc.editor?.tessellationMode;
     if (m != null && m !== "rotation" && m !== "torus") {
       errors.push('editor.tessellationMode must be "rotation" or "torus"');
+    }
+  }
+  if (doc.schemaVersion >= 9) {
+    if (doc.textureAssets != null && typeof doc.textureAssets !== "object") {
+      errors.push("textureAssets must be an object map");
+    } else if (doc.textureAssets) {
+      for (const [guid, tex] of Object.entries(doc.textureAssets)) {
+        if (!tex || typeof tex !== "object") {
+          errors.push(`textureAssets[${guid}] invalid`);
+          continue;
+        }
+        if (!Array.isArray(tex.layers)) errors.push(`textureAssets[${guid}].layers must be an array`);
+      }
     }
   }
   return errors;

--- a/gallery/game_engine/v2/mesh_editor/library/README.md
+++ b/gallery/game_engine/v2/mesh_editor/library/README.md
@@ -46,6 +46,9 @@ copy or symlink selected folders into a tracked tree, or temporarily force-add.
   `surface`) for 3D preview raycast attach and surface-drag while editing a child.
   Embedded assets also persist `spineProfileKnots` / `spineOrbitKnots` and
   `placementNormal` (shortened child spines must not reset on save).
+- v9 adds `textureAssets` — params-only procedural textures (first kind: `eye`
+  with named layers eyeball/iris/pupil/reflection/eyelid). No baked pixels;
+  rasterize at runtime for animation / mesh assign later.
 
 When you change the document shape, bump the version and add a step; old folders
 keep working.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Refactor
- Extract shared knot/segment helpers to `lib/pathModel.js`
- Add `usePathEditor` for single-path Bezier editing (texture layers, etc.)
- `useSplineEditor` now imports sync helpers from `pathModel`
- `SplineCanvas` gains feature flags (`pathClosed`, `showLatheGuides`, placement/attachments/mirror overrides) so mesh lathe chrome can be turned off

### Texture sector (schema **v9**)
Top-level **Mesh | Texture** toggle. First texture kind: **eye**.

**Layers** (named, reorder, enable/disable):
| Layer | Behaviour |
|-------|-----------|
| Eyeball | Closed Bezier silhouette |
| Iris | Constrained inside eyeball |
| Pupil | Constrained inside iris |
| Reflection | Shine, constrained inside eyeball |
| Eyelid | Open Bezier + clipped fill, drawn on top of iris/pupil/reflection |

Only **params** are persisted in `textureAssets` (no baked pixels). `renderEyeTexture` rasterizes at runtime for the preview (animatable later). Mesh UV projection / vertex-colour background assign is intentionally out of scope for this PR.

### Tests
`smoke-eye-texture.mjs` + existing smokes updated for schema 9.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

