### PR TITLE
v2 engine: close review leaks, bugs, and hot-path costs

### DIFF
--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -68,8 +68,9 @@ handle → separate object / membership / GPU lifetimes) is now advancing on the
       tests, and the Sponza typed accessors. Full gate stays 89/89.
       Follow-ups (live-path polish, not blockers): sky/background, light-probe GI,
       first-person controls, material textures/PBR — all documented; the SW
-      rasteriser's `w*8` span guard still drops huge flat quads (subdivide meshes;
-      see the "remove the 8x span guard" item). A true **Sponza-atrium** live demo
+      rasteriser's 8× span guard (now axis-correct: limX=w*8, limY=h*8) still
+      drops huge flat quads (subdivide meshes; see "remove the 8x span guard").
+      A true **Sponza-atrium** live demo
       is also a follow-up — it needs a Sponza `.gltf`/`.glb` asset that is not
       in-tree (the current `courtyard_live` is procedural primitives, not Sponza).
 

--- a/gallery/game_engine/v2/TODO.md
+++ b/gallery/game_engine/v2/TODO.md
@@ -1023,17 +1023,18 @@ Done since the first debt write-up:
 
 Still to clean up later:
 
+- [x] **`web/` + `menu/` gated** — `check_boundaries.py` `LIVE_PREFIXES` now
+      includes both (guests/tests excluded). Title list is derived from
+      `games/*/game.info` + classic forbidden names. `web/web_live2d_host.rgr`
+      no longer bakes a title sky colour (presenter `setClearRgb` / scene.json).
+- [x] **Menu catalog comments neutralized** — `menu/game_catalog.rgr` no longer
+      names titles; dual-fork merge (menu vs scripting copy) still open.
+- [x] **`menu/launcher.tsx` catalog honest** — drops phantom Chess / Breakout /
+      Sprites; lists the four real `game.info` packages. Still hardcoded in TSX
+      (not filesystem discovery) — generating from `game.info` remains open.
 - [ ] **Dual `game_catalog.rgr` fork** — `menu/game_catalog.rgr` and
-      `scripting/game_catalog.rgr` diverged. Scripting copy is gate-neutral;
-      menu copy still names `autopeli` in comments (menu/ is excluded from the
-      title-name check). Neutralize the menu comments (or delete the menu copy
-      and import the scripting one), then consider adding `menu/` to
-      `LIVE_PREFIXES`.
-- [ ] **`menu/launcher.tsx` still hardcodes a guest catalog** — Pomppija /
-      Chess / Breakout / Sprites paths in TSX (Chess/Breakout are not v2 games
-      today). Guest-side is allowed by the boundary map, but it should mirror
-      discovery (or a generated list) so the TSX menu and Ranger UI do not
-      disagree.
+      `scripting/game_catalog.rgr` diverged. Both are gate-neutral now; delete
+      the menu copy and import the scripting one when convenient.
 - [ ] **Default action-map conventions live in the SDL host** —
       `mapMask` hardwires `jump = up | action` and fixed bit→action names;
       `RgAttractDriver` hardwires left/right/jump bit packing. Document as the

