### PR TITLE
Fix Texture Bezier handle dragging under CSS-scaled canvas

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -69,6 +69,22 @@ assert.ok(right2 && left, "left/right tips exist after symmetry rebuild");
 assert.ok(Math.abs(right2.x - ax - (ax - left.x)) < 1e-6, "left mirrors right about centroid");
 assert.ok(Math.abs(left.y - right2.y) < 1e-6, "left mirrors right y");
 
+// Handle-only edit + symmetry must keep hx/hy (no auto-smooth wipe)
+{
+  const circ = makeEllipsePath({ cx: 0, cy: 0, rx: 0.72, ry: 0.72, n: 4 });
+  const tip = circ.knots.find((k) => k.x > 0.5);
+  tip.hx = 0.12;
+  tip.hy = 0.55;
+  rebuildClosedYSymmetry(circ.knots);
+  const tip2 = circ.knots.find((k) => k.id === tip.id);
+  assert.ok(tip2, "edited knot id preserved");
+  assert.ok(Math.abs(tip2.hx - 0.12) < 1e-6, "handle hx survives symmetry");
+  assert.ok(Math.abs(tip2.hy - 0.55) < 1e-6, "handle hy survives symmetry");
+  const mir = circ.knots.find((k) => Math.abs(k.x + tip2.x) < 1e-3 && Math.abs(k.y - tip2.y) < 1e-3);
+  assert.ok(mir, "mirror knot exists");
+  assert.ok(Math.abs(mir.hx + tip2.hx) < 1e-6, "mirror hx negates");
+}
+
 // Move iris far outside, then constrain — centroid should land inside eyeball
 const iris = findLayer(eye, "iris");
 for (const k of iris.knots) {

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
@@ -44,12 +44,35 @@ const emit = defineEmits([
 ]);
 
 const canvasRef = ref(null);
-const size = 560;
+/** Fallback logical size when the canvas is not laid out yet. */
+const SIZE_FALLBACK = 560;
 let dragging = null;
 let draggingChild = null;
 let draggingNormal = null; // 'start' | 'end'
 let raf = 0;
 const hoverAdd = ref(null);
+
+/**
+ * CSS display size (not the hardcoded buffer). Texture layout scales the canvas
+ * below 560px — hit-tests must use clientWidth/Height or handles miss the cursor.
+ */
+function viewSize() {
+  const canvas = canvasRef.value;
+  if (!canvas) return { w: SIZE_FALLBACK, h: SIZE_FALLBACK };
+  const w = canvas.clientWidth || canvas.getBoundingClientRect().width || SIZE_FALLBACK;
+  const h = canvas.clientHeight || canvas.getBoundingClientRect().height || SIZE_FALLBACK;
+  return { w: Math.max(1, w), h: Math.max(1, h) };
+}
+
+/** Map pointer into the same CSS-pixel space used by draw/hit-test (border-safe). */
+function pointerLocal(e) {
+  const canvas = canvasRef.value;
+  const rect = canvas.getBoundingClientRect();
+  const { w, h } = viewSize();
+  const sx = rect.width > 0 ? ((e.clientX - rect.left) / rect.width) * w : 0;
+  const sy = rect.height > 0 ? ((e.clientY - rect.top) / rect.height) * h : 0;
+  return { sx, sy, w, h };
+}
 
 /** Orbit chrome (axes / unit circle) — mesh orbit view only. */
 const isOrbitView = computed(() => props.viewMode === "orbit");
@@ -210,10 +233,11 @@ function drawPlacementNormal(ctx, w, h) {
 
 function hitTestPlacementNormal(sx, sy) {
   if (!showPlacementNormal.value || !props.placementNormal) return null;
+  const { w, h } = viewSize();
   const s = props.placementNormal.start;
   const e = props.placementNormal.end;
-  const [x0, y0] = worldToScreen(s.x, s.y, size, size);
-  const [x1, y1] = worldToScreen(e.x, e.y, size, size);
+  const [x0, y0] = worldToScreen(s.x, s.y, w, h);
+  const [x1, y1] = worldToScreen(e.x, e.y, w, h);
   if (Math.hypot(x1 - sx, y1 - sy) <= 14) return "end";
   if (Math.hypot(x0 - sx, y0 - sy) <= 14) return "start";
   return null;
@@ -224,13 +248,13 @@ function draw() {
   if (!canvas) return;
   const ctx = canvas.getContext("2d");
   const dpr = window.devicePixelRatio || 1;
-  const w = size;
-  const h = size;
-  if (canvas.width !== w * dpr) {
-    canvas.width = w * dpr;
-    canvas.height = h * dpr;
-    canvas.style.width = w + "px";
-    canvas.style.height = h + "px";
+  // Match backing store to CSS box — do not force style.width (breaks Texture layout).
+  const { w, h } = viewSize();
+  const bw = Math.round(w * dpr);
+  const bh = Math.round(h * dpr);
+  if (canvas.width !== bw || canvas.height !== bh) {
+    canvas.width = bw;
+    canvas.height = bh;
   }
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   ctx.clearRect(0, 0, w, h);
@@ -444,26 +468,35 @@ function drawHandle(ctx, x, y, selected) {
 }
 
 function hitTestPoint(sx, sy) {
+  const { w, h } = viewSize();
   const thresh = 10;
   for (let ki = 0; ki < props.knots.length; ki++) {
     const k = props.knots[ki];
     if (props.curveType === 0 && props.toolMode === "edit" && knotUsesBezierHandles(ki)) {
-      const [hx, hy] = worldToScreen(k.x + k.hx, k.y + k.hy, size, size);
-      if (Math.hypot(hx - sx, hy - sy) <= thresh) return { id: k.id, mode: "handle" };
+      // Both Bezier handle ends (outgoing + mirrored incoming)
+      const [hx, hy] = worldToScreen(k.x + k.hx, k.y + k.hy, w, h);
+      if (Math.hypot(hx - sx, hy - sy) <= thresh) {
+        return { id: k.id, mode: "handle", side: "out" };
+      }
+      const [ix, iy] = worldToScreen(k.x - k.hx, k.y - k.hy, w, h);
+      if (Math.hypot(ix - sx, iy - sy) <= thresh) {
+        return { id: k.id, mode: "handle", side: "in" };
+      }
     }
-    const [px, py] = worldToScreen(k.x, k.y, size, size);
+    const [px, py] = worldToScreen(k.x, k.y, w, h);
     if (Math.hypot(px - sx, py - sy) <= thresh) return { id: k.id, mode: "point" };
   }
   return null;
 }
 
 function hitTestSegment(sx, sy) {
+  const { w, h } = viewSize();
   const thresh = 12;
   const segCount = pathIsClosed.value ? props.knots.length : props.knots.length - 1;
   for (let i = 0; i < segCount; i++) {
     const mid = evalMid(i);
     if (!mid) continue;
-    const [mx, my] = worldToScreen(mid.x, mid.y, size, size);
+    const [mx, my] = worldToScreen(mid.x, mid.y, w, h);
     if (Math.hypot(mx - sx, my - sy) <= thresh) return i;
   }
   return -1;
@@ -471,13 +504,14 @@ function hitTestSegment(sx, sy) {
 
 function hitTestChild(sx, sy) {
   if (!showAttachments.value) return null;
+  const { w, h } = viewSize();
   for (const ch of props.children) {
     if (ch.visible === false) continue;
     const ax = ch.transform.snapCenterline ? 0 : ch.transform.x;
     const ay = ch.transform.y;
     const half = 0.06 * Math.max(0.5, ch.transform.scale / 0.28);
-    const [x0, y0] = worldToScreen(ax - half, ay + half, size, size);
-    const [x1, y1] = worldToScreen(ax + half, ay - half, size, size);
+    const [x0, y0] = worldToScreen(ax - half, ay + half, w, h);
+    const [x1, y1] = worldToScreen(ax + half, ay - half, w, h);
     const left = Math.min(x0, x1);
     const right = Math.max(x0, x1);
     const top = Math.min(y0, y1);
@@ -488,10 +522,8 @@ function hitTestChild(sx, sy) {
 }
 
 function onPointerDown(e) {
-  const rect = canvasRef.value.getBoundingClientRect();
-  const sx = e.clientX - rect.left;
-  const sy = e.clientY - rect.top;
-  const [wx, wy] = screenToWorld(sx, sy, size, size);
+  const { sx, sy, w, h } = pointerLocal(e);
+  const [wx, wy] = screenToWorld(sx, sy, w, h);
 
   if (props.toolMode === "add") {
     emit("add-on-curve", clampWorldX(wx), wy);
@@ -539,10 +571,8 @@ function onPointerDown(e) {
 }
 
 function onPointerMove(e) {
-  const rect = canvasRef.value.getBoundingClientRect();
-  const sx = e.clientX - rect.left;
-  const sy = e.clientY - rect.top;
-  const [wx, wy] = screenToWorld(sx, sy, size, size);
+  const { sx, sy, w, h } = pointerLocal(e);
+  const [wx, wy] = screenToWorld(sx, sy, w, h);
 
   if (props.toolMode === "add") {
     hoverAdd.value = props.findClosestOnCurve(clampWorldX(wx), wy, 0.14);
@@ -573,6 +603,9 @@ function onPointerMove(e) {
   if (!k) return;
   if (dragging.mode === "point") {
     emit("update-knot", dragging.id, { x: clampWorldX(wx), y: wy });
+  } else if (dragging.side === "in") {
+    // Incoming handle is at (x - hx, y - hy)
+    emit("update-knot", dragging.id, { hx: k.x - wx, hy: k.y - wy });
   } else {
     emit("update-knot", dragging.id, { hx: wx - k.x, hy: wy - k.y });
   }
@@ -614,14 +647,25 @@ watch(
   { deep: true },
 );
 
+let resizeObserver = null;
+
 onMounted(() => {
   schedule();
   window.addEventListener("resize", schedule);
+  // Texture column CSS-scales the canvas; keep backing store + hit-tests in sync.
+  if (typeof ResizeObserver !== "undefined" && canvasRef.value) {
+    resizeObserver = new ResizeObserver(() => schedule());
+    resizeObserver.observe(canvasRef.value);
+  }
 });
 
 onBeforeUnmount(() => {
   cancelAnimationFrame(raf);
   window.removeEventListener("resize", schedule);
+  if (resizeObserver) {
+    resizeObserver.disconnect();
+    resizeObserver = null;
+  }
 });
 </script>
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/usePathEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/usePathEditor.js
@@ -100,17 +100,45 @@ export function usePathEditor(opts = {}) {
     }
   }
 
-  function loadPath(knots, segments, { closed } = {}) {
+  function loadPath(knots, segments, { closed, preserveSelection = false } = {}) {
     if (closed != null) state.closed = !!closed;
+    const prevSel = state.selectedId;
     state.knots = (knots || []).map((k) => ({ ...k }));
     state.segments = (segments || []).map((s) => ({ ...s, textureData: null }));
     syncSegments();
-    state.selectedId = state.knots[0]?.id || null;
-    state.selectedIds = state.selectedId ? [state.selectedId] : [];
-    state.selectedSegmentIndex = -1;
+    if (preserveSelection && prevSel && state.knots.some((k) => k.id === prevSel)) {
+      state.selectedId = prevSel;
+      state.selectedIds = [prevSel];
+    } else {
+      state.selectedId = state.knots[0]?.id || null;
+      state.selectedIds = state.selectedId ? [state.selectedId] : [];
+      state.selectedSegmentIndex = -1;
+    }
     history.clear();
     history.baseline(snapshot());
     refreshHistoryFlags();
+  }
+
+  /** Copy knot fields from an external list without resetting selection/history. */
+  function applyKnotsFrom(knots) {
+    if (!knots?.length) return;
+    const sameIds =
+      knots.length === state.knots.length && knots.every((k, i) => k.id === state.knots[i]?.id);
+    if (sameIds) {
+      for (let i = 0; i < state.knots.length; i++) Object.assign(state.knots[i], knots[i]);
+      return;
+    }
+    // Symmetry rebuild may reorder/add mirrors — replace in place, keep selection.
+    const prevSel = state.selectedId;
+    state.knots = knots.map((k) => ({ ...k }));
+    syncSegments();
+    if (prevSel && state.knots.some((k) => k.id === prevSel)) {
+      state.selectedId = prevSel;
+      state.selectedIds = [prevSel];
+    } else if (!state.knots.some((k) => k.id === state.selectedId)) {
+      state.selectedId = state.knots[0]?.id || null;
+      state.selectedIds = state.selectedId ? [state.selectedId] : [];
+    }
   }
 
   function sampleCurvePoints(n = 28) {
@@ -250,6 +278,7 @@ export function usePathEditor(opts = {}) {
       return state.closed;
     },
     loadPath,
+    applyKnotsFrom,
     syncSegments,
     sampleCurvePoints,
     findClosestOnCurve,

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
@@ -91,8 +91,10 @@ export function useTextureEditor() {
     layer.segments = path.state.segments.map((s) => ({ ...s }));
     layer.color = layer.color || path.state.knots[0]?.color || layer.color;
     constrainEyeLayer(tex, layer.id);
-    // If constrain moved knots, reload path editor
-    path.loadPath(layer.knots, layer.segments, { closed: layer.type !== "eyelid" });
+    // Sync constrain/symmetry results back without wiping selection mid-drag
+    // (full loadPath was resetting selectedId and fighting handle drags).
+    path.applyKnotsFrom(layer.knots);
+    layer.segments = path.state.segments.map((s) => ({ ...s }));
   }
 
   watch(
@@ -201,6 +203,9 @@ export function useTextureEditor() {
     return pathCentroid(knots).x;
   }
 
+  /** True if the current gesture moved a knot (not only Bezier handles). */
+  let gestureMovedPoint = false;
+
   function onPathKnotUpdate(id, patch) {
     // With symmetry, keep edits on the right half relative to path centroid.
     if (layerWantsSymmetry(selectedLayer.value) && patch.x != null) {
@@ -209,12 +214,15 @@ export function useTextureEditor() {
     }
     path.updateKnot(id, patch);
     const movedPoint = patch.x != null || patch.y != null;
+    if (movedPoint) gestureMovedPoint = true;
     pushPathToLayer({ movedPoint });
   }
 
   function onPathDragEnd() {
     path.endGesture();
-    pushPathToLayer({ movedPoint: true });
+    // Auto-smooth only after knot moves — handle-only drags must keep hx/hy.
+    pushPathToLayer({ movedPoint: gestureMovedPoint });
+    gestureMovedPoint = false;
   }
 
   function onPathAdd(x, y) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Texture-side Bezier handles looked selectable but did not track the mouse; Mesh worked because its canvas stayed at the logical 560px size.

### Cause
1. **Hit-test vs CSS scale** — `SplineCanvas` hit-tested and mapped pointers with a hardcoded `560` while the Texture column CSS-scales the canvas (`max-width: 480px`), so orange handles did not line up with the cursor.
2. **Path reload mid-drag** — `pushPathToLayer` called full `loadPath` after every update, resetting selection and fighting handle edits.
3. **Auto-smooth on drag-end** — releasing a handle-only drag still ran auto-smooth (`movedPoint: true`), wiping custom `hx`/`hy`.

### Fix
- Size draw/hit-test/pointer mapping from the live CSS box (`clientWidth` / border-safe pointer mapping) and observe resizes.
- Sync constrain/symmetry results with `applyKnotsFrom` (no selection wipe).
- Track whether the gesture moved a knot vs only handles; auto-smooth only after knot moves.
- Smoke: handle edit survives Y-symmetry rebuild without auto-smooth.

### Verify
- Texture → Eye → Edit tool: drag orange Bezier handles — they should follow the cursor (with Symmetry on).
- Mesh orbit/profile handles still drag as before.
- `node gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

