### PR TITLE
Optional eyelid border with separate fill and stroke colors

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -106,6 +106,30 @@ const irisPoly = layerPolygon(findLayer(eye, "iris"));
 const pc = pathCentroid(pupil.knots);
 assert.ok(pointInPolygon(pc.x, pc.y, irisPoly), "pupil centroid inside iris after constrain");
 
+// Eyelid optional border + separate fill / border colors
+{
+  const lid = findLayer(eye, "eyelid");
+  assert.ok(lid, "eyelid layer");
+  assert.equal(lid.border, false);
+  lid.enabled = true;
+  lid.border = true;
+  lid.borderWidth = 0.05;
+  lid.borderColor = "#112233";
+  lid.color = "#aabbcc";
+  const serLid = serializeEyeTexture(eye);
+  const lidSer = serLid.layers.find((L) => L.type === "eyelid");
+  assert.equal(lidSer.border, true);
+  assert.equal(lidSer.borderWidth, 0.05);
+  assert.equal(lidSer.borderColor, "#112233");
+  assert.equal(lidSer.color, "#aabbcc");
+  const againLid = normalizeEyeTexture(serLid);
+  const lid2 = findLayer(againLid, "eyelid");
+  assert.equal(lid2.border, true);
+  assert.equal(lid2.borderWidth, 0.05);
+  assert.equal(lid2.borderColor, "#112233");
+  assert.equal(lid2.color, "#aabbcc");
+}
+
 const ser = serializeEyeTexture(eye);
 const again = normalizeEyeTexture(ser);
 assert.equal(again.name, "TestEye");

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -731,6 +731,7 @@ onBeforeUnmount(() => {
         @add-layer="tex.addLayer"
         @remove-layer="tex.removeLayer"
         @set-color="tex.setLayerColor"
+        @patch-layer="tex.patchLayer"
       />
       <div class="side-stack">
         <TexturePreview :texture="texSelected" />

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/TextureLayerPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/TextureLayerPanel.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { computed } from "vue";
+
 const props = defineProps({
   layers: { type: Array, default: () => [] },
   selectedLayerId: { type: String, default: null },
@@ -13,6 +15,7 @@ const emit = defineEmits([
   "add-layer",
   "remove-layer",
   "set-color",
+  "patch-layer",
 ]);
 
 const addTypes = [
@@ -21,6 +24,9 @@ const addTypes = [
   { id: "reflection", label: "+ Shine" },
   { id: "eyelid", label: "+ Eyelid" },
 ];
+
+const selected = computed(() => props.layers.find((L) => L.id === props.selectedLayerId) || null);
+const eyelidSelected = computed(() => selected.value?.type === "eyelid");
 </script>
 
 <template>
@@ -57,6 +63,7 @@ const addTypes = [
         <input
           class="swatch"
           type="color"
+          :title="L.type === 'eyelid' ? 'Fill color' : 'Color'"
           :value="L.color || '#ffffff'"
           @click.stop
           @input="emit('set-color', L.id, $event.target.value)"
@@ -74,6 +81,63 @@ const addTypes = [
         </button>
       </li>
     </ul>
+
+    <div v-if="eyelidSelected" class="lid-opts">
+      <p class="lid-title">Eyelid</p>
+      <label class="row">
+        Fill
+        <input
+          class="swatch"
+          type="color"
+          :value="selected.color || '#c4a484'"
+          @input="emit('patch-layer', selected.id, { color: $event.target.value })"
+        />
+      </label>
+      <label class="row check">
+        <input
+          type="checkbox"
+          :checked="!!selected.border"
+          @change="emit('patch-layer', selected.id, { border: $event.target.checked })"
+        />
+        Border
+      </label>
+      <template v-if="selected.border">
+        <label class="row">
+          Border color
+          <input
+            class="swatch"
+            type="color"
+            :value="selected.borderColor || '#6e4f38'"
+            @input="emit('patch-layer', selected.id, { borderColor: $event.target.value })"
+          />
+        </label>
+        <label class="row">
+          Width
+          <input
+            class="num"
+            type="number"
+            min="0.005"
+            max="0.25"
+            step="0.005"
+            :value="selected.borderWidth ?? 0.035"
+            @change="
+              emit('patch-layer', selected.id, { borderWidth: Number($event.target.value) })
+            "
+          />
+        </label>
+      </template>
+      <label class="row">
+        Fill side
+        <select
+          :value="selected.fillSide === 'below' ? 'below' : 'above'"
+          @change="emit('patch-layer', selected.id, { fillSide: $event.target.value })"
+        >
+          <option value="above">Above curve</option>
+          <option value="below">Below curve</option>
+        </select>
+      </label>
+    </div>
+
     <div v-if="textureKind === 'eye'" class="add-row">
       <button v-for="t in addTypes" :key="t.id" type="button" @click="emit('add-layer', t.id)">
         {{ t.label }}
@@ -181,5 +245,48 @@ button.danger:disabled {
 }
 .en {
   display: flex;
+}
+.lid-opts {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.55rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.18);
+}
+.lid-title {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--ink);
+}
+.lid-opts .row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--ink-dim);
+}
+.lid-opts .row.check {
+  justify-content: flex-start;
+  gap: 0.4rem;
+}
+.lid-opts .num {
+  width: 4.5rem;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.75rem;
+  color: var(--ink);
+}
+.lid-opts select {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.75rem;
+  color: var(--ink);
 }
 </style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
@@ -145,6 +145,26 @@ export function useTextureEditor() {
     for (const k of L.knots || []) k.color = color;
   }
 
+  /** Patch eyelid (or other) layer fields: border, borderWidth, borderColor, fillSide, … */
+  function patchLayer(layerId, patch) {
+    const L = selectedTexture.value?.layers.find((x) => x.id === layerId);
+    if (!L || !patch || typeof patch !== "object") return;
+    if (patch.color != null) {
+      setLayerColor(layerId, patch.color);
+    }
+    if (patch.fillSide != null && L.type === "eyelid") {
+      L.fillSide = patch.fillSide === "below" ? "below" : "above";
+    }
+    if (L.type === "eyelid") {
+      if (patch.border != null) L.border = !!patch.border;
+      if (patch.borderWidth != null) {
+        const w = Number(patch.borderWidth);
+        if (Number.isFinite(w)) L.borderWidth = Math.min(0.25, Math.max(0.005, w));
+      }
+      if (patch.borderColor != null) L.borderColor = String(patch.borderColor);
+    }
+  }
+
   function moveLayer(layerId, dir) {
     const tex = selectedTexture.value;
     if (!tex) return;
@@ -307,6 +327,7 @@ export function useTextureEditor() {
     renameLayer,
     setLayerEnabled,
     setLayerColor,
+    patchLayer,
     moveLayer,
     addLayer,
     removeLayer,

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -59,14 +59,17 @@ export function createEyeLayer(type, overrides = {}) {
     }),
     eyelid: () => ({
       name: "Eyelid",
-      color: "#c4a484",
+      color: "#c4a484", // fill
       closed: false,
       fillSide: "above", // above | below — region clipped to eyeball
+      border: false,
+      borderWidth: 0.035, // authoring units → stroke in texture space
+      borderColor: "#6e4f38",
       ...makeOpenArcPath({ y: 0.12, halfWidth: 0.7, bulge: 0.28, color: "#c4a484" }),
     }),
   };
   const base = (defaults[type] || defaults.eyeball)();
-  return {
+  const layer = {
     id: layerId(),
     type,
     name: overrides.name || base.name,
@@ -78,6 +81,23 @@ export function createEyeLayer(type, overrides = {}) {
     segments: overrides.segments || base.segments,
     clipTo: EYE_CLIP_PARENT[type] ?? null,
   };
+  if (type === "eyelid") {
+    layer.border = overrides.border != null ? !!overrides.border : !!base.border;
+    layer.borderWidth =
+      overrides.borderWidth != null ? Number(overrides.borderWidth) : Number(base.borderWidth) || 0.035;
+    layer.borderColor = overrides.borderColor || base.borderColor || "#6e4f38";
+  }
+  return layer;
+}
+
+/** Clamp / normalize eyelid stroke fields (params only). */
+export function normalizeEyelidBorder(L) {
+  if (!L || L.type !== "eyelid") return L;
+  L.border = !!L.border;
+  const w = Number(L.borderWidth);
+  L.borderWidth = Number.isFinite(w) ? Math.min(0.25, Math.max(0.005, w)) : 0.035;
+  L.borderColor = typeof L.borderColor === "string" && L.borderColor ? L.borderColor : "#6e4f38";
+  return L;
 }
 
 export function createDefaultEyeTexture({ name = "Eye" } = {}) {
@@ -132,17 +152,27 @@ export function serializeEyeTexture(tex) {
     height: Number(tex.height) || 256,
     backgroundFrom: tex.backgroundFrom === "solid" ? "solid" : "vertexColors",
     previewBackground: tex.previewBackground || "#6a8f6a",
-    layers: (tex.layers || []).map((L) => ({
-      id: L.id,
-      type: EYE_LAYER_TYPES.includes(L.type) ? L.type : "eyeball",
-      name: L.name || L.type,
-      enabled: L.enabled !== false,
-      color: L.color || "#ffffff",
-      closed: L.closed !== false && L.type !== "eyelid",
-      fillSide: L.fillSide === "below" ? "below" : L.type === "eyelid" ? "above" : null,
-      clipTo: L.clipTo || EYE_CLIP_PARENT[L.type] || null,
-      ...serializePathBlock(L),
-    })),
+    layers: (tex.layers || []).map((L) => {
+      const type = EYE_LAYER_TYPES.includes(L.type) ? L.type : "eyeball";
+      const row = {
+        id: L.id,
+        type,
+        name: L.name || L.type,
+        enabled: L.enabled !== false,
+        color: L.color || "#ffffff",
+        closed: L.closed !== false && L.type !== "eyelid",
+        fillSide: L.fillSide === "below" ? "below" : type === "eyelid" ? "above" : null,
+        clipTo: L.clipTo || EYE_CLIP_PARENT[type] || null,
+        ...serializePathBlock(L),
+      };
+      if (type === "eyelid") {
+        const w = Number(L.borderWidth);
+        row.border = !!L.border;
+        row.borderWidth = Number.isFinite(w) ? Math.min(0.25, Math.max(0.005, w)) : 0.035;
+        row.borderColor = L.borderColor || "#6e4f38";
+      }
+      return row;
+    }),
   };
 }
 
@@ -156,7 +186,7 @@ export function normalizeEyeTexture(raw) {
       const type = EYE_LAYER_TYPES.includes(L.type) ? L.type : "eyeball";
       const def = createEyeLayer(type);
       const path = serializePathBlock(L.knots ? L : def);
-      return {
+      const row = {
         ...def,
         id: L.id || def.id,
         type,
@@ -172,6 +202,14 @@ export function normalizeEyeTexture(raw) {
             ? syncOpenSegments(path.knots, path.segments, "bezier")
             : syncClosedSegments(path.knots, path.segments, "bezier"),
       };
+      if (type === "eyelid") {
+        row.border = L.border != null ? !!L.border : !!def.border;
+        const bw = Number(L.borderWidth);
+        row.borderWidth = Number.isFinite(bw) ? bw : def.borderWidth;
+        row.borderColor = L.borderColor || def.borderColor;
+        normalizeEyelidBorder(row);
+      }
+      return row;
     });
   } else {
     layers = base.layers;
@@ -320,6 +358,26 @@ export function renderEyeTexture(ctx, tex, opts = {}) {
       ctx.closePath();
       ctx.fillStyle = layer.color || "#c4a484";
       ctx.fill();
+
+      // Optional crease stroke along the eyelid curve (separate border color)
+      if (layer.border) {
+        const pad = 0.08;
+        const worldSpan = 2 + 2 * pad;
+        const bw = Number(layer.borderWidth);
+        const worldW = Number.isFinite(bw) ? Math.min(0.25, Math.max(0.005, bw)) : 0.035;
+        const lineW = Math.max(1, (worldW / worldSpan) * w);
+        ctx.beginPath();
+        ctx.moveTo(x0, y0);
+        for (let i = 1; i < pts.length; i++) {
+          const [x, y] = worldToTex(pts[i].x, pts[i].y, w, h);
+          ctx.lineTo(x, y);
+        }
+        ctx.strokeStyle = layer.borderColor || "#6e4f38";
+        ctx.lineWidth = lineW;
+        ctx.lineCap = "round";
+        ctx.lineJoin = "round";
+        ctx.stroke();
+      }
     } else {
       if (layer.type === "iris" || layer.type === "pupil") {
         const parentType = layer.clipTo;

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -136,18 +136,28 @@ function serializeChild(ch) {
 function serializeTextureAsset(tex) {
   if (!tex || typeof tex !== "object") return null;
   const kind = tex.kind === "eye" ? "eye" : String(tex.kind || "eye");
-  const layers = (tex.layers || []).map((L) => ({
-    id: L.id,
-    type: L.type || "eyeball",
-    name: L.name || L.type || "layer",
-    enabled: L.enabled !== false,
-    color: L.color || "#ffffff",
-    closed: L.closed !== false && L.type !== "eyelid",
-    fillSide: L.fillSide === "below" ? "below" : L.type === "eyelid" ? "above" : null,
-    clipTo: L.clipTo || null,
-    knots: (L.knots || []).map(serializeKnot),
-    segments: (L.segments || []).map(serializeSegment),
-  }));
+  const layers = (tex.layers || []).map((L) => {
+    const type = L.type || "eyeball";
+    const row = {
+      id: L.id,
+      type,
+      name: L.name || L.type || "layer",
+      enabled: L.enabled !== false,
+      color: L.color || "#ffffff",
+      closed: L.closed !== false && type !== "eyelid",
+      fillSide: L.fillSide === "below" ? "below" : type === "eyelid" ? "above" : null,
+      clipTo: L.clipTo || null,
+      knots: (L.knots || []).map(serializeKnot),
+      segments: (L.segments || []).map(serializeSegment),
+    };
+    if (type === "eyelid") {
+      const w = Number(L.borderWidth);
+      row.border = !!L.border;
+      row.borderWidth = Number.isFinite(w) ? Math.min(0.25, Math.max(0.005, w)) : 0.035;
+      row.borderColor = L.borderColor || "#6e4f38";
+    }
+    return row;
+  });
   return {
     assetGuid: tex.assetGuid,
     name: tex.name || "Texture",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Eyelid layers can optionally draw a crease stroke along the curve with its own border color and width, while `color` remains the fill.

### Changes
- Params: `border`, `borderWidth` (authoring units), `borderColor` on eyelid layers; serialize/normalize/schema round-trip
- Renderer: fill first, then optional round stroke along the eyelid path (clipped to eyeball)
- Layers panel: when an eyelid is selected — fill color, Border toggle, border color, width, fill side
- Smoke covers border persistence through serialize → normalize

### How to try
1. Texture → New eye → enable **Eyelid**
2. Select the eyelid layer → turn on **Border**
3. Set fill vs border colors and width; preview updates live
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

