### PR TITLE
Fix eye default to Orbit-like circle and restore handle dragging

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -184,9 +184,10 @@ Layers can be named, reordered, enabled/disabled. Only **params** are saved
 (`knots` / `segments` / colours) — `renderEyeTexture` rebuilds pixels at runtime
 (animatable). Mesh UV projection / vertex-colour background assign is next.
 
-Eye paths default to a **4-knot** Y-symmetric ellipse (easy width/height). Toolbar
+Eye paths default to a **4-knot circle** (same κ ≈ 0.552 as Mesh Orbit). Toolbar
 **Symmetry** mirrors the left from the right (centroid axis); **Auto smooth**
-recomputes Bezier handles after moving a point. Use **Add** to insert more knots.
+recomputes Bezier handles after moving a **point** (not while dragging handles).
+Use **Add** to insert more knots.
 
 ## Shading base
 

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -14,6 +14,8 @@ import {
   autoSmoothHandles,
   rebuildClosedYSymmetry,
   makeEllipsePath,
+  CIRCLE_BEZIER_KAPPA,
+  samplePath,
 } from "../src/lib/pathModel.js";
 import { migrateProject } from "../src/library/migrations.js";
 import { CURRENT_SCHEMA_VERSION, buildProjectDocument } from "../src/library/schema.js";
@@ -24,16 +26,29 @@ assert.ok(eye.layers.some((L) => L.type === "eyeball"));
 assert.ok(eye.layers.some((L) => L.type === "iris"));
 assert.ok(eye.layers.some((L) => L.type === "pupil"));
 
-// Default eyeball uses a compact 4-knot symmetric ellipse
+// Default eyeball: 4-knot circle like Mesh Orbit (κ handles, not a square)
 const eyeball = findLayer(eye, "eyeball");
 assert.equal(eyeball.knots.length, 4, "eyeball starts with 4 knots");
+const rightTip = eyeball.knots.find((k) => k.x > 0.5);
+assert.ok(rightTip, "right tip");
 assert.ok(
-  eyeball.knots.some((k) => k.x > 0.5) && eyeball.knots.some((k) => k.x < -0.5),
-  "eyeball spans left/right for width edits",
+  Math.abs(Math.abs(rightTip.hy) - 0.72 * CIRCLE_BEZIER_KAPPA) < 1e-6,
+  `orbit-like κ handle, got hy=${rightTip.hy}`,
 );
+// Sampled radius should stay near 0.72 (square would bulge on diagonals)
+const eyePts = samplePath(eyeball.knots, eyeball.segments, { closed: true, samplesPerSpan: 16 });
+let maxR = 0;
+let minR = Infinity;
+for (const p of eyePts) {
+  const r = Math.hypot(p.x, p.y);
+  maxR = Math.max(maxR, r);
+  minR = Math.min(minR, r);
+}
+assert.ok(maxR - minR < 0.04, `near-circular (maxR-minR=${maxR - minR})`);
 
-const ell = makeEllipsePath({ cx: 0, cy: 0, rx: 1, ry: 0.5, n: 4 });
+const ell = makeEllipsePath({ cx: 0, cy: 0, rx: 1, ry: 1, n: 4 });
 assert.equal(ell.knots.length, 4);