--- a/gallery/game_engine/v2/games/ylos3d_wasm/src/lib.rs
+++ b/gallery/game_engine/v2/games/ylos3d_wasm/src/lib.rs
@@ -357,7 +357,9 @@ pub extern "C" fn init() -> i32 {
     cb.rg2d_camera_create(CAM[0]);
     cb.rg2d_camera_create(CAM[1]);
     // celebrate one-shot source (clip != source, D-LIFE)
-    cb.rgcore_audio_clip_create(CLIP, 440.0, 0, 0.35, 80);
+    // schema: (freqHz:d, durationMs:i, volume:d, wave:i) — defaults match
+    // ranger_core.tsx AudioClip (440 Hz / 80 ms / 0.35 / wave 0).
+    cb.rgcore_audio_clip_create(CLIP, 440.0, 80, 0.35, 0);
     cb.rgcore_audio_source_create(CEL_SFX, CLIP);
 
     // player sprites: LPC walk + super sheet, one per player

--- a/gallery/game_engine/v2/interp/engine/RgRegistryBridge.rgr
+++ b/gallery/game_engine/v2/interp/engine/RgRegistryBridge.rgr
@@ -78,6 +78,11 @@ class RgDecodedArgs {
     fn guestIdAt:int (i:int) { return (itemAt this.guestIds i) }
 }
 
+; Pre-split argSpec tokens for one command-table row (avoids strsplit per call).
+class RgArgTokRow {
+    def toks:[string]
+}
+
 ; Captures the last synth burst pushed by GameAudio so the one-shot PCM path is
 ; observable from the bridge (and asserted by tests): a v1-faithful one-shot
 ; must yield REAL, non-silent PCM, not a silent lifecycle probe.
@@ -109,6 +114,14 @@ class CapturingAudioSink extends GameAudioSink {
 class RgRegistryBridge extends EvalNativeBridge {
     ; the ONE command table (generated from the authored module schemas)
     def table:[RgCommand]
+    ; Parallel to table: pre-split argSpec tokens so decode() does not
+    ; strsplit + allocate on every bridge call (hot path).
+    def argToks:[RgArgTokRow]
+    ; Last has()/invoke() name→row cache — the interpreter typically calls
+    ; has then invoke for the same name; avoid a second full-table scan.
+    def cachedName:string ""
+    def cachedRow:RgCommand (RgCommand.of((0 - 1) "" ""))
+    def cachedIdx:int (0 - 1)
 
     ; host modules (the real Phase 2–11 arenas)
     def d2:RgRanger2D (new RgRanger2D)
@@ -153,11 +166,50 @@ class RgRegistryBridge extends EvalNativeBridge {
         def base:[RgCommand] (RgCodegen.tableUnion(core twoD))
         def withThree:[RgCommand] (RgCodegen.tableAppend(base three))
         b.table = (RgCodegen.tableAppend(withThree cannon))
+        ; Pre-split every row's argSpec once — decodeAt() reads argToks[i].
+        def toks:[RgArgTokRow]
+        def ti 0
+        while (ti < (array_length b.table)) {
+            def row:RgCommand (itemAt b.table ti)
+            def entry:RgArgTokRow (new RgArgTokRow)
+            if (row.argSpec != "") {
+                entry.toks = (strsplit row.argSpec ":")
+            }
+            push toks entry
+            ti = (ti + 1)
+        }
+        b.argToks = toks
         ; build the synth tables (sine/midi) and wire the capturing sink so the
         ; one-shot path can synthesise real PCM the moment a guest plays it.
         b.gameAudio.init()
         b.gameAudio.setSink(b.audioSink)
         return b
+    }
+
+    ; Resolve a command row by name with a one-entry cache (has → invoke).
+    ; Returns the table index, or -1 when unknown; fills cachedRow.
+    fn resolveName:int (name:string) {
+        if (name == this.cachedName) {
+            return this.cachedIdx
+        }
+        def n:int (array_length this.table)
+        def i 0
+        while (i < n) {
+            def c:RgCommand (itemAt this.table i)
+            if (c.tombstone == false) {
+                if (c.name == name) {
+                    this.cachedName = name
+                    this.cachedRow = c
+                    this.cachedIdx = i
+                    return i
+                }
+            }
+            i = (i + 1)
+        }
+        this.cachedName = name
+        this.cachedRow = (RgCommand.of((0 - 1) "" ""))
+        this.cachedIdx = (0 - 1)
+        return (0 - 1)
     }
 
     ; one-shot PCM observability (asserted by tests/unit/audio/one_shot_pcm_test):
@@ -224,16 +276,17 @@ class RgRegistryBridge extends EvalNativeBridge {
 
     ; ---- EvalNativeBridge (pure table lookups) ------------------------------
     fn has:boolean (name:string) {
-        def row:RgCommand (RgCodegen.findByName(this.table name))
-        return (row.id != (0 - 1))
+        def idx:int (this.resolveName(name))
+        return (idx != (0 - 1))
     }
 
     fn invoke:EvalValue (name:string args:[EvalValue]) {
-        def row:RgCommand (RgCodegen.findByName(this.table name))
-        if (row.id == (0 - 1)) {
+        def idx:int (this.resolveName(name))
+        if (idx == (0 - 1)) {
             return (this.fail("unknown-command:" + name))
         }
-        def dec:RgDecodedArgs (this.decode(row args))
+        def row:RgCommand this.cachedRow
+        def dec:RgDecodedArgs (this.decodeAt(idx row args))
         if (dec.ok == false) {
             return (this.fail(dec.err))
         }
@@ -242,10 +295,25 @@ class RgRegistryBridge extends EvalNativeBridge {
 
     ; ---- generic decode (driven only by the row's argSpec) ------------------
     fn decode:RgDecodedArgs (row:RgCommand args:[EvalValue]) {
+        ; Fallback for callers that still pass a row without a table index
+        ; (coverage / unit tests). Prefer decodeAt on the hot path.
+        def idx:int (this.resolveName(row.name))
+        return (this.decodeAt(idx row args))
+    }
+
+    fn decodeAt:RgDecodedArgs (idx:int row:RgCommand args:[EvalValue]) {
         def dec:RgDecodedArgs (new RgDecodedArgs)
         def toks:[string]
-        if (row.argSpec != "") {
-            toks = (strsplit row.argSpec ":")
+        if (idx >= 0) {
+            if (idx < (array_length this.argToks)) {
+                def entry:RgArgTokRow (itemAt this.argToks idx)
+                toks = entry.toks
+            }
+        }
+        if ((array_length toks) == 0) {
+            if (row.argSpec != "") {
+                toks = (strsplit row.argSpec ":")
+            }
         }
         def want:int (array_length toks)
         if ((array_length args) != want) {

--- a/gallery/game_engine/v2/menu/game_catalog.rgr
+++ b/gallery/game_engine/v2/menu/game_catalog.rgr
@@ -28,10 +28,10 @@ class GameCatalogEntry {
     ; perspective — the game itself does nothing. "never" = single pane.
     def splitScreen:string ""
     ; splitWorld: shared | separate — the world model behind a two-pane split.
-    ;   separate = two INDEPENDENT game sessions, one per pane (e.g. pinball: two
+    ;   separate = two INDEPENDENT game sessions, one per pane (e.g. two
     ;              unrelated boards). This is the default for tsx games.
     ;   shared   = ONE simulated world/physics viewed by two cameras following
-    ;              different players (e.g. autopeli: one road + physics, two views).
+    ;              different players (e.g. one road + physics, two views).
     ;              This is the default for wasm+physics games.
     ; When empty the host infers it from the backend (see resolveSplitWorld) to keep
     ; today's behaviour; setting it explicitly decouples the choice from the engine.
@@ -219,8 +219,8 @@ class GameCatalog {
     ; Resolve the world model for a two-pane split: "shared" (one world/physics,
     ; two cameras) or "separate" (two independent sessions). An explicit
     ; splitWorld= wins; otherwise infer from the backend to preserve today's
-    ; behaviour — wasm+physics games share a world (autopeli), everything else
-    ; runs separate sessions (pinball and the other tsx games).
+    ; behaviour — wasm+physics games share a world, everything else runs
+    ; separate sessions.
     fn resolveSplitWorld:string (entry:GameCatalogEntry) {
         if (entry.splitWorld == "shared") {
             return "shared"

--- a/gallery/game_engine/v2/menu/launcher.tsx
+++ b/gallery/game_engine/v2/menu/launcher.tsx
@@ -11,14 +11,14 @@
 import { runtime } from "ranger:core";
 import * as TWO from "ranger:2d";
 
+// Honest catalog mirroring games/*/game.info (RgLauncherUi.scan). Phantom
+// Chess/Breakout/Sprites tiles removed — they are not v2 packages today.
 const CATALOG = [
   { name: "Games", entries: [
     { label: "Pomppija", path: "games/ylos2" },
-    { label: "Chess", path: "games/chess" },
-    { label: "Breakout", path: "games/breakout" }
-  ] },
-  { name: "Tests", entries: [
-    { label: "Sprites", path: "tests/sprite_char" }
+    { label: "Ylos3D (WASM)", path: "games/ylos3d_wasm" },
+    { label: "Cannon 3D", path: "games/cannon3d" },
+    { label: "Pinball", path: "games/pinball" }
   ] }
 ];
 

--- a/gallery/game_engine/v2/modules/ranger_2d/RgRanger2D.rgr
+++ b/gallery/game_engine/v2/modules/ranger_2d/RgRanger2D.rgr
@@ -438,10 +438,10 @@ class RgRanger2D {
         return tx.hasPixels
     }
 
-    ; Sample one texel (clamped). Returns 0xRRGGBB; a=0 (via texelA) means the
-    ; texel is transparent / out of a store-less texture.
-    fn texelRGB:int (textureH:RgHandle px:int py:int) {
-        def tx:RgTexture2D (this.textureResolve(textureH))
+    ; Sample one texel from an already-resolved texture (clamped). Hot blit
+    ; paths must resolve once per sprite and call these — not texelRGB/texelA,
+    ; which re-resolve the handle on every pixel.
+    fn texelRGBOf:int (tx:RgTexture2D px:int py:int) {
         if (tx.hasPixels == false) { return 0 }
         if (tx.width <= 0) { return 0 }
         if (tx.height <= 0) { return 0 }
@@ -456,8 +456,7 @@ class RgRanger2D {
         if (idx >= (array_length tx.rgb)) { return 0 }
         return (itemAt tx.rgb idx)
     }
-    fn texelA:int (textureH:RgHandle px:int py:int) {
-        def tx:RgTexture2D (this.textureResolve(textureH))
+    fn texelAOf:int (tx:RgTexture2D px:int py:int) {
         if (tx.hasPixels == false) { return 0 }
         if (tx.width <= 0) { return 0 }
         if (tx.height <= 0) { return 0 }
@@ -471,6 +470,15 @@ class RgRanger2D {
         if (idx < 0) { return 0 }
         if (idx >= (array_length tx.alpha)) { return 0 }
         return (itemAt tx.alpha idx)
+    }
+
+    ; Sample one texel (clamped). Returns 0xRRGGBB; a=0 (via texelA) means the
+    ; texel is transparent / out of a store-less texture.
+    fn texelRGB:int (textureH:RgHandle px:int py:int) {
+        return (this.texelRGBOf((this.textureResolve(textureH)) px py))
+    }
+    fn texelA:int (textureH:RgHandle px:int py:int) {
+        return (this.texelAOf((this.textureResolve(textureH)) px py))
     }
 
     ; atlas retains its texture (shared retain, D-OWN)

--- a/gallery/game_engine/v2/render/backends/software/RgSoftwareRenderer2D.rgr
+++ b/gallery/game_engine/v2/render/backends/software/RgSoftwareRenderer2D.rgr
@@ -17,6 +17,10 @@ class RgFramebuffer {
     def width:int 0
     def height:int 0
     def pixels:[int]
+    ; Persistent RGBA present buffer — rebuilt only when size changes so the
+    ; SDL present path does not allocate ~518 KB/pane every frame.
+    def rgbaBuf:buffer (buffer_alloc 0)
+    def rgbaBytes:int 0
 
     sfn create:RgFramebuffer (width:int height:int) {
         def fb:RgFramebuffer (new RgFramebuffer)
@@ -70,10 +74,16 @@ class RgFramebuffer {
     ; Pack the 0xRRGGBB int grid into a tightly-packed RGBA byte buffer
     ; (w*h*4, opaque) — the format the native present operators (gfx_present /
     ; gfx_present_split, SDL_PIXELFORMAT_RGBA32) expect. Pure conversion;
-    ; testable headlessly, independent of any window.
+    ; testable headlessly, independent of any window. Reuses rgbaBuf across
+    ; frames when the pane size is unchanged.
     fn toRgbaBuffer:buffer () {
         def n:int (this.width * this.height)
-        def buf:buffer (buffer_alloc (n * 4))
+        def need:int (n * 4)
+        if (need != this.rgbaBytes) {
+            this.rgbaBuf = (buffer_alloc need)
+            this.rgbaBytes = need
+        }
+        def buf:buffer this.rgbaBuf
         def i 0
         while (i < n) {
             def c:int (itemAt this.pixels i)

--- a/gallery/game_engine/v2/render/backends/software/RgTexturedRenderer2D.rgr
+++ b/gallery/game_engine/v2/render/backends/software/RgTexturedRenderer2D.rgr
@@ -157,6 +157,10 @@ class RgTexturedRenderer2D {
             def reg:RgSpriteRegion (d.spriteSrcRegion(sh))
             if (reg.w > 0) {
                 if (reg.h > 0) {
+                    ; Resolve the texture ONCE per sprite — texelA/texelRGB each
+                    ; re-run registry.resolveTyped, which blew the Pi 2D budget
+                    ; when done per output pixel.
+                    def tex:RgTexture2D (d.textureResolve(texH))
                     ; destination size in world units (native region if unset)
                     def dwW:double (d.spriteW(sh))
                     def dhW:double (d.spriteH(sh))
@@ -171,26 +175,29 @@ class RgTexturedRenderer2D {
                     def x0:int (scx - (idiv Ws 2))
                     def y0:int (scy - (idiv Hs 2))
                     def flip:boolean (d.spriteFlipX(sh))
+                    ; Incremental source stepping (avoid per-pixel divide+floor).
+                    def uStep:double ((to_double reg.w) / (to_double Ws))
+                    def vStep:double ((to_double reg.h) / (to_double Hs))
                     def py 0
+                    def vAcc:double (0.5 * vStep)
                     while (py < Hs) {
-                        def v:double (((to_double py) + 0.5) / (to_double Hs))
-                        def ly:int (floor (v * (to_double reg.h)))
+                        def ly:int (floor vAcc)
                         if (ly < 0) { ly = 0 }
                         if (ly >= reg.h) { ly = (reg.h - 1) }
                         def ty:int (reg.y + ly)
                         def dy:int (y0 + py)
                         def px 0
+                        def uAcc:double (0.5 * uStep)
                         while (px < Ws) {
-                            def u:double (((to_double px) + 0.5) / (to_double Ws))
-                            def lx:int (floor (u * (to_double reg.w)))
+                            def lx:int (floor uAcc)
                             if (lx < 0) { lx = 0 }
                             if (lx >= reg.w) { lx = (reg.w - 1) }
                             if flip { lx = ((reg.w - 1) - lx) }
                             def tx:int (reg.x + lx)
-                            def a:int (d.texelA(texH tx ty))
+                            def a:int (d.texelAOf(tex tx ty))
                             if (a > 0) {
                                 def dx:int (x0 + px)
-                                def srgb:int (d.texelRGB(texH tx ty))
+                                def srgb:int (d.texelRGBOf(tex tx ty))
                                 if (a >= 255) {
                                     fb.plot(dx dy srgb)
                                 } {
@@ -198,8 +205,10 @@ class RgTexturedRenderer2D {
                                     fb.plot(dx dy (RgTexturedRenderer2D.blend(srgb dstc a)))
                                 }
                             }
+                            uAcc = (uAcc + uStep)
                             px = (px + 1)
                         }
+                        vAcc = (vAcc + vStep)
                         py = (py + 1)
                     }
                     drawn = (drawn + 1)

--- a/gallery/game_engine/v2/tests/check_boundaries.py
+++ b/gallery/game_engine/v2/tests/check_boundaries.py
@@ -8,12 +8,12 @@
 #   1. No .rgr files live under games/ (games are TSX-only).
 #   2. Every Import "…" that resolves OUTSIDE v2/ is listed in
 #      boundary_import_allowlist.txt (shrink the list; do not grow it).
-#   3. Live-core .rgr files contain no game-title identifiers (ylos*, autopeli,
-#      pong, pacman, invaders, breakout, chess as whole words).
+#   3. Live-core .rgr files contain no game-title identifiers (discovered
+#      from games/*/game.info folder names + classic forbidden titles).
 #
 # Live core = runtime host modules render registry bridge interp imaging audio
-# evg + top-level framebuffer/rgba — excluding **/tests/** and *_test.rgr.
-# menu/ is excluded from (3) until the hardcoded catalog is data-driven.
+# evg scripting web menu + top-level framebuffer/rgba — excluding **/tests/**,
+# **/guests/**, and *_test.rgr.
 # ==============================================================================
 from __future__ import annotations
 
@@ -27,9 +27,15 @@ REPO_ROOT = os.path.abspath(os.path.join(V2_ROOT, "..", "..", ".."))
 ALLOWLIST_PATH = os.path.join(os.path.dirname(__file__), "boundary_import_allowlist.txt")
 
 IMPORT_RE = re.compile(r'Import\s+"([^"]+)"')
-# Title names that must not appear in generic core .rgr (AGENTS.md).
-GAME_NAME_RE = re.compile(
-    r"(?i)(?<![A-Za-z0-9_])(ylos\d*|autopeli|\bpong\b|pacman|invaders|breakout|\bchess\b)(?![A-Za-z0-9_])"
+
+# Classic titles that must stay out of core even when not present under games/.
+CLASSIC_TITLES = (
+    "autopeli",
+    "pong",
+    "pacman",
+    "invaders",
+    "breakout",
+    "chess",
 )
 
 LIVE_PREFIXES = (
@@ -44,14 +50,17 @@ LIVE_PREFIXES = (
     "audio/",
     "evg/",
     "scripting/",
+    "web/",
+    "menu/",
     "framebuffer.rgr",
     "rgba_fast_blit.rgr",
 )
 
-# Paths under live prefixes that are allowed to mention game names (none today).
+# Paths under live prefixes that are allowed to mention game names.
 GAME_NAME_EXCLUDE_SUFFIXES = (
     "/tests/",
     "_test.rgr",
+    "/guests/",
 )
 
 
@@ -70,6 +79,36 @@ def load_allowlist() -> set[str]:
                 continue
             entries.add(line)
     return entries
+
+
+def discover_game_titles() -> list[str]:
+    """Folder names under games/ that have game.info, plus classic titles.
+
+    Also keeps a ylos\\w* family match so ylos3d (no game.info today) and
+    comment forms like ylos2_screenshot stay gated.
+    """
+    names: set[str] = set(CLASSIC_TITLES)
+    games = os.path.join(V2_ROOT, "games")
+    if os.path.isdir(games):
+        for entry in sorted(os.listdir(games)):
+            gdir = os.path.join(games, entry)
+            if not os.path.isdir(gdir):
+                continue
+            if os.path.isfile(os.path.join(gdir, "game.info")):
+                names.add(entry)
+    # Always gate the ylos* family (folder names + legacy spellings).
+    alts = sorted(re.escape(n) for n in names)
+    alts.append(r"ylos\w*")
+    return alts
+
+
+def build_game_name_re() -> re.Pattern[str]:
+    alts = discover_game_titles()
+    # Longer alternatives first so ylos3d_wasm wins over ylos3d over ylos.
+    alts.sort(key=lambda s: (-len(s.replace("\\", "")), s))
+    return re.compile(
+        r"(?i)(?<![A-Za-z0-9_])(" + "|".join(alts) + r")(?![A-Za-z0-9_])"
+    )
 
 
 def resolve_import(from_file: str, import_path: str) -> str:
@@ -127,14 +166,10 @@ def check_out_of_v2_imports(allowlist: set[str]) -> tuple[list[str], list[str]]:
                 found.add(key)
     new_violations = sorted(found - allowlist)
     stale = sorted(allowlist - found)
-    # Format new with a hint path for the banner
-    detailed = []
-    for key in new_violations:
-        detailed.append(key)
-    return detailed, stale
+    return new_violations, stale
 
 
-def check_game_names_in_live_core() -> list[str]:
+def check_game_names_in_live_core(game_name_re: re.Pattern[str]) -> list[str]:
     hits: list[str] = []
     for fp in iter_rgr_files():
         rel = rel_v2(fp)
@@ -142,19 +177,20 @@ def check_game_names_in_live_core() -> list[str]:
             continue
         with open(fp, encoding="utf-8", errors="replace") as fh:
             for lineno, line in enumerate(fh, 1):
-                # skip pure comment noise? still flag — comments naming a title
-                # in core are the smell we want. Allow "game" as generic word.
-                if GAME_NAME_RE.search(line):
+                # Flag comments too — naming a title in core is the smell.
+                if game_name_re.search(line):
                     hits.append(f"{rel}:{lineno}: {line.rstrip()}")
     return hits
 
 
 def main() -> int:
     allowlist = load_allowlist()
+    game_name_re = build_game_name_re()
     failed = 0
 
     print("### boundary gate (static)")
     print("  v2 root: gallery/game_engine/v2")
+    print(f"  titles: {len(discover_game_titles())} patterns (games/*/game.info + classics)")
 
     games_rgr = check_no_rgr_in_games()
     if games_rgr:
@@ -185,7 +221,7 @@ def main() -> int:
         if len(stale) > 12:
             print(f"    … and {len(stale) - 12} more")
 
-    name_hits = check_game_names_in_live_core()
+    name_hits = check_game_names_in_live_core(game_name_re)
     if name_hits:
         failed += 1
         print("  FAIL game title identifier in live-core .rgr:")

--- a/gallery/game_engine/v2/tests/e2e/launcher_e2e_test.rgr
+++ b/gallery/game_engine/v2/tests/e2e/launcher_e2e_test.rgr
@@ -22,9 +22,19 @@ class LauncherE2ETest {
         t.ok("menu test fixture loaded"
             (host.loadFixture("gallery/game_engine/v2/menu/tests" "probe.tsx")))
         t.eqInt("categories page open" (to_int (host.callSlot("currentPage" 0))) 0)
-        t.eqInt("two category tiles" (to_int (host.callSlot("tileCount" 0))) 2)
-        t.eqInt("three retained sprites (2 tiles + cursor)"
-            (host.bridge.d2.liveOfType((Rg2DType.sprite()))) 3)
+        ; One real category (Games) — no phantom Tests tile.
+        t.eqInt("one category tile" (to_int (host.callSlot("tileCount" 0))) 1)
+        t.eqInt("two retained sprites (1 tile + cursor)"
+            (host.bridge.d2.liveOfType((Rg2DType.sprite()))) 2)
+
+        ; ---- drill into Games; page turn must not leak arena slots ----------
+        host.press(0 "action")
+        t.eqInt("games page open" (to_int (host.callSlot("currentPage" 0))) 1)
+        ; Four real games (Pomppija / Ylos3D WASM / Cannon 3D / Pinball) + cursor.
+        t.eqInt("page turn released old tiles (4 tiles + cursor)"
+            (host.bridge.d2.liveOfType((Rg2DType.sprite()))) 5)
+        t.eqInt("select sfx one-shot fired" host.bridge.oneShotCount 1)
+        t.ok("Pomppija selected" ((host.callSlot("selectedLabelIsPomppija" 0)) > 0.5))
 
         ; ---- D-pad navigation on action EDGES (generic press) ---------------
         host.press(0 "right")
@@ -38,18 +48,11 @@ class LauncherE2ETest {
         t.eqInt("held key does not repeat" (to_int (host.callSlot("selectedIndex" 0))) 1)
         host.press(0 "left")
         t.eqInt("left moves back" (to_int (host.callSlot("selectedIndex" 0))) 0)
-
-        ; ---- drill into Games; page turn must not leak arena slots ----------
-        host.press(0 "action")
-        t.eqInt("games page open" (to_int (host.callSlot("currentPage" 0))) 1)
-        t.eqInt("page turn released old tiles (3 tiles + cursor)"
-            (host.bridge.d2.liveOfType((Rg2DType.sprite()))) 4)
-        t.eqInt("select sfx one-shot fired" host.bridge.oneShotCount 1)
-        t.ok("Pomppija selected" ((host.callSlot("selectedLabelIsPomppija" 0)) > 0.5))
+        t.ok("Pomppija selected again" ((host.callSlot("selectedLabelIsPomppija" 0)) > 0.5))
 
         ; ---- menu presents pixels via the generic protocol ------------------
         def fb:RgFramebuffer (RgFramebuffer.create(96 96))
-        t.eqInt("menu present drew 3 tiles + cursor" (Rg2DPresenter.present(host.bridge 0 fb)) 4)
+        t.eqInt("menu present drew 4 tiles + cursor" (Rg2DPresenter.present(host.bridge 0 fb)) 5)
         t.ok("selected tile at camera centre" ((fb.at(48 48)) != 0))
 
         ; ---- select Pomppija → GENERIC handoff ------------------------------

--- a/gallery/game_engine/v2/tests/e2e/launcher_e2e_test.rgr
+++ b/gallery/game_engine/v2/tests/e2e/launcher_e2e_test.rgr
@@ -36,16 +36,18 @@ class LauncherE2ETest {
         t.eqInt("select sfx one-shot fired" host.bridge.oneShotCount 1)
         t.ok("Pomppija selected" ((host.callSlot("selectedLabelIsPomppija" 0)) > 0.5))
 
-        ; ---- D-pad navigation on action EDGES (generic press) ---------------
-        host.press(0 "right")
-        t.eqInt("right moves selection" (to_int (host.callSlot("selectedIndex" 0))) 1)
-        ; edge, not level: holding must not repeat
+        ; ---- D-pad navigation on action EDGES (mid-list, so a false level
+        ;      repeat would still have room to advance) -----------------------
+        ; Rising edge moves once…
         host.bridge.input.setAction(0 "right" true)
         host.frame(33.333)
+        t.eqInt("right edge moves selection" (to_int (host.callSlot("selectedIndex" 0))) 1)
+        ; …and holding the same level must not keep stepping.
         host.frame(33.333)
-        host.bridge.input.setAction(0 "right" false)
         host.frame(33.333)
         t.eqInt("held key does not repeat" (to_int (host.callSlot("selectedIndex" 0))) 1)
+        host.bridge.input.setAction(0 "right" false)
+        host.frame(33.333)
         host.press(0 "left")
         t.eqInt("left moves back" (to_int (host.callSlot("selectedIndex" 0))) 0)
         t.ok("Pomppija selected again" ((host.callSlot("selectedLabelIsPomppija" 0)) > 0.5))

--- a/gallery/game_engine/v2/three/port/src/three_software_backend.rgr
+++ b/gallery/game_engine/v2/three/port/src/three_software_backend.rgr
@@ -227,11 +227,13 @@ class ThreeSoftwareBackend extends ThreeRenderBackend {
         def minY:double (this.dmin3(y0 y1 y2))
         def spanX:double (maxX - minX)
         def spanY:double (maxY - minY)
-        def lim:double ((to_double w) * 8.0)
-        if (spanX > lim) {
+        ; Guard each axis against 8× that axis's framebuffer size (not w for both).
+        def limX:double ((to_double w) * 8.0)
+        def limY:double ((to_double h) * 8.0)
+        if (spanX > limX) {
             return
         }
-        if (spanY > lim) {
+        if (spanY > limY) {
             return
         }
         def minx:int (to_int (this.dmin3(x0 x1 x2)))

--- a/gallery/game_engine/v2/web/build-live2d.mjs
+++ b/gallery/game_engine/v2/web/build-live2d.mjs
@@ -125,8 +125,10 @@ for (const f of FACADES) addRepoFile(f);
 for (const f of GAME_ASSETS) addRepoFile(f);
 
 fs.writeFileSync(path.join(OUT, "scene.zip"), makeStoredZip(entries));
+// Demo-side clear colour for this title (0x4f96cf). Kept in scene.json — not
+// baked into WebLive2dHost — so the engine host stays title-neutral.
 fs.writeFileSync(path.join(OUT, "scene.json"), JSON.stringify(
-  { gameDir: GAME_DIR, gameFile: GAME_FILE, width: WIDTH, height: HEIGHT }, null, 2));
+  { gameDir: GAME_DIR, gameFile: GAME_FILE, width: WIDTH, height: HEIGHT, clearRgb: 0x4f96cf }, null, 2));
 log("packaged " + FACADES.length + " façade(s) + game + assets (" + entries.length + " files)");
 for (const e of entries) log("  packaged:", e.name);
 

--- a/gallery/game_engine/v2/web/live2d.html
+++ b/gallery/game_engine/v2/web/live2d.html
@@ -69,10 +69,11 @@
           await window.RangerLive2d.launch({
             bundleSource, zipBuffer, canvas,
             width: scene.width || 480, height: scene.height || 270,
+            clearRgb: scene.clearRgb || 0,
             gameDir: scene.gameDir, gameFile: scene.gameFile,
           });
           canvas.focus();
-          setStatus("rendering — the LIVE ylos2 climber (arrows / space = player 1)");
+          setStatus("rendering — live ranger:2d game (arrows / space = player 1)");
         } catch (e) {
           setStatus("error: " + e.message);
           console.error(e);

--- a/gallery/game_engine/v2/web/src/live2d-viewer.js
+++ b/gallery/game_engine/v2/web/src/live2d-viewer.js
@@ -1,15 +1,14 @@
 // ============================================================================
-// live2d-viewer.js — drive the LIVE ylos2 (ranger:2d) game onto a 2D canvas.
+// live2d-viewer.js — drive a LIVE ranger:2d game onto a 2D canvas.
 // ============================================================================
 //
-// The 2D cousin of live3d-viewer.js. Instead of a ranger:three scene, it boots
-// the REAL ylos2 game through WebLive2dHost (which wraps the generic RgGameHost,
-// the same one that boots ylos2 headlessly). load() evaluates index.tsx + runs
-// __rgGameInit(); each rAF we call host.frame(dtMs) — which advances one
-// host-owned game tick then presents pane 0 through the sampling backend — and
-// blit host.framePixels() (w*h*3 RGB) onto the canvas. Arrow keys + space drive
-// player 0's left/right/jump through host.input(). Same VFS + engine-host runtime
-// as the 3D live viewer.
+// The 2D cousin of live3d-viewer.js. Boots a TSX game through WebLive2dHost
+// (generic RgGameHost). load() evaluates index.tsx + runs __rgGameInit(); each
+// rAF we call host.frame(dtMs) — one host-owned tick then present pane 0 through
+// the sampling backend — and blit host.framePixels() (w*h*3 RGB) onto the canvas.
+// Arrow keys + space drive player 0's left/right/action through host.input().
+// Optional config.clearRgb (0xRRGGBB) sets the presenter clear colour (title
+// palettes stay in the viewer/demo, not the engine host).
 // ============================================================================
 
 (function (root) {
@@ -22,12 +21,13 @@
       this.host = config.host; // engine WebLive2dHost instance
       this.w = config.width || 480;
       this.h = config.height || 270;
+      this.clearRgb = config.clearRgb | 0;
       this.canvas.width = this.w;
       this.canvas.height = this.h;
       this._image = this.ctx.createImageData(this.w, this.h);
       this._raf = 0;
       this._last = 0;
-      this._keys = { left: false, right: false, jump: false };
+      this._keys = { left: false, right: false, action: false };
       this._tick = this._tick.bind(this);
     }
 
@@ -37,6 +37,7 @@
     // the mounted VFS zip exactly like the headless boot. Render frame 0.
     load(dir, file) {
       this.host.setup();
+      if (this.host.setClearRgb) this.host.setClearRgb(this.clearRgb);
       const ok = this.host.loadFromVfs
         ? this.host.loadFromVfs(dir, file, this.w, this.h)
         : this.host.load(dir, file, this.w, this.h);
@@ -49,7 +50,7 @@
 
     _applyInput() {
       // Player 0 driven by the keyboard; player 1 stays attract/idle.
-      this.host.input(0, this._keys.left, this._keys.right, this._keys.jump);
+      this.host.input(0, this._keys.left, this._keys.right, this._keys.action);
     }
 
     renderOnce(dtMs) {
@@ -72,7 +73,7 @@
         switch (e.key) {
           case "ArrowLeft": case "a": case "A": this._keys.left = down; break;
           case "ArrowRight": case "d": case "D": this._keys.right = down; break;
-          case "ArrowUp": case " ": case "w": case "W": this._keys.jump = down; break;
+          case "ArrowUp": case " ": case "w": case "W": this._keys.action = down; break;
           default: hit = false;
         }
         if (hit) e.preventDefault();

--- a/gallery/game_engine/v2/web/web_live2d_host.rgr
+++ b/gallery/game_engine/v2/web/web_live2d_host.rgr
@@ -1,17 +1,15 @@
 ; ==============================================================================
-; web_live2d_host — the REAL ylos2 (ranger:2d) game, software-rendered in-browser.
+; web_live2d_host — generic ranger:2d game host, software-rendered in-browser.
 ; ==============================================================================
 ; The LIVE-PATH 2D web host — the v1-parity cousin of web_live3d_host. Where the
 ; 3D host drives the ranger:three façade, this one wraps the SAME generic
-; RgGameHost that boots interpreted ranger:2d TSX games headlessly
-; (tests/tools/ylos2_screenshot.rgr uses it), and presents a pane through the
-; SAMPLING backend (RgTexturedRenderer2D via Rg2DPresenter.presentTextured) into
-; a w*h*3 RGB buffer the JS viewer blits.
+; RgGameHost that boots interpreted ranger:2d TSX games headlessly, and presents
+; a pane through the SAMPLING backend (RgTexturedRenderer2D via
+; Rg2DPresenter.presentTextured) into a w*h*3 RGB buffer the JS viewer blits.
 ;
 ;   game index.tsx  ── import { runtime } from "ranger:core"
 ;                      import * as TWO   from "ranger:2d"
-;     __rgGameInit()   loads pkg:// atlases (real LPC PNG walk sheets), declares
-;                      the split-screen pane views ONCE  ──▶  RgRegistryBridge
+;     __rgGameInit()   loads pkg:// atlases, declares pane views ONCE  ──▶  bridge
 ;     __rgGameUpdate() moves players / camera per host-owned tick     │
 ;                                                                     ▼
 ;                                     Rg2DPresenter.presentTextured(pane) →
@@ -20,6 +18,10 @@
 ;
 ; No 3D, no ranger:three arena is touched by the game. Compiles to JS for the
 ; browser (build-live2d.mjs) exactly like the other web hosts.
+;
+; Scene clear colour is a presenter parameter (setClearRgb) — never a title
+; palette baked into this host. Input uses the default host action profile
+; (left/right + action, with action also feeding up/jump like RgSdlGameHost).
 ; ==============================================================================
 
 Import "../runtime/game_host/RgGameHost.rgr"
@@ -30,21 +32,26 @@ class WebLive2dHost {
     def ready:boolean false
     def w:int 480
     def h:int 270
-    ; base sky under the gradient bands (0x4f96cf) — same value ylos2_screenshot
-    ; passes to presentTextured (the app/scene sky is a presenter parameter).
-    def sky:int 5215951
-    ; The resolved w*h*3 RGB frame the viewer blits.
+    ; Neutral clear under guest paint / bg cmds. Viewers that want a title's
+    ; base colour pass it via setClearRgb (guest/demo side), never a baked const.
+    def clearRgb:int 0
+    ; The resolved w*h*3 RGB frame the viewer blits (reused across frames).
     def outBuf:buffer (buffer_alloc 0)
+    def outBufBytes:int 0
 
     ; Idempotent — load() does the real work; the viewer may call either.
     fn setup:void () {
     }
 
+    ; Optional clear colour for presentTextured (0xRRGGBB). Call before frame().
+    fn setClearRgb:void (rgb:int) {
+        this.clearRgb = rgb
+    }
+
     ; Boot the REAL game from the VFS: RgGameHost.load registers the ranger:core /
     ; ranger:2d / ranger:three virtual modules (read from modules/ under v2Root),
     ; sets the bridge packageDir to `dir` so pkg:// atlases + their PNG sheets
-    ; resolve, evaluates index.tsx and runs __rgGameInit(). Mirrors the headless
-    ; boot in ylos2_screenshot.rgr.
+    ; resolve, evaluates index.tsx and runs __rgGameInit().
     fn load:string (dir:string file:string winW:int winH:int) {
         this.w = winW
         this.h = winH
@@ -54,7 +61,7 @@ class WebLive2dHost {
         }
         this.ready = true
         ; Advance a few frames so moving platforms / players settle into a live
-        ; pose before the first present (ylos2_screenshot steps 4 frames).
+        ; pose before the first present.
         def f 0
         while (f < 4) {
             this.host.frame(33.333)
@@ -63,16 +70,19 @@ class WebLive2dHost {
         return "ok"
     }
 
-    ; Feed logical key state for one player (slot 0/1). left/right/jump map to the
-    ; exact actions ylos2 reads (pad.isDown("left"/"right"/"jump")). down persists
-    ; across frames; the frame-boundary clears only the wasPressed edge.
-    fn input:void (slot:int left:boolean right:boolean jump:boolean) {
+    ; Feed logical key state for one player (slot 0/1). left/right/action map to
+    ; the default host profile (same as RgSdlGameHost.mapMask: action also sets
+    ; up + jump). down persists across frames; the frame-boundary clears only
+    ; the wasPressed edge.
+    fn input:void (slot:int left:boolean right:boolean action:boolean) {
         if (this.ready == false) {
             return
         }
         this.host.bridge.input.setAction(slot "left" left)
         this.host.bridge.input.setAction(slot "right" right)
-        this.host.bridge.input.setAction(slot "jump" jump)
+        this.host.bridge.input.setAction(slot "up" action)
+        this.host.bridge.input.setAction(slot "action" action)
+        this.host.bridge.input.setAction(slot "jump" action)
     }
 
     ; Advance the live game one host-owned tick, then present pane 0 through the
@@ -83,9 +93,13 @@ class WebLive2dHost {
         }
         this.host.frame(dtMs)
         def fb:RgFramebuffer (RgFramebuffer.create(this.w this.h))
-        Rg2DPresenter.presentTextured(this.host.bridge 0 fb this.sky)
+        Rg2DPresenter.presentTextured(this.host.bridge 0 fb this.clearRgb)
         def total:int ((this.w * this.h) * 3)
-        def out:buffer (buffer_alloc total)
+        if (total != this.outBufBytes) {
+            this.outBuf = (buffer_alloc total)
+            this.outBufBytes = total
+        }
+        def out:buffer this.outBuf
         def y 0
         while (y < this.h) {
             def x 0
@@ -102,7 +116,6 @@ class WebLive2dHost {
             }
             y = (y + 1)
         }
-        this.outBuf = out
     }
 
     ; The last presented frame as a w*h*3 RGB buffer.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lands the highest-impact fixes from the `gallery/game_engine/v2` abstraction/performance review.

### Boundary / abstraction
- Neutralize `web/web_live2d_host.rgr`: sky clear is `setClearRgb` / demo `scene.json`, not a baked ylos2 colour; input API uses the default host action profile.
- Harden `tests/check_boundaries.py`: gate `web/` + `menu/` (guests/tests excluded); derive title patterns from `games/*/game.info` + classic forbidden names.
- Neutralize title names in `menu/game_catalog.rgr` comments.
- Make `menu/launcher.tsx` catalog honest (Pomppija / Ylos3D WASM / Cannon 3D / Pinball) and update `launcher_e2e_test`.

### Bugs
- SW rasterizer span guard now uses `limX = w*8` and `limY = h*8` (was `w*8` for both axes).
- `games/ylos3d_wasm` `rgcore_audio_clip_create` arg order fixed to `(freqHz, durationMs, volume, wave)`.

### Performance (Pi budget paths)
- `RgTexturedRenderer2D`: resolve texture once per sprite; incremental u/v stepping; sample via `texelAOf` / `texelRGBOf`.
- `RgFramebuffer.toRgbaBuffer`: persistent buffer, realloc only on size change.
- `RgRegistryBridge`: one-entry name→row cache (has→invoke) + pre-split `argSpec` tokens.

### Docs
- `TODO.md` marks gated web/menu + honest launcher debt items done.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e683191-324a-495a-b721-73c245860a19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e683191-324a-495a-b721-73c245860a19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

