### PR TITLE
Library mesh/texture filter + assign eye pair to mesh UVs

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -15,6 +15,7 @@ import {
   editableLayers,
   restoreLayerToCircle,
   EYE_CIRCLE_RADII,
+  rasterizeEyePairUvMap,
 } from "../src/lib/texture/eyeTexture.js";
 import {
   pointInPolygon,
@@ -26,7 +27,11 @@ import {
   samplePath,
 } from "../src/lib/pathModel.js";
 import { migrateProject } from "../src/library/migrations.js";
-import { CURRENT_SCHEMA_VERSION, buildProjectDocument } from "../src/library/schema.js";
+import {
+  CURRENT_SCHEMA_VERSION,
+  buildProjectDocument,
+  validateProject,
+} from "../src/library/schema.js";
 
 const eye = createDefaultEyeTexture({ name: "TestEye" });
 assert.equal(eye.kind, "eye");
@@ -216,7 +221,6 @@ const doc = buildProjectDocument({
     symmetry: true,
     viewMode: "profile",
     spineSource: "profile",
-    objectMaterial: { color: null, roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient" },
     knots: [
       { id: "a", x: 0, y: -1, hx: 0, hy: 0, color: "#fff" },
       { id: "b", x: 0.4, y: 1, hx: 0, hy: 0, color: "#fff" },
@@ -263,20 +267,47 @@ const doc = buildProjectDocument({
     embeddedAssets: {},
     children: [],
     textureAssets: { [ser.assetGuid]: ser },
+    projectKind: "mesh",
+    objectMaterial: {
+      color: null,
+      roughness: 0.4,
+      metalness: 0,
+      opacity: 1,
+      texture: "asset",
+      textureAsset: ser.assetGuid,
+      textureAssign: "eyePair",
+    },
   },
   name: "With eye texture",
   slug: "with-eye",
+  projectKind: "mesh",
 });
-assert.equal(doc.schemaVersion, 9);
+assert.equal(doc.schemaVersion, 10);
+assert.equal(doc.projectKind, "mesh");
 assert.ok(doc.textureAssets[ser.assetGuid]);
+assert.equal(doc.objectMaterial.textureAssign, "eyePair");
 
 const mig = migrateProject(doc);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
-assert.equal(CURRENT_SCHEMA_VERSION, 9);
-assert.equal(mig.doc.schemaVersion, 9);
+assert.equal(CURRENT_SCHEMA_VERSION, 10);
+assert.equal(mig.doc.schemaVersion, 10);
+assert.equal(mig.doc.projectKind, "mesh");
 assert.ok(mig.doc.textureAssets[ser.assetGuid].layers.length >= 4);
+
+// Texture-only library entry validates without mesh profile
+const texOnly = {
+  kind: "ranger.splineProject",
+  schemaVersion: 10,
+  projectKind: "texture",
+  name: "Eyes only",
+  textureAssets: { [ser.assetGuid]: ser },
+};
+assert.deepEqual(validateProject(texOnly), []);
+const uv = rasterizeEyePairUvMap(eye, 64, 64);
+assert.ok(uv && uv.w === 64 && uv.h === 64 && uv.rgba.length === 64 * 64 * 4);
 
 console.log("smoke-eye-texture: ok", {
   schema: mig.doc.schemaVersion,
+  projectKind: mig.doc.projectKind,
   layers: mig.doc.textureAssets[ser.assetGuid].layers.map((L) => L.type),
 });

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -141,8 +141,8 @@ const v7 = {
 
 const mig = migrateProject(v7);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
-assert.equal(CURRENT_SCHEMA_VERSION, 9);
-assert.equal(mig.doc.schemaVersion, 9);
+assert.equal(CURRENT_SCHEMA_VERSION, 10);
+assert.equal(mig.doc.schemaVersion, 10);
 assert.equal(mig.doc.children[0].transform.surface, false);
 assert.equal(mig.doc.children[0].transform.z, 0);
 

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-placement-normal.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-placement-normal.mjs
@@ -121,7 +121,7 @@ const v5 = {
 const mig = migrateProject(v5);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
 assert.equal(mig.doc.schemaVersion, CURRENT_SCHEMA_VERSION);
-assert.equal(CURRENT_SCHEMA_VERSION, 9);
+assert.equal(CURRENT_SCHEMA_VERSION, 10);
 assert.deepEqual(mig.doc.placementNormal.start, { x: 0, y: -1 });
 assert.deepEqual(mig.doc.placementNormal.end, { x: 0, y: 1 });
 assert.equal(mig.doc.editor.tessellationMode, "rotation");

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
@@ -156,7 +156,7 @@ const v6 = {
 const mig = migrateProject(v6);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
 assert.equal(mig.doc.schemaVersion, CURRENT_SCHEMA_VERSION);
-assert.equal(CURRENT_SCHEMA_VERSION, 9);
+assert.equal(CURRENT_SCHEMA_VERSION, 10);
 assert.equal(mig.doc.editor.tessellationMode, "rotation");
 const errs = validateProject(mig.doc);
 assert.equal(errs.length, 0, errs.join("; "));

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, onMounted, onBeforeUnmount, ref } from "vue";
+// api used for assigning a library texture project onto the mesh without leaving Mesh mode
 import SplineCanvas from "./components/SplineCanvas.vue";
 import PointEditor from "./components/PointEditor.vue";
 import Preview3D from "./components/Preview3D.vue";
@@ -50,6 +51,9 @@ const {
   endGesture,
   isEditingChild,
   activePlacementNormal,
+  setTextureAssetsProvider,
+  assignEyeTextureToRoot,
+  clearAssignedTexture,
 } = useSplineEditor();
 
 const tex = useTextureEditor();
@@ -65,28 +69,80 @@ const texFlipX = tex.flipX;
 const texCanvasToolMode = tex.canvasToolMode;
 
 const workspace = ref("mesh"); // mesh | texture
+const assignTexGuid = ref("");
+const assignLibSlug = ref("");
+
+setTextureAssetsProvider(() => tex.snapshotTextures());
 
 function snapshotState() {
   return {
     ...snapshotMeshState(),
     textureAssets: tex.snapshotTextures(),
+    projectKind: workspace.value === "texture" ? "texture" : "mesh",
   };
 }
 
 function applyProject(doc) {
-  applyMeshProject(doc);
+  const kind = doc?.projectKind === "texture" ? "texture" : "mesh";
+  workspace.value = kind;
+  if (doc?.profile?.knots?.length >= 2) {
+    applyMeshProject(doc);
+  }
   tex.loadTextures(doc?.textureAssets || {});
+  const first = Object.keys(texState.textures)[0] || "";
+  assignTexGuid.value = state.objectMaterial?.textureAsset || first;
 }
 
 if (!Object.keys(texState.textures).length) {
   tex.createEye("Eye");
 }
+assignTexGuid.value = Object.keys(texState.textures)[0] || "";
 
 const { lib, refresh, load, save, saveAs, remove, exportJson, importJsonFile } = useLibrary({
   snapshotState,
   applyProject,
   tessellate,
 });
+
+const loadedTextures = computed(() => Object.values(texState.textures || {}));
+const libraryTextures = computed(() =>
+  (lib.projects || []).filter((p) => !p.error && p.projectKind === "texture"),
+);
+
+function onAssignLoadedTexture() {
+  const guid = assignTexGuid.value || loadedTextures.value[0]?.assetGuid;
+  if (!guid) {
+    state.status = "No eye texture loaded — create/open one in Texture mode.";
+    return;
+  }
+  if (assignEyeTextureToRoot(guid)) tessellate();
+}
+
+async function onAssignLibraryTexture() {
+  const slug = assignLibSlug.value;
+  if (!slug) {
+    state.status = "Pick a saved texture from the list.";
+    return;
+  }
+  try {
+    const doc = await api.loadProject(slug);
+    const incoming = doc?.textureAssets || {};
+    const merged = { ...tex.snapshotTextures(), ...incoming };
+    tex.loadTextures(merged);
+    const guid =
+      Object.keys(incoming)[0] || Object.keys(merged)[0] || "";
+    assignTexGuid.value = guid;
+    if (guid && assignEyeTextureToRoot(guid)) tessellate();
+    else state.status = "Texture project had no eye assets.";
+  } catch (err) {
+    state.status = "Assign failed: " + (err.message || err);
+  }
+}
+
+function onClearAssignedTexture() {
+  clearAssignedTexture();
+  tessellate();
+}
 
 const materials = [
   { id: 0, label: "Wire" },
@@ -548,6 +604,38 @@ onBeforeUnmount(() => {
         />
         Show mirror
       </label>
+      <label class="field">
+        Eye texture
+        <select v-model="assignTexGuid">
+          <option disabled value="">Loaded textures…</option>
+          <option v-for="t in loadedTextures" :key="t.assetGuid" :value="t.assetGuid">
+            {{ t.name }} ({{ t.kind || "eye" }})
+          </option>
+        </select>
+      </label>
+      <button type="button" class="primary" title="Map left+right eyes onto mesh UVs" @click="onAssignLoadedTexture">
+        Assign to mesh
+      </button>
+      <label class="field">
+        From library
+        <select v-model="assignLibSlug">
+          <option disabled value="">Saved textures…</option>
+          <option v-for="p in libraryTextures" :key="p.slug" :value="p.slug">
+            {{ p.name || p.slug }}
+          </option>
+        </select>
+      </label>
+      <button type="button" :disabled="!assignLibSlug" @click="onAssignLibraryTexture">
+        Assign saved
+      </button>
+      <button
+        type="button"
+        :disabled="!state.objectMaterial?.textureAsset"
+        title="Remove UV eye assignment"
+        @click="onClearAssignedTexture"
+      >
+        Clear texture
+      </button>
       <div class="mats">
         <span>Shading base</span>
         <div class="mat-row">
@@ -675,7 +763,7 @@ onBeforeUnmount(() => {
           :embedded-assets="state.embeddedAssets"
           :selected-child-guid="state.selectedChildGuid"
           :edit-target="state.editTarget"
-          :projects="lib.projects"
+          :projects="(lib.projects || []).filter((p) => !p.error && p.projectKind !== 'texture')"
           :asset-guid="state.assetGuid"
           :place-mode="!!placePending"
           :place-label="placeLabel"
@@ -724,6 +812,7 @@ onBeforeUnmount(() => {
       </div>
       <LibraryPanel
         :lib="lib"
+        project-kind="mesh"
         @refresh="refresh"
         @load="load"
         @save="save"
@@ -815,6 +904,7 @@ onBeforeUnmount(() => {
       </div>
       <LibraryPanel
         :lib="lib"
+        project-kind="texture"
         @refresh="refresh"
         @load="load"
         @save="save"

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/LibraryPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/LibraryPanel.vue
@@ -1,8 +1,10 @@
 <script setup>
-import { ref } from "vue";
+import { ref, computed } from "vue";
 
-defineProps({
+const props = defineProps({
   lib: { type: Object, required: true },
+  /** mesh | texture — filters the saved list */
+  projectKind: { type: String, default: "mesh" },
 });
 
 const emit = defineEmits([
@@ -17,10 +19,29 @@ const emit = defineEmits([
 
 const fileRef = ref(null);
 
+const filtered = computed(() => {
+  const kind = props.projectKind === "texture" ? "texture" : "mesh";
+  return (props.lib.projects || []).filter((p) => {
+    if (p.error) return true;
+    const pk = p.projectKind === "texture" ? "texture" : "mesh";
+    return pk === kind;
+  });
+});
+
+const kindLabel = computed(() => (props.projectKind === "texture" ? "textures" : "meshes"));
+
 function onFile(ev) {
   const f = ev.target.files?.[0];
   if (f) emit("import-file", f);
   ev.target.value = "";
+}
+
+function metaLine(p) {
+  if (p.error) return p.error;
+  if (p.projectKind === "texture") {
+    return `${p.textureCount || p.knotCount || "?"} tex · ${(p.updatedAt || "").slice(0, 19)}`;
+  }
+  return `${p.knotCount || "?"} pts · ${(p.updatedAt || "").slice(0, 19)}`;
 }
 </script>
 
@@ -29,7 +50,7 @@ function onFile(ev) {
     <header>
       <h2>Library</h2>
       <p v-if="lib.available" class="path" :title="lib.root">
-        v{{ lib.schemaVersion }} · {{ lib.root }}
+        v{{ lib.schemaVersion }} · {{ kindLabel }} · {{ lib.root }}
       </p>
       <p v-else class="path warn">{{ lib.status || "Library offline" }}</p>
     </header>
@@ -38,7 +59,7 @@ function onFile(ev) {
       <input
         v-model="lib.saveAsName"
         type="text"
-        placeholder="Name (e.g. tall vase)"
+        :placeholder="projectKind === 'texture' ? 'Name (e.g. eyes)' : 'Name (e.g. tall vase)'"
         @keyup.enter="emit('save-as', lib.saveAsName)"
       />
       <button type="button" class="primary" :disabled="lib.busy" @click="emit('save-as', lib.saveAsName)">
@@ -66,15 +87,15 @@ function onFile(ev) {
     </p>
 
     <ul class="list">
-      <li v-if="!lib.projects.length" class="empty">No saved splines yet.</li>
+      <li v-if="!filtered.length" class="empty">No saved {{ kindLabel }} yet.</li>
       <li
-        v-for="p in lib.projects"
+        v-for="p in filtered"
         :key="p.slug"
         :class="{ active: p.slug === lib.currentSlug, bad: !!p.error }"
       >
         <button type="button" class="open" :disabled="!!p.error" @click="emit('load', p.slug)">
           <strong>{{ p.name || p.slug }}</strong>
-          <span>{{ p.error || `${p.knotCount || "?"} pts · ${p.updatedAt?.slice(0, 19) || ""}` }}</span>
+          <span>{{ metaLine(p) }}</span>
         </button>
         <button
           type="button"

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -1,6 +1,7 @@
 import { reactive, computed, watch } from "vue";
 import { SplineLathe } from "../../../tessellate/spline_lathe.mjs";
 import { tessellateBody } from "../lib/latheTessellate.js";
+import { rasterizeEyePairUvMap, normalizeEyeTexture } from "../lib/texture/eyeTexture.js";
 import { transformParts } from "../lib/meshTransform.js";
 import { evalSpan as evalPathSpan } from "../lib/pathSample.js";
 import { createEditHistory } from "../lib/editHistory.js";
@@ -55,7 +56,15 @@ function defaultOrbitKnots() {
 }
 
 function defaultObjectMaterial() {
-  return { color: null, roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient" };
+  return {
+    color: null,
+    roughness: 0.4,
+    metalness: 0,
+    opacity: 1,
+    texture: "gradient",
+    textureAsset: null,
+    textureAssign: null,
+  };
 }
 
 function projectDocToBody(doc, { newGuidForCopy = true } = {}) {
@@ -119,6 +128,9 @@ function loadSpineBlock(block, fallbackKnots) {
 }
 
 export function useSplineEditor() {
+  /** Optional provider for procedural texture assets (from Texture editor / library). */
+  let textureAssetsProvider = () => /** @type {Record<string, any>} */ ({});
+
   const state = reactive({
     assetGuid: newGuid(),
     viewMode: "profile", // profile | orbit | spine
@@ -893,9 +905,61 @@ export function useSplineEditor() {
     }
   }
 
+  function resolveTextureMap(om) {
+    if (!om) return null;
+    const guid = om.textureAsset;
+    if (!guid) return null;
+    if (om.texture !== "asset" && om.textureAssign !== "eyePair") return null;
+    const assets = textureAssetsProvider() || {};
+    const raw = assets[guid];
+    if (!raw) return null;
+    const tex = raw.kind === "eye" || !raw.kind ? normalizeEyeTexture(raw) : raw;
+    if (tex.kind === "eye" || om.textureAssign === "eyePair") {
+      return rasterizeEyePairUvMap(tex, 512, 512);
+    }
+    return null;
+  }
+
+  function setTextureAssetsProvider(fn) {
+    textureAssetsProvider = typeof fn === "function" ? fn : () => ({});
+  }
+
+  /** Assign a procedural eye texture (both eyes) onto the root mesh UV atlas. */
+  function assignEyeTextureToRoot(assetGuid) {
+    if (!assetGuid) return false;
+    const assets = textureAssetsProvider() || {};
+    if (!assets[assetGuid]) {
+      state.status = "Texture asset not loaded — open it in Texture or import the project.";
+      return false;
+    }
+    beginGesture("assign-eye-texture");
+    state.objectMaterial = {
+      ...state.objectMaterial,
+      texture: "asset",
+      textureAsset: assetGuid,
+      textureAssign: "eyePair",
+    };
+    endGesture();
+    state.status = "Assigned eye texture to mesh UVs (left + right).";
+    return true;
+  }
+
+  function clearAssignedTexture() {
+    beginGesture("clear-texture");
+    state.objectMaterial = {
+      ...state.objectMaterial,
+      texture: "gradient",
+      textureAsset: null,
+      textureAssign: null,
+    };
+    endGesture();
+    state.status = "Cleared assigned body texture.";
+  }
+
   function tessellate() {
+    const tessOpts = { resolveTextureMap };
     // Always assemble from ROOT + children (preview shows full object even when editing a child).
-    const root = tessellateBody(rootBodySnapshot());
+    const root = tessellateBody(rootBodySnapshot(), tessOpts);
     state.rootMesh = { parts: root.parts.slice() };
     // Spine / profile edits move the root surface — re-seat surface children on it.
     resnapSurfaceChildren(state.rootMesh.parts);
@@ -907,7 +971,7 @@ export function useSplineEditor() {
       if (ch.visible === false) continue;
       const body = state.embeddedAssets[ch.contentGuid];
       if (!body || body.knots.length < 2 || body.orbitKnots.length < 3) continue;
-      const child = tessellateBody(body);
+      const child = tessellateBody(body, tessOpts);
       const xf = ch.transform || defaultChildTransform();
       pushTransformedParts(parts, child.parts, xf, false, body, ch.instanceGuid);
       totalV += child.verts;
@@ -1152,6 +1216,11 @@ export function useSplineEditor() {
       metalness: doc.objectMaterial?.metalness ?? 0,
       opacity: doc.objectMaterial?.opacity ?? 1,
       texture: doc.objectMaterial?.texture || "gradient",
+      textureAsset: doc.objectMaterial?.textureAsset || null,
+      textureAssign:
+        doc.objectMaterial?.textureAssign === "eyePair"
+          ? "eyePair"
+          : doc.objectMaterial?.textureAssign || null,
     };
     state.knots = doc.profile.knots.map((k) => ({ ...k }));
     state.segments = (doc.profile.segments || []).map((s) => ({
@@ -1333,6 +1402,9 @@ export function useSplineEditor() {
     syncSegments,
     applyProject,
     snapshotState,
+    setTextureAssetsProvider,
+    assignEyeTextureToRoot,
+    clearAssignedTexture,
     attachFromProject,
     selectChild,
     editRoot,

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/latheTessellate.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/latheTessellate.js
@@ -193,8 +193,10 @@ function resolveCombinedStyle(body, pi, oi) {
 
 /**
  * Tessellate one spline body into mesh parts (mixed path types per segment).
+ * @param {object} body
+ * @param {{ resolveTextureMap?: (om: object) => { rgba: any, w: number, h: number } | null }} [opts]
  */
-export function tessellateBody(body) {
+export function tessellateBody(body, opts = {}) {
   const curveType = body.curveType | 0;
   const pathSegments = body.pathSegments || 12;
   const angularSteps = body.angularSteps || 24;
@@ -237,23 +239,34 @@ export function tessellateBody(body) {
     closed,
   );
 
+  let bodyMap = null;
+  const om = body.objectMaterial;
+  if (
+    om &&
+    (om.texture === "asset" || om.textureAssign === "eyePair") &&
+    typeof opts.resolveTextureMap === "function"
+  ) {
+    bodyMap = opts.resolveTextureMap(om);
+  }
+
   const parts = [];
   let totalV = 0;
   let totalT = 0;
   for (const piece of pieces) {
     const style = resolveCombinedStyle(body, piece.profileSeg, piece.orbitSeg);
+    const map = bodyMap || style.map;
     parts.push({
       positions: piece.positions,
       normals: piece.normals,
       uvs: piece.uvs,
       indices: piece.indices,
-      colorHex: style.colorHex,
+      colorHex: bodyMap ? 0xffffff : style.colorHex,
       shininess: style.shininess,
       reflectivity: style.reflectivity,
       opacity: style.opacity,
-      mapRgba: style.map ? Array.from(style.map.rgba) : null,
-      mapW: style.map ? style.map.w : 0,
-      mapH: style.map ? style.map.h : 0,
+      mapRgba: map ? Array.from(map.rgba) : null,
+      mapW: map ? map.w : 0,
+      mapH: map ? map.h : 0,
     });
     totalV += (piece.positions.length / 3) | 0;
     totalT += (piece.indices.length / 3) | 0;

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -683,3 +683,71 @@ export function rasterizeEyeTexture(tex, width, height) {
   renderEyeTexture(ctx, tex);
   return ctx.getImageData(0, 0, w, h);
 }
+
+/**
+ * Rasterize left+right eyes into a UV atlas (white background for multiply lighting).
+ * Lathe UVs: u around orbit, v along profile — eyes sit near the front of the head.
+ *
+ * @returns {{ rgba: Uint8ClampedArray|number[], w: number, h: number, name: string } | null}
+ */
+export function rasterizeEyePairUvMap(tex, width = 512, height = 512, opts = {}) {
+  const w = Math.max(64, width | 0);
+  const h = Math.max(64, height | 0);
+  const pair = normalizeEyePair(tex?.eyePair);
+  const centerU = opts.centerU != null ? Number(opts.centerU) : 0.5;
+  const centerV = opts.centerV != null ? Number(opts.centerV) : 0.58;
+  const sepU =
+    opts.eyeSeparationU != null
+      ? Number(opts.eyeSeparationU)
+      : 0.1 + pair.distance * 0.08;
+  const eyeWU = opts.eyeWidthU != null ? Number(opts.eyeWidthU) : 0.11;
+  const eyeHV = opts.eyeHeightV != null ? Number(opts.eyeHeightV) : 0.13;
+
+  if (typeof document === "undefined") {
+    // Node smoke: solid white map (assignment path is browser/WebGL).
+    const rgba = new Uint8ClampedArray(w * h * 4);
+    for (let i = 0; i < rgba.length; i += 4) {
+      rgba[i] = 255;
+      rgba[i + 1] = 255;
+      rgba[i + 2] = 255;
+      rgba[i + 3] = 255;
+    }
+    return { rgba, w, h, name: (tex?.name || "eye") + "-uv" };
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, w, h);
+
+  const cellW = Math.max(8, Math.round(eyeWU * w));
+  const cellH = Math.max(8, Math.round(eyeHV * h));
+  const left = tex.layers || [];
+  const right = rightEyeLayers(tex);
+
+  function blit(layers, uCenter) {
+    const x = Math.round(uCenter * w - cellW / 2);
+    const y = Math.round((1 - centerV) * h - cellH / 2);
+    const off = document.createElement("canvas");
+    off.width = cellW;
+    off.height = cellH;
+    const octx = off.getContext("2d");
+    octx.fillStyle = "#ffffff";
+    octx.fillRect(0, 0, cellW, cellH);
+    drawEyeLayers(octx, layers, cellW, cellH);
+    ctx.drawImage(off, x, y);
+  }
+
+  blit(left, centerU - sepU / 2);
+  blit(right, centerU + sepU / 2);
+
+  const img = ctx.getImageData(0, 0, w, h);
+  return {
+    rgba: img.data,
+    w,
+    h,
+    name: (tex?.name || "eye") + "-uv",
+  };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -10,6 +10,7 @@ import {
   nowIso,
   slugify,
   validateProject,
+  normalizeProjectKind,
 } from "./schema.js";
 import { normalizeEyeTexture } from "../lib/texture/eyeTexture.js";
 
@@ -464,6 +465,28 @@ function normalizeV9(doc) {
   return v8;
 }
 
+function normalizeV10(doc) {
+  const v9 = normalizeV9(doc);
+  v9.schemaVersion = 10;
+  const hasMesh = Array.isArray(v9.profile?.knots) && v9.profile.knots.length >= 2;
+  const texN = Object.keys(v9.textureAssets || {}).length;
+  let kind =
+    doc.projectKind === "texture" || doc.projectKind === "mesh" ? doc.projectKind : null;
+  if (!kind) kind = !hasMesh && texN > 0 ? "texture" : "mesh";
+  v9.projectKind = normalizeProjectKind(kind);
+  const om = v9.objectMaterial || {};
+  v9.objectMaterial = {
+    color: om.color ?? null,
+    roughness: Number(om.roughness ?? 0.4),
+    metalness: Number(om.metalness ?? 0),
+    opacity: Number(om.opacity ?? 1),
+    texture: om.texture || "gradient",
+    textureAsset: om.textureAsset || null,
+    textureAssign: om.textureAssign === "eyePair" ? "eyePair" : om.textureAssign || null,
+  };
+  return v9;
+}
+
 /** @type {Record<number, (doc: any) => any>} */
 const STEPS = {
   1(doc) {
@@ -498,6 +521,10 @@ const STEPS = {
   // 8 → 9: textureAssets (params-only procedural textures, eye editor first)
   9(doc) {
     return normalizeV9(doc);
+  },
+  // 9 → 10: projectKind mesh|texture + objectMaterial.textureAsset assign
+  10(doc) {
+    return normalizeV10(doc);
   },
 };
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -4,9 +4,14 @@
 
 import { serializeEyeTexture } from "../lib/texture/eyeTexture.js";
 
-export const CURRENT_SCHEMA_VERSION = 9;
+export const CURRENT_SCHEMA_VERSION = 10;
 
 export const SCHEMA_KIND = "ranger.splineProject";
+
+/** Library list / save filter: mesh projects vs texture-only authoring. */
+export function normalizeProjectKind(kind) {
+  return kind === "texture" ? "texture" : "mesh";
+}
 
 /**
  * @typedef {object} ChildInstanceV3
@@ -163,9 +168,11 @@ export function buildProjectDocument(opts) {
   for (const [guid, body] of Object.entries(st.embeddedAssets || {})) {
     embedded[guid] = serializeBodyContent(body);
   }
+  const projectKind = normalizeProjectKind(opts.projectKind || st.projectKind || "mesh");
   return {
     kind: SCHEMA_KIND,
     schemaVersion: CURRENT_SCHEMA_VERSION,
+    projectKind,
     id: opts.id || newId(),
     assetGuid: st.assetGuid || newId(),
     slug: opts.slug || slugify(name),
@@ -192,6 +199,11 @@ export function buildProjectDocument(opts) {
       metalness: Number(st.objectMaterial?.metalness ?? 0),
       opacity: Number(st.objectMaterial?.opacity ?? 1),
       texture: st.objectMaterial?.texture || "gradient",
+      textureAsset: st.objectMaterial?.textureAsset || null,
+      textureAssign:
+        st.objectMaterial?.textureAssign === "eyePair"
+          ? "eyePair"
+          : st.objectMaterial?.textureAssign || null,
     },
     profile: {
       knots: (st.knots || []).map(serializeKnot),
@@ -233,6 +245,29 @@ export function validateProject(doc) {
     errors.push(`unexpected kind "${doc.kind}" (expected ${SCHEMA_KIND})`);
   }
   if (!doc.name) errors.push("missing name");
+  const projectKind = normalizeProjectKind(doc.projectKind);
+  if (doc.schemaVersion >= 10 && doc.projectKind != null && doc.projectKind !== "mesh" && doc.projectKind !== "texture") {
+    errors.push('projectKind must be "mesh" or "texture"');
+  }
+
+  // Texture-library entries: params only — mesh profile optional.
+  if (projectKind === "texture") {
+    if (doc.textureAssets == null || typeof doc.textureAssets !== "object") {
+      errors.push("texture project needs textureAssets map");
+    } else if (!Object.keys(doc.textureAssets).length) {
+      errors.push("texture project needs at least one textureAssets entry");
+    } else {
+      for (const [guid, tex] of Object.entries(doc.textureAssets)) {
+        if (!tex || typeof tex !== "object") {
+          errors.push(`textureAssets[${guid}] invalid`);
+          continue;
+        }
+        if (!Array.isArray(tex.layers)) errors.push(`textureAssets[${guid}].layers must be an array`);
+      }
+    }
+    return errors;
+  }
+
   if (!doc.profile || !Array.isArray(doc.profile.knots)) errors.push("missing profile.knots");
   if (doc.profile && doc.profile.knots && doc.profile.knots.length < 2) {
     errors.push("profile.knots needs at least 2 points");

--- a/gallery/game_engine/v2/mesh_editor/app/vite-plugin-library.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/vite-plugin-library.mjs
@@ -66,6 +66,8 @@ function listProjects(root) {
         continue;
       }
       const d = mig.doc;
+      const projectKind = d.projectKind === "texture" ? "texture" : "mesh";
+      const textureCount = Object.keys(d.textureAssets || {}).length;
       out.push({
         slug: d.slug || name,
         id: d.id,
@@ -75,7 +77,12 @@ function listProjects(root) {
         updatedAt: d.updatedAt,
         createdAt: d.createdAt,
         schemaVersion: d.schemaVersion,
-        knotCount: d.profile.knots.length,
+        projectKind,
+        textureCount,
+        knotCount:
+          projectKind === "texture"
+            ? textureCount
+            : d.profile?.knots?.length || 0,
       });
     } catch (err) {
       out.push({ slug: name, name, error: String(err.message || err) });

--- a/gallery/game_engine/v2/mesh_editor/library/README.md
+++ b/gallery/game_engine/v2/mesh_editor/library/README.md
@@ -49,6 +49,9 @@ copy or symlink selected folders into a tracked tree, or temporarily force-add.
 - v9 adds `textureAssets` — params-only procedural textures (first kind: `eye`
   with named layers eyeball/iris/pupil/reflection/eyelid). No baked pixels;
   rasterize at runtime for animation / mesh assign later.
+- v10 adds `projectKind` (`mesh` | `texture`) so the library list filters by
+  workspace, plus optional `objectMaterial.textureAsset` / `textureAssign`
+  (`eyePair`) to map a saved eye texture onto lathe UVs (both eyes).
 
 When you change the document shape, bump the version and add a step; old folders
 keep working.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Library filtering
Schema **v10** adds `projectKind: "mesh" | "texture"`.
- **Mesh** workspace → Library shows only meshes
- **Texture** workspace → Library shows only textures  
Save/Save as tags the project from the active workspace.

### Assign eye texture to mesh UVs
In Mesh toolbar:
1. Pick a **loaded** eye texture → **Assign to mesh**, or
2. Pick a **saved texture** project → **Assign saved**

Rasterizes left+right eyes into a UV atlas (white background) and applies it to the lathed mesh via `objectMaterial.textureAsset` / `textureAssign: "eyePair"` (rebuilt on tessellate). **Clear texture** removes the assignment.

### Try
1. Texture → edit eyes → Save as `eyes`
2. Mesh → open/create a head-like lathe → **Assign saved** → `eyes`
3. Preview should show both eyes on the front of the mesh

Note: eye placement uses default UV centers (`u≈0.5`, `v≈0.58`); tune later if orbit front differs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