+assert.ok(Math.abs(ell.knots[0].hy - CIRCLE_BEZIER_KAPPA) < 1e-9);
 // Auto-smooth should keep finite handles
 for (const k of ell.knots) {
   k.hx = 0;

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
@@ -68,12 +68,16 @@ export function useTextureEditor() {
 
   function applyPathPolish({ movedPoint = false } = {}) {
     const closed = path.state.closed;
+    // Only rewrite handles after moving a knot — never while dragging Bezier handles.
     if (movedPoint && state.autoSmooth) {
       autoSmoothHandles(path.state.knots, { closed });
     }
     if (layerWantsSymmetry(selectedLayer.value) && closed) {
       rebuildClosedYSymmetry(path.state.knots);
-      if (state.autoSmooth) autoSmoothHandles(path.state.knots, { closed: true });
+      // Symmetry rebuild must not auto-smooth on handle edits (would wipe hx/hy).
+      if (movedPoint && state.autoSmooth) {
+        autoSmoothHandles(path.state.knots, { closed: true });
+      }
       path.syncSegments();
     }
   }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/pathModel.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/pathModel.js
@@ -63,10 +63,12 @@ export function syncClosedSegments(knots, segments, defaultPathType = "bezier") 
   return next;
 }
 
+/** Same κ as Mesh Orbit unit-circle (4 cubics): 4*(√2-1)/3. */
+export const CIRCLE_BEZIER_KAPPA = 0.5522847498307936;
+
 /**
- * Closed ellipse/circle as cubic Bezier knots with correct κ handles.
- * Default n=4 (like a smooth almond/eye) — fewer points, easier width/height edits.
- * Shape is Y-symmetric when centred on x=0.
+ * Closed ellipse/circle as cubic Bezier knots.
+ * Default n=4 matches Mesh Orbit: cardinal knots + κ handles → round circle, not a squircle.
  */
 export function makeEllipsePath({
   cx = 0,
@@ -77,8 +79,9 @@ export function makeEllipsePath({
   n = 4,
 } = {}) {
   const count = Math.max(3, n | 0);
-  // κ for a circular arc spanning 2π/n with symmetric in/out handles
-  const kappa = (4 / 3) * Math.tan(Math.PI / count);
+  // κ = (4/3)·tan(π/(2n)) — for n=4 this is CIRCLE_BEZIER_KAPPA (NOT tan(π/n), which squares it)
+  const kappa =
+    count === 4 ? CIRCLE_BEZIER_KAPPA : (4 / 3) * Math.tan(Math.PI / (2 * count));
   const knots = [];
   for (let i = 0; i < count; i++) {
     const t = (i / count) * Math.PI * 2;
@@ -86,7 +89,7 @@ export function makeEllipsePath({
       id: knotUid(),
       x: cx + Math.cos(t) * rx,
       y: cy + Math.sin(t) * ry,
-      // Tangent (−sin, cos) × ellipse radii × κ
+      // Orbit-style: handle along tangent (−sin, cos) × radii × κ
       hx: -Math.sin(t) * rx * kappa,
       hy: Math.cos(t) * ry * kappa,
       color,
@@ -163,7 +166,7 @@ export function rebuildClosedYSymmetry(knots) {
     const nk = { ...k };
     if (Math.abs(nk.x - ax) < eps) {
       nk.x = ax;
-      nk.hx = 0;
+      // Keep hx — top/bottom of a circle need horizontal handles (Orbit style).
     }
     right.push(nk);
   }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -32,12 +32,12 @@ function layerId() {
 
 export function createEyeLayer(type, overrides = {}) {
   const defaults = {
-    // 4-knot Y-symmetric almond — drag left/right corners for width, top/bottom for height
+    // 4-knot circle like Mesh Orbit (κ ≈ 0.552) — not a squircle
     eyeball: () => ({
       name: "Eyeball",
       color: "#f2f0ea",
       closed: true,
-      ...makeEllipsePath({ cx: 0, cy: 0, rx: 0.78, ry: 0.42, color: "#f2f0ea", n: 4 }),
+      ...makeEllipsePath({ cx: 0, cy: 0, rx: 0.72, ry: 0.72, color: "#f2f0ea", n: 4 }),
     }),
     iris: () => ({
       name: "Iris",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Round circle (not square)
4-knot defaults used κ = `(4/3)·tan(π/n)` ≈ **1.33**, which makes a squircle. Mesh Orbit uses κ ≈ **0.552**. Defaults now match Orbit so the eyeball starts as a round circle.

### Handle dragging
With **Symmetry** on, **Auto smooth** was re-running after every edit (including handle drags) and immediately overwriting `hx/hy`. Auto smooth now runs only after moving a **knot**, so orange Bezier handles stay editable.

Click **New eye** to pick up the round default; existing textures keep their stored paths.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

