### PR TITLE
Restore to circle + fix texture Undo/Redo

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -13,6 +13,8 @@ import {
   rightEyeLayers,
   resetEyePairToMirror,
   editableLayers,
+  restoreLayerToCircle,
+  EYE_CIRCLE_RADII,
 } from "../src/lib/texture/eyeTexture.js";
 import {
   pointInPolygon,
@@ -170,6 +172,25 @@ assert.ok(pointInPolygon(pc.x, pc.y, irisPoly), "pupil centroid inside iris afte
   assert.equal(e3.eyePair.linked, true);
   assert.equal(e3.rightLayers, null);
   assert.equal(editableLayers(e3), e3.layers);
+}
+
+// Restore to circle keeps center, resets radius to default
+{
+  const e4 = createDefaultEyeTexture({ name: "Restore" });
+  const pupil = findLayer(e4, "pupil");
+  const c0 = pathCentroid(pupil.knots);
+  for (const k of pupil.knots) {
+    k.x = c0.x + (k.x - c0.x) * 0.15;
+    k.y = c0.y + (k.y - c0.y) * 0.15;
+  }
+  assert.ok(restoreLayerToCircle(pupil, { keepCenter: true }));
+  const c1 = pathCentroid(pupil.knots);
+  assert.ok(Math.abs(c1.x - c0.x) < 1e-5 && Math.abs(c1.y - c0.y) < 1e-5, "center kept");
+  const tip = pupil.knots.reduce((a, k) => (k.x > a.x ? k : a), pupil.knots[0]);
+  assert.ok(
+    Math.abs(tip.x - (c1.x + EYE_CIRCLE_RADII.pupil.rx)) < 1e-5,
+    "pupil radius restored",
+  );
 }
 
 const ser = serializeEyeTexture(eye);

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -138,17 +138,20 @@ assert.ok(pointInPolygon(pc.x, pc.y, irisPoly), "pupil centroid inside iris afte
   assert.equal(lid2.color, "#aabbcc");
 }
 
-// Layer Move: translating iris also moves pupil
+// Layer Move: translating iris also moves pupil + reflection
 {
   const e2 = createDefaultEyeTexture({ name: "Move" });
   const iris = findLayer(e2, "iris");
   const pupil = findLayer(e2, "pupil");
+  const shine = findLayer(e2, "reflection");
   const ix = iris.knots[0].x;
   const px = pupil.knots[0].x;
+  const sx = shine.knots[0].x;
   translateLayerTree(e2.layers, iris.id, 0.1, 0);
   assert.ok(Math.abs(iris.knots[0].x - (ix + 0.1)) < 1e-6, "iris translated");
   assert.ok(Math.abs(pupil.knots[0].x - (px + 0.1)) < 1e-6, "pupil follows iris");
-  assert.deepEqual(companionLayerTypes("iris"), ["pupil"]);
+  assert.ok(Math.abs(shine.knots[0].x - (sx + 0.1)) < 1e-6, "reflection follows iris");
+  assert.deepEqual(companionLayerTypes("iris"), ["pupil", "reflection"]);
 }
 
 // Left/right pair: linked right is mirror; reset re-links

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -221,11 +221,11 @@ function onKeyDown(e) {
   const key = e.key.toLowerCase();
   if (key === "z" && !e.shiftKey) {
     e.preventDefault();
-    if (workspace.value === "texture") texPath.undo();
+    if (workspace.value === "texture") tex.undo();
     else onUndo();
   } else if ((key === "z" && e.shiftKey) || key === "y") {
     e.preventDefault();
-    if (workspace.value === "texture") texPath.redo();
+    if (workspace.value === "texture") tex.redo();
     else onRedo();
   }
 }
@@ -479,15 +479,15 @@ onBeforeUnmount(() => {
         </template>
         <template v-else>
           <button
-            @click="texPath.undo()"
-            :disabled="!texPath.state.history.canUndo"
+            @click="tex.undo()"
+            :disabled="!texState.history.canUndo"
             title="Ctrl+Z"
           >
             Undo
           </button>
           <button
-            @click="texPath.redo()"
-            :disabled="!texPath.state.history.canRedo"
+            @click="tex.redo()"
+            :disabled="!texState.history.canRedo"
             title="Ctrl+Shift+Z"
           >
             Redo
@@ -784,6 +784,7 @@ onBeforeUnmount(() => {
         @set-color="tex.setLayerColor"
         @patch-layer="tex.patchLayer"
         @set-layer-mode="tex.setLayerMode"
+        @restore-circle="tex.restoreLayerCircle"
       />
       <div class="side-stack">
         <TexturePreview

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/TextureLayerPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/TextureLayerPanel.vue
@@ -18,6 +18,7 @@ const emit = defineEmits([
   "set-color",
   "patch-layer",
   "set-layer-mode",
+  "restore-circle",
 ]);
 
 const addTypes = [
@@ -29,6 +30,12 @@ const addTypes = [
 
 const selected = computed(() => props.layers.find((L) => L.id === props.selectedLayerId) || null);
 const eyelidSelected = computed(() => selected.value?.type === "eyelid");
+const canRestoreCircle = computed(
+  () =>
+    !!selected.value &&
+    selected.value.type !== "eyelid" &&
+    selected.value.closed !== false,
+);
 </script>
 
 <template>
@@ -100,6 +107,18 @@ const eyelidSelected = computed(() => selected.value?.type === "eyelid");
         </button>
       </li>
     </ul>
+
+    <div v-if="canRestoreCircle" class="lid-opts">
+      <p class="lid-title">{{ selected.name || selected.type }}</p>
+      <button
+        type="button"
+        class="restore"
+        title="Rebuild as a round Bezier circle at the current center"
+        @click="emit('restore-circle', selected.id)"
+      >
+        Restore to circle
+      </button>
+    </div>
 
     <div v-if="eyelidSelected" class="lid-opts">
       <p class="lid-title">Eyelid</p>
@@ -318,5 +337,10 @@ button.danger:disabled {
   padding: 0.2rem 0.35rem;
   font-size: 0.75rem;
   color: var(--ink);
+}
+.lid-opts .restore {
+  width: 100%;
+  font-size: 0.75rem;
+  padding: 0.35rem 0.5rem;
 }
 </style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useTextureEditor.js
@@ -15,6 +15,7 @@ import {
   mirrorLayersX,
   resetEyePairToMirror,
   normalizeEyePair,
+  restoreLayerToCircle,
   EYE_LAYER_TYPES,
 } from "../lib/texture/eyeTexture.js";
 import { usePathEditor } from "./usePathEditor.js";
@@ -37,14 +38,19 @@ export function useTextureEditor() {
     /** Layer panel: edit knots/handles vs translate whole layer (+nest). */
     layerMode: "edit", // edit | move
     status: "Texture editor — params only (rasterized at runtime).",
+    history: { canUndo: false, canRedo: false },
   });
 
   const path = usePathEditor({
     closed: true,
-    // Canvas clamps via SplineCanvas prop; eyelid must allow signed X.
     clampNonNegativeX: false,
     viewport: { min: -1.2, max: 1.2 },
   });
+
+  /** Whole-texture undo (layers + eyePair) — path-only history can't undo Move/nest. */
+  let past = [];
+  let future = [];
+  let texGestureOpen = false;
 
   const selectedTexture = computed(() =>
     state.selectedGuid ? state.textures[state.selectedGuid] || null : null,
@@ -59,13 +65,92 @@ export function useTextureEditor() {
 
   const eyePair = computed(() => normalizeEyePair(selectedTexture.value?.eyePair));
 
-  /** Canvas flips X when editing the linked right eye (storage stays left). */
   const flipX = computed(() => {
     const tex = selectedTexture.value;
     if (!tex) return false;
     const pair = normalizeEyePair(tex.eyePair);
     return pair.linked && pair.editSide === "right";
   });
+
+  function refreshHistFlags() {
+    state.history.canUndo = past.length > 0;
+    state.history.canRedo = future.length > 0;
+  }
+
+  function cloneTexSnap(tex) {
+    return {
+      layers: JSON.parse(JSON.stringify(tex.layers || [])),
+      rightLayers: tex.rightLayers ? JSON.parse(JSON.stringify(tex.rightLayers)) : null,
+      eyePair: { ...normalizeEyePair(tex.eyePair) },
+      selectedLayerId: state.selectedLayerId,
+    };
+  }
+
+  function applyTexSnap(snap) {
+    const tex = selectedTexture.value;
+    if (!tex || !snap) return;
+    tex.layers = snap.layers;
+    tex.rightLayers = snap.rightLayers;
+    tex.eyePair = { ...snap.eyePair };
+    const list = editableLayers(tex);
+    state.selectedLayerId =
+      (snap.selectedLayerId && list.some((L) => L.id === snap.selectedLayerId)
+        ? snap.selectedLayerId
+        : null) ||
+      list[0]?.id ||
+      null;
+    syncPathFromLayer({ soft: false });
+    refreshHistFlags();
+  }
+
+  /** Snapshot current texture before a discrete edit (or first stroke of a gesture). */
+  function pushTexHistory() {
+    const tex = selectedTexture.value;
+    if (!tex) return;
+    past.push(cloneTexSnap(tex));
+    if (past.length > 80) past.shift();
+    future = [];
+    refreshHistFlags();
+  }
+
+  function beginTexGesture() {
+    if (texGestureOpen) return;
+    pushTexHistory();
+    texGestureOpen = true;
+  }
+
+  function endTexGesture() {
+    texGestureOpen = false;
+  }
+
+  function undo() {
+    const tex = selectedTexture.value;
+    if (!tex || !past.length) return false;
+    future.push(cloneTexSnap(tex));
+    applyTexSnap(past.pop());
+    texGestureOpen = false;
+    path.endGesture();
+    state.status = "Undo.";
+    return true;
+  }
+
+  function redo() {
+    const tex = selectedTexture.value;
+    if (!tex || !future.length) return false;
+    past.push(cloneTexSnap(tex));
+    applyTexSnap(future.pop());
+    texGestureOpen = false;
+    path.endGesture();
+    state.status = "Redo.";
+    return true;
+  }
+
+  function clearTexHistory() {
+    past = [];
+    future = [];
+    texGestureOpen = false;
+    refreshHistFlags();
+  }
 
   function ensureEyePair(tex) {
     if (!tex) return null;
@@ -87,7 +172,11 @@ export function useTextureEditor() {
     return state.symmetry && layer && layer.type !== "eyelid" && layer.closed !== false;
   }
 
-  function syncPathFromLayer() {
+  /**
+   * @param {{ soft?: boolean }} [opts] soft=true: update knots without wiping path history
+   *   (used mid Move-drag; texture history is the source of truth for Undo).
+   */
+  function syncPathFromLayer({ soft = false } = {}) {
     const layer = selectedLayer.value;
     if (!layer) {
       path.loadPath([], [], { closed: true });
@@ -95,7 +184,12 @@ export function useTextureEditor() {
       return;
     }
     const closed = layer.type !== "eyelid";
-    path.loadPath(layer.knots, layer.segments, { closed });
+    if (soft && path.state.knots.length === layer.knots.length && path.state.closed === closed) {
+      path.applyKnotsFrom(layer.knots);
+      path.state.segments = (layer.segments || []).map((s) => ({ ...s, textureData: null }));
+      return;
+    }
+    path.loadPath(layer.knots, layer.segments, { closed, preserveSelection: soft });
   }
 
   function applyPathPolish({ movedPoint = false } = {}) {
@@ -141,6 +235,7 @@ export function useTextureEditor() {
     state.selectedGuid = tex.assetGuid;
     state.selectedLayerId = tex.layers[0]?.id || null;
     constrainAllEyeLayers(tex);
+    clearTexHistory();
     syncPathFromLayer();
     state.status = `Created eye texture “${tex.name}”.`;
     return tex;
@@ -150,6 +245,7 @@ export function useTextureEditor() {
     state.selectedGuid = guid;
     const tex = state.textures[guid];
     state.selectedLayerId = editableLayers(tex)[0]?.id || null;
+    clearTexHistory();
     syncPathFromLayer();
   }
 
@@ -165,18 +261,21 @@ export function useTextureEditor() {
   function renameLayer(layerId, name) {
     const L = findWorkingLayer(layerId);
     if (!L) return;
+    pushTexHistory();
     L.name = String(name || L.type).trim() || L.type;
   }
 
   function setLayerEnabled(layerId, enabled) {
     const L = findWorkingLayer(layerId);
     if (!L) return;
+    pushTexHistory();
     L.enabled = !!enabled;
   }
 
   function setLayerColor(layerId, color) {
     const L = findWorkingLayer(layerId);
     if (!L) return;
+    pushTexHistory();
     L.color = color;
     for (const k of L.knots || []) k.color = color;
   }
@@ -184,7 +283,11 @@ export function useTextureEditor() {
   function patchLayer(layerId, patch) {
     const L = findWorkingLayer(layerId);
     if (!L || !patch || typeof patch !== "object") return;
-    if (patch.color != null) setLayerColor(layerId, patch.color);
+    pushTexHistory();
+    if (patch.color != null) {
+      L.color = patch.color;
+      for (const k of L.knots || []) k.color = patch.color;
+    }
     if (patch.fillSide != null && L.type === "eyelid") {
       L.fillSide = patch.fillSide === "below" ? "below" : "above";
     }
@@ -204,6 +307,7 @@ export function useTextureEditor() {
     if (i < 0) return;
     const j = i + dir;
     if (j < 0 || j >= list.length) return;
+    pushTexHistory();
     const [row] = list.splice(i, 1);
     list.splice(j, 0, row);
   }
@@ -219,6 +323,7 @@ export function useTextureEditor() {
       if (existing) selectLayer(existing.id);
       return existing;
     }
+    pushTexHistory();
     const layer = createEyeLayer(type);
     if (type === "eyelid") layer.enabled = true;
     if (type === "eyelid") list.push(layer);
@@ -242,6 +347,7 @@ export function useTextureEditor() {
       state.status = "Eyeball layer is required.";
       return;
     }
+    pushTexHistory();
     const next = list.filter((x) => x.id !== layerId);
     const pair = ensureEyePair(tex);
     if (pair.editSide === "right" && !pair.linked) tex.rightLayers = next;
@@ -250,6 +356,33 @@ export function useTextureEditor() {
       state.selectedLayerId = next[0]?.id || null;
       syncPathFromLayer();
     }
+  }
+
+  function restoreSelectedToCircle() {
+    const layer = selectedLayer.value;
+    if (!layer) return false;
+    if (layer.type === "eyelid") {
+      state.status = "Eyelid is an open curve — Restore to circle is for closed layers.";
+      return false;
+    }
+    pushTexHistory();
+    restoreLayerToCircle(layer, { keepCenter: true });
+    constrainEyeLayer(workingTex(), layer.id);
+    syncPathFromLayer();
+    state.status = `Restored “${layer.name}” to a circle.`;
+    return true;
+  }
+
+  function restoreLayerCircle(layerId) {
+    const L = findWorkingLayer(layerId);
+    if (!L) return false;
+    if (L.type === "eyelid") return false;
+    pushTexHistory();
+    restoreLayerToCircle(L, { keepCenter: true });
+    constrainEyeLayer(workingTex(), L.id);
+    if (state.selectedLayerId === layerId) syncPathFromLayer();
+    state.status = `Restored “${L.name}” to a circle.`;
+    return true;
   }
 
   function setLayerMode(mode) {
@@ -261,19 +394,19 @@ export function useTextureEditor() {
   function translateSelectedLayer(dx, dy) {
     const layer = selectedLayer.value;
     if (!layer) return;
-    // SplineCanvas flipX already maps pointer → storage-space world coords.
     translateLayerTree(workingLayers(), layer.id, dx, dy);
-    syncPathFromLayer();
+    syncPathFromLayer({ soft: true });
   }
 
   function onTranslatePath(dx, dy) {
-    path.beginGesture("move-layer");
+    beginTexGesture();
     translateSelectedLayer(dx, dy);
   }
 
   function setEditSide(side) {
     const tex = selectedTexture.value;
     if (!tex) return;
+    pushTexHistory();
     const pair = ensureEyePair(tex);
     if (side === "both") {
       pair.editSide = "both";
@@ -289,7 +422,6 @@ export function useTextureEditor() {
         }
       }
     }
-    // Remap selection by type across stacks
     const prevType = selectedLayer.value?.type;
     const list = editableLayers(tex);
     state.selectedLayerId =
@@ -304,6 +436,7 @@ export function useTextureEditor() {
   function setEyeLinked(linked) {
     const tex = selectedTexture.value;
     if (!tex) return;
+    pushTexHistory();
     const pair = ensureEyePair(tex);
     if (linked) {
       resetEyePairToMirror(tex, "left");
@@ -323,12 +456,16 @@ export function useTextureEditor() {
     if (!tex) return;
     const pair = ensureEyePair(tex);
     const d = Number(value);
-    pair.distance = Number.isFinite(d) ? Math.min(1, Math.max(0, d)) : pair.distance;
+    const next = Number.isFinite(d) ? Math.min(1, Math.max(0, d)) : pair.distance;
+    if (next === pair.distance) return;
+    // Distance is preview-only layout — don't spam history on every slider tick
+    pair.distance = next;
   }
 
   function resetToMirrorImage() {
     const tex = selectedTexture.value;
     if (!tex) return;
+    pushTexHistory();
     const pair = ensureEyePair(tex);
     const source = pair.editSide === "right" ? "right" : "left";
     resetEyePairToMirror(tex, source);
@@ -347,6 +484,7 @@ export function useTextureEditor() {
   let gestureMovedPoint = false;
 
   function onPathKnotUpdate(id, patch) {
+    beginTexGesture();
     if (layerWantsSymmetry(selectedLayer.value) && patch.x != null) {
       const ax = symmetryAxisX();
       patch = { ...patch, x: Math.max(ax, Number(patch.x) || 0) };
@@ -358,6 +496,7 @@ export function useTextureEditor() {
   }
 
   function onPathDragEnd() {
+    endTexGesture();
     path.endGesture();
     if (state.layerMode === "move") {
       gestureMovedPoint = false;
@@ -371,19 +510,26 @@ export function useTextureEditor() {
     const wx = layerWantsSymmetry(selectedLayer.value)
       ? Math.max(symmetryAxisX(), x)
       : x;
+    pushTexHistory();
     if (path.insertKnotOnCurve(wx, y)) pushPathToLayer({ movedPoint: true });
   }
 
   function setSymmetry(on) {
     state.symmetry = !!on;
     if (state.symmetry && path.state.closed) {
+      beginTexGesture();
       pushPathToLayer({ movedPoint: true });
+      endTexGesture();
     }
   }
 
   function setAutoSmooth(on) {
     state.autoSmooth = !!on;
-    if (state.autoSmooth) pushPathToLayer({ movedPoint: true });
+    if (state.autoSmooth) {
+      beginTexGesture();
+      pushPathToLayer({ movedPoint: true });
+      endTexGesture();
+    }
   }
 
   function removeSelectedTexture() {
@@ -392,6 +538,7 @@ export function useTextureEditor() {
     const keys = Object.keys(state.textures);
     state.selectedGuid = keys[0] || null;
     state.selectedLayerId = editableLayers(selectedTexture.value)[0]?.id || null;
+    clearTexHistory();
     syncPathFromLayer();
   }
 
@@ -416,6 +563,7 @@ export function useTextureEditor() {
     const keys = Object.keys(state.textures);
     state.selectedGuid = keys[0] || null;
     state.selectedLayerId = editableLayers(selectedTexture.value)[0]?.id || null;
+    clearTexHistory();
     syncPathFromLayer();
   }
 
@@ -455,6 +603,8 @@ export function useTextureEditor() {
     moveLayer,
     addLayer,
     removeLayer,
+    restoreSelectedToCircle,
+    restoreLayerCircle,
     setLayerMode,
     onTranslatePath,
     setEditSide,
@@ -471,5 +621,7 @@ export function useTextureEditor() {
     loadTextures,
     pushPathToLayer,
     syncPathFromLayer,
+    undo,
+    redo,
   };
 }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -11,8 +11,17 @@ import {
   syncClosedSegments,
   syncOpenSegments,
   translatePath,
+  pathCentroid,
 } from "../pathModel.js";
 import { newGuid } from "../assetClone.js";
+
+/** Default radii for “Restore to circle” (and createEyeLayer closed parts). */
+export const EYE_CIRCLE_RADII = {
+  eyeball: { rx: 0.72, ry: 0.72, cx: 0, cy: 0 },
+  iris: { rx: 0.28, ry: 0.28, cx: 0.06, cy: 0.02 },
+  pupil: { rx: 0.15, ry: 0.15, cx: 0.06, cy: 0.02 },
+  reflection: { rx: 0.05, ry: 0.065, cx: -0.02, cy: 0.1 },
+};
 
 /** Default left/right pair layout (preview + edit target). */
 export const DEFAULT_EYE_PAIR = {
@@ -48,19 +57,40 @@ export function createEyeLayer(type, overrides = {}) {
       name: "Eyeball",
       color: "#f2f0ea",
       closed: true,
-      ...makeEllipsePath({ cx: 0, cy: 0, rx: 0.72, ry: 0.72, color: "#f2f0ea", n: 4 }),
+      ...makeEllipsePath({
+        cx: EYE_CIRCLE_RADII.eyeball.cx,
+        cy: EYE_CIRCLE_RADII.eyeball.cy,
+        rx: EYE_CIRCLE_RADII.eyeball.rx,
+        ry: EYE_CIRCLE_RADII.eyeball.ry,
+        color: "#f2f0ea",
+        n: 4,
+      }),
     }),
     iris: () => ({
       name: "Iris",
       color: "#3a70d0",
       closed: true,
-      ...makeEllipsePath({ cx: 0.06, cy: 0.02, rx: 0.28, ry: 0.28, color: "#3a70d0", n: 4 }),
+      ...makeEllipsePath({
+        cx: EYE_CIRCLE_RADII.iris.cx,
+        cy: EYE_CIRCLE_RADII.iris.cy,
+        rx: EYE_CIRCLE_RADII.iris.rx,
+        ry: EYE_CIRCLE_RADII.iris.ry,
+        color: "#3a70d0",
+        n: 4,
+      }),
     }),
     pupil: () => ({
       name: "Pupil",
       color: "#0a0a0c",
       closed: true,
-      ...makeEllipsePath({ cx: 0.06, cy: 0.02, rx: 0.12, ry: 0.12, color: "#0a0a0c", n: 4 }),
+      ...makeEllipsePath({
+        cx: EYE_CIRCLE_RADII.pupil.cx,
+        cy: EYE_CIRCLE_RADII.pupil.cy,
+        rx: EYE_CIRCLE_RADII.pupil.rx,
+        ry: EYE_CIRCLE_RADII.pupil.ry,
+        color: "#0a0a0c",
+        n: 4,
+      }),
     }),
     reflection: () => ({
       name: "Reflection",
@@ -230,6 +260,34 @@ export function translateLayerTree(layers, layerId, dx, dy) {
     const L = findLayer(layers, order);
     if (L) constrainEyeLayer(fake, L.id);
   }
+}
+
+/**
+ * Rebuild a closed eye layer as a round/elliptical Bezier circle at its
+ * current centroid (or type default center). Keeps color / id / type.
+ */
+export function restoreLayerToCircle(layer, { keepCenter = true } = {}) {
+  if (!layer || layer.type === "eyelid" || layer.closed === false) return false;
+  const def = EYE_CIRCLE_RADII[layer.type] || { rx: 0.2, ry: 0.2, cx: 0, cy: 0 };
+  let cx = def.cx;
+  let cy = def.cy;
+  if (keepCenter && layer.knots?.length) {
+    const c = pathCentroid(layer.knots);
+    cx = c.x;
+    cy = c.y;
+  }
+  const fresh = makeEllipsePath({
+    cx,
+    cy,
+    rx: def.rx,
+    ry: def.ry,
+    color: layer.color || "#ffffff",
+    n: 4,
+  });
+  layer.knots = fresh.knots;
+  layer.segments = fresh.segments;
+  layer.closed = true;
+  return true;
 }
 
 /** Force right = mirror(left) and re-link. */

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -212,7 +212,9 @@ export function mirrorLayersX(layers) {
 /** Types that translate together when the root layer moves. */
 export function companionLayerTypes(type) {
   if (type === "eyeball") return ["iris", "pupil", "reflection", "eyelid"];
-  if (type === "iris") return ["pupil"];
+  // Iris move carries pupil + shine (reflection sits on the iris stack).
+  if (type === "iris") return ["pupil", "reflection"];
+  if (type === "pupil") return ["reflection"];
   return [];
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Restore to circle
Closed layers (eyeball / iris / pupil / reflection) get a **Restore to circle** button in the Layers panel — rebuilds a default Bezier circle at the current center. Pupil default radius bumped slightly (`0.12` → `0.15`) so it stays easier to grab.

### Undo / Redo
Texture Undo/Redo previously only touched the path editor and did not write back to the texture (and Move cleared history). It now snapshots the whole texture (`layers` + `rightLayers` + `eyePair`) so Edit, Move (including iris→pupil), and Restore reverse correctly.

### Move companions
- Moving **iris** also moves **pupil** and **reflection**
- Moving **pupil** also moves **reflection**

### Answers (also in PR for context)
- **Saving textures:** yes — via project Save into `project.json` as `textureAssets` (params only, no baked pixels).
- **Separate DB section:** no separate texture table; textures live inside the mesh project document. Library is folders + JSON, not a SQL DB.
- **GUID:** yes — each texture has its own `assetGuid` (key in `textureAssets`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

