### PR TITLE
Assign eye texture via dialog + 3D UV corner pick

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -16,6 +16,11 @@ import {
   restoreLayerToCircle,
   EYE_CIRCLE_RADII,
   rasterizeEyePairUvMap,
+  normalizeEyeUv,
+  averageKnotColorHex,
+  eyeUvFromCorners,
+  eyeUvMoveCenter,
+  unwrapUvPairU,
 } from "../src/lib/texture/eyeTexture.js";
 import {
   pointInPolygon,
@@ -303,8 +308,26 @@ const texOnly = {
   textureAssets: { [ser.assetGuid]: ser },
 };
 assert.deepEqual(validateProject(texOnly), []);
-const uv = rasterizeEyePairUvMap(eye, 64, 64);
+const uv = rasterizeEyePairUvMap(eye, 64, 64, {
+  background: averageKnotColorHex([{ color: "#c8a070" }, { color: "#c8a070" }]),
+  uv: normalizeEyeUv({ centerU: 0.4, centerV: 0.6, scale: 1.2, eyeSeparationU: 0.14 }),
+});
 assert.ok(uv && uv.w === 64 && uv.h === 64 && uv.rgba.length === 64 * 64 * 4);
+assert.equal(averageKnotColorHex([{ color: "#ff0000" }, { color: "#0000ff" }]), "#800080");
+assert.equal(averageKnotColorHex([], ""), "");
+assert.equal(normalizeEyeUv({ scale: 99 }).scale, 3);
+assert.equal(normalizeEyeUv({ centerU: 0.4, eyeSeparationU: 0.14 }).eyeSeparationU, 0.14);
+
+const fromCorners = eyeUvFromCorners(0.35, 0.7, 0.65, 0.45);
+assert.ok(Math.abs(fromCorners.centerU - 0.5) < 1e-6);
+assert.ok(Math.abs(fromCorners.centerV - 0.575) < 1e-6);
+assert.ok(fromCorners.scale > 0.5);
+assert.ok(fromCorners.eyeSeparationU > 0.02);
+assert.deepEqual(unwrapUvPairU(0.9, 0.1)[0] <= unwrapUvPairU(0.9, 0.1)[1], true);
+const moved = eyeUvMoveCenter(fromCorners, 0.42, 0.55);
+assert.ok(Math.abs(moved.centerU - 0.42) < 1e-9);
+assert.ok(Math.abs(moved.centerV - 0.55) < 1e-9);
+assert.equal(moved.scale, fromCorners.scale);
 
 console.log("smoke-eye-texture: ok", {
   schema: mig.doc.schemaVersion,

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -26,12 +26,27 @@ const t = intersectTriangle(
   [1, -1, 0],
   [1, 1, 0],
 );
-assert.ok(t != null && Math.abs(t - 2) < 1e-6);
+assert.ok(t != null && Math.abs(t.t - 2) < 1e-6);
 
 const hit = raycastMeshParts([0, 0, 3], [0, 0, -1], parts);
 assert.ok(hit);
 assert.ok(Math.abs(hit.point[2]) < 1e-5);
 assert.ok(hit.normal[2] > 0.9);
+
+// UV interpolation at triangle centroid-ish (hit near origin on square)
+const uvParts = [
+  {
+    positions: [-1, -1, 0, 1, -1, 0, 1, 1, 0, -1, 1, 0],
+    normals: [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1],
+    // v0=(0,0) v1=(1,0) v2=(1,1) v3=(0,1)
+    uvs: [0, 0, 1, 0, 1, 1, 0, 1],
+    indices: [0, 1, 2, 0, 2, 3],
+  },
+];
+const uvHit = raycastMeshParts([0, 0, 3], [0, 0, -1], uvParts);
+assert.ok(uvHit?.uv);
+assert.ok(Math.abs(uvHit.uv[0] - 0.5) < 0.05);
+assert.ok(Math.abs(uvHit.uv[1] - 0.5) < 0.05);
 
 const tagged = [{ ...parts[0], instanceGuid: "child-a" }];
 const hitTagged = raycastMeshParts([0, 0, 3], [0, 0, -1], tagged);

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -8,10 +8,12 @@ import LibraryPanel from "./components/LibraryPanel.vue";
 import ChildrenPanel from "./components/ChildrenPanel.vue";
 import TextureLayerPanel from "./components/TextureLayerPanel.vue";
 import TexturePreview from "./components/TexturePreview.vue";
+import AssignTextureDialog from "./components/AssignTextureDialog.vue";
 import { useSplineEditor } from "./composables/useSplineEditor.js";
 import { useTextureEditor } from "./composables/useTextureEditor.js";
 import { useLibrary } from "./composables/useLibrary.js";
 import * as api from "./library/api.js";
+import { eyeUvFromCorners, eyeUvMoveCenter } from "./lib/texture/eyeTexture.js";
 
 const {
   state,
@@ -48,6 +50,7 @@ const {
   addSymmetricTwin,
   undo,
   redo,
+  beginGesture,
   endGesture,
   isEditingChild,
   activePlacementNormal,
@@ -69,8 +72,10 @@ const texFlipX = tex.flipX;
 const texCanvasToolMode = tex.canvasToolMode;
 
 const workspace = ref("mesh"); // mesh | texture
-const assignTexGuid = ref("");
-const assignLibSlug = ref("");
+const assignDialogOpen = ref(false);
+const assignBusy = ref(false);
+/** @type {import('vue').Ref<null | { guid:string, phase:'tl'|'br'|'refine', cornerA?:{u:number,v:number}, seedUv:object }>} */
+const uvAssignPending = ref(null);
 
 setTextureAssetsProvider(() => tex.snapshotTextures());
 
@@ -89,14 +94,11 @@ function applyProject(doc) {
     applyMeshProject(doc);
   }
   tex.loadTextures(doc?.textureAssets || {});
-  const first = Object.keys(texState.textures)[0] || "";
-  assignTexGuid.value = state.objectMaterial?.textureAsset || first;
 }
 
 if (!Object.keys(texState.textures).length) {
   tex.createEye("Eye");
 }
-assignTexGuid.value = Object.keys(texState.textures)[0] || "";
 
 const { lib, refresh, load, save, saveAs, remove, exportJson, importJsonFile } = useLibrary({
   snapshotState,
@@ -105,43 +107,132 @@ const { lib, refresh, load, save, saveAs, remove, exportJson, importJsonFile } =
 });
 
 const loadedTextures = computed(() => Object.values(texState.textures || {}));
-const libraryTextures = computed(() =>
-  (lib.projects || []).filter((p) => !p.error && p.projectKind === "texture"),
+/** Saved texture projects + any project that embeds textureAssets (legacy mesh saves). */
+const libraryTextureProjects = computed(() =>
+  (lib.projects || []).filter(
+    (p) => !p.error && (p.projectKind === "texture" || (p.textureCount || 0) > 0),
+  ),
 );
 
-function onAssignLoadedTexture() {
-  const guid = assignTexGuid.value || loadedTextures.value[0]?.assetGuid;
-  if (!guid) {
-    state.status = "No eye texture loaded — create/open one in Texture mode.";
-    return;
-  }
-  if (assignEyeTextureToRoot(guid)) tessellate();
+async function openAssignDialog() {
+  uvAssignPending.value = null;
+  await refresh();
+  assignDialogOpen.value = true;
 }
 
-async function onAssignLibraryTexture() {
-  const slug = assignLibSlug.value;
-  if (!slug) {
-    state.status = "Pick a saved texture from the list.";
-    return;
-  }
+function mergeAssignAssets(assets) {
+  if (assets) tex.loadTextures({ ...tex.snapshotTextures(), ...assets });
+}
+
+function onAssignApply({ guid, uv, assets }) {
+  assignBusy.value = true;
   try {
-    const doc = await api.loadProject(slug);
-    const incoming = doc?.textureAssets || {};
-    const merged = { ...tex.snapshotTextures(), ...incoming };
-    tex.loadTextures(merged);
-    const guid =
-      Object.keys(incoming)[0] || Object.keys(merged)[0] || "";
-    assignTexGuid.value = guid;
-    if (guid && assignEyeTextureToRoot(guid)) tessellate();
-    else state.status = "Texture project had no eye assets.";
-  } catch (err) {
-    state.status = "Assign failed: " + (err.message || err);
+    mergeAssignAssets(assets);
+    if (assignEyeTextureToRoot(guid, uv)) tessellate();
+    assignDialogOpen.value = false;
+    uvAssignPending.value = null;
+  } finally {
+    assignBusy.value = false;
   }
+}
+
+/** Pick texture in dialog → two corner clicks on 3D preview → drag refine. */
+function onAssignPlace({ guid, uv, assets }) {
+  assignBusy.value = true;
+  try {
+    mergeAssignAssets(assets);
+    placePending.value = null;
+    assignDialogOpen.value = false;
+    if (!state.rootMesh) tessellate();
+    uvAssignPending.value = {
+      guid,
+      phase: "tl",
+      seedUv: uv || state.objectMaterial?.textureUv,
+    };
+    state.status =
+      "Eye assign — click the TOP-LEFT corner of the eye pair on the 3D mesh.";
+  } finally {
+    assignBusy.value = false;
+  }
+}
+
+/** Live preview while dragging sliders (loaded textures only; library applies on Apply). */
+let previewTimer = 0;
+function onAssignPreview({ sourceKey, uv }) {
+  if (uvAssignPending.value) return;
+  if (!sourceKey?.startsWith("loaded:")) return;
+  const guid = sourceKey.slice("loaded:".length);
+  if (!guid || !texState.textures[guid]) return;
+  clearTimeout(previewTimer);
+  previewTimer = setTimeout(() => {
+    if (assignEyeTextureToRoot(guid, uv, { recordHistory: false })) tessellate();
+  }, 120);
 }
 
 function onClearAssignedTexture() {
+  uvAssignPending.value = null;
   clearAssignedTexture();
   tessellate();
+}
+
+const uvAssignPhase = computed(() => uvAssignPending.value?.phase || "");
+
+function onUvAssignClick(hit) {
+  const pending = uvAssignPending.value;
+  if (!pending || !hit?.uv) {
+    state.status = "No UV on that surface — aim at the lathed root mesh.";
+    return;
+  }
+  const [u, v] = hit.uv;
+  if (pending.phase === "tl") {
+    uvAssignPending.value = {
+      ...pending,
+      phase: "br",
+      cornerA: { u, v },
+    };
+    state.status = "Eye assign — click the BOTTOM-RIGHT corner.";
+    return;
+  }
+  if (pending.phase === "br" && pending.cornerA) {
+    const nextUv = eyeUvFromCorners(pending.cornerA.u, pending.cornerA.v, u, v, {
+      eyeSeparationU: pending.seedUv?.eyeSeparationU,
+    });
+    if (assignEyeTextureToRoot(pending.guid, nextUv)) tessellate();
+    uvAssignPending.value = {
+      guid: pending.guid,
+      phase: "refine",
+      seedUv: nextUv,
+    };
+    state.status = "Eye assign — drag to reposition, then Done (or Esc).";
+  }
+}
+
+function onUvAssignDrag(hit) {
+  const pending = uvAssignPending.value;
+  if (!pending || pending.phase !== "refine" || !hit?.uv) return;
+  beginGesture("move-eye-texture");
+  const [u, v] = hit.uv;
+  const nextUv = eyeUvMoveCenter(state.objectMaterial?.textureUv || pending.seedUv, u, v);
+  if (assignEyeTextureToRoot(pending.guid, nextUv, { recordHistory: false })) {
+    tessellate();
+  }
+}
+
+function onUvAssignDragEnd() {
+  endGesture();
+}
+
+function onUvAssignDone() {
+  uvAssignPending.value = null;
+  state.status = "Eye texture placement done.";
+}
+
+function onUvAssignCancel() {
+  const phase = uvAssignPending.value?.phase;
+  uvAssignPending.value = null;
+  state.status =
+    phase === "refine" ? "Eye texture placement kept (cancel during refine)." : "Eye assign cancelled.";
+  // If cancelled mid-corners before apply, leave mesh as it was.
 }
 
 const materials = [
@@ -297,6 +388,7 @@ const placeLabel = computed(() => {
 async function onBeginPlace({ slug, mode, symmetric }) {
   try {
     const doc = await api.loadProject(slug);
+    uvAssignPending.value = null;
     placePending.value = { slug, mode, symmetric, doc };
     state.status = `Place mode — click the root surface in 3D to attach “${doc.name || slug}”.`;
     if (!state.rootMesh) tessellate();
@@ -604,29 +696,13 @@ onBeforeUnmount(() => {
         />
         Show mirror
       </label>
-      <label class="field">
-        Eye texture
-        <select v-model="assignTexGuid">
-          <option disabled value="">Loaded textures…</option>
-          <option v-for="t in loadedTextures" :key="t.assetGuid" :value="t.assetGuid">
-            {{ t.name }} ({{ t.kind || "eye" }})
-          </option>
-        </select>
-      </label>
-      <button type="button" class="primary" title="Map left+right eyes onto mesh UVs" @click="onAssignLoadedTexture">
+      <button
+        type="button"
+        class="primary"
+        title="Choose eye texture and place both eyes on the mesh"
+        @click="openAssignDialog"
+      >
         Assign to mesh
-      </button>
-      <label class="field">
-        From library
-        <select v-model="assignLibSlug">
-          <option disabled value="">Saved textures…</option>
-          <option v-for="p in libraryTextures" :key="p.slug" :value="p.slug">
-            {{ p.name || p.slug }}
-          </option>
-        </select>
-      </label>
-      <button type="button" :disabled="!assignLibSlug" @click="onAssignLibraryTexture">
-        Assign saved
       </button>
       <button
         type="button"
@@ -750,10 +826,16 @@ onBeforeUnmount(() => {
           :material-mode="state.materialMode"
           :placement-normal="state.placementNormal"
           :place-mode="!!placePending"
+          :uv-assign-phase="uvAssignPhase"
           :surface-drag-content-guid="surfaceDragContentGuid"
           :children="state.children"
           @place-commit="onPlaceCommit"
           @place-cancel="onCancelPlace"
+          @uv-assign-click="onUvAssignClick"
+          @uv-assign-drag="onUvAssignDrag"
+          @uv-assign-drag-end="onUvAssignDragEnd"
+          @uv-assign-done="onUvAssignDone"
+          @uv-assign-cancel="onUvAssignCancel"
           @surface-drag="onSurfaceDrag"
           @surface-drag-end="onSurfaceDragEnd"
           @select-child="selectChild"
@@ -914,6 +996,18 @@ onBeforeUnmount(() => {
         @import-file="importJsonFile"
       />
     </main>
+    <AssignTextureDialog
+      :open="assignDialogOpen"
+      :loaded-textures="loadedTextures"
+      :library-projects="libraryTextureProjects"
+      :initial-uv="state.objectMaterial?.textureUv"
+      :initial-guid="state.objectMaterial?.textureAsset || ''"
+      :busy="assignBusy"
+      @close="assignDialogOpen = false"
+      @apply="onAssignApply"
+      @place="onAssignPlace"
+      @preview="onAssignPreview"
+    />
   </div>
 </template>
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/AssignTextureDialog.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/AssignTextureDialog.vue
@@ -1,0 +1,353 @@
+<script setup>
+import { computed, nextTick, reactive, ref, watch } from "vue";
+import { DEFAULT_EYE_UV, normalizeEyeUv } from "../lib/texture/eyeTexture.js";
+import * as api from "../library/api.js";
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  /** Currently loaded texture assets [{ assetGuid, name, kind }] */
+  loadedTextures: { type: Array, default: () => [] },
+  /** Library projects that may contain textures (with optional .textures summaries) */
+  libraryProjects: { type: Array, default: () => [] },
+  /** Current objectMaterial.textureUv */
+  initialUv: { type: Object, default: null },
+  /** Preselected asset guid if already assigned */
+  initialGuid: { type: String, default: "" },
+  busy: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["close", "apply", "place", "preview"]);
+
+/** "loaded:<guid>" | "lib:<slug>:<guid>" */
+const sourceKey = ref("");
+const uv = reactive({
+  ...normalizeEyeUv(props.initialUv || DEFAULT_EYE_UV),
+  eyeSeparationU: 0.12,
+});
+const status = ref("");
+const resolving = ref(false);
+/** Block live preview while the dialog is initializing (no auto-assign). */
+const previewReady = ref(false);
+
+const sources = computed(() => {
+  const rows = [];
+  const seen = new Set();
+
+  for (const t of props.loadedTextures || []) {
+    if (!t?.assetGuid || seen.has(t.assetGuid)) continue;
+    seen.add(t.assetGuid);
+    rows.push({
+      key: `loaded:${t.assetGuid}`,
+      label: `${t.name || "Texture"} (open in editor)`,
+      kind: "loaded",
+      guid: t.assetGuid,
+      slug: null,
+    });
+  }
+
+  for (const p of props.libraryProjects || []) {
+    if (p.error) continue;
+    const texList = Array.isArray(p.textures) ? p.textures : [];
+    if (texList.length) {
+      for (const t of texList) {
+        if (!t?.assetGuid) continue;
+        // Prefer the already-open copy when the same guid is loaded.
+        if (seen.has(t.assetGuid)) continue;
+        seen.add(t.assetGuid);
+        rows.push({
+          key: `lib:${p.slug}:${t.assetGuid}`,
+          label: `${t.name || "Texture"} · ${p.name || p.slug}`,
+          kind: "library",
+          guid: t.assetGuid,
+          slug: p.slug,
+        });
+      }
+      continue;
+    }
+    // Legacy list entries without per-texture summaries
+    const texN = p.textureCount || 0;
+    if (p.projectKind === "texture" || texN > 0) {
+      rows.push({
+        key: `lib:${p.slug}:`,
+        label: `${p.name || p.slug}${texN ? ` · ${texN} tex` : ""} (saved)`,
+        kind: "library",
+        guid: null,
+        slug: p.slug,
+      });
+    }
+  }
+  return rows;
+});
+
+function resetFromProps() {
+  const next = normalizeEyeUv(props.initialUv || DEFAULT_EYE_UV);
+  Object.assign(uv, {
+    ...next,
+    eyeSeparationU: next.eyeSeparationU != null ? next.eyeSeparationU : 0.12,
+  });
+  status.value = "";
+
+  // Only preselect when this mesh already has an assignment — never auto-pick “latest”.
+  const want = props.initialGuid || "";
+  if (want) {
+    const match = sources.value.find((s) => s.guid === want);
+    sourceKey.value = match?.key || (props.loadedTextures.some((t) => t.assetGuid === want)
+      ? `loaded:${want}`
+      : "");
+  } else {
+    sourceKey.value = "";
+  }
+}
+
+watch(
+  () => props.open,
+  async (on) => {
+    previewReady.value = false;
+    if (!on) return;
+    resetFromProps();
+    await nextTick();
+    previewReady.value = true;
+  },
+);
+
+// Library list may arrive right after open (refresh). Re-bind selection if needed.
+watch(
+  () => props.libraryProjects,
+  () => {
+    if (!props.open || sourceKey.value) return;
+    if (props.initialGuid) resetFromProps();
+  },
+  { deep: true },
+);
+
+function emitPreview() {
+  if (!previewReady.value || !sourceKey.value) return;
+  emit("preview", { sourceKey: sourceKey.value, uv: normalizeEyeUv(uv) });
+}
+
+watch(uv, () => emitPreview(), { deep: true });
+watch(sourceKey, () => emitPreview());
+
+async function resolveSelection() {
+  const key = sourceKey.value;
+  if (!key) return null;
+
+  if (key.startsWith("loaded:")) {
+    return { guid: key.slice("loaded:".length), assets: null };
+  }
+
+  if (key.startsWith("lib:")) {
+    const rest = key.slice("lib:".length);
+    const colon = rest.indexOf(":");
+    const slug = colon >= 0 ? rest.slice(0, colon) : rest;
+    const wantGuid = colon >= 0 ? rest.slice(colon + 1) : "";
+    resolving.value = true;
+    status.value = "Loading saved texture…";
+    try {
+      const doc = await api.loadProject(slug);
+      const assets = doc?.textureAssets || {};
+      const guids = Object.keys(assets);
+      if (!guids.length) {
+        status.value = "That project has no texture assets.";
+        return null;
+      }
+      const guid = wantGuid && assets[wantGuid] ? wantGuid : guids[0];
+      return { guid, assets };
+    } catch (err) {
+      status.value = "Load failed: " + (err.message || err);
+      return null;
+    } finally {
+      resolving.value = false;
+    }
+  }
+  return null;
+}
+
+function currentUv() {
+  return normalizeEyeUv({
+    ...uv,
+    eyeSeparationU: uv.eyeSeparationU != null ? uv.eyeSeparationU : 0.12,
+  });
+}
+
+async function onApply() {
+  const resolved = await resolveSelection();
+  if (!resolved?.guid) {
+    if (!status.value) status.value = "Pick a texture first.";
+    return;
+  }
+  emit("apply", {
+    guid: resolved.guid,
+    uv: currentUv(),
+    assets: resolved.assets,
+  });
+}
+
+/** Resolve texture then place with two corner clicks on the 3D preview. */
+async function onPlace() {
+  const resolved = await resolveSelection();
+  if (!resolved?.guid) {
+    if (!status.value) status.value = "Pick a texture first.";
+    return;
+  }
+  emit("place", {
+    guid: resolved.guid,
+    uv: currentUv(),
+    assets: resolved.assets,
+  });
+}
+
+function onBackdrop(e) {
+  if (e.target === e.currentTarget) emit("close");
+}
+</script>
+
+<template>
+  <div v-if="open" class="backdrop" @click="onBackdrop">
+    <section class="dialog" role="dialog" aria-labelledby="assign-tex-title">
+      <header>
+        <h2 id="assign-tex-title">Assign eye texture</h2>
+        <button type="button" class="x" @click="emit('close')">×</button>
+      </header>
+      <p class="hint">
+        Pick a texture, then <strong>Place on mesh</strong> and click the top-left and
+        bottom-right corners in the 3D preview. Drag afterward to fine-tune. Sliders here
+        adjust gap / fallback UV; atlas sclera uses mesh knot colors.
+      </p>
+
+      <label class="field">
+        Texture
+        <select v-model="sourceKey">
+          <option value="">Select a texture…</option>
+          <option v-for="s in sources" :key="s.key" :value="s.key">{{ s.label }}</option>
+        </select>
+      </label>
+      <p v-if="!sources.length" class="warn">
+        No textures found. Save one in Texture mode (Save As), or keep an eye open in the editor.
+      </p>
+
+      <div class="sliders">
+        <label>
+          Left ← → Right
+          <input v-model.number="uv.centerU" type="range" min="0.15" max="0.85" step="0.01" />
+          <span>{{ Number(uv.centerU).toFixed(2) }}</span>
+        </label>
+        <label>
+          Down ← → Up
+          <input v-model.number="uv.centerV" type="range" min="0.2" max="0.9" step="0.01" />
+          <span>{{ Number(uv.centerV).toFixed(2) }}</span>
+        </label>
+        <label>
+          Scale
+          <input v-model.number="uv.scale" type="range" min="0.35" max="2.5" step="0.05" />
+          <span>{{ Number(uv.scale).toFixed(2) }}×</span>
+        </label>
+        <label>
+          Eye gap
+          <input
+            v-model.number="uv.eyeSeparationU"
+            type="range"
+            min="0.04"
+            max="0.35"
+            step="0.01"
+          />
+          <span>{{ Number(uv.eyeSeparationU || 0.12).toFixed(2) }}</span>
+        </label>
+      </div>
+
+      <p v-if="status" class="status">{{ status }}</p>
+
+      <footer>
+        <button type="button" @click="emit('close')">Cancel</button>
+        <button type="button" :disabled="busy || resolving || !sourceKey" @click="onApply">
+          Apply UV
+        </button>
+        <button
+          type="button"
+          class="primary"
+          :disabled="busy || resolving || !sourceKey"
+          @click="onPlace"
+        >
+          {{ resolving ? "Loading…" : "Place on mesh" }}
+        </button>
+      </footer>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(0, 0, 0, 0.55);
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+}
+.dialog {
+  width: min(420px, 100%);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 1rem 1.1rem;
+  display: grid;
+  gap: 0.75rem;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.45);
+}
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+  font-weight: 400;
+}
+.x {
+  padding: 0.15rem 0.45rem;
+  font-size: 1.1rem;
+}
+.hint,
+.warn,
+.status {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--ink-dim);
+  line-height: 1.35;
+}
+.warn {
+  color: #e8a070;
+}
+.field {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  color: var(--ink-dim);
+}
+.field select {
+  width: 100%;
+}
+.sliders {
+  display: grid;
+  gap: 0.55rem;
+}
+.sliders label {
+  display: grid;
+  grid-template-columns: 7.5rem 1fr 2.4rem;
+  gap: 0.45rem;
+  align-items: center;
+  font-size: 0.75rem;
+  color: var(--ink-dim);
+}
+.sliders input[type="range"] {
+  width: 100%;
+}
+footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+</style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
@@ -17,6 +17,11 @@ const props = defineProps({
     default: () => ({ start: { x: 0, y: -1 }, end: { x: 0, y: 1 } }),
   },
   placeMode: { type: Boolean, default: false },
+  /**
+   * Eye UV assign on the root surface:
+   * '' | 'tl' (top-left click) | 'br' (bottom-right) | 'refine' (drag to move).
+   */
+  uvAssignPhase: { type: String, default: "" },
   /** When set (editing a sub-object), hover+drag that content’s instances on the root surface. */
   surfaceDragContentGuid: { type: String, default: null },
   children: { type: Array, default: () => [] },
@@ -26,6 +31,11 @@ const emit = defineEmits([
   "place-hover",
   "place-commit",
   "place-cancel",
+  "uv-assign-click",
+  "uv-assign-drag",
+  "uv-assign-drag-end",
+  "uv-assign-done",
+  "uv-assign-cancel",
   "surface-drag",
   "surface-drag-end",
   "select-child",
@@ -44,9 +54,17 @@ let dragGuid = null;
 let blockHostOrbit = false;
 let dragRaf = 0;
 let pendingDragHit = null;
+let uvDragging = false;
+
+const uvAssignActive = computed(() => {
+  const p = props.uvAssignPhase;
+  return p === "tl" || p === "br" || p === "refine";
+});
+
+const surfacePickActive = computed(() => props.placeMode || uvAssignActive.value);
 
 const surfaceDragActive = computed(
-  () => !!props.surfaceDragContentGuid && !props.placeMode,
+  () => !!props.surfaceDragContentGuid && !surfacePickActive.value,
 );
 
 const displayMesh = computed(() =>
@@ -58,6 +76,14 @@ const orientInv = computed(() => {
   // Display = R * authoring, so inv = R^T where R maps dir → +Y
   const R = rotationAligning(dir, { x: 0, y: 1, z: 0 });
   return transposeMat3(R);
+});
+
+const uvBanner = computed(() => {
+  const p = props.uvAssignPhase;
+  if (p === "tl") return "Eye texture · click TOP-LEFT corner on the mesh · Esc cancel · right-drag orbit";
+  if (p === "br") return "Eye texture · click BOTTOM-RIGHT corner · Esc cancel · right-drag orbit";
+  if (p === "refine") return "Eye texture · drag to reposition · Done / Esc to finish · right-drag orbit";
+  return "";
 });
 
 function pushDisplay() {
@@ -105,8 +131,10 @@ function pickEditableChild(sx, sy) {
 function syncCursor() {
   const el = canvasRef.value;
   if (!el) return;
-  if (props.placeMode) el.style.cursor = "copy";
-  else if (surfaceDragging) el.style.cursor = "grabbing";
+  if (props.placeMode || props.uvAssignPhase === "tl" || props.uvAssignPhase === "br") {
+    el.style.cursor = "copy";
+  } else if (uvDragging || surfaceDragging) el.style.cursor = "grabbing";
+  else if (props.uvAssignPhase === "refine") el.style.cursor = "grab";
   else if (hoverChildGuid.value) el.style.cursor = "grab";
   else el.style.cursor = "crosshair";
 }
@@ -115,7 +143,12 @@ function flushSurfaceDrag() {
   dragRaf = 0;
   const hit = pendingDragHit;
   pendingDragHit = null;
-  if (!hit || !dragGuid) return;
+  if (!hit) return;
+  if (uvDragging) {
+    emit("uv-assign-drag", hit);
+    return;
+  }
+  if (!dragGuid) return;
   emit("surface-drag", {
     instanceGuid: dragGuid,
     point: hit.point,
@@ -130,7 +163,7 @@ function queueSurfaceDrag(hit) {
 }
 
 function onPointerDown(e) {
-  if (props.placeMode) {
+  if (surfacePickActive.value) {
     if (e.button === 2 || e.button === 1) {
       draggingOrbit = true;
       blockHostOrbit = false;
@@ -138,6 +171,23 @@ function onPointerDown(e) {
       return;
     }
     if (e.button !== 0) return;
+    if (props.uvAssignPhase === "refine") {
+      const hit = pickRoot(e.offsetX, e.offsetY);
+      if (hit?.uv) {
+        uvDragging = true;
+        blockHostOrbit = true;
+        session?.setAutoRotate?.(false);
+        queueSurfaceDrag(hit);
+        try {
+          canvasRef.value?.setPointerCapture?.(e.pointerId);
+        } catch {
+          /* ignore */
+        }
+        e.stopPropagation();
+        syncCursor();
+        return;
+      }
+    }
     downPos = { x: e.offsetX, y: e.offsetY };
     e.stopPropagation();
     return;
@@ -168,14 +218,19 @@ function onPointerDown(e) {
 }
 
 function onPointerMove(e) {
-  if (props.placeMode) {
+  if (surfacePickActive.value) {
     if (draggingOrbit) {
       session?.host?.pointerMove?.(e.offsetX, e.offsetY);
       return;
     }
+    if (uvDragging) {
+      const rootHit = pickRoot(e.offsetX, e.offsetY);
+      if (rootHit) queueSurfaceDrag(rootHit);
+      return;
+    }
     const hit = pickRoot(e.offsetX, e.offsetY);
     hoverHit.value = hit;
-    emit("place-hover", hit);
+    if (props.placeMode) emit("place-hover", hit);
     return;
   }
 
@@ -193,7 +248,21 @@ function onPointerMove(e) {
 }
 
 function onPointerUp(e) {
-  if (props.placeMode) {
+  if (uvDragging) {
+    if (dragRaf) {
+      cancelAnimationFrame(dragRaf);
+      dragRaf = 0;
+    }
+    flushSurfaceDrag();
+    uvDragging = false;
+    blockHostOrbit = false;
+    session?.setAutoRotate?.(!surfacePickActive.value);
+    emit("uv-assign-drag-end");
+    syncCursor();
+    return;
+  }
+
+  if (surfacePickActive.value) {
     if (draggingOrbit) {
       session?.host?.pointerUp?.();
       draggingOrbit = false;
@@ -204,7 +273,11 @@ function onPointerUp(e) {
     downPos = null;
     if (dist > 6) return;
     const hit = pickRoot(e.offsetX, e.offsetY);
-    if (hit) emit("place-commit", hit);
+    if (!hit) return;
+    if (props.placeMode) emit("place-commit", hit);
+    else if (props.uvAssignPhase === "tl" || props.uvAssignPhase === "br") {
+      emit("uv-assign-click", hit);
+    }
     return;
   }
 
@@ -217,24 +290,24 @@ function onPointerUp(e) {
     surfaceDragging = false;
     dragGuid = null;
     blockHostOrbit = false;
-    session?.setAutoRotate?.(!props.placeMode);
+    session?.setAutoRotate?.(!surfacePickActive.value);
     emit("surface-drag-end");
     syncCursor();
   }
 }
 
 function onKeyDown(e) {
-  if (props.placeMode && e.key === "Escape") {
-    emit("place-cancel");
-  }
+  if (e.key !== "Escape") return;
+  if (props.placeMode) emit("place-cancel");
+  else if (uvAssignActive.value) emit("uv-assign-cancel");
 }
 
 function onContextMenu(e) {
-  if (props.placeMode || surfaceDragging) e.preventDefault();
+  if (surfacePickActive.value || surfaceDragging || uvDragging) e.preventDefault();
 }
 
 function onPointerLeave() {
-  if (surfaceDragging) return;
+  if (surfaceDragging || uvDragging) return;
   hoverChildGuid.value = null;
   syncCursor();
 }
@@ -242,7 +315,7 @@ function onPointerLeave() {
 onMounted(async () => {
   try {
     session = await createPreviewSession(canvasRef.value, 420, {
-      placeModeGetter: () => props.placeMode || blockHostOrbit,
+      placeModeGetter: () => surfacePickActive.value || blockHostOrbit,
     });
     backendLabel.value = session.useGL ? "Ranger Three · WebGL" : "Ranger Three · software";
     pushDisplay();
@@ -272,9 +345,9 @@ watch(
 );
 
 watch(
-  () => props.placeMode,
-  (on) => {
-    session?.setAutoRotate?.(!on && !surfaceDragging);
+  () => [props.placeMode, props.uvAssignPhase],
+  () => {
+    session?.setAutoRotate?.(!surfacePickActive.value && !surfaceDragging && !uvDragging);
     hoverHit.value = null;
     hoverChildGuid.value = null;
     syncCursor();
@@ -300,7 +373,11 @@ watch(
   <div
     ref="wrapRef"
     class="preview"
-    :class="{ placing: placeMode, 'surface-drag': surfaceDragActive }"
+    :class="{
+      placing: placeMode,
+      'uv-assign': uvAssignActive,
+      'surface-drag': surfaceDragActive,
+    }"
   >
     <header>
       <h2>3D preview</h2>
@@ -310,7 +387,10 @@ watch(
       <canvas
         ref="canvasRef"
         class="view"
-        :class="{ place: placeMode, grab: !!hoverChildGuid || surfaceDragging }"
+        :class="{
+          place: placeMode || uvAssignPhase === 'tl' || uvAssignPhase === 'br',
+          grab: !!hoverChildGuid || surfaceDragging || uvAssignPhase === 'refine',
+        }"
         @pointerdown.capture="onPointerDown"
         @pointermove.capture="onPointerMove"
         @pointerup.capture="onPointerUp"
@@ -320,12 +400,32 @@ watch(
       <div v-if="placeMode" class="place-banner">
         Place on surface · hover (+) · click to attach · Esc cancel · right-drag orbit
       </div>
+      <div v-else-if="uvAssignActive" class="place-banner uv">
+        <span>{{ uvBanner }}</span>
+        <button
+          v-if="uvAssignPhase === 'refine'"
+          type="button"
+          class="done"
+          @click.stop="emit('uv-assign-done')"
+        >
+          Done
+        </button>
+      </div>
       <div v-else-if="surfaceDragActive" class="place-banner drag">
         Sub edit · hover sub-object · drag along surface · right-drag orbit
       </div>
     </div>
     <p class="hint">
       <template v-if="placeMode">Aim at the root surface — sub-object aligns to the normal</template>
+      <template v-else-if="uvAssignPhase === 'tl'">
+        Click where the top-left of the eye pair should sit
+      </template>
+      <template v-else-if="uvAssignPhase === 'br'">
+        Click the bottom-right corner to set size and position
+      </template>
+      <template v-else-if="uvAssignPhase === 'refine'">
+        Drag on the surface to slide the eyes · open Assign again for scale / gap sliders
+      </template>
       <template v-else-if="surfaceDragActive">
         Drag the sub-object on the root surface (follows normals)
       </template>
@@ -348,6 +448,10 @@ watch(
 .preview.placing {
   border-color: rgba(59, 130, 246, 0.55);
   box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.25);
+}
+.preview.uv-assign {
+  border-color: rgba(250, 204, 21, 0.5);
+  box-shadow: 0 0 0 1px rgba(250, 204, 21, 0.22);
 }
 .preview.surface-drag {
   border-color: rgba(52, 211, 153, 0.45);
@@ -409,9 +513,28 @@ span {
   font-size: 0.68rem;
   pointer-events: none;
   text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 .place-banner.drag {
   color: #a7f3d0;
+}
+.place-banner.uv {
+  color: #fde68a;
+  pointer-events: none;
+}
+.place-banner .done {
+  pointer-events: auto;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.68rem;
+  border-radius: 6px;
+  border: 1px solid rgba(250, 204, 21, 0.45);
+  background: rgba(250, 204, 21, 0.18);
+  color: #fef3c7;
+  cursor: pointer;
 }
 
 .hint {

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -1,7 +1,13 @@
 import { reactive, computed, watch } from "vue";
 import { SplineLathe } from "../../../tessellate/spline_lathe.mjs";
 import { tessellateBody } from "../lib/latheTessellate.js";
-import { rasterizeEyePairUvMap, normalizeEyeTexture } from "../lib/texture/eyeTexture.js";
+import {
+  rasterizeEyePairUvMap,
+  normalizeEyeTexture,
+  normalizeEyeUv,
+  averageKnotColorHex,
+  DEFAULT_EYE_UV,
+} from "../lib/texture/eyeTexture.js";
 import { transformParts } from "../lib/meshTransform.js";
 import { evalSpan as evalPathSpan } from "../lib/pathSample.js";
 import { createEditHistory } from "../lib/editHistory.js";
@@ -64,6 +70,7 @@ function defaultObjectMaterial() {
     texture: "gradient",
     textureAsset: null,
     textureAssign: null,
+    textureUv: { ...DEFAULT_EYE_UV },
   };
 }
 
@@ -905,6 +912,13 @@ export function useSplineEditor() {
     }
   }
 
+  function meshBackgroundColor() {
+    // Prefer profile knot (vertex) colors so the UV atlas matches the painted mesh.
+    const fromKnots = averageKnotColorHex(state.knots, "");
+    if (fromKnots) return fromKnots;
+    return state.objectMaterial?.color || "#e8e4dc";
+  }
+
   function resolveTextureMap(om) {
     if (!om) return null;
     const guid = om.textureAsset;
@@ -915,7 +929,10 @@ export function useSplineEditor() {
     if (!raw) return null;
     const tex = raw.kind === "eye" || !raw.kind ? normalizeEyeTexture(raw) : raw;
     if (tex.kind === "eye" || om.textureAssign === "eyePair") {
-      return rasterizeEyePairUvMap(tex, 512, 512);
+      return rasterizeEyePairUvMap(tex, 512, 512, {
+        uv: normalizeEyeUv(om.textureUv),
+        background: meshBackgroundColor(),
+      });
     }
     return null;
   }
@@ -924,23 +941,30 @@ export function useSplineEditor() {
     textureAssetsProvider = typeof fn === "function" ? fn : () => ({});
   }
 
-  /** Assign a procedural eye texture (both eyes) onto the root mesh UV atlas. */
-  function assignEyeTextureToRoot(assetGuid) {
+  /**
+   * Assign a procedural eye texture (both eyes) onto the root mesh UV atlas.
+   * @param {string} assetGuid
+   * @param {object} [uv] centerU/centerV/scale/eyeSeparationU
+   * @param {{ recordHistory?: boolean }} [opts]
+   */
+  function assignEyeTextureToRoot(assetGuid, uv, opts = {}) {
     if (!assetGuid) return false;
     const assets = textureAssetsProvider() || {};
     if (!assets[assetGuid]) {
       state.status = "Texture asset not loaded — open it in Texture or import the project.";
       return false;
     }
-    beginGesture("assign-eye-texture");
+    const record = opts.recordHistory !== false;
+    if (record) beginGesture("assign-eye-texture");
     state.objectMaterial = {
       ...state.objectMaterial,
       texture: "asset",
       textureAsset: assetGuid,
       textureAssign: "eyePair",
+      textureUv: normalizeEyeUv(uv || state.objectMaterial?.textureUv),
     };
-    endGesture();
-    state.status = "Assigned eye texture to mesh UVs (left + right).";
+    if (record) endGesture();
+    if (record) state.status = "Assigned eye texture to mesh UVs (left + right).";
     return true;
   }
 
@@ -951,6 +975,7 @@ export function useSplineEditor() {
       texture: "gradient",
       textureAsset: null,
       textureAssign: null,
+      textureUv: { ...DEFAULT_EYE_UV },
     };
     endGesture();
     state.status = "Cleared assigned body texture.";
@@ -1221,6 +1246,7 @@ export function useSplineEditor() {
         doc.objectMaterial?.textureAssign === "eyePair"
           ? "eyePair"
           : doc.objectMaterial?.textureAssign || null,
+      textureUv: normalizeEyeUv(doc.objectMaterial?.textureUv),
     };
     state.knots = doc.profile.knots.map((k) => ({ ...k }));
     state.segments = (doc.profile.segments || []).map((s) => ({
@@ -1416,6 +1442,7 @@ export function useSplineEditor() {
     addSymmetricTwin,
     undo,
     redo,
+    beginGesture,
     beginGesture,
     endGesture,
     commitToHistory,

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/meshPick.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/meshPick.js
@@ -94,7 +94,11 @@ export function applyPreviewEulerInv(p, rx, ry) {
   return [x, y2, z2];
 }
 
-/** Möller–Trumbore; returns t or null. */
+/**
+ * Möller–Trumbore; returns hit with barycentric (u,v) or null.
+ * Weights: w0 = 1-u-v (v0), w1 = u (v1), w2 = v (v2).
+ * @returns {{ t:number, u:number, v:number } | null}
+ */
 export function intersectTriangle(origin, dir, v0, v1, v2) {
   const eps = 1e-8;
   const e1 = sub3(v1, v0);
@@ -111,12 +115,13 @@ export function intersectTriangle(origin, dir, v0, v1, v2) {
   if (v < 0 || u + v > 1) return null;
   const t = dot3(e2, qvec) * invDet;
   if (t < eps) return null;
-  return t;
+  return { t, u, v };
 }
 
 /**
  * Raycast mesh parts in the same space as the ray.
- * @returns {{ point:[number,number,number], normal:[number,number,number], t:number, instanceGuid?:string } | null}
+ * When `part.uvs` is present, interpolates lathe UV at the hit.
+ * @returns {{ point:[number,number,number], normal:[number,number,number], t:number, uv?:[number,number], instanceGuid?:string } | null}
  */
 export function raycastMeshParts(origin, dir, parts) {
   let bestT = Infinity;
@@ -125,17 +130,21 @@ export function raycastMeshParts(origin, dir, parts) {
     const pos = part.positions;
     const idx = part.indices;
     const nrm = part.normals;
+    const uvs = part.uvs;
     if (!pos?.length || !idx?.length) continue;
     for (let i = 0; i + 2 < idx.length; i += 3) {
-      const i0 = idx[i] * 3;
-      const i1 = idx[i + 1] * 3;
-      const i2 = idx[i + 2] * 3;
+      const ia = idx[i];
+      const ib = idx[i + 1];
+      const ic = idx[i + 2];
+      const i0 = ia * 3;
+      const i1 = ib * 3;
+      const i2 = ic * 3;
       const v0 = [pos[i0], pos[i0 + 1], pos[i0 + 2]];
       const v1 = [pos[i1], pos[i1 + 1], pos[i1 + 2]];
       const v2 = [pos[i2], pos[i2 + 1], pos[i2 + 2]];
-      const t = intersectTriangle(origin, dir, v0, v1, v2);
-      if (t == null || t >= bestT) continue;
-      bestT = t;
+      const hitT = intersectTriangle(origin, dir, v0, v1, v2);
+      if (hitT == null || hitT.t >= bestT) continue;
+      bestT = hitT.t;
       let n = cross3(sub3(v1, v0), sub3(v2, v0));
       if (len3(n) < 1e-12 && nrm) {
         n = [nrm[i0], nrm[i0 + 1], nrm[i0 + 2]];
@@ -143,10 +152,22 @@ export function raycastMeshParts(origin, dir, parts) {
       n = normalize3(n);
       // Face toward the ray
       if (dot3(n, dir) > 0) n = mul3(n, -1);
+      let uv = undefined;
+      if (uvs && uvs.length >= (Math.max(ia, ib, ic) + 1) * 2) {
+        const bu = hitT.u;
+        const bv = hitT.v;
+        const bw = 1 - bu - bv;
+        const u =
+          bw * uvs[ia * 2] + bu * uvs[ib * 2] + bv * uvs[ic * 2];
+        const v =
+          bw * uvs[ia * 2 + 1] + bu * uvs[ib * 2 + 1] + bv * uvs[ic * 2 + 1];
+        uv = [u, v];
+      }
       best = {
-        point: add3(origin, mul3(dir, t)),
+        point: add3(origin, mul3(dir, hitT.t)),
         normal: n,
-        t,
+        t: hitT.t,
+        uv,
         instanceGuid: part.instanceGuid || undefined,
       };
     }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -684,9 +684,130 @@ export function rasterizeEyeTexture(tex, width, height) {
   return ctx.getImageData(0, 0, w, h);
 }
 
+/** Default UV placement for eye-pair assignment on a lathe mesh. */
+export const DEFAULT_EYE_UV = {
+  centerU: 0.5,
+  centerV: 0.58,
+  /** Uniform size multiplier for both eyes. */
+  scale: 1,
+  /** Gap between eye centers in U; null → derive from eyePair.distance. */
+  eyeSeparationU: null,
+};
+
+export function normalizeEyeUv(uv) {
+  const u = uv && typeof uv === "object" ? uv : {};
+  const centerU = Number(u.centerU);
+  const centerV = Number(u.centerV);
+  const scale = Number(u.scale);
+  const sep = u.eyeSeparationU == null ? null : Number(u.eyeSeparationU);
+  return {
+    centerU: Number.isFinite(centerU) ? Math.min(1, Math.max(0, centerU)) : DEFAULT_EYE_UV.centerU,
+    centerV: Number.isFinite(centerV) ? Math.min(1, Math.max(0, centerV)) : DEFAULT_EYE_UV.centerV,
+    scale: Number.isFinite(scale) ? Math.min(3, Math.max(0.25, scale)) : DEFAULT_EYE_UV.scale,
+    eyeSeparationU:
+      sep == null || !Number.isFinite(sep) ? null : Math.min(0.5, Math.max(0.02, sep)),
+  };
+}
+
+/** Default single-eye footprint in UV (before scale). */
+export const EYE_UV_FOOTPRINT = { eyeWidthU: 0.11, eyeHeightV: 0.13 };
+
 /**
- * Rasterize left+right eyes into a UV atlas (white background for multiply lighting).
- * Lathe UVs: u around orbit, v along profile — eyes sit near the front of the head.
+ * Unwrap a U pair across the 0–1 seam (shortest arc).
+ * @returns {[number, number]} ordered [uLo, uHi] (hi may be > 1)
+ */
+export function unwrapUvPairU(u1, u2) {
+  let a = ((Number(u1) % 1) + 1) % 1;
+  let b = ((Number(u2) % 1) + 1) % 1;
+  if (!Number.isFinite(a)) a = 0;
+  if (!Number.isFinite(b)) b = 0;
+  let d = b - a;
+  if (d > 0.5) b -= 1;
+  else if (d < -0.5) b += 1;
+  return a <= b ? [a, b] : [b, a];
+}
+
+/**
+ * Build eye-pair textureUv from two mesh UV corners (top-left then bottom-right).
+ * Lathe: u around orbit, v along profile (higher v = higher on mesh).
+ */
+export function eyeUvFromCorners(u1, v1, u2, v2, opts = {}) {
+  const [uLo, uHi] = unwrapUvPairU(u1, u2);
+  let vA = Number(v1);
+  let vB = Number(v2);
+  if (!Number.isFinite(vA)) vA = 0.5;
+  if (!Number.isFinite(vB)) vB = 0.5;
+  const vLo = Math.min(vA, vB);
+  const vHi = Math.max(vA, vB);
+  const width = Math.max(0.02, uHi - uLo);
+  const height = Math.max(0.02, vHi - vLo);
+  const eyeWU = opts.eyeWidthU != null ? Number(opts.eyeWidthU) : EYE_UV_FOOTPRINT.eyeWidthU;
+  const eyeHV = opts.eyeHeightV != null ? Number(opts.eyeHeightV) : EYE_UV_FOOTPRINT.eyeHeightV;
+  const scaleH = height / (eyeHV || 0.13);
+  const preferSep =
+    opts.eyeSeparationU != null && Number.isFinite(Number(opts.eyeSeparationU))
+      ? Number(opts.eyeSeparationU)
+      : null;
+  let scale;
+  let eyeSeparationU;
+  if (preferSep != null) {
+    scale = (scaleH + width / (preferSep + eyeWU)) / 2;
+    eyeSeparationU = preferSep;
+  } else {
+    scale = scaleH;
+    eyeSeparationU = Math.min(0.45, Math.max(0.04, width - eyeWU * scale));
+  }
+  let centerU = (uLo + uHi) / 2;
+  centerU = ((centerU % 1) + 1) % 1;
+  const centerV = (vLo + vHi) / 2;
+  return normalizeEyeUv({ centerU, centerV, scale, eyeSeparationU });
+}
+
+/** Move eye-pair center to a UV hit while keeping scale / gap. */
+export function eyeUvMoveCenter(uv, u, v) {
+  const cur = normalizeEyeUv(uv);
+  const cu = ((Number(u) % 1) + 1) % 1;
+  const cv = Number(v);
+  return normalizeEyeUv({
+    ...cur,
+    centerU: Number.isFinite(cu) ? cu : cur.centerU,
+    centerV: Number.isFinite(cv) ? Math.min(1, Math.max(0, cv)) : cur.centerV,
+  });
+}
+
+/** Average knot colors → hex (mesh “vertex” tint for UV atlas background). */
+export function averageKnotColorHex(knots, fallback = "#e8e4dc") {
+  const list = knots || [];
+  if (!list.length) return fallback;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  let n = 0;
+  for (const k of list) {
+    const hex = String(k?.color || "").replace("#", "");
+    if (hex.length < 6) continue;
+    r += parseInt(hex.slice(0, 2), 16);
+    g += parseInt(hex.slice(2, 4), 16);
+    b += parseInt(hex.slice(4, 6), 16);
+    n += 1;
+  }
+  if (!n) return fallback;
+  const to = (v) => Math.round(v / n).toString(16).padStart(2, "0");
+  return `#${to(r)}${to(g)}${to(b)}`;
+}
+
+/** Clone layers with eyeball fill remapped (UV project uses mesh/vertex tint as sclera). */
+export function layersWithEyeballColor(layers, color) {
+  if (!color) return layers || [];
+  return (layers || []).map((L) =>
+    L?.type === "eyeball" ? { ...L, color } : L,
+  );
+}
+
+/**
+ * Rasterize left+right eyes into a UV atlas.
+ * Background defaults to mesh/vertex tint (not pure white) so the atlas blends.
+ * Lathe UVs: u around orbit, v along profile.
  *
  * @returns {{ rgba: Uint8ClampedArray|number[], w: number, h: number, name: string } | null}
  */
@@ -694,22 +815,27 @@ export function rasterizeEyePairUvMap(tex, width = 512, height = 512, opts = {})
   const w = Math.max(64, width | 0);
   const h = Math.max(64, height | 0);
   const pair = normalizeEyePair(tex?.eyePair);
-  const centerU = opts.centerU != null ? Number(opts.centerU) : 0.5;
-  const centerV = opts.centerV != null ? Number(opts.centerV) : 0.58;
+  const uv = normalizeEyeUv(opts.uv || opts);
+  const centerU = uv.centerU;
+  const centerV = uv.centerV;
+  const scale = uv.scale;
   const sepU =
-    opts.eyeSeparationU != null
-      ? Number(opts.eyeSeparationU)
-      : 0.1 + pair.distance * 0.08;
-  const eyeWU = opts.eyeWidthU != null ? Number(opts.eyeWidthU) : 0.11;
-  const eyeHV = opts.eyeHeightV != null ? Number(opts.eyeHeightV) : 0.13;
+    uv.eyeSeparationU != null ? uv.eyeSeparationU : 0.1 + pair.distance * 0.08;
+  const eyeWU = (opts.eyeWidthU != null ? Number(opts.eyeWidthU) : 0.11) * scale;
+  const eyeHV = (opts.eyeHeightV != null ? Number(opts.eyeHeightV) : 0.13) * scale;
+  const bg = opts.background || "#e8e4dc";
 
   if (typeof document === "undefined") {
-    // Node smoke: solid white map (assignment path is browser/WebGL).
+    // Node smoke: solid bg map (assignment path is browser/WebGL).
     const rgba = new Uint8ClampedArray(w * h * 4);
+    const hex = String(bg).replace("#", "");
+    const br = hex.length >= 6 ? parseInt(hex.slice(0, 2), 16) : 232;
+    const bg_ = hex.length >= 6 ? parseInt(hex.slice(2, 4), 16) : 228;
+    const bb = hex.length >= 6 ? parseInt(hex.slice(4, 6), 16) : 220;
     for (let i = 0; i < rgba.length; i += 4) {
-      rgba[i] = 255;
-      rgba[i + 1] = 255;
-      rgba[i + 2] = 255;
+      rgba[i] = br;
+      rgba[i + 1] = bg_;
+      rgba[i + 2] = bb;
       rgba[i + 3] = 255;
     }
     return { rgba, w, h, name: (tex?.name || "eye") + "-uv" };
@@ -719,13 +845,14 @@ export function rasterizeEyePairUvMap(tex, width = 512, height = 512, opts = {})
   canvas.width = w;
   canvas.height = h;
   const ctx = canvas.getContext("2d");
-  ctx.fillStyle = "#ffffff";
+  ctx.fillStyle = bg;
   ctx.fillRect(0, 0, w, h);
 
   const cellW = Math.max(8, Math.round(eyeWU * w));
   const cellH = Math.max(8, Math.round(eyeHV * h));
-  const left = tex.layers || [];
-  const right = rightEyeLayers(tex);
+  // Eyeball sclera follows mesh/vertex tint so the UV patch is not a white disc.
+  const left = layersWithEyeballColor(tex.layers || [], bg);
+  const right = layersWithEyeballColor(rightEyeLayers(tex), bg);
 
   function blit(layers, uCenter) {
     const x = Math.round(uCenter * w - cellW / 2);
@@ -734,7 +861,7 @@ export function rasterizeEyePairUvMap(tex, width = 512, height = 512, opts = {})
     off.width = cellW;
     off.height = cellH;
     const octx = off.getContext("2d");
-    octx.fillStyle = "#ffffff";
+    octx.fillStyle = bg;
     octx.fillRect(0, 0, cellW, cellH);
     drawEyeLayers(octx, layers, cellW, cellH);
     ctx.drawImage(off, x, y);

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -12,7 +12,7 @@ import {
   validateProject,
   normalizeProjectKind,
 } from "./schema.js";
-import { normalizeEyeTexture } from "../lib/texture/eyeTexture.js";
+import { normalizeEyeTexture, normalizeEyeUv } from "../lib/texture/eyeTexture.js";
 
 function defaultOrbitDoc() {
   const raw = SplineLathe.defaultOrbitKnots();
@@ -483,6 +483,7 @@ function normalizeV10(doc) {
     texture: om.texture || "gradient",
     textureAsset: om.textureAsset || null,
     textureAssign: om.textureAssign === "eyePair" ? "eyePair" : om.textureAssign || null,
+    textureUv: normalizeEyeUv(om.textureUv),
   };
   return v9;
 }

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -2,7 +2,7 @@
 // schema.js — semantic spline-project document + versioned migrations.
 // ============================================================================
 
-import { serializeEyeTexture } from "../lib/texture/eyeTexture.js";
+import { serializeEyeTexture, normalizeEyeUv } from "../lib/texture/eyeTexture.js";
 
 export const CURRENT_SCHEMA_VERSION = 10;
 
@@ -204,6 +204,7 @@ export function buildProjectDocument(opts) {
         st.objectMaterial?.textureAssign === "eyePair"
           ? "eyePair"
           : st.objectMaterial?.textureAssign || null,
+      textureUv: normalizeEyeUv(st.objectMaterial?.textureUv),
     },
     profile: {
       knots: (st.knots || []).map(serializeKnot),

--- a/gallery/game_engine/v2/mesh_editor/app/vite-plugin-library.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/vite-plugin-library.mjs
@@ -67,7 +67,13 @@ function listProjects(root) {
       }
       const d = mig.doc;
       const projectKind = d.projectKind === "texture" ? "texture" : "mesh";
-      const textureCount = Object.keys(d.textureAssets || {}).length;
+      const textureAssets = d.textureAssets || {};
+      const textures = Object.values(textureAssets).map((t) => ({
+        assetGuid: t.assetGuid,
+        name: t.name || "Texture",
+        kind: t.kind || "eye",
+      }));
+      const textureCount = textures.length;
       out.push({
         slug: d.slug || name,
         id: d.id,
@@ -79,6 +85,7 @@ function listProjects(root) {
         schemaVersion: d.schemaVersion,
         projectKind,
         textureCount,
+        textures,
         knotCount:
           projectKind === "texture"
             ? textureCount


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Improves eye-texture assignment on the mesh editor:

1. **Assign to mesh** opens a dialog to pick a loaded or **saved** texture (library list now includes per-texture summaries), with UV sliders for gap / fallback placement.
2. **Place on mesh** starts a 3D raycast flow: click **top-left**, then **bottom-right** on the root surface; lathe UVs are interpolated from the hit triangle and converted into `textureUv` (center, scale, eye gap).
3. After the second click, **drag** on the surface to reposition; **Done** / Esc finishes refine.
4. UV atlas background and eyeball sclera use **mesh knot / vertex colors** instead of a white disc.

## How to try
1. Texture mode → author an eye → Save As (texture project).
2. Mesh mode → **Assign to mesh** → select the saved texture → **Place on mesh**.
3. In 3D preview: click TL corner, then BR corner → drag to nudge → Done.

## Tests
- `node scripts/smoke-eye-texture.mjs`
- `node scripts/smoke-mesh-pick.mjs` (UV interpolation on hits)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

