### PR TITLE
Improve eye Bezier defaults, auto-smooth, and texture layout

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -184,6 +184,10 @@ Layers can be named, reordered, enabled/disabled. Only **params** are saved
 (`knots` / `segments` / colours) — `renderEyeTexture` rebuilds pixels at runtime
 (animatable). Mesh UV projection / vertex-colour background assign is next.
 
+Eye paths default to a **4-knot** Y-symmetric ellipse (easy width/height). Toolbar
+**Symmetry** mirrors the left from the right (centroid axis); **Auto smooth**
+recomputes Bezier handles after moving a point. Use **Add** to insert more knots.
+
 ## Shading base
 
 Teapot-inspired modes exercised against Ranger Three:

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -8,7 +8,13 @@ import {
   findLayer,
   layerPolygon,
 } from "../src/lib/texture/eyeTexture.js";
-import { pointInPolygon, pathCentroid } from "../src/lib/pathModel.js";
+import {
+  pointInPolygon,
+  pathCentroid,
+  autoSmoothHandles,
+  rebuildClosedYSymmetry,
+  makeEllipsePath,
+} from "../src/lib/pathModel.js";
 import { migrateProject } from "../src/library/migrations.js";
 import { CURRENT_SCHEMA_VERSION, buildProjectDocument } from "../src/library/schema.js";
 
@@ -17,6 +23,36 @@ assert.equal(eye.kind, "eye");
 assert.ok(eye.layers.some((L) => L.type === "eyeball"));
 assert.ok(eye.layers.some((L) => L.type === "iris"));
 assert.ok(eye.layers.some((L) => L.type === "pupil"));
+
+// Default eyeball uses a compact 4-knot symmetric ellipse
+const eyeball = findLayer(eye, "eyeball");
+assert.equal(eyeball.knots.length, 4, "eyeball starts with 4 knots");
+assert.ok(
+  eyeball.knots.some((k) => k.x > 0.5) && eyeball.knots.some((k) => k.x < -0.5),
+  "eyeball spans left/right for width edits",
+);
+
+const ell = makeEllipsePath({ cx: 0, cy: 0, rx: 1, ry: 0.5, n: 4 });
+assert.equal(ell.knots.length, 4);
+// Auto-smooth should keep finite handles
+for (const k of ell.knots) {
+  k.hx = 0;
+  k.hy = 0;
+}
+autoSmoothHandles(ell.knots, { closed: true });
+assert.ok(ell.knots.some((k) => Math.hypot(k.hx, k.hy) > 0.01), "auto-smooth sets handles");
+
+// Y-symmetry rebuild: move right tip, left should mirror about centroid X
+const right = ell.knots.find((k) => k.x > 0.5);
+right.x = 0.9;
+right.y = 0.05;
+rebuildClosedYSymmetry(ell.knots);
+const ax = pathCentroid(ell.knots).x;
+const right2 = ell.knots.find((k) => k.x > ax + 0.3);
+const left = ell.knots.find((k) => k.x < ax - 0.3);
+assert.ok(right2 && left, "left/right tips exist after symmetry rebuild");
+assert.ok(Math.abs(right2.x - ax - (ax - left.x)) < 1e-6, "left mirrors right about centroid");
+assert.ok(Math.abs(left.y - right2.y) < 1e-6, "left mirrors right y");
 
 // Move iris far outside, then constrain — centroid should land inside eyeball
 const iris = findLayer(eye, "iris");

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -58,6 +58,8 @@ const texPath = tex.path;
 const texLayers = tex.layers;
 const texSelected = tex.selectedTexture;
 const texPathClosed = tex.pathClosed;
+const texClampX = tex.clampNonNegativeX;
+const texShowMirror = tex.showMirror;
 
 const workspace = ref("mesh"); // mesh | texture
 
