### PR TITLE
Eye layer Move mode + left/right preview with mirror link

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -106,6 +106,30 @@ const irisPoly = layerPolygon(findLayer(eye, "iris"));
 const pc = pathCentroid(pupil.knots);
 assert.ok(pointInPolygon(pc.x, pc.y, irisPoly), "pupil centroid inside iris after constrain");
 
+// Eyelid optional border + separate fill / border colors
+{
+  const lid = findLayer(eye, "eyelid");
+  assert.ok(lid, "eyelid layer");
+  assert.equal(lid.border, false);
+  lid.enabled = true;
+  lid.border = true;
+  lid.borderWidth = 0.05;
+  lid.borderColor = "#112233";
+  lid.color = "#aabbcc";
+  const serLid = serializeEyeTexture(eye);
+  const lidSer = serLid.layers.find((L) => L.type === "eyelid");
+  assert.equal(lidSer.border, true);
+  assert.equal(lidSer.borderWidth, 0.05);
+  assert.equal(lidSer.borderColor, "#112233");
+  assert.equal(lidSer.color, "#aabbcc");
+  const againLid = normalizeEyeTexture(serLid);
+  const lid2 = findLayer(againLid, "eyelid");
+  assert.equal(lid2.border, true);
+  assert.equal(lid2.borderWidth, 0.05);
+  assert.equal(lid2.borderColor, "#112233");
+  assert.equal(lid2.color, "#aabbcc");
+}
+
 const ser = serializeEyeTexture(eye);
 const again = normalizeEyeTexture(ser);
 assert.equal(again.name, "TestEye");

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -7,6 +7,12 @@ import {
   constrainAllEyeLayers,
   findLayer,
   layerPolygon,
+  mirrorLayersX,
+  translateLayerTree,
+  companionLayerTypes,
+  rightEyeLayers,
+  resetEyePairToMirror,
+  editableLayers,
 } from "../src/lib/texture/eyeTexture.js";
 import {
   pointInPolygon,
@@ -130,10 +136,48 @@ assert.ok(pointInPolygon(pc.x, pc.y, irisPoly), "pupil centroid inside iris afte
   assert.equal(lid2.color, "#aabbcc");
 }
 
+// Layer Move: translating iris also moves pupil
+{
+  const e2 = createDefaultEyeTexture({ name: "Move" });
+  const iris = findLayer(e2, "iris");
+  const pupil = findLayer(e2, "pupil");
+  const ix = iris.knots[0].x;
+  const px = pupil.knots[0].x;
+  translateLayerTree(e2.layers, iris.id, 0.1, 0);
+  assert.ok(Math.abs(iris.knots[0].x - (ix + 0.1)) < 1e-6, "iris translated");
+  assert.ok(Math.abs(pupil.knots[0].x - (px + 0.1)) < 1e-6, "pupil follows iris");
+  assert.deepEqual(companionLayerTypes("iris"), ["pupil"]);
+}
+
+// Left/right pair: linked right is mirror; reset re-links
+{
+  const e3 = createDefaultEyeTexture({ name: "Pair" });
+  assert.equal(e3.eyePair.linked, true);
+  const right = rightEyeLayers(e3);
+  const leftIris = findLayer(e3.layers, "iris");
+  const rightIris = findLayer(right, "iris");
+  assert.ok(
+    Math.abs(rightIris.knots[0].x + leftIris.knots[0].x) < 1e-6,
+    "linked right iris mirrors left X",
+  );
+  e3.eyePair.linked = false;
+  e3.eyePair.editSide = "right";
+  e3.rightLayers = mirrorLayersX(e3.layers);
+  // Nudge right iris independently
+  const rIris = findLayer(e3.rightLayers, "iris");
+  rIris.knots[0].x += 0.2;
+  resetEyePairToMirror(e3, "left");
+  assert.equal(e3.eyePair.linked, true);
+  assert.equal(e3.rightLayers, null);
+  assert.equal(editableLayers(e3), e3.layers);
+}
+
 const ser = serializeEyeTexture(eye);
 const again = normalizeEyeTexture(ser);
 assert.equal(again.name, "TestEye");
 assert.equal(again.layers.length, eye.layers.length);
+assert.ok(again.eyePair);
+assert.equal(again.eyePair.linked, true);
 
 // Schema v9 migrate round-trip
 const doc = buildProjectDocument({

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -60,6 +60,9 @@ const texSelected = tex.selectedTexture;
 const texPathClosed = tex.pathClosed;
 const texClampX = tex.clampNonNegativeX;
 const texShowMirror = tex.showMirror;
+const texEyePair = tex.eyePair;
+const texFlipX = tex.flipX;
+const texCanvasToolMode = tex.canvasToolMode;
 
 const workspace = ref("mesh"); // mesh | texture
 
@@ -360,6 +363,49 @@ onBeforeUnmount(() => {
           >
             Delete texture
           </button>
+          <button
+            type="button"
+            :class="{ active: texEyePair.editSide === 'left', primary: texEyePair.editSide === 'left' }"
+            title="Edit left eye"
+            @click="tex.setEditSide('left')"
+          >
+            Left
+          </button>
+          <button
+            type="button"
+            :class="{ active: texEyePair.editSide === 'right', primary: texEyePair.editSide === 'right' }"
+            title="Edit right eye"
+            @click="tex.setEditSide('right')"
+          >
+            Right
+          </button>
+          <button
+            type="button"
+            :class="{ active: texEyePair.editSide === 'both', primary: texEyePair.editSide === 'both' }"
+            title="Both eyes stay linked as mirrors"
+            @click="tex.setEditSide('both')"
+          >
+            Both
+          </button>
+          <label
+            class="tex-check"
+            title="When linked, right eye is always a mirror of left"
+          >
+            <input
+              type="checkbox"
+              :checked="texEyePair.linked"
+              @change="tex.setEyeLinked($event.target.checked)"
+            />
+            Linked mirrors
+          </label>
+          <button
+            type="button"
+            title="Copy active side to the other as a mirror image and link"
+            :disabled="!texState.selectedGuid"
+            @click="tex.resetToMirrorImage()"
+          >
+            Reset to mirror image
+          </button>
           <label class="tex-check" title="Edit right half; left is mirrored (like mesh profile)">
             <input
               type="checkbox"
@@ -391,14 +437,16 @@ onBeforeUnmount(() => {
               active:
                 workspace === 'mesh'
                   ? state.toolMode === t.id
-                  : texPath.state.toolMode === t.id,
+                  : texState.layerMode === 'edit' && texPath.state.toolMode === t.id,
               primary:
                 workspace === 'mesh'
                   ? state.toolMode === t.id
-                  : texPath.state.toolMode === t.id,
+                  : texState.layerMode === 'edit' && texPath.state.toolMode === t.id,
             }"
             @click="
-              workspace === 'mesh' ? setToolMode(t.id) : texPath.setToolMode(t.id)
+              workspace === 'mesh'
+                ? setToolMode(t.id)
+                : (tex.setLayerMode('edit'), texPath.setToolMode(t.id))
             "
           >
             {{ t.label }}
@@ -696,7 +744,8 @@ onBeforeUnmount(() => {
           :selected-segment-index="texPath.state.selectedSegmentIndex"
           :curve-type="texPath.state.curveType"
           :symmetry="texShowMirror"
-          :tool-mode="texPath.state.toolMode"
+          :tool-mode="texCanvasToolMode"
+          :flip-x="texFlipX"
           view-mode="profile"
           :path-closed="texPathClosed"
           :show-unit-circle="false"
@@ -713,6 +762,7 @@ onBeforeUnmount(() => {
           @select-segment="texPath.selectSegment"
           @update-knot="tex.onPathKnotUpdate"
           @add-on-curve="tex.onPathAdd"
+          @translate-path="tex.onTranslatePath"
           @drag-end="tex.onPathDragEnd"
         />
         <p class="tex-canvas-hint">
@@ -724,6 +774,7 @@ onBeforeUnmount(() => {
         :layers="texLayers"
         :selected-layer-id="texState.selectedLayerId"
         :texture-kind="texSelected?.kind || 'eye'"
+        :layer-mode="texState.layerMode"
         @select-layer="tex.selectLayer"
         @rename-layer="tex.renameLayer"
         @toggle-layer="tex.setLayerEnabled"
@@ -732,9 +783,16 @@ onBeforeUnmount(() => {
         @remove-layer="tex.removeLayer"
         @set-color="tex.setLayerColor"
         @patch-layer="tex.patchLayer"
+        @set-layer-mode="tex.setLayerMode"
       />
       <div class="side-stack">
-        <TexturePreview :texture="texSelected" />
+        <TexturePreview
+          :texture="texSelected"
+          :pair="true"
+          :edit-side="texEyePair.editSide"
+          :distance="texEyePair.distance"
+          @update-distance="tex.setInterEyeDistance"
+        />
         <section class="tex-list panel-ish">
           <h2>Textures</h2>
           <p class="hint">{{ texState.status }}</p>

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -731,6 +731,7 @@ onBeforeUnmount(() => {
         @add-layer="tex.addLayer"
         @remove-layer="tex.removeLayer"
         @set-color="tex.setLayerColor"
+        @patch-layer="tex.patchLayer"
       />
       <div class="side-stack">
         <TexturePreview :texture="texSelected" />

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/SplineCanvas.vue
@@ -30,6 +30,8 @@ const props = defineProps({
   showMirror: { type: Boolean, default: null },
   /** When false, skip lathe axes / unit-circle / spine guides (texture editor). */
   showLatheGuides: { type: Boolean, default: true },
+  /** Flip world X for linked right-eye editing (storage stays left-canonical). */
+  flipX: { type: Boolean, default: false },
 });
 
 const emit = defineEmits([
@@ -41,6 +43,7 @@ const emit = defineEmits([
   "drag-end",
   "select-child",
   "move-child",
+  "translate-path",
 ]);
 
 const canvasRef = ref(null);
@@ -49,6 +52,8 @@ const SIZE_FALLBACK = 560;
 let dragging = null;
 let draggingChild = null;
 let draggingNormal = null; // 'start' | 'end'
+let draggingTranslate = false;
+let lastWorld = null; // {x,y} for move-mode deltas
 let raf = 0;
 const hoverAdd = ref(null);
 
@@ -114,12 +119,16 @@ function clampWorldX(wx) {
 
 function worldToScreen(x, y, w, h) {
   const { min, max } = props.viewport;
-  return [((x - min) / (max - min)) * w, ((max - y) / (max - min)) * h];
+  const wx = props.flipX ? -x : x;
+  return [((wx - min) / (max - min)) * w, ((max - y) / (max - min)) * h];
 }
 
 function screenToWorld(sx, sy, w, h) {
   const { min, max } = props.viewport;
-  return [min + (sx / w) * (max - min), max - (sy / h) * (max - min)];
+  let x = min + (sx / w) * (max - min);
+  const y = max - (sy / h) * (max - min);
+  if (props.flipX) x = -x;
+  return [x, y];
 }
 
 function drawGradientStroke(ctx, pts, getColor, w, h) {
@@ -530,6 +539,13 @@ function onPointerDown(e) {
     return;
   }
 
+  if (props.toolMode === "move") {
+    draggingTranslate = true;
+    lastWorld = { x: wx, y: wy };
+    canvasRef.value.setPointerCapture(e.pointerId);
+    return;
+  }
+
   if (props.toolMode === "edit" && showPlacementNormal.value) {
     const nh = hitTestPlacementNormal(sx, sy);
     if (nh) {
@@ -580,6 +596,14 @@ function onPointerMove(e) {
     return;
   }
 
+  if (draggingTranslate && props.toolMode === "move" && lastWorld) {
+    const dx = wx - lastWorld.x;
+    const dy = wy - lastWorld.y;
+    lastWorld = { x: wx, y: wy };
+    if (dx || dy) emit("translate-path", dx, dy);
+    return;
+  }
+
   if (draggingNormal && props.toolMode === "edit") {
     if (draggingNormal === "start") {
       emit("update-placement-normal", { start: { x: wx, y: wy } });
@@ -612,12 +636,19 @@ function onPointerMove(e) {
 }
 
 function onPointerUp() {
-  if ((dragging || draggingChild || draggingNormal) && props.toolMode === "edit") {
+  if (
+    (dragging || draggingChild || draggingNormal) && props.toolMode === "edit"
+  ) {
+    emit("drag-end");
+  }
+  if (draggingTranslate && props.toolMode === "move") {
     emit("drag-end");
   }
   dragging = null;
   draggingChild = null;
   draggingNormal = null;
+  draggingTranslate = false;
+  lastWorld = null;
 }
 
 function schedule() {
@@ -635,6 +666,7 @@ watch(
     props.curveType,
     props.symmetry,
     props.toolMode,
+    props.flipX,
     props.viewMode,
     props.children,
     props.selectedChildGuid,
@@ -723,6 +755,9 @@ onBeforeUnmount(() => {
 }
 .spline-canvas.color {
   cursor: pointer;
+}
+.spline-canvas.move {
+  cursor: move;
 }
 
 .legend {

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/TextureLayerPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/TextureLayerPanel.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { computed } from "vue";
+
 const props = defineProps({
   layers: { type: Array, default: () => [] },
   selectedLayerId: { type: String, default: null },
@@ -13,6 +15,7 @@ const emit = defineEmits([
   "add-layer",
   "remove-layer",
   "set-color",
+  "patch-layer",
 ]);
 
 const addTypes = [
@@ -21,6 +24,9 @@ const addTypes = [
   { id: "reflection", label: "+ Shine" },
   { id: "eyelid", label: "+ Eyelid" },
 ];
+
+const selected = computed(() => props.layers.find((L) => L.id === props.selectedLayerId) || null);
+const eyelidSelected = computed(() => selected.value?.type === "eyelid");
 </script>
 
 <template>
@@ -57,6 +63,7 @@ const addTypes = [
         <input
           class="swatch"
           type="color"
+          :title="L.type === 'eyelid' ? 'Fill color' : 'Color'"
           :value="L.color || '#ffffff'"
           @click.stop
           @input="emit('set-color', L.id, $event.target.value)"
@@ -74,6 +81,63 @@ const addTypes = [
         </button>
       </li>
     </ul>
+
+    <div v-if="eyelidSelected" class="lid-opts">
+      <p class="lid-title">Eyelid</p>
+      <label class="row">
+        Fill
+        <input
+          class="swatch"
+          type="color"
+          :value="selected.color || '#c4a484'"
+          @input="emit('patch-layer', selected.id, { color: $event.target.value })"
+        />
+      </label>
+      <label class="row check">
+        <input
+          type="checkbox"
+          :checked="!!selected.border"
+          @change="emit('patch-layer', selected.id, { border: $event.target.checked })"
+        />
+        Border
+      </label>
+      <template v-if="selected.border">
+        <label class="row">
+          Border color
+          <input
+            class="swatch"
+            type="color"
+            :value="selected.borderColor || '#6e4f38'"
+            @input="emit('patch-layer', selected.id, { borderColor: $event.target.value })"
+          />
+        </label>
+        <label class="row">
+          Width
+          <input
+            class="num"
+            type="number"
+            min="0.005"
+            max="0.25"
+            step="0.005"
+            :value="selected.borderWidth ?? 0.035"
+            @change="
+              emit('patch-layer', selected.id, { borderWidth: Number($event.target.value) })
+            "
+          />
+        </label>
+      </template>
+      <label class="row">
+        Fill side
+        <select
+          :value="selected.fillSide === 'below' ? 'below' : 'above'"
+          @change="emit('patch-layer', selected.id, { fillSide: $event.target.value })"
+        >
+          <option value="above">Above curve</option>
+          <option value="below">Below curve</option>
+        </select>
+      </label>
+    </div>
+
     <div v-if="textureKind === 'eye'" class="add-row">
       <button v-for="t in addTypes" :key="t.id" type="button" @click="emit('add-layer', t.id)">
         {{ t.label }}
@@ -181,5 +245,48 @@ button.danger:disabled {
 }
 .en {
   display: flex;
+}
+.lid-opts {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.55rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.18);
+}
+.lid-title {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--ink);
+}
+.lid-opts .row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--ink-dim);
+}
+.lid-opts .row.check {
+  justify-content: flex-start;
+  gap: 0.4rem;
+}
+.lid-opts .num {
+  width: 4.5rem;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.75rem;
+  color: var(--ink);
+}
+.lid-opts select {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.75rem;
+  color: var(--ink);
 }
 </style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/TextureLayerPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/TextureLayerPanel.vue
@@ -5,6 +5,7 @@ const props = defineProps({
   layers: { type: Array, default: () => [] },
   selectedLayerId: { type: String, default: null },
   textureKind: { type: String, default: "eye" },
+  layerMode: { type: String, default: "edit" },
 });
 
 const emit = defineEmits([
@@ -16,6 +17,7 @@ const emit = defineEmits([
   "remove-layer",
   "set-color",
   "patch-layer",
+  "set-layer-mode",
 ]);
 
 const addTypes = [
@@ -35,9 +37,26 @@ const eyelidSelected = computed(() => selected.value?.type === "eyelid");
       <h2>Layers</h2>
       <span>{{ layers.length }}</span>
     </header>
+    <div class="mode-row">
+      <button
+        type="button"
+        :class="{ active: layerMode === 'edit', primary: layerMode === 'edit' }"
+        title="Edit knots and Bezier handles"
+        @click="emit('set-layer-mode', 'edit')"
+      >
+        Edit
+      </button>
+      <button
+        type="button"
+        :class="{ active: layerMode === 'move', primary: layerMode === 'move' }"
+        title="Drag to translate the selected layer (iris also moves pupil)"
+        @click="emit('set-layer-mode', 'move')"
+      >
+        Move
+      </button>
+    </div>
     <p class="hint">
-      Named parts · enable/disable · reorder. Iris stays in the eyeball, pupil in the iris,
-      reflection in the eye; eyelid draws on top (clipped).
+      Edit = shape handles · Move = place layer (iris moves pupil with it). Reorder with ↑↓.
     </p>
     <ul class="list">
       <li
@@ -68,8 +87,8 @@ const eyelidSelected = computed(() => selected.value?.type === "eyelid");
           @click.stop
           @input="emit('set-color', L.id, $event.target.value)"
         />
-        <button type="button" title="Move up" @click.stop="emit('move-layer', L.id, -1)">↑</button>
-        <button type="button" title="Move down" @click.stop="emit('move-layer', L.id, 1)">↓</button>
+        <button type="button" title="Order up" @click.stop="emit('move-layer', L.id, -1)">↑</button>
+        <button type="button" title="Order down" @click.stop="emit('move-layer', L.id, 1)">↓</button>
         <button
           type="button"
           class="danger"
@@ -245,6 +264,17 @@ button.danger:disabled {
 }
 .en {
   display: flex;
+}
+.mode-row {
+  display: flex;
+  gap: 0.35rem;
+}
+.mode-row button {
+  flex: 1;
+  font-size: 0.78rem;
+}
+.mode-row button.active {
+  outline: 1px solid rgba(126, 207, 106, 0.55);
 }
 .lid-opts {
   display: grid;

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/TexturePreview.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/TexturePreview.vue
@@ -1,13 +1,29 @@
 <script setup>
-import { onMounted, onBeforeUnmount, ref, watch } from "vue";
-import { renderEyeTexture } from "../lib/texture/eyeTexture.js";
+import { onMounted, onBeforeUnmount, ref, watch, computed } from "vue";
+import { renderEyeTexture, normalizeEyePair } from "../lib/texture/eyeTexture.js";
 
 const props = defineProps({
   texture: { type: Object, default: null },
-  size: { type: Number, default: 256 },
+  /** Square eye cell size; pair canvas is wider. */
+  size: { type: Number, default: 220 },
+  pair: { type: Boolean, default: true },
+  editSide: { type: String, default: "both" },
+  distance: { type: Number, default: 0.35 },
 });
 
+const emit = defineEmits(["update-distance"]);
+
 const canvasRef = ref(null);
+
+const pairInfo = computed(() => normalizeEyePair(props.texture?.eyePair));
+
+const canvasW = computed(() => {
+  if (!props.pair) return props.size;
+  const gap = Math.round(8 + (props.distance ?? pairInfo.value.distance) * props.size * 0.45);
+  return props.size * 2 + gap + 24;
+});
+
+const canvasH = computed(() => props.size + 16);
 
 function paint() {
   const c = canvasRef.value;
@@ -23,22 +39,24 @@ function paint() {
     return;
   }
   if (props.texture.kind === "eye") {
-    renderEyeTexture(ctx, props.texture);
+    renderEyeTexture(ctx, props.texture, {
+      pair: props.pair,
+      editSide: props.editSide || pairInfo.value.editSide,
+    });
   }
 }
 
-onMounted(paint);
+function syncSize() {
+  const c = canvasRef.value;
+  if (!c) return;
+  c.width = canvasW.value;
+  c.height = canvasH.value;
+  paint();
+}
+
+onMounted(syncSize);
 watch(() => props.texture, paint, { deep: true });
-watch(
-  () => props.size,
-  (s) => {
-    if (canvasRef.value) {
-      canvasRef.value.width = s;
-      canvasRef.value.height = s;
-      paint();
-    }
-  },
-);
+watch(() => [props.size, props.pair, props.distance, props.editSide], syncSize);
 
 onBeforeUnmount(() => {});
 </script>
@@ -47,12 +65,23 @@ onBeforeUnmount(() => {});
   <section class="panel">
     <header>
       <h2>Texture preview</h2>
-      <span>dynamic · params only</span>
+      <span>{{ pair ? "left · right" : "dynamic" }}</span>
     </header>
-    <canvas ref="canvasRef" class="view" :width="size" :height="size" />
+    <canvas ref="canvasRef" class="view" :class="{ pair }" />
+    <label v-if="pair" class="dist">
+      Eye distance
+      <input
+        type="range"
+        min="0"
+        max="1"
+        step="0.02"
+        :value="distance"
+        @input="emit('update-distance', Number($event.target.value))"
+      />
+    </label>
     <p class="hint">
-      Rasterized at runtime from layer params (animatable). Mesh assign / UV projection comes later —
-      background from vertex colours when applied.
+      Left &amp; right eyes from params. Linked eyes stay mirror images — unlink to edit
+      separately, or Reset to mirror image.
     </p>
   </section>
 </template>
@@ -90,6 +119,23 @@ span {
   border: 1px solid var(--line);
   background: #0a0e0c;
   display: block;
+}
+.view.pair {
+  width: min(100%, 420px);
+  aspect-ratio: auto;
+  height: auto;
+}
+.dist {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.55rem;
+  align-items: center;
+  width: 100%;
+  font-size: 0.72rem;
+  color: var(--ink-dim);
+}
+.dist input {
+  width: 100%;
 }
 .hint {
   margin: 0;

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
@@ -10,6 +10,11 @@ import {
   serializeEyeTexture,
   constrainEyeLayer,
   constrainAllEyeLayers,
+  editableLayers,
+  translateLayerTree,
+  mirrorLayersX,
+  resetEyePairToMirror,
+  normalizeEyePair,
   EYE_LAYER_TYPES,
 } from "../lib/texture/eyeTexture.js";
 import { usePathEditor } from "./usePathEditor.js";
@@ -29,6 +34,8 @@ export function useTextureEditor() {
     symmetry: true,
     /** Recompute Bezier handles after moving a knot (smooth joins). */
     autoSmooth: true,
+    /** Layer panel: edit knots/handles vs translate whole layer (+nest). */
+    layerMode: "edit", // edit | move
     status: "Texture editor — params only (rasterized at runtime).",
   });
 
@@ -43,13 +50,38 @@ export function useTextureEditor() {
     state.selectedGuid ? state.textures[state.selectedGuid] || null : null,
   );
 
+  const layers = computed(() => editableLayers(selectedTexture.value));
+
   const selectedLayer = computed(() => {
-    const tex = selectedTexture.value;
-    if (!tex || !state.selectedLayerId) return null;
-    return tex.layers.find((L) => L.id === state.selectedLayerId) || null;
+    if (!state.selectedLayerId) return null;
+    return layers.value.find((L) => L.id === state.selectedLayerId) || null;
   });
 
-  const layers = computed(() => selectedTexture.value?.layers || []);
+  const eyePair = computed(() => normalizeEyePair(selectedTexture.value?.eyePair));
+
+  /** Canvas flips X when editing the linked right eye (storage stays left). */
+  const flipX = computed(() => {
+    const tex = selectedTexture.value;
+    if (!tex) return false;
+    const pair = normalizeEyePair(tex.eyePair);
+    return pair.linked && pair.editSide === "right";
+  });
+
+  function ensureEyePair(tex) {
+    if (!tex) return null;
+    tex.eyePair = normalizeEyePair(tex.eyePair);
+    return tex.eyePair;
+  }
+
+  function workingLayers() {
+    return editableLayers(selectedTexture.value);
+  }
+
+  function workingTex() {
+    const tex = selectedTexture.value;
+    if (!tex) return null;
+    return { layers: workingLayers() };
+  }
 
   function layerWantsSymmetry(layer) {
     return state.symmetry && layer && layer.type !== "eyelid" && layer.closed !== false;
@@ -68,13 +100,11 @@ export function useTextureEditor() {
 
   function applyPathPolish({ movedPoint = false } = {}) {
     const closed = path.state.closed;
-    // Only rewrite handles after moving a knot — never while dragging Bezier handles.
     if (movedPoint && state.autoSmooth) {
       autoSmoothHandles(path.state.knots, { closed });
     }
     if (layerWantsSymmetry(selectedLayer.value) && closed) {
       rebuildClosedYSymmetry(path.state.knots);
-      // Symmetry rebuild must not auto-smooth on handle edits (would wipe hx/hy).
       if (movedPoint && state.autoSmooth) {
         autoSmoothHandles(path.state.knots, { closed: true });
       }
@@ -90,15 +120,18 @@ export function useTextureEditor() {
     layer.knots = path.state.knots.map((k) => ({ ...k }));
     layer.segments = path.state.segments.map((s) => ({ ...s }));
     layer.color = layer.color || path.state.knots[0]?.color || layer.color;
-    constrainEyeLayer(tex, layer.id);
-    // Sync constrain/symmetry results back without wiping selection mid-drag
-    // (full loadPath was resetting selectedId and fighting handle drags).
+    constrainEyeLayer(workingTex(), layer.id);
     path.applyKnotsFrom(layer.knots);
     layer.segments = path.state.segments.map((s) => ({ ...s }));
   }
 
   watch(
-    () => [state.selectedGuid, state.selectedLayerId],
+    () => [
+      state.selectedGuid,
+      state.selectedLayerId,
+      selectedTexture.value?.eyePair?.editSide,
+      selectedTexture.value?.eyePair?.linked,
+    ],
     () => syncPathFromLayer(),
   );
 
@@ -116,7 +149,7 @@ export function useTextureEditor() {
   function selectTexture(guid) {
     state.selectedGuid = guid;
     const tex = state.textures[guid];
-    state.selectedLayerId = tex?.layers?.[0]?.id || null;
+    state.selectedLayerId = editableLayers(tex)[0]?.id || null;
     syncPathFromLayer();
   }
 
@@ -125,33 +158,33 @@ export function useTextureEditor() {
     syncPathFromLayer();
   }
 
+  function findWorkingLayer(layerId) {
+    return workingLayers().find((x) => x.id === layerId) || null;
+  }
+
   function renameLayer(layerId, name) {
-    const tex = selectedTexture.value;
-    const L = tex?.layers.find((x) => x.id === layerId);
+    const L = findWorkingLayer(layerId);
     if (!L) return;
     L.name = String(name || L.type).trim() || L.type;
   }
 
   function setLayerEnabled(layerId, enabled) {
-    const L = selectedTexture.value?.layers.find((x) => x.id === layerId);
+    const L = findWorkingLayer(layerId);
     if (!L) return;
     L.enabled = !!enabled;
   }
 
   function setLayerColor(layerId, color) {
-    const L = selectedTexture.value?.layers.find((x) => x.id === layerId);
+    const L = findWorkingLayer(layerId);
     if (!L) return;
     L.color = color;
     for (const k of L.knots || []) k.color = color;
   }
 
-  /** Patch eyelid (or other) layer fields: border, borderWidth, borderColor, fillSide, … */
   function patchLayer(layerId, patch) {
-    const L = selectedTexture.value?.layers.find((x) => x.id === layerId);
+    const L = findWorkingLayer(layerId);
     if (!L || !patch || typeof patch !== "object") return;
-    if (patch.color != null) {
-      setLayerColor(layerId, patch.color);
-    }
+    if (patch.color != null) setLayerColor(layerId, patch.color);
     if (patch.fillSide != null && L.type === "eyelid") {
       L.fillSide = patch.fillSide === "below" ? "below" : "above";
     }
@@ -166,36 +199,34 @@ export function useTextureEditor() {
   }
 
   function moveLayer(layerId, dir) {
-    const tex = selectedTexture.value;
-    if (!tex) return;
-    const i = tex.layers.findIndex((L) => L.id === layerId);
+    const list = workingLayers();
+    const i = list.findIndex((L) => L.id === layerId);
     if (i < 0) return;
     const j = i + dir;
-    if (j < 0 || j >= tex.layers.length) return;
-    const [row] = tex.layers.splice(i, 1);
-    tex.layers.splice(j, 0, row);
+    if (j < 0 || j >= list.length) return;
+    const [row] = list.splice(i, 1);
+    list.splice(j, 0, row);
   }
 
   function addLayer(type) {
     const tex = selectedTexture.value;
     if (!tex || tex.kind !== "eye") return null;
     if (!EYE_LAYER_TYPES.includes(type)) return null;
-    // One of each core type preferred; allow extra eyelids
-    if (type !== "eyelid" && tex.layers.some((L) => L.type === type)) {
+    const list = workingLayers();
+    if (type !== "eyelid" && list.some((L) => L.type === type)) {
       state.status = `Layer type “${type}” already exists — select it to edit.`;
-      const existing = tex.layers.find((L) => L.type === type);
+      const existing = list.find((L) => L.type === type);
       if (existing) selectLayer(existing.id);
       return existing;
     }
     const layer = createEyeLayer(type);
     if (type === "eyelid") layer.enabled = true;
-    // Insert eyelid near top; others after eyeball
-    if (type === "eyelid") tex.layers.push(layer);
+    if (type === "eyelid") list.push(layer);
     else {
-      const eyeballIdx = tex.layers.findIndex((L) => L.type === "eyeball");
-      tex.layers.splice(eyeballIdx + 1, 0, layer);
+      const eyeballIdx = list.findIndex((L) => L.type === "eyeball");
+      list.splice(eyeballIdx + 1, 0, layer);
     }
-    constrainEyeLayer(tex, layer.id);
+    constrainEyeLayer(workingTex(), layer.id);
     selectLayer(layer.id);
     state.status = `Added “${layer.name}”.`;
     return layer;
@@ -204,17 +235,107 @@ export function useTextureEditor() {
   function removeLayer(layerId) {
     const tex = selectedTexture.value;
     if (!tex) return;
-    const L = tex.layers.find((x) => x.id === layerId);
+    const list = workingLayers();
+    const L = list.find((x) => x.id === layerId);
     if (!L) return;
     if (L.type === "eyeball") {
       state.status = "Eyeball layer is required.";
       return;
     }
-    tex.layers = tex.layers.filter((x) => x.id !== layerId);
+    const next = list.filter((x) => x.id !== layerId);
+    const pair = ensureEyePair(tex);
+    if (pair.editSide === "right" && !pair.linked) tex.rightLayers = next;
+    else tex.layers = next;
     if (state.selectedLayerId === layerId) {
-      state.selectedLayerId = tex.layers[0]?.id || null;
+      state.selectedLayerId = next[0]?.id || null;
       syncPathFromLayer();
     }
+  }
+
+  function setLayerMode(mode) {
+    state.layerMode = mode === "move" ? "move" : "edit";
+    if (state.layerMode === "move") path.setToolMode("move");
+    else if (path.state.toolMode === "move") path.setToolMode("edit");
+  }
+
+  function translateSelectedLayer(dx, dy) {
+    const layer = selectedLayer.value;
+    if (!layer) return;
+    // SplineCanvas flipX already maps pointer → storage-space world coords.
+    translateLayerTree(workingLayers(), layer.id, dx, dy);
+    syncPathFromLayer();
+  }
+
+  function onTranslatePath(dx, dy) {
+    path.beginGesture("move-layer");
+    translateSelectedLayer(dx, dy);
+  }
+
+  function setEditSide(side) {
+    const tex = selectedTexture.value;
+    if (!tex) return;
+    const pair = ensureEyePair(tex);
+    if (side === "both") {
+      pair.editSide = "both";
+      pair.linked = true;
+      tex.rightLayers = null;
+    } else if (side === "left") {
+      pair.editSide = "left";
+    } else if (side === "right") {
+      pair.editSide = "right";
+      if (!pair.linked) {
+        if (!Array.isArray(tex.rightLayers) || !tex.rightLayers.length) {
+          tex.rightLayers = mirrorLayersX(tex.layers);
+        }
+      }
+    }
+    // Remap selection by type across stacks
+    const prevType = selectedLayer.value?.type;
+    const list = editableLayers(tex);
+    state.selectedLayerId =
+      (prevType && list.find((L) => L.type === prevType)?.id) || list[0]?.id || null;
+    syncPathFromLayer();
+    state.status =
+      pair.editSide === "both"
+        ? "Editing both eyes (linked mirrors)."
+        : `Editing ${pair.editSide} eye${pair.linked ? " (linked mirror)" : ""}.`;
+  }
+
+  function setEyeLinked(linked) {
+    const tex = selectedTexture.value;
+    if (!tex) return;
+    const pair = ensureEyePair(tex);
+    if (linked) {
+      resetEyePairToMirror(tex, "left");
+      pair.editSide = pair.editSide === "right" ? "both" : pair.editSide;
+      state.status = "Eyes linked — right is a mirror of left.";
+    } else {
+      pair.linked = false;
+      if (pair.editSide === "both") pair.editSide = "left";
+      tex.rightLayers = mirrorLayersX(tex.layers);
+      state.status = "Eyes unlinked — left and right can differ.";
+    }
+    syncPathFromLayer();
+  }
+
+  function setInterEyeDistance(value) {
+    const tex = selectedTexture.value;
+    if (!tex) return;
+    const pair = ensureEyePair(tex);
+    const d = Number(value);
+    pair.distance = Number.isFinite(d) ? Math.min(1, Math.max(0, d)) : pair.distance;
+  }
+
+  function resetToMirrorImage() {
+    const tex = selectedTexture.value;
+    if (!tex) return;
+    const pair = ensureEyePair(tex);
+    const source = pair.editSide === "right" ? "right" : "left";
+    resetEyePairToMirror(tex, source);
+    pair.editSide = "both";
+    state.selectedLayerId = tex.layers[0]?.id || null;
+    syncPathFromLayer();
+    state.status = "Reset to mirror image — both eyes linked.";
   }
 
   function symmetryAxisX() {
@@ -223,11 +344,9 @@ export function useTextureEditor() {
     return pathCentroid(knots).x;
   }
 
-  /** True if the current gesture moved a knot (not only Bezier handles). */
   let gestureMovedPoint = false;
 
   function onPathKnotUpdate(id, patch) {
-    // With symmetry, keep edits on the right half relative to path centroid.
     if (layerWantsSymmetry(selectedLayer.value) && patch.x != null) {
       const ax = symmetryAxisX();
       patch = { ...patch, x: Math.max(ax, Number(patch.x) || 0) };
@@ -240,7 +359,10 @@ export function useTextureEditor() {
 
   function onPathDragEnd() {
     path.endGesture();
-    // Auto-smooth only after knot moves — handle-only drags must keep hx/hy.
+    if (state.layerMode === "move") {
+      gestureMovedPoint = false;
+      return;
+    }
     pushPathToLayer({ movedPoint: gestureMovedPoint });
     gestureMovedPoint = false;
   }
@@ -269,7 +391,7 @@ export function useTextureEditor() {
     delete state.textures[state.selectedGuid];
     const keys = Object.keys(state.textures);
     state.selectedGuid = keys[0] || null;
-    state.selectedLayerId = selectedTexture.value?.layers?.[0]?.id || null;
+    state.selectedLayerId = editableLayers(selectedTexture.value)[0]?.id || null;
     syncPathFromLayer();
   }
 
@@ -293,24 +415,23 @@ export function useTextureEditor() {
     }
     const keys = Object.keys(state.textures);
     state.selectedGuid = keys[0] || null;
-    state.selectedLayerId = selectedTexture.value?.layers?.[0]?.id || null;
+    state.selectedLayerId = editableLayers(selectedTexture.value)[0]?.id || null;
     syncPathFromLayer();
   }
 
-  /** Path editor presents as closed for non-eyelid layers. */
   const pathClosed = computed(() => selectedLayer.value?.type !== "eyelid");
 
-  /**
-   * Canvas clamp for symmetry: only force world x≥0 for eyeball (centred on 0).
-   * Off-centre iris/pupil still get centroid-based rebuild after edits.
-   */
   const clampNonNegativeX = computed(() => {
     const layer = selectedLayer.value;
     return layerWantsSymmetry(layer) && layer?.type === "eyeball";
   });
 
-  // Real left knots are stored (rebuilt from the right); no ghost-mirror overlay.
   const showMirror = computed(() => false);
+
+  const canvasToolMode = computed(() => {
+    if (state.layerMode === "move") return "move";
+    return path.state.toolMode;
+  });
 
   return {
     state,
@@ -318,6 +439,9 @@ export function useTextureEditor() {
     selectedTexture,
     selectedLayer,
     layers,
+    eyePair,
+    flipX,
+    canvasToolMode,
     pathClosed,
     clampNonNegativeX,
     showMirror,
@@ -331,6 +455,12 @@ export function useTextureEditor() {
     moveLayer,
     addLayer,
     removeLayer,
+    setLayerMode,
+    onTranslatePath,
+    setEditSide,
+    setEyeLinked,
+    setInterEyeDistance,
+    resetToMirrorImage,
     onPathKnotUpdate,
     onPathDragEnd,
     onPathAdd,

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
@@ -145,6 +145,26 @@ export function useTextureEditor() {
     for (const k of L.knots || []) k.color = color;
   }
 
+  /** Patch eyelid (or other) layer fields: border, borderWidth, borderColor, fillSide, … */
+  function patchLayer(layerId, patch) {
+    const L = selectedTexture.value?.layers.find((x) => x.id === layerId);
+    if (!L || !patch || typeof patch !== "object") return;
+    if (patch.color != null) {
+      setLayerColor(layerId, patch.color);
+    }
+    if (patch.fillSide != null && L.type === "eyelid") {
+      L.fillSide = patch.fillSide === "below" ? "below" : "above";
+    }
+    if (L.type === "eyelid") {
+      if (patch.border != null) L.border = !!patch.border;
+      if (patch.borderWidth != null) {
+        const w = Number(patch.borderWidth);
+        if (Number.isFinite(w)) L.borderWidth = Math.min(0.25, Math.max(0.005, w));
+      }
+      if (patch.borderColor != null) L.borderColor = String(patch.borderColor);
+    }
+  }
+
   function moveLayer(layerId, dir) {
     const tex = selectedTexture.value;
     if (!tex) return;
@@ -307,6 +327,7 @@ export function useTextureEditor() {
     renameLayer,
     setLayerEnabled,
     setLayerColor,
+    patchLayer,
     moveLayer,
     addLayer,
     removeLayer,

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -59,14 +59,17 @@ export function createEyeLayer(type, overrides = {}) {
     }),
     eyelid: () => ({
       name: "Eyelid",
-      color: "#c4a484",
+      color: "#c4a484", // fill
       closed: false,
       fillSide: "above", // above | below — region clipped to eyeball
+      border: false,
+      borderWidth: 0.035, // authoring units → stroke in texture space
+      borderColor: "#6e4f38",
       ...makeOpenArcPath({ y: 0.12, halfWidth: 0.7, bulge: 0.28, color: "#c4a484" }),
     }),
   };
   const base = (defaults[type] || defaults.eyeball)();
-  return {
+  const layer = {
     id: layerId(),
     type,
     name: overrides.name || base.name,
@@ -78,6 +81,23 @@ export function createEyeLayer(type, overrides = {}) {
     segments: overrides.segments || base.segments,
     clipTo: EYE_CLIP_PARENT[type] ?? null,
   };
+  if (type === "eyelid") {
+    layer.border = overrides.border != null ? !!overrides.border : !!base.border;
+    layer.borderWidth =
+      overrides.borderWidth != null ? Number(overrides.borderWidth) : Number(base.borderWidth) || 0.035;
+    layer.borderColor = overrides.borderColor || base.borderColor || "#6e4f38";
+  }
+  return layer;
+}
+
+/** Clamp / normalize eyelid stroke fields (params only). */
+export function normalizeEyelidBorder(L) {
+  if (!L || L.type !== "eyelid") return L;
+  L.border = !!L.border;
+  const w = Number(L.borderWidth);
+  L.borderWidth = Number.isFinite(w) ? Math.min(0.25, Math.max(0.005, w)) : 0.035;
+  L.borderColor = typeof L.borderColor === "string" && L.borderColor ? L.borderColor : "#6e4f38";
+  return L;
 }
 
 export function createDefaultEyeTexture({ name = "Eye" } = {}) {
@@ -132,17 +152,27 @@ export function serializeEyeTexture(tex) {
     height: Number(tex.height) || 256,
     backgroundFrom: tex.backgroundFrom === "solid" ? "solid" : "vertexColors",
     previewBackground: tex.previewBackground || "#6a8f6a",
-    layers: (tex.layers || []).map((L) => ({
-      id: L.id,
-      type: EYE_LAYER_TYPES.includes(L.type) ? L.type : "eyeball",
-      name: L.name || L.type,
-      enabled: L.enabled !== false,
-      color: L.color || "#ffffff",
-      closed: L.closed !== false && L.type !== "eyelid",
-      fillSide: L.fillSide === "below" ? "below" : L.type === "eyelid" ? "above" : null,
-      clipTo: L.clipTo || EYE_CLIP_PARENT[L.type] || null,
-      ...serializePathBlock(L),
-    })),
+    layers: (tex.layers || []).map((L) => {
+      const type = EYE_LAYER_TYPES.includes(L.type) ? L.type : "eyeball";
+      const row = {
+        id: L.id,
+        type,
+        name: L.name || L.type,
+        enabled: L.enabled !== false,
+        color: L.color || "#ffffff",
+        closed: L.closed !== false && L.type !== "eyelid",
+        fillSide: L.fillSide === "below" ? "below" : type === "eyelid" ? "above" : null,
+        clipTo: L.clipTo || EYE_CLIP_PARENT[type] || null,
+        ...serializePathBlock(L),
+      };
+      if (type === "eyelid") {
+        const w = Number(L.borderWidth);
+        row.border = !!L.border;
+        row.borderWidth = Number.isFinite(w) ? Math.min(0.25, Math.max(0.005, w)) : 0.035;
+        row.borderColor = L.borderColor || "#6e4f38";
+      }
+      return row;
+    }),
   };
 }
 
@@ -156,7 +186,7 @@ export function normalizeEyeTexture(raw) {
       const type = EYE_LAYER_TYPES.includes(L.type) ? L.type : "eyeball";
       const def = createEyeLayer(type);
       const path = serializePathBlock(L.knots ? L : def);
-      return {
+      const row = {
         ...def,
         id: L.id || def.id,
         type,
@@ -172,6 +202,14 @@ export function normalizeEyeTexture(raw) {
             ? syncOpenSegments(path.knots, path.segments, "bezier")
             : syncClosedSegments(path.knots, path.segments, "bezier"),
       };
+      if (type === "eyelid") {
+        row.border = L.border != null ? !!L.border : !!def.border;
+        const bw = Number(L.borderWidth);
+        row.borderWidth = Number.isFinite(bw) ? bw : def.borderWidth;
+        row.borderColor = L.borderColor || def.borderColor;
+        normalizeEyelidBorder(row);
+      }
+      return row;
     });
   } else {
     layers = base.layers;
@@ -320,6 +358,26 @@ export function renderEyeTexture(ctx, tex, opts = {}) {
       ctx.closePath();
       ctx.fillStyle = layer.color || "#c4a484";
       ctx.fill();
+
+      // Optional crease stroke along the eyelid curve (separate border color)
+      if (layer.border) {
+        const pad = 0.08;
+        const worldSpan = 2 + 2 * pad;
+        const bw = Number(layer.borderWidth);
+        const worldW = Number.isFinite(bw) ? Math.min(0.25, Math.max(0.005, bw)) : 0.035;
+        const lineW = Math.max(1, (worldW / worldSpan) * w);
+        ctx.beginPath();
+        ctx.moveTo(x0, y0);
+        for (let i = 1; i < pts.length; i++) {
+          const [x, y] = worldToTex(pts[i].x, pts[i].y, w, h);
+          ctx.lineTo(x, y);
+        }
+        ctx.strokeStyle = layer.borderColor || "#6e4f38";
+        ctx.lineWidth = lineW;
+        ctx.lineCap = "round";
+        ctx.lineJoin = "round";
+        ctx.stroke();
+      }
     } else {
       if (layer.type === "iris" || layer.type === "pupil") {
         const parentType = layer.clipTo;

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -10,8 +10,19 @@ import {
   knotUid,
   syncClosedSegments,
   syncOpenSegments,
+  translatePath,
 } from "../pathModel.js";
 import { newGuid } from "../assetClone.js";
+
+/** Default left/right pair layout (preview + edit target). */
+export const DEFAULT_EYE_PAIR = {
+  /** Gap between eye centers in preview (0 = touching cells, 1 = wide). */
+  distance: 0.35,
+  /** When true, right eye is always a mirror of left (`layers`). */
+  linked: true,
+  /** Which side the editor targets: left | right | both (both ⇒ linked). */
+  editSide: "both",
+};
 
 export const EYE_LAYER_TYPES = ["eyeball", "iris", "pupil", "reflection", "eyelid"];
 
@@ -115,7 +126,122 @@ export function createDefaultEyeTexture({ name = "Eye" } = {}) {
     backgroundFrom: "vertexColors",
     previewBackground: "#6a8f6a",
     layers,
+    /** Independent right-eye stack when eyePair.linked === false. */
+    rightLayers: null,
+    eyePair: { ...DEFAULT_EYE_PAIR },
   };
+}
+
+export function normalizeEyePair(raw) {
+  const d = Number(raw?.distance);
+  const side = raw?.editSide;
+  return {
+    distance: Number.isFinite(d) ? Math.min(1, Math.max(0, d)) : DEFAULT_EYE_PAIR.distance,
+    linked: raw?.linked !== false,
+    editSide: side === "left" || side === "right" || side === "both" ? side : "both",
+  };
+}
+
+/** Deep-clone a layer stack (new knot object refs; keeps ids). */
+export function cloneLayers(layers) {
+  return (layers || []).map((L) => {
+    const path = serializePathBlock(L);
+    const row = {
+      id: L.id,
+      type: L.type,
+      name: L.name,
+      enabled: L.enabled !== false,
+      color: L.color,
+      closed: L.closed !== false && L.type !== "eyelid",
+      fillSide: L.fillSide ?? null,
+      clipTo: L.clipTo ?? EYE_CLIP_PARENT[L.type] ?? null,
+      knots: path.knots,
+      segments: path.segments,
+    };
+    if (L.type === "eyelid") {
+      row.border = !!L.border;
+      row.borderWidth = L.borderWidth;
+      row.borderColor = L.borderColor;
+      normalizeEyelidBorder(row);
+    }
+    return row;
+  });
+}
+
+/** Mirror a layer stack about local X = 0 (left ↔ right eye). */
+export function mirrorLayersX(layers) {
+  return cloneLayers(layers).map((L) => {
+    for (const k of L.knots) {
+      k.x = -k.x;
+      k.hx = -k.hx;
+    }
+    return L;
+  });
+}
+
+/** Types that translate together when the root layer moves. */
+export function companionLayerTypes(type) {
+  if (type === "eyeball") return ["iris", "pupil", "reflection", "eyelid"];
+  if (type === "iris") return ["pupil"];
+  return [];
+}
+
+/**
+ * Layer list currently shown/edited for this texture + eyePair settings.
+ * Left/`both`/linked → `tex.layers`; unlinked right → `tex.rightLayers`.
+ */
+export function editableLayers(tex) {
+  if (!tex) return [];
+  const pair = normalizeEyePair(tex.eyePair);
+  if (pair.editSide === "right" && !pair.linked && Array.isArray(tex.rightLayers)) {
+    return tex.rightLayers;
+  }
+  return tex.layers || [];
+}
+
+/** Layers used to draw the right eye in the pair preview. */
+export function rightEyeLayers(tex) {
+  if (!tex) return [];
+  const pair = normalizeEyePair(tex.eyePair);
+  if (pair.linked || !Array.isArray(tex.rightLayers) || !tex.rightLayers.length) {
+    return mirrorLayersX(tex.layers);
+  }
+  return tex.rightLayers;
+}
+
+/**
+ * Translate a layer and nested companions (iris → pupil, eyeball → all).
+ * @param {object[]} layers
+ * @param {string} layerId
+ * @param {number} dx
+ * @param {number} dy
+ */
+export function translateLayerTree(layers, layerId, dx, dy) {
+  if (!layers?.length || (!dx && !dy)) return;
+  const root = findLayer(layers, layerId);
+  if (!root) return;
+  const types = new Set([root.type, ...companionLayerTypes(root.type)]);
+  for (const L of layers) {
+    if (types.has(L.type) && L.knots?.length) translatePath(L.knots, dx, dy);
+  }
+  const fake = { layers };
+  for (const order of ["iris", "pupil", "reflection"]) {
+    if (!types.has(order)) continue;
+    const L = findLayer(layers, order);
+    if (L) constrainEyeLayer(fake, L.id);
+  }
+}
+
+/** Force right = mirror(left) and re-link. */
+export function resetEyePairToMirror(tex, source = "left") {
+  if (!tex) return;
+  tex.eyePair = normalizeEyePair(tex.eyePair);
+  if (source === "right" && Array.isArray(tex.rightLayers) && tex.rightLayers.length) {
+    tex.layers = mirrorLayersX(tex.rightLayers);
+  }
+  tex.rightLayers = null;
+  tex.eyePair.linked = true;
+  if (tex.eyePair.editSide === "right") tex.eyePair.editSide = "both";
 }
 
 export function serializePathBlock(block) {
@@ -143,8 +269,61 @@ export function serializePathBlock(block) {
   };
 }
 
+function serializeLayerRow(L) {
+  const type = EYE_LAYER_TYPES.includes(L.type) ? L.type : "eyeball";
+  const row = {
+    id: L.id,
+    type,
+    name: L.name || L.type,
+    enabled: L.enabled !== false,
+    color: L.color || "#ffffff",
+    closed: L.closed !== false && type !== "eyelid",
+    fillSide: L.fillSide === "below" ? "below" : type === "eyelid" ? "above" : null,
+    clipTo: L.clipTo || EYE_CLIP_PARENT[type] || null,
+    ...serializePathBlock(L),
+  };
+  if (type === "eyelid") {
+    const w = Number(L.borderWidth);
+    row.border = !!L.border;
+    row.borderWidth = Number.isFinite(w) ? Math.min(0.25, Math.max(0.005, w)) : 0.035;
+    row.borderColor = L.borderColor || "#6e4f38";
+  }
+  return row;
+}
+
+function normalizeLayerRow(L) {
+  const type = EYE_LAYER_TYPES.includes(L.type) ? L.type : "eyeball";
+  const def = createEyeLayer(type);
+  const path = serializePathBlock(L.knots ? L : def);
+  const row = {
+    ...def,
+    id: L.id || def.id,
+    type,
+    name: L.name || def.name,
+    enabled: L.enabled !== false,
+    color: L.color || def.color,
+    closed: type !== "eyelid",
+    fillSide: type === "eyelid" ? (L.fillSide === "below" ? "below" : "above") : null,
+    clipTo: L.clipTo || EYE_CLIP_PARENT[type],
+    knots: path.knots,
+    segments:
+      type === "eyelid"
+        ? syncOpenSegments(path.knots, path.segments, "bezier")
+        : syncClosedSegments(path.knots, path.segments, "bezier"),
+  };
+  if (type === "eyelid") {
+    row.border = L.border != null ? !!L.border : !!def.border;
+    const bw = Number(L.borderWidth);
+    row.borderWidth = Number.isFinite(bw) ? bw : def.borderWidth;
+    row.borderColor = L.borderColor || def.borderColor;
+    normalizeEyelidBorder(row);
+  }
+  return row;
+}
+
 export function serializeEyeTexture(tex) {
-  return {
+  const pair = normalizeEyePair(tex.eyePair);
+  const out = {
     assetGuid: tex.assetGuid,
     name: tex.name || "Eye",
     kind: "eye",
@@ -152,68 +331,27 @@ export function serializeEyeTexture(tex) {
     height: Number(tex.height) || 256,
     backgroundFrom: tex.backgroundFrom === "solid" ? "solid" : "vertexColors",
     previewBackground: tex.previewBackground || "#6a8f6a",
-    layers: (tex.layers || []).map((L) => {
-      const type = EYE_LAYER_TYPES.includes(L.type) ? L.type : "eyeball";
-      const row = {
-        id: L.id,
-        type,
-        name: L.name || L.type,
-        enabled: L.enabled !== false,
-        color: L.color || "#ffffff",
-        closed: L.closed !== false && L.type !== "eyelid",
-        fillSide: L.fillSide === "below" ? "below" : type === "eyelid" ? "above" : null,
-        clipTo: L.clipTo || EYE_CLIP_PARENT[type] || null,
-        ...serializePathBlock(L),
-      };
-      if (type === "eyelid") {
-        const w = Number(L.borderWidth);
-        row.border = !!L.border;
-        row.borderWidth = Number.isFinite(w) ? Math.min(0.25, Math.max(0.005, w)) : 0.035;
-        row.borderColor = L.borderColor || "#6e4f38";
-      }
-      return row;
-    }),
+    layers: (tex.layers || []).map(serializeLayerRow),
+    eyePair: pair,
+    rightLayers: null,
   };
+  if (!pair.linked && Array.isArray(tex.rightLayers) && tex.rightLayers.length) {
+    out.rightLayers = tex.rightLayers.map(serializeLayerRow);
+  }
+  return out;
 }
 
 export function normalizeEyeTexture(raw) {
   if (!raw || typeof raw !== "object") return createDefaultEyeTexture();
   const base = createDefaultEyeTexture({ name: raw.name || "Eye" });
   const layersIn = Array.isArray(raw.layers) ? raw.layers : null;
-  let layers;
-  if (layersIn?.length) {
-    layers = layersIn.map((L) => {
-      const type = EYE_LAYER_TYPES.includes(L.type) ? L.type : "eyeball";
-      const def = createEyeLayer(type);
-      const path = serializePathBlock(L.knots ? L : def);
-      const row = {
-        ...def,
-        id: L.id || def.id,
-        type,
-        name: L.name || def.name,
-        enabled: L.enabled !== false,
-        color: L.color || def.color,
-        closed: type !== "eyelid",
-        fillSide: type === "eyelid" ? (L.fillSide === "below" ? "below" : "above") : null,
-        clipTo: L.clipTo || EYE_CLIP_PARENT[type],
-        knots: path.knots,
-        segments:
-          type === "eyelid"
-            ? syncOpenSegments(path.knots, path.segments, "bezier")
-            : syncClosedSegments(path.knots, path.segments, "bezier"),
-      };
-      if (type === "eyelid") {
-        row.border = L.border != null ? !!L.border : !!def.border;
-        const bw = Number(L.borderWidth);
-        row.borderWidth = Number.isFinite(bw) ? bw : def.borderWidth;
-        row.borderColor = L.borderColor || def.borderColor;
-        normalizeEyelidBorder(row);
-      }
-      return row;
-    });
-  } else {
-    layers = base.layers;
+  const layers = layersIn?.length ? layersIn.map(normalizeLayerRow) : base.layers;
+  const pair = normalizeEyePair(raw.eyePair);
+  let rightLayers = null;
+  if (!pair.linked && Array.isArray(raw.rightLayers) && raw.rightLayers.length) {
+    rightLayers = raw.rightLayers.map(normalizeLayerRow);
   }
+  if (pair.editSide === "both") pair.linked = true;
   return {
     assetGuid: raw.assetGuid || base.assetGuid,
     name: raw.name || base.name,
@@ -223,11 +361,14 @@ export function normalizeEyeTexture(raw) {
     backgroundFrom: raw.backgroundFrom === "solid" ? "solid" : "vertexColors",
     previewBackground: raw.previewBackground || base.previewBackground,
     layers,
+    rightLayers,
+    eyePair: pair,
   };
 }
 
-export function findLayer(tex, typeOrId) {
-  return (tex.layers || []).find((L) => L.id === typeOrId || L.type === typeOrId) || null;
+export function findLayer(texOrLayers, typeOrId) {
+  const layers = Array.isArray(texOrLayers) ? texOrLayers : texOrLayers?.layers || [];
+  return layers.find((L) => L.id === typeOrId || L.type === typeOrId) || null;
 }
 
 export function layerPolygon(layer, samplesPerSpan = 20) {
@@ -290,27 +431,17 @@ function tracePath(ctx, pts, w, h, closed) {
 }
 
 /**
- * Render eye texture params into a 2D canvas context (dynamic — no bake).
+ * Draw one eye's layers into a w×h pixel rect (no background clear).
  * @param {CanvasRenderingContext2D} ctx
- * @param {object} tex normalizeEyeTexture result
- * @param {{ background?: string }} [opts]
+ * @param {object[]} layers
+ * @param {number} w
+ * @param {number} h
  */
-export function renderEyeTexture(ctx, tex, opts = {}) {
-  const w = ctx.canvas.width;
-  const h = ctx.canvas.height;
-  const bg =
-    opts.background ||
-    (tex.backgroundFrom === "solid" ? tex.previewBackground : tex.previewBackground) ||
-    "#6a8f6a";
-  ctx.clearRect(0, 0, w, h);
-  ctx.fillStyle = bg;
-  ctx.fillRect(0, 0, w, h);
-
-  const eyeball = findLayer(tex, "eyeball");
+export function drawEyeLayers(ctx, layers, w, h) {
+  const eyeball = findLayer(layers, "eyeball");
   const eyePoly = eyeball ? layerPolygon(eyeball) : [];
 
-  const drawOrder = [...(tex.layers || [])];
-  // Ensure eyelid after iris/pupil/reflection
+  const drawOrder = [...(layers || [])];
   drawOrder.sort((a, b) => {
     const rank = (t) => {
       const i = EYE_DEFAULT_ORDER.indexOf(t);
@@ -335,7 +466,6 @@ export function renderEyeTexture(ctx, tex, opts = {}) {
     }
 
     if (layer.type === "eyelid") {
-      // Fill region above/below curve, clipped to eyeball
       const side = layer.fillSide === "below" ? "below" : "above";
       const [x0, y0] = worldToTex(pts[0].x, pts[0].y, w, h);
       ctx.beginPath();
@@ -359,7 +489,6 @@ export function renderEyeTexture(ctx, tex, opts = {}) {
       ctx.fillStyle = layer.color || "#c4a484";
       ctx.fill();
 
-      // Optional crease stroke along the eyelid curve (separate border color)
       if (layer.border) {
         const pad = 0.08;
         const worldSpan = 2 + 2 * pad;
@@ -381,7 +510,7 @@ export function renderEyeTexture(ctx, tex, opts = {}) {
     } else {
       if (layer.type === "iris" || layer.type === "pupil") {
         const parentType = layer.clipTo;
-        const parent = parentType ? findLayer(tex, parentType) : null;
+        const parent = parentType ? findLayer(layers, parentType) : null;
         if (parent?.enabled !== false && parent) {
           const ppoly = layerPolygon(parent);
           if (ppoly.length >= 3) {
@@ -396,6 +525,87 @@ export function renderEyeTexture(ctx, tex, opts = {}) {
     }
     ctx.restore();
   }
+}
+
+/**
+ * Render eye texture params into a 2D canvas context (dynamic — no bake).
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {object} tex normalizeEyeTexture result
+ * @param {{ background?: string, pair?: boolean, editSide?: string }} [opts]
+ */
+export function renderEyeTexture(ctx, tex, opts = {}) {
+  const w = ctx.canvas.width;
+  const h = ctx.canvas.height;
+  const bg =
+    opts.background ||
+    (tex.backgroundFrom === "solid" ? tex.previewBackground : tex.previewBackground) ||
+    "#6a8f6a";
+  ctx.clearRect(0, 0, w, h);
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, w, h);
+
+  if (opts.pair) {
+    renderEyePairPreview(ctx, tex, opts);
+    return;
+  }
+  drawEyeLayers(ctx, tex.layers || [], w, h);
+}
+
+/**
+ * Side-by-side left/right eyes. `eyePair.distance` grows the gap between cells.
+ */
+export function renderEyePairPreview(ctx, tex, opts = {}) {
+  const w = ctx.canvas.width;
+  const h = ctx.canvas.height;
+  const pair = normalizeEyePair(tex.eyePair);
+  const editSide = opts.editSide || pair.editSide;
+  const gap = Math.round(8 + pair.distance * Math.min(w, h) * 0.45);
+  const cell = Math.max(32, Math.min(h - 8, Math.floor((w - gap) / 2)));
+  const total = cell * 2 + gap;
+  const x0 = Math.floor((w - total) / 2);
+  const y0 = Math.floor((h - cell) / 2);
+
+  const left = tex.layers || [];
+  const right = rightEyeLayers(tex);
+
+  function blit(layers, x, active) {
+    if (typeof document === "undefined") {
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(x, y0, cell, cell);
+      ctx.clip();
+      ctx.translate(x, y0);
+      const sx = cell / Math.max(cell, 1);
+      ctx.scale(sx, sx);
+      drawEyeLayers(ctx, layers, cell, cell);
+      ctx.restore();
+    } else {
+      const off = document.createElement("canvas");
+      off.width = cell;
+      off.height = cell;
+      const octx = off.getContext("2d");
+      octx.fillStyle = ctx.fillStyle;
+      // Transparent over already-filled bg — draw eye only
+      drawEyeLayers(octx, layers, cell, cell);
+      ctx.drawImage(off, x, y0);
+    }
+    if (active) {
+      ctx.strokeStyle = "rgba(200,232,122,0.85)";
+      ctx.lineWidth = 2;
+      ctx.strokeRect(x + 1, y0 + 1, cell - 2, cell - 2);
+    }
+  }
+
+  const activeLeft = editSide === "left" || editSide === "both";
+  const activeRight = editSide === "right" || editSide === "both";
+  blit(left, x0, activeLeft);
+  blit(right, x0 + cell + gap, activeRight);
+
+  ctx.fillStyle = "rgba(200,220,200,0.55)";
+  ctx.font = `${Math.max(10, Math.round(cell * 0.06))}px sans-serif`;
+  ctx.textAlign = "center";
+  ctx.fillText("L", x0 + cell / 2, y0 + cell - 6);
+  ctx.fillText("R", x0 + cell + gap + cell / 2, y0 + cell - 6);
 }
 
 /** Offscreen render → ImageData (for tests / future mesh assign). */

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -136,18 +136,28 @@ function serializeChild(ch) {
 function serializeTextureAsset(tex) {
   if (!tex || typeof tex !== "object") return null;
   const kind = tex.kind === "eye" ? "eye" : String(tex.kind || "eye");
-  const layers = (tex.layers || []).map((L) => ({
-    id: L.id,
-    type: L.type || "eyeball",
-    name: L.name || L.type || "layer",
-    enabled: L.enabled !== false,
-    color: L.color || "#ffffff",
-    closed: L.closed !== false && L.type !== "eyelid",
-    fillSide: L.fillSide === "below" ? "below" : L.type === "eyelid" ? "above" : null,
-    clipTo: L.clipTo || null,
-    knots: (L.knots || []).map(serializeKnot),
-    segments: (L.segments || []).map(serializeSegment),
-  }));
+  const layers = (tex.layers || []).map((L) => {
+    const type = L.type || "eyeball";
+    const row = {
+      id: L.id,
+      type,
+      name: L.name || L.type || "layer",
+      enabled: L.enabled !== false,
+      color: L.color || "#ffffff",
+      closed: L.closed !== false && type !== "eyelid",
+      fillSide: L.fillSide === "below" ? "below" : type === "eyelid" ? "above" : null,
+      clipTo: L.clipTo || null,
+      knots: (L.knots || []).map(serializeKnot),
+      segments: (L.segments || []).map(serializeSegment),
+    };
+    if (type === "eyelid") {
+      const w = Number(L.borderWidth);
+      row.border = !!L.border;
+      row.borderWidth = Number.isFinite(w) ? Math.min(0.25, Math.max(0.005, w)) : 0.035;
+      row.borderColor = L.borderColor || "#6e4f38";
+    }
+    return row;
+  });
   return {
     assetGuid: tex.assetGuid,
     name: tex.name || "Texture",

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -2,6 +2,8 @@
 // schema.js — semantic spline-project document + versioned migrations.
 // ============================================================================
 
+import { serializeEyeTexture } from "../lib/texture/eyeTexture.js";
+
 export const CURRENT_SCHEMA_VERSION = 9;
 
 export const SCHEMA_KIND = "ranger.splineProject";
@@ -135,38 +137,18 @@ function serializeChild(ch) {
 /** Texture assets store editable params only (no baked pixels). */
 function serializeTextureAsset(tex) {
   if (!tex || typeof tex !== "object") return null;
-  const kind = tex.kind === "eye" ? "eye" : String(tex.kind || "eye");
-  const layers = (tex.layers || []).map((L) => {
-    const type = L.type || "eyeball";
-    const row = {
-      id: L.id,
-      type,
-      name: L.name || L.type || "layer",
-      enabled: L.enabled !== false,
-      color: L.color || "#ffffff",
-      closed: L.closed !== false && type !== "eyelid",
-      fillSide: L.fillSide === "below" ? "below" : type === "eyelid" ? "above" : null,
-      clipTo: L.clipTo || null,
-      knots: (L.knots || []).map(serializeKnot),
-      segments: (L.segments || []).map(serializeSegment),
-    };
-    if (type === "eyelid") {
-      const w = Number(L.borderWidth);
-      row.border = !!L.border;
-      row.borderWidth = Number.isFinite(w) ? Math.min(0.25, Math.max(0.005, w)) : 0.035;
-      row.borderColor = L.borderColor || "#6e4f38";
-    }
-    return row;
-  });
+  if (tex.kind === "eye" || !tex.kind) {
+    return serializeEyeTexture(tex);
+  }
   return {
     assetGuid: tex.assetGuid,
     name: tex.name || "Texture",
-    kind,
+    kind: String(tex.kind),
     width: Number(tex.width) || 256,
     height: Number(tex.height) || 256,
     backgroundFrom: tex.backgroundFrom === "solid" ? "solid" : "vertexColors",
     previewBackground: tex.previewBackground || "#6a8f6a",
-    layers,
+    layers: tex.layers || [],
   };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Builds on the eyelid border work and adds layer placement + dual-eye editing.

### Layers: Edit vs Move
- **Edit** — knots / Bezier handles (existing)
- **Move** — drag translates the whole selected layer
- Moving **iris** also moves **pupil**; moving **eyeball** moves nested parts (iris, pupil, reflection, eyelid)

### Left / right eye pair
- Preview renders **L** and **R** eyes side by side
- **Eye distance** slider in the preview
- Toolbar: **Left** / **Right** / **Both**, **Linked mirrors**, **Reset to mirror image**
- Linked (default / Both): right is always a mirror of left
- Unlinked: independent `rightLayers`; reset copies the active side as a mirror and re-links
- Editing linked **Right** flips the canvas so you work in right-eye view while storage stays left-canonical

### Also includes
- Optional eyelid border + separate fill/border colors (same as open #472 — this PR can supersede it)

### Try
1. Texture → Layers → **Move** → drag iris (pupil follows)
2. Preview: adjust distance; switch Left / Right / Both
3. Uncheck Linked mirrors, edit Right, then **Reset to mirror image**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