@@ -358,6 +360,25 @@ onBeforeUnmount(() => {
           >
             Delete texture
           </button>
+          <label class="tex-check" title="Edit right half; left is mirrored (like mesh profile)">
+            <input
+              type="checkbox"
+              :checked="texState.symmetry"
+              @change="tex.setSymmetry($event.target.checked)"
+            />
+            Symmetry
+          </label>
+          <label
+            class="tex-check"
+            title="After moving a point, recompute Bezier handles for smooth joins"
+          >
+            <input
+              type="checkbox"
+              :checked="texState.autoSmooth"
+              @change="tex.setAutoSmooth($event.target.checked)"
+            />
+            Auto smooth
+          </label>
         </div>
         <p v-if="workspace === 'mesh' && state.viewMode === 'spine'" class="spine-hint">
           Editing {{ spinePlaneLabel }} · pick Profile/Orbit first to choose which bend
@@ -666,33 +687,39 @@ onBeforeUnmount(() => {
     </main>
 
     <main v-else class="workspace texture-workspace">
-      <SplineCanvas
-        :knots="texPath.state.knots"
-        :segments="texPath.state.segments"
-        :selected-id="texPath.state.selectedId"
-        :selected-ids="texPath.state.selectedIds"
-        :selected-segment-index="texPath.state.selectedSegmentIndex"
-        :curve-type="texPath.state.curveType"
-        :symmetry="false"
-        :tool-mode="texPath.state.toolMode"
-        view-mode="profile"
-        :path-closed="texPathClosed"
-        :show-unit-circle="false"
-        :show-placement-normal-prop="false"
-        :show-attachments-prop="false"
-        :show-mirror="false"
-        :show-lathe-guides="false"
-        :clamp-non-negative-x="false"
-        :children="[]"
-        :viewport="texPath.state.viewport"
-        :sample-curve-points="texPath.sampleCurvePoints"
-        :find-closest-on-curve="texPath.findClosestOnCurve"
-        @select="(id, opts) => texPath.select(id, opts || {})"
-        @select-segment="texPath.selectSegment"
-        @update-knot="tex.onPathKnotUpdate"
-        @add-on-curve="tex.onPathAdd"
-        @drag-end="tex.onPathDragEnd"
-      />
+      <div class="tex-canvas-col">
+        <SplineCanvas
+          :knots="texPath.state.knots"
+          :segments="texPath.state.segments"
+          :selected-id="texPath.state.selectedId"
+          :selected-ids="texPath.state.selectedIds"
+          :selected-segment-index="texPath.state.selectedSegmentIndex"
+          :curve-type="texPath.state.curveType"
+          :symmetry="texShowMirror"
+          :tool-mode="texPath.state.toolMode"
+          view-mode="profile"
+          :path-closed="texPathClosed"
+          :show-unit-circle="false"
+          :show-placement-normal-prop="false"
+          :show-attachments-prop="false"
+          :show-mirror="texShowMirror"
+          :show-lathe-guides="false"
+          :clamp-non-negative-x="texClampX"
+          :children="[]"
+          :viewport="texPath.state.viewport"
+          :sample-curve-points="texPath.sampleCurvePoints"
+          :find-closest-on-curve="texPath.findClosestOnCurve"
+          @select="(id, opts) => texPath.select(id, opts || {})"
+          @select-segment="texPath.selectSegment"
+          @update-knot="tex.onPathKnotUpdate"
+          @add-on-curve="tex.onPathAdd"
+          @drag-end="tex.onPathDragEnd"
+        />
+        <p class="tex-canvas-hint">
+          Few control points · Symmetry mirrors left · Add tool inserts knots · Auto smooth
+          keeps joins continuous
+        </p>
+      </div>
       <TextureLayerPanel
         :layers="texLayers"
         :selected-layer-id="texState.selectedLayerId"
@@ -905,6 +932,49 @@ h1 {
   gap: 1rem;
   min-height: 0;
   align-items: stretch;
+}
+
+/* Keep Bezier canvas from spilling over Layers checkboxes */
+.texture-workspace {
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 300px) minmax(0, 0.9fr) minmax(180px, 0.65fr);
+}
+.tex-canvas-col {
+  min-width: 0;
+  overflow: hidden;
+  display: grid;
+  gap: 0.45rem;
+  align-content: start;
+}
+.tex-canvas-col :deep(.spline-wrap) {
+  min-width: 0;
+  width: 100%;
+  overflow: hidden;
+}
+.tex-canvas-col :deep(.spline-canvas) {
+  width: 100%;
+  max-width: min(100%, 480px);
+  justify-self: center;
+}
+.tex-canvas-hint {
+  margin: 0;
+  font-size: 0.7rem;
+  color: var(--ink-dim);
+  text-align: center;
+}
+.tex-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  color: var(--ink-dim);
+  padding: 0.35rem 0.55rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  cursor: pointer;
+  user-select: none;
+}
+.tex-check input {
+  margin: 0;
 }
 
 .side-stack {

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/TextureLayerPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/TextureLayerPanel.vue
@@ -91,7 +91,10 @@ const addTypes = [
   border-radius: var(--radius);
   padding: 0.85rem;
   min-height: 0;
+  min-width: 0;
   align-content: start;
+  position: relative;
+  z-index: 1;
 }
 header {
   display: flex;

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
@@ -14,17 +14,28 @@ import {
 } from "../lib/texture/eyeTexture.js";
 import { usePathEditor } from "./usePathEditor.js";
 import { newGuid } from "../lib/assetClone.js";
+import {
+  autoSmoothHandles,
+  rebuildClosedYSymmetry,
+  pathCentroid,
+} from "../lib/pathModel.js";
 
 export function useTextureEditor() {
   const state = reactive({
     textures: /** @type {Record<string, any>} */ ({}),
     selectedGuid: /** @type {string|null} */ (null),
     selectedLayerId: /** @type {string|null} */ (null),
+    /** Y-mirror like mesh profile — edit right half (x ≥ 0). */
+    symmetry: true,
+    /** Recompute Bezier handles after moving a knot (smooth joins). */
+    autoSmooth: true,
     status: "Texture editor — params only (rasterized at runtime).",
   });
 
   const path = usePathEditor({
     closed: true,
+    // Canvas clamps via SplineCanvas prop; eyelid must allow signed X.
+    clampNonNegativeX: false,
     viewport: { min: -1.2, max: 1.2 },
   });
 
@@ -40,25 +51,44 @@ export function useTextureEditor() {
 
   const layers = computed(() => selectedTexture.value?.layers || []);
 
+  function layerWantsSymmetry(layer) {
+    return state.symmetry && layer && layer.type !== "eyelid" && layer.closed !== false;
+  }
+
   function syncPathFromLayer() {
     const layer = selectedLayer.value;
     if (!layer) {
       path.loadPath([], [], { closed: true });
+      path.state.closed = true;
       return;
     }
-    path.loadPath(layer.knots, layer.segments, { closed: layer.type !== "eyelid" });
+    const closed = layer.type !== "eyelid";
+    path.loadPath(layer.knots, layer.segments, { closed });
   }
 
-  function pushPathToLayer() {
+  function applyPathPolish({ movedPoint = false } = {}) {
+    const closed = path.state.closed;
+    if (movedPoint && state.autoSmooth) {
+      autoSmoothHandles(path.state.knots, { closed });
+    }
+    if (layerWantsSymmetry(selectedLayer.value) && closed) {
+      rebuildClosedYSymmetry(path.state.knots);
+      if (state.autoSmooth) autoSmoothHandles(path.state.knots, { closed: true });
+      path.syncSegments();
+    }
+  }
+
+  function pushPathToLayer(opts = {}) {
     const tex = selectedTexture.value;
     const layer = selectedLayer.value;
     if (!tex || !layer) return;
+    applyPathPolish(opts);
     layer.knots = path.state.knots.map((k) => ({ ...k }));
     layer.segments = path.state.segments.map((s) => ({ ...s }));
     layer.color = layer.color || path.state.knots[0]?.color || layer.color;
     constrainEyeLayer(tex, layer.id);
     // If constrain moved knots, reload path editor
-    path.loadPath(layer.knots, layer.segments);
+    path.loadPath(layer.knots, layer.segments, { closed: layer.type !== "eyelid" });
   }
 
   watch(
@@ -161,18 +191,45 @@ export function useTextureEditor() {
     }
   }
 
+  function symmetryAxisX() {
+    const knots = path.state.knots;
+    if (!knots?.length) return 0;
+    return pathCentroid(knots).x;
+  }
+
   function onPathKnotUpdate(id, patch) {
+    // With symmetry, keep edits on the right half relative to path centroid.
+    if (layerWantsSymmetry(selectedLayer.value) && patch.x != null) {
+      const ax = symmetryAxisX();
+      patch = { ...patch, x: Math.max(ax, Number(patch.x) || 0) };
+    }
     path.updateKnot(id, patch);
-    pushPathToLayer();
+    const movedPoint = patch.x != null || patch.y != null;
+    pushPathToLayer({ movedPoint });
   }
 
   function onPathDragEnd() {
     path.endGesture();
-    pushPathToLayer();
+    pushPathToLayer({ movedPoint: true });
   }
 
   function onPathAdd(x, y) {
-    if (path.insertKnotOnCurve(x, y)) pushPathToLayer();
+    const wx = layerWantsSymmetry(selectedLayer.value)
+      ? Math.max(symmetryAxisX(), x)
+      : x;
+    if (path.insertKnotOnCurve(wx, y)) pushPathToLayer({ movedPoint: true });
+  }
+
+  function setSymmetry(on) {
+    state.symmetry = !!on;
+    if (state.symmetry && path.state.closed) {
+      pushPathToLayer({ movedPoint: true });
+    }
+  }
+
+  function setAutoSmooth(on) {
+    state.autoSmooth = !!on;
+    if (state.autoSmooth) pushPathToLayer({ movedPoint: true });
   }
 
   function removeSelectedTexture() {
@@ -211,6 +268,18 @@ export function useTextureEditor() {
   /** Path editor presents as closed for non-eyelid layers. */
   const pathClosed = computed(() => selectedLayer.value?.type !== "eyelid");
 
+  /**
+   * Canvas clamp for symmetry: only force world x≥0 for eyeball (centred on 0).
+   * Off-centre iris/pupil still get centroid-based rebuild after edits.
+   */
+  const clampNonNegativeX = computed(() => {
+    const layer = selectedLayer.value;
+    return layerWantsSymmetry(layer) && layer?.type === "eyeball";
+  });
+
+  // Real left knots are stored (rebuilt from the right); no ghost-mirror overlay.
+  const showMirror = computed(() => false);
+
   return {
     state,
     path,
@@ -218,6 +287,8 @@ export function useTextureEditor() {
     selectedLayer,
     layers,
     pathClosed,
+    clampNonNegativeX,
+    showMirror,
     createEye,
     selectTexture,
     selectLayer,
@@ -230,6 +301,8 @@ export function useTextureEditor() {
     onPathKnotUpdate,
     onPathDragEnd,
     onPathAdd,
+    setSymmetry,
+    setAutoSmooth,
     removeSelectedTexture,
     snapshotTextures,
     loadTextures,

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/pathModel.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/pathModel.js
@@ -63,42 +63,146 @@ export function syncClosedSegments(knots, segments, defaultPathType = "bezier") 
   return next;
 }
 
+/**
+ * Closed ellipse/circle as cubic Bezier knots with correct κ handles.
+ * Default n=4 (like a smooth almond/eye) — fewer points, easier width/height edits.
+ * Shape is Y-symmetric when centred on x=0.
+ */
 export function makeEllipsePath({
   cx = 0,
   cy = 0,
   rx = 0.45,
   ry = 0.55,
   color = "#ffffff",
-  n = 8,
+  n = 4,
 } = {}) {
+  const count = Math.max(3, n | 0);
+  // κ for a circular arc spanning 2π/n with symmetric in/out handles
+  const kappa = (4 / 3) * Math.tan(Math.PI / count);
   const knots = [];
-  for (let i = 0; i < n; i++) {
-    const t = (i / n) * Math.PI * 2;
-    const x = cx + Math.cos(t) * rx;
-    const y = cy + Math.sin(t) * ry;
-    // Approximate cubic handles for a circle/ellipse
-    const tang = 0.5522847498;
-    const tx = -Math.sin(t) * rx * tang;
-    const ty = Math.cos(t) * ry * tang;
+  for (let i = 0; i < count; i++) {
+    const t = (i / count) * Math.PI * 2;
     knots.push({
       id: knotUid(),
-      x,
-      y,
-      hx: tx / n,
-      hy: ty / n,
+      x: cx + Math.cos(t) * rx,
+      y: cy + Math.sin(t) * ry,
+      // Tangent (−sin, cos) × ellipse radii × κ
+      hx: -Math.sin(t) * rx * kappa,
+      hy: Math.cos(t) * ry * kappa,
       color,
     });
-  }
-  // Better ellipse handles: adjacent Bezier control for circular arc
-  for (let i = 0; i < n; i++) {
-    const t = (i / n) * Math.PI * 2;
-    const k = 4 * Math.tan(Math.PI / n) / 3;
-    knots[i].hx = (-Math.sin(t) * rx * k) / 2;
-    knots[i].hy = (Math.cos(t) * ry * k) / 2;
   }
   const segments = syncClosedSegments(knots, [], "bezier");
   for (const s of segments) s.color = color;
   return { knots, segments };
+}
+
+/**
+ * After moving a knot, set symmetric Bezier handles from neighbour finite
+ * differences so the polyline corners stay smooth (C1-ish).
+ */
+export function autoSmoothHandles(knots, { closed = false } = {}) {
+  const n = knots?.length || 0;
+  if (n < 2) return;
+  for (let i = 0; i < n; i++) {
+    const k = knots[i];
+    let prev;
+    let next;
+    if (closed) {
+      prev = knots[(i - 1 + n) % n];
+      next = knots[(i + 1) % n];
+    } else {
+      prev = i > 0 ? knots[i - 1] : null;
+      next = i < n - 1 ? knots[i + 1] : null;
+      if (!prev && next) {
+        // Start: aim toward next
+        const dx = next.x - k.x;
+        const dy = next.y - k.y;
+        const L = Math.hypot(dx, dy) || 1;
+        const s = L / 3;
+        k.hx = (dx / L) * s;
+        k.hy = (dy / L) * s;
+        continue;
+      }
+      if (!next && prev) {
+        const dx = k.x - prev.x;
+        const dy = k.y - prev.y;
+        const L = Math.hypot(dx, dy) || 1;
+        const s = L / 3;
+        k.hx = (dx / L) * s;
+        k.hy = (dy / L) * s;
+        continue;
+      }
+      if (!prev || !next) continue;
+    }
+    const dx = next.x - prev.x;
+    const dy = next.y - prev.y;
+    const L = Math.hypot(dx, dy) || 1;
+    const dPrev = Math.hypot(k.x - prev.x, k.y - prev.y);
+    const dNext = Math.hypot(next.x - k.x, next.y - k.y);
+    const scale = (dPrev + dNext) / 6;
+    k.hx = (dx / L) * scale;
+    k.hy = (dy / L) * scale;
+  }
+}
+
+/**
+ * Keep a closed path Y-symmetric about its centroid X (3D-profile style):
+ * edit the right half (local x ≥ 0); rebuild the left from mirrors.
+ * Preserves knot ids when possible.
+ */
+export function rebuildClosedYSymmetry(knots) {
+  if (!knots?.length) return;
+  const eps = 1e-3;
+  const c = pathCentroid(knots);
+  const ax = c.x;
+  const leftPool = knots.filter((k) => k.x < ax - eps).map((k) => ({ ...k }));
+  const right = [];
+  for (const k of knots) {
+    if (k.x < ax - eps) continue;
+    const nk = { ...k };
+    if (Math.abs(nk.x - ax) < eps) {
+      nk.x = ax;
+      nk.hx = 0;
+    }
+    right.push(nk);
+  }
+  if (right.length < 2) return;
+  right.sort((a, b) => Math.atan2(a.y - c.y, a.x - ax) - Math.atan2(b.y - c.y, b.x - ax));
+
+  const left = [];
+  for (const k of right) {
+    if (k.x <= ax + eps) continue;
+    let id = knotUid();
+    let bestI = -1;
+    let bestD = 0.25;
+    const wantX = ax - (k.x - ax);
+    for (let i = 0; i < leftPool.length; i++) {
+      const m = leftPool[i];
+      const d = Math.hypot(m.x - wantX, m.y - k.y);
+      if (d < bestD) {
+        bestD = d;
+        bestI = i;
+      }
+    }
+    if (bestI >= 0) {
+      id = leftPool[bestI].id;
+      leftPool.splice(bestI, 1);
+    }
+    left.push({
+      id,
+      x: wantX,
+      y: k.y,
+      hx: -k.hx,
+      hy: k.hy,
+      color: k.color,
+    });
+  }
+
+  const all = [...right, ...left];
+  all.sort((a, b) => Math.atan2(a.y - c.y, a.x - ax) - Math.atan2(b.y - c.y, b.x - ax));
+  knots.length = 0;
+  for (const k of all) knots.push(k);
 }
 
 export function makeOpenArcPath({

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -32,29 +32,30 @@ function layerId() {
 
 export function createEyeLayer(type, overrides = {}) {
   const defaults = {
+    // 4-knot Y-symmetric almond — drag left/right corners for width, top/bottom for height
     eyeball: () => ({
       name: "Eyeball",
       color: "#f2f0ea",
       closed: true,
-      ...makeEllipsePath({ cx: 0, cy: 0, rx: 0.72, ry: 0.55, color: "#f2f0ea", n: 8 }),
+      ...makeEllipsePath({ cx: 0, cy: 0, rx: 0.78, ry: 0.42, color: "#f2f0ea", n: 4 }),
     }),
     iris: () => ({
       name: "Iris",
       color: "#3a70d0",
       closed: true,
-      ...makeEllipsePath({ cx: 0.05, cy: 0.02, rx: 0.32, ry: 0.32, color: "#3a70d0", n: 8 }),
+      ...makeEllipsePath({ cx: 0.06, cy: 0.02, rx: 0.28, ry: 0.28, color: "#3a70d0", n: 4 }),
     }),
     pupil: () => ({
       name: "Pupil",
       color: "#0a0a0c",
       closed: true,
-      ...makeEllipsePath({ cx: 0.05, cy: 0.02, rx: 0.14, ry: 0.14, color: "#0a0a0c", n: 6 }),
+      ...makeEllipsePath({ cx: 0.06, cy: 0.02, rx: 0.12, ry: 0.12, color: "#0a0a0c", n: 4 }),
     }),
     reflection: () => ({
       name: "Reflection",
       color: "#ffffff",
       closed: true,
-      ...makeEllipsePath({ cx: -0.02, cy: 0.1, rx: 0.05, ry: 0.07, color: "#ffffff", n: 6 }),
+      ...makeEllipsePath({ cx: -0.02, cy: 0.1, rx: 0.05, ry: 0.065, color: "#ffffff", n: 4 }),
     }),
     eyelid: () => ({
       name: "Eyelid",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Eye shape editing
- Default closed eye layers use a **4-knot** ellipse with correct κ handles (was 6–8 points) — easier to pull wide/narrow
- Eyeball starts as a wider almond (`rx/ry`)
- **Symmetry** (on by default): edit the right half; left is rebuilt about the path centroid (same idea as mesh profile mirror)
- **Auto smooth** (on by default): after moving a knot, Bezier handles are recomputed from neighbours so joins stay continuous
- **Add** tool still inserts knots when you want more detail

### Layout
- Texture workspace grid + `minmax(0)` / overflow on the canvas column so the Bezier view no longer covers Layers checkboxes

### Note
Create a **New eye** (or new layers) to get the 4-knot defaults; already-saved eyes keep their stored knot counts.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

