### PR TITLE
Assign eye texture via 3D square region + stepped loader

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -16,12 +16,18 @@ import {
   restoreLayerToCircle,
   EYE_CIRCLE_RADII,
   rasterizeEyePairUvMap,
+  rasterizeEyePairUvMapAsync,
   normalizeEyeUv,
   averageKnotColorHex,
   eyeUvFromCorners,
   eyeUvMoveCenter,
   unwrapUvPairU,
 } from "../src/lib/texture/eyeTexture.js";
+import {
+  clampAssignRegion,
+  regionCorners,
+  DEFAULT_ASSIGN_REGION,
+} from "../src/lib/assignRegion.js";
 import {
   pointInPolygon,
   pathCentroid,
@@ -328,6 +334,16 @@ const moved = eyeUvMoveCenter(fromCorners, 0.42, 0.55);
 assert.ok(Math.abs(moved.centerU - 0.42) < 1e-9);
 assert.ok(Math.abs(moved.centerV - 0.55) < 1e-9);
 assert.equal(moved.scale, fromCorners.scale);
+
+const reg = clampAssignRegion(DEFAULT_ASSIGN_REGION);
+const rc = regionCorners(reg);
+assert.ok(rc.tl.x < rc.br.x && rc.tl.y < rc.br.y);
+const asyncMap = await rasterizeEyePairUvMapAsync(eye, 64, 64, {
+  background: "#c8a070",
+  uv: fromCorners,
+});
+assert.equal(asyncMap.w, 64);
+assert.equal(asyncMap.rgba.length, 64 * 64 * 4);
 
 console.log("smoke-eye-texture: ok", {
   schema: mig.doc.schemaVersion,

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -13,7 +13,6 @@ import { useSplineEditor } from "./composables/useSplineEditor.js";
 import { useTextureEditor } from "./composables/useTextureEditor.js";
 import { useLibrary } from "./composables/useLibrary.js";
 import * as api from "./library/api.js";
-import { eyeUvFromCorners, eyeUvMoveCenter } from "./lib/texture/eyeTexture.js";
 
 const {
   state,
@@ -50,12 +49,11 @@ const {
   addSymmetricTwin,
   undo,
   redo,
-  beginGesture,
   endGesture,
   isEditingChild,
   activePlacementNormal,
   setTextureAssetsProvider,
-  assignEyeTextureToRoot,
+  assignEyeTextureToRootAsync,
   clearAssignedTexture,
 } = useSplineEditor();
 
@@ -74,8 +72,11 @@ const texCanvasToolMode = tex.canvasToolMode;
 const workspace = ref("mesh"); // mesh | texture
 const assignDialogOpen = ref(false);
 const assignBusy = ref(false);
-/** @type {import('vue').Ref<null | { guid:string, phase:'tl'|'br'|'refine', cornerA?:{u:number,v:number}, seedUv:object }>} */
-const uvAssignPending = ref(null);
+const assignProgress = ref("");
+/** Square region mode on 3D preview (before texture dialog). */
+const assignRegionMode = ref(false);
+/** UV derived from the confirmed square (fed into the texture dialog). */
+const assignRegionUv = ref(null);
 
 setTextureAssetsProvider(() => tex.snapshotTextures());
 
@@ -114,125 +115,64 @@ const libraryTextureProjects = computed(() =>
   ),
 );
 
-async function openAssignDialog() {
-  uvAssignPending.value = null;
+/** Orbit first, then place a square on the mesh, then pick a texture. */
+function startAssignRegion() {
+  placePending.value = null;
+  assignDialogOpen.value = false;
+  assignRegionUv.value = null;
+  if (!state.rootMesh) tessellate();
+  assignRegionMode.value = true;
+  state.status =
+    "Assign — orbit the mesh, fit the yellow square over the eyes, then OK.";
+}
+
+function onAssignRegionCancel() {
+  assignRegionMode.value = false;
+  assignRegionUv.value = null;
+  state.status = "Eye assign cancelled.";
+}
+
+async function onAssignRegionConfirm({ textureUv }) {
+  assignRegionMode.value = false;
+  assignRegionUv.value = textureUv || null;
+  assignProgress.value = "";
   await refresh();
   assignDialogOpen.value = true;
+  state.status = "Square placed — choose which eye texture to assign.";
 }
 
 function mergeAssignAssets(assets) {
   if (assets) tex.loadTextures({ ...tex.snapshotTextures(), ...assets });
 }
 
-function onAssignApply({ guid, uv, assets }) {
+async function onAssignApply({ guid, uv, assets }) {
   assignBusy.value = true;
+  assignProgress.value = "Loading texture…";
   try {
+    await new Promise((r) => setTimeout(r, 0));
     mergeAssignAssets(assets);
-    if (assignEyeTextureToRoot(guid, uv)) tessellate();
-    assignDialogOpen.value = false;
-    uvAssignPending.value = null;
+    assignProgress.value = "Starting UV bake…";
+    const ok = await assignEyeTextureToRootAsync(guid, uv || assignRegionUv.value, {
+      onProgress: (label) => {
+        assignProgress.value = label;
+      },
+    });
+    if (ok) {
+      assignDialogOpen.value = false;
+      assignRegionUv.value = null;
+      state.status = "Eye texture assigned.";
+    }
   } finally {
     assignBusy.value = false;
+    assignProgress.value = "";
   }
-}
-
-/** Pick texture in dialog → two corner clicks on 3D preview → drag refine. */
-function onAssignPlace({ guid, uv, assets }) {
-  assignBusy.value = true;
-  try {
-    mergeAssignAssets(assets);
-    placePending.value = null;
-    assignDialogOpen.value = false;
-    if (!state.rootMesh) tessellate();
-    uvAssignPending.value = {
-      guid,
-      phase: "tl",
-      seedUv: uv || state.objectMaterial?.textureUv,
-    };
-    state.status =
-      "Eye assign — click the TOP-LEFT corner of the eye pair on the 3D mesh.";
-  } finally {
-    assignBusy.value = false;
-  }
-}
-
-/** Live preview while dragging sliders (loaded textures only; library applies on Apply). */
-let previewTimer = 0;
-function onAssignPreview({ sourceKey, uv }) {
-  if (uvAssignPending.value) return;
-  if (!sourceKey?.startsWith("loaded:")) return;
-  const guid = sourceKey.slice("loaded:".length);
-  if (!guid || !texState.textures[guid]) return;
-  clearTimeout(previewTimer);
-  previewTimer = setTimeout(() => {
-    if (assignEyeTextureToRoot(guid, uv, { recordHistory: false })) tessellate();
-  }, 120);
 }
 
 function onClearAssignedTexture() {
-  uvAssignPending.value = null;
+  assignRegionMode.value = false;
+  assignRegionUv.value = null;
   clearAssignedTexture();
   tessellate();
-}
-
-const uvAssignPhase = computed(() => uvAssignPending.value?.phase || "");
-
-function onUvAssignClick(hit) {
-  const pending = uvAssignPending.value;
-  if (!pending || !hit?.uv) {
-    state.status = "No UV on that surface — aim at the lathed root mesh.";
-    return;
-  }
-  const [u, v] = hit.uv;
-  if (pending.phase === "tl") {
-    uvAssignPending.value = {
-      ...pending,
-      phase: "br",
-      cornerA: { u, v },
-    };
-    state.status = "Eye assign — click the BOTTOM-RIGHT corner.";
-    return;
-  }
-  if (pending.phase === "br" && pending.cornerA) {
-    const nextUv = eyeUvFromCorners(pending.cornerA.u, pending.cornerA.v, u, v, {
-      eyeSeparationU: pending.seedUv?.eyeSeparationU,
-    });
-    if (assignEyeTextureToRoot(pending.guid, nextUv)) tessellate();
-    uvAssignPending.value = {
-      guid: pending.guid,
-      phase: "refine",
-      seedUv: nextUv,
-    };
-    state.status = "Eye assign — drag to reposition, then Done (or Esc).";
-  }
-}
-
-function onUvAssignDrag(hit) {
-  const pending = uvAssignPending.value;
-  if (!pending || pending.phase !== "refine" || !hit?.uv) return;
-  beginGesture("move-eye-texture");
-  const [u, v] = hit.uv;
-  const nextUv = eyeUvMoveCenter(state.objectMaterial?.textureUv || pending.seedUv, u, v);
-  if (assignEyeTextureToRoot(pending.guid, nextUv, { recordHistory: false })) {
-    tessellate();
-  }
-}
-
-function onUvAssignDragEnd() {
-  endGesture();
-}
-
-function onUvAssignDone() {
-  uvAssignPending.value = null;
-  state.status = "Eye texture placement done.";
-}
-
-function onUvAssignCancel() {
-  const phase = uvAssignPending.value?.phase;
-  uvAssignPending.value = null;
-  state.status =
-    phase === "refine" ? "Eye texture placement kept (cancel during refine)." : "Eye assign cancelled.";
-  // If cancelled mid-corners before apply, leave mesh as it was.
 }
 
 const materials = [
@@ -388,7 +328,7 @@ const placeLabel = computed(() => {
 async function onBeginPlace({ slug, mode, symmetric }) {
   try {
     const doc = await api.loadProject(slug);
-    uvAssignPending.value = null;
+    assignRegionMode.value = false;
     placePending.value = { slug, mode, symmetric, doc };
     state.status = `Place mode — click the root surface in 3D to attach “${doc.name || slug}”.`;
     if (!state.rootMesh) tessellate();
@@ -699,8 +639,8 @@ onBeforeUnmount(() => {
       <button
         type="button"
         class="primary"
-        title="Choose eye texture and place both eyes on the mesh"
-        @click="openAssignDialog"
+        title="Place a square on the 3D preview, then choose an eye texture"
+        @click="startAssignRegion"
       >
         Assign to mesh
       </button>
@@ -826,16 +766,13 @@ onBeforeUnmount(() => {
           :material-mode="state.materialMode"
           :placement-normal="state.placementNormal"
           :place-mode="!!placePending"
-          :uv-assign-phase="uvAssignPhase"
+          :region-mode="assignRegionMode"
           :surface-drag-content-guid="surfaceDragContentGuid"
           :children="state.children"
           @place-commit="onPlaceCommit"
           @place-cancel="onCancelPlace"
-          @uv-assign-click="onUvAssignClick"
-          @uv-assign-drag="onUvAssignDrag"
-          @uv-assign-drag-end="onUvAssignDragEnd"
-          @uv-assign-done="onUvAssignDone"
-          @uv-assign-cancel="onUvAssignCancel"
+          @region-confirm="onAssignRegionConfirm"
+          @region-cancel="onAssignRegionCancel"
           @surface-drag="onSurfaceDrag"
           @surface-drag-end="onSurfaceDragEnd"
           @select-child="selectChild"
@@ -1000,13 +937,16 @@ onBeforeUnmount(() => {
       :open="assignDialogOpen"
       :loaded-textures="loadedTextures"
       :library-projects="libraryTextureProjects"
-      :initial-uv="state.objectMaterial?.textureUv"
+      :initial-uv="assignRegionUv || state.objectMaterial?.textureUv"
       :initial-guid="state.objectMaterial?.textureAsset || ''"
       :busy="assignBusy"
-      @close="assignDialogOpen = false"
+      :progress-label="assignProgress"
+      @close="
+        () => {
+          if (!assignBusy) assignDialogOpen = false;
+        }
+      "
       @apply="onAssignApply"
-      @place="onAssignPlace"
-      @preview="onAssignPreview"
     />
   </div>
 </template>

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/AssignTextureDialog.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/AssignTextureDialog.vue
@@ -9,14 +9,16 @@ const props = defineProps({
   loadedTextures: { type: Array, default: () => [] },
   /** Library projects that may contain textures (with optional .textures summaries) */
   libraryProjects: { type: Array, default: () => [] },
-  /** Current objectMaterial.textureUv */
+  /** UV from the 3D square region (required placement). */
   initialUv: { type: Object, default: null },
   /** Preselected asset guid if already assigned */
   initialGuid: { type: String, default: "" },
   busy: { type: Boolean, default: false },
+  /** Progress label while assign runs (loader). */
+  progressLabel: { type: String, default: "" },
 });
 
-const emit = defineEmits(["close", "apply", "place", "preview"]);
+const emit = defineEmits(["close", "apply"]);
 
 /** "loaded:<guid>" | "lib:<slug>:<guid>" */
 const sourceKey = ref("");
@@ -26,8 +28,6 @@ const uv = reactive({
 });
 const status = ref("");
 const resolving = ref(false);
-/** Block live preview while the dialog is initializing (no auto-assign). */
-const previewReady = ref(false);
 
 const sources = computed(() => {
   const rows = [];
@@ -51,7 +51,6 @@ const sources = computed(() => {
     if (texList.length) {
       for (const t of texList) {
         if (!t?.assetGuid) continue;
-        // Prefer the already-open copy when the same guid is loaded.
         if (seen.has(t.assetGuid)) continue;
         seen.add(t.assetGuid);
         rows.push({
@@ -64,7 +63,6 @@ const sources = computed(() => {
       }
       continue;
     }
-    // Legacy list entries without per-texture summaries
     const texN = p.textureCount || 0;
     if (p.projectKind === "texture" || texN > 0) {
       rows.push({
@@ -87,13 +85,12 @@ function resetFromProps() {
   });
   status.value = "";
 
-  // Only preselect when this mesh already has an assignment — never auto-pick “latest”.
   const want = props.initialGuid || "";
   if (want) {
     const match = sources.value.find((s) => s.guid === want);
-    sourceKey.value = match?.key || (props.loadedTextures.some((t) => t.assetGuid === want)
-      ? `loaded:${want}`
-      : "");
+    sourceKey.value =
+      match?.key ||
+      (props.loadedTextures.some((t) => t.assetGuid === want) ? `loaded:${want}` : "");
   } else {
     sourceKey.value = "";
   }
@@ -102,15 +99,12 @@ function resetFromProps() {
 watch(
   () => props.open,
   async (on) => {
-    previewReady.value = false;
     if (!on) return;
     resetFromProps();
     await nextTick();
-    previewReady.value = true;
   },
 );
 
-// Library list may arrive right after open (refresh). Re-bind selection if needed.
 watch(
   () => props.libraryProjects,
   () => {
@@ -120,13 +114,18 @@ watch(
   { deep: true },
 );
 
-function emitPreview() {
-  if (!previewReady.value || !sourceKey.value) return;
-  emit("preview", { sourceKey: sourceKey.value, uv: normalizeEyeUv(uv) });
-}
-
-watch(uv, () => emitPreview(), { deep: true });
-watch(sourceKey, () => emitPreview());
+watch(
+  () => props.initialUv,
+  (v) => {
+    if (!props.open || !v) return;
+    const next = normalizeEyeUv(v);
+    Object.assign(uv, {
+      ...next,
+      eyeSeparationU: next.eyeSeparationU != null ? next.eyeSeparationU : uv.eyeSeparationU,
+    });
+  },
+  { deep: true },
+);
 
 async function resolveSelection() {
   const key = sourceKey.value;
@@ -163,13 +162,6 @@ async function resolveSelection() {
   return null;
 }
 
-function currentUv() {
-  return normalizeEyeUv({
-    ...uv,
-    eyeSeparationU: uv.eyeSeparationU != null ? uv.eyeSeparationU : 0.12,
-  });
-}
-
 async function onApply() {
   const resolved = await resolveSelection();
   if (!resolved?.guid) {
@@ -178,26 +170,16 @@ async function onApply() {
   }
   emit("apply", {
     guid: resolved.guid,
-    uv: currentUv(),
-    assets: resolved.assets,
-  });
-}
-
-/** Resolve texture then place with two corner clicks on the 3D preview. */
-async function onPlace() {
-  const resolved = await resolveSelection();
-  if (!resolved?.guid) {
-    if (!status.value) status.value = "Pick a texture first.";
-    return;
-  }
-  emit("place", {
-    guid: resolved.guid,
-    uv: currentUv(),
+    uv: normalizeEyeUv({
+      ...uv,
+      eyeSeparationU: uv.eyeSeparationU != null ? uv.eyeSeparationU : 0.12,
+    }),
     assets: resolved.assets,
   });
 }
 
 function onBackdrop(e) {
+  if (props.busy) return;
   if (e.target === e.currentTarget) emit("close");
 }
 </script>
@@ -206,18 +188,17 @@ function onBackdrop(e) {
   <div v-if="open" class="backdrop" @click="onBackdrop">
     <section class="dialog" role="dialog" aria-labelledby="assign-tex-title">
       <header>
-        <h2 id="assign-tex-title">Assign eye texture</h2>
-        <button type="button" class="x" @click="emit('close')">×</button>
+        <h2 id="assign-tex-title">Choose eye texture</h2>
+        <button type="button" class="x" :disabled="busy" @click="emit('close')">×</button>
       </header>
       <p class="hint">
-        Pick a texture, then <strong>Place on mesh</strong> and click the top-left and
-        bottom-right corners in the 3D preview. Drag afterward to fine-tune. Sliders here
-        adjust gap / fallback UV; atlas sclera uses mesh knot colors.
+        Placement comes from the square on the 3D preview. Pick which eye texture to paint
+        there — assignment may take a moment.
       </p>
 
       <label class="field">
         Texture
-        <select v-model="sourceKey">
+        <select v-model="sourceKey" :disabled="busy">
           <option value="">Select a texture…</option>
           <option v-for="s in sources" :key="s.key" :value="s.key">{{ s.label }}</option>
         </select>
@@ -226,49 +207,34 @@ function onBackdrop(e) {
         No textures found. Save one in Texture mode (Save As), or keep an eye open in the editor.
       </p>
 
-      <div class="sliders">
-        <label>
-          Left ← → Right
-          <input v-model.number="uv.centerU" type="range" min="0.15" max="0.85" step="0.01" />
-          <span>{{ Number(uv.centerU).toFixed(2) }}</span>
-        </label>
-        <label>
-          Down ← → Up
-          <input v-model.number="uv.centerV" type="range" min="0.2" max="0.9" step="0.01" />
-          <span>{{ Number(uv.centerV).toFixed(2) }}</span>
-        </label>
-        <label>
-          Scale
-          <input v-model.number="uv.scale" type="range" min="0.35" max="2.5" step="0.05" />
-          <span>{{ Number(uv.scale).toFixed(2) }}×</span>
-        </label>
-        <label>
-          Eye gap
-          <input
-            v-model.number="uv.eyeSeparationU"
-            type="range"
-            min="0.04"
-            max="0.35"
-            step="0.01"
-          />
-          <span>{{ Number(uv.eyeSeparationU || 0.12).toFixed(2) }}</span>
-        </label>
-      </div>
+      <label class="gap">
+        Eye gap
+        <input
+          v-model.number="uv.eyeSeparationU"
+          type="range"
+          min="0.04"
+          max="0.35"
+          step="0.01"
+          :disabled="busy"
+        />
+        <span>{{ Number(uv.eyeSeparationU || 0.12).toFixed(2) }}</span>
+      </label>
 
-      <p v-if="status" class="status">{{ status }}</p>
+      <div v-if="busy || progressLabel" class="loader" aria-live="polite">
+        <div class="spinner" />
+        <p>{{ progressLabel || "Assigning…" }}</p>
+      </div>
+      <p v-else-if="status" class="status">{{ status }}</p>
 
       <footer>
-        <button type="button" @click="emit('close')">Cancel</button>
-        <button type="button" :disabled="busy || resolving || !sourceKey" @click="onApply">
-          Apply UV
-        </button>
+        <button type="button" :disabled="busy" @click="emit('close')">Cancel</button>
         <button
           type="button"
           class="primary"
           :disabled="busy || resolving || !sourceKey"
-          @click="onPlace"
+          @click="onApply"
         >
-          {{ resolving ? "Loading…" : "Place on mesh" }}
+          {{ busy ? "Working…" : resolving ? "Loading…" : "Assign" }}
         </button>
       </footer>
     </section>
@@ -330,20 +296,44 @@ h2 {
 .field select {
   width: 100%;
 }
-.sliders {
+.gap {
   display: grid;
-  gap: 0.55rem;
-}
-.sliders label {
-  display: grid;
-  grid-template-columns: 7.5rem 1fr 2.4rem;
+  grid-template-columns: 5rem 1fr 2.4rem;
   gap: 0.45rem;
   align-items: center;
   font-size: 0.75rem;
   color: var(--ink-dim);
 }
-.sliders input[type="range"] {
+.gap input[type="range"] {
   width: 100%;
+}
+.loader {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.22);
+  border: 1px solid var(--line);
+}
+.loader p {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--ink);
+}
+.spinner {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 50%;
+  border: 2px solid rgba(250, 204, 21, 0.25);
+  border-top-color: #facc15;
+  animation: spin 0.7s linear infinite;
+  flex: 0 0 auto;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 footer {
   display: flex;

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, onBeforeUnmount, ref, watch, computed } from "vue";
+import { onMounted, onBeforeUnmount, ref, watch, computed, reactive } from "vue";
 import { createPreviewSession } from "../lib/rangerPreview.js";
 import {
   orientMeshToPlacementNormal,
@@ -7,6 +7,13 @@ import {
   rotationAligning,
 } from "../lib/placementNormal.js";
 import { pickRootSurface, transposeMat3 } from "../lib/meshPick.js";
+import {
+  DEFAULT_ASSIGN_REGION,
+  clampAssignRegion,
+  regionCorners,
+  regionToCanvas,
+} from "../lib/assignRegion.js";
+import { eyeUvFromCorners } from "../lib/texture/eyeTexture.js";
 
 const props = defineProps({
   mesh: { type: Object, default: null },
@@ -17,11 +24,8 @@ const props = defineProps({
     default: () => ({ start: { x: 0, y: -1 }, end: { x: 0, y: 1 } }),
   },
   placeMode: { type: Boolean, default: false },
-  /**
-   * Eye UV assign on the root surface:
-   * '' | 'tl' (top-left click) | 'br' (bottom-right) | 'refine' (drag to move).
-   */
-  uvAssignPhase: { type: String, default: "" },
+  /** Square region placement for eye UV assign (before texture dialog). */
+  regionMode: { type: Boolean, default: false },
   /** When set (editing a sub-object), hover+drag that content’s instances on the root surface. */
   surfaceDragContentGuid: { type: String, default: null },
   children: { type: Array, default: () => [] },
@@ -31,11 +35,8 @@ const emit = defineEmits([
   "place-hover",
   "place-commit",
   "place-cancel",
-  "uv-assign-click",
-  "uv-assign-drag",
-  "uv-assign-drag-end",
-  "uv-assign-done",
-  "uv-assign-cancel",
+  "region-confirm",
+  "region-cancel",
   "surface-drag",
   "surface-drag-end",
   "select-child",
@@ -46,6 +47,8 @@ const wrapRef = ref(null);
 const backendLabel = ref("…");
 const hoverHit = ref(null);
 const hoverChildGuid = ref(null);
+const region = reactive({ ...DEFAULT_ASSIGN_REGION });
+const regionError = ref("");
 let session = null;
 let draggingOrbit = false;
 let downPos = null;
@@ -54,14 +57,10 @@ let dragGuid = null;
 let blockHostOrbit = false;
 let dragRaf = 0;
 let pendingDragHit = null;
-let uvDragging = false;
+/** @type {null | 'center' | 'tl' | 'tr' | 'bl' | 'br'} */
+let regionDrag = null;
 
-const uvAssignActive = computed(() => {
-  const p = props.uvAssignPhase;
-  return p === "tl" || p === "br" || p === "refine";
-});
-
-const surfacePickActive = computed(() => props.placeMode || uvAssignActive.value);
+const surfacePickActive = computed(() => props.placeMode || props.regionMode);
 
 const surfaceDragActive = computed(
   () => !!props.surfaceDragContentGuid && !surfacePickActive.value,
@@ -73,17 +72,20 @@ const displayMesh = computed(() =>
 
 const orientInv = computed(() => {
   const dir = placementNormalDirection3(props.placementNormal);
-  // Display = R * authoring, so inv = R^T where R maps dir → +Y
   const R = rotationAligning(dir, { x: 0, y: 1, z: 0 });
   return transposeMat3(R);
 });
 
-const uvBanner = computed(() => {
-  const p = props.uvAssignPhase;
-  if (p === "tl") return "Eye texture · click TOP-LEFT corner on the mesh · Esc cancel · right-drag orbit";
-  if (p === "br") return "Eye texture · click BOTTOM-RIGHT corner · Esc cancel · right-drag orbit";
-  if (p === "refine") return "Eye texture · drag to reposition · Done / Esc to finish · right-drag orbit";
-  return "";
+const corners = computed(() => regionCorners(region));
+
+const regionStyle = computed(() => {
+  const c = corners.value;
+  return {
+    left: c.tl.x * 100 + "%",
+    top: c.tl.y * 100 + "%",
+    width: (c.br.x - c.tl.x) * 100 + "%",
+    height: (c.br.y - c.tl.y) * 100 + "%",
+  };
 });
 
 function pushDisplay() {
@@ -93,6 +95,29 @@ function pushDisplay() {
 
 function getView() {
   return session?.getView?.() || null;
+}
+
+/** CSS offset → canvas pixel coords (handles CSS-scaled canvas). */
+function eventToCanvas(e) {
+  const el = canvasRef.value;
+  if (!el) return { sx: e.offsetX, sy: e.offsetY };
+  const cw = el.clientWidth || 1;
+  const ch = el.clientHeight || 1;
+  return {
+    sx: (e.offsetX / cw) * (el.width || cw),
+    sy: (e.offsetY / ch) * (el.height || ch),
+  };
+}
+
+function eventToNorm(e) {
+  const el = canvasRef.value;
+  if (!el) return { x: 0.5, y: 0.5 };
+  const cw = el.clientWidth || 1;
+  const ch = el.clientHeight || 1;
+  return {
+    x: Math.min(1, Math.max(0, e.offsetX / cw)),
+    y: Math.min(1, Math.max(0, e.offsetY / ch)),
+  };
 }
 
 function pickParts(sx, sy, parts) {
@@ -131,10 +156,9 @@ function pickEditableChild(sx, sy) {
 function syncCursor() {
   const el = canvasRef.value;
   if (!el) return;
-  if (props.placeMode || props.uvAssignPhase === "tl" || props.uvAssignPhase === "br") {
-    el.style.cursor = "copy";
-  } else if (uvDragging || surfaceDragging) el.style.cursor = "grabbing";
-  else if (props.uvAssignPhase === "refine") el.style.cursor = "grab";
+  if (props.placeMode) el.style.cursor = "copy";
+  else if (props.regionMode) el.style.cursor = regionDrag ? "grabbing" : "default";
+  else if (surfaceDragging) el.style.cursor = "grabbing";
   else if (hoverChildGuid.value) el.style.cursor = "grab";
   else el.style.cursor = "crosshair";
 }
@@ -143,12 +167,7 @@ function flushSurfaceDrag() {
   dragRaf = 0;
   const hit = pendingDragHit;
   pendingDragHit = null;
-  if (!hit) return;
-  if (uvDragging) {
-    emit("uv-assign-drag", hit);
-    return;
-  }
-  if (!dragGuid) return;
+  if (!hit || !dragGuid) return;
   emit("surface-drag", {
     instanceGuid: dragGuid,
     point: hit.point,
@@ -162,8 +181,111 @@ function queueSurfaceDrag(hit) {
   dragRaf = requestAnimationFrame(flushSurfaceDrag);
 }
 
+function resetRegion() {
+  Object.assign(region, clampAssignRegion(DEFAULT_ASSIGN_REGION));
+  regionError.value = "";
+  regionDrag = null;
+}
+
+function applyRegionDrag(nx, ny) {
+  if (!regionDrag) return;
+  if (regionDrag === "center") {
+    Object.assign(region, clampAssignRegion({ cx: nx, cy: ny, half: region.half }));
+    return;
+  }
+  const half = Math.max(Math.abs(nx - region.cx), Math.abs(ny - region.cy));
+  Object.assign(region, clampAssignRegion({ cx: region.cx, cy: region.cy, half }));
+}
+
+function hitOnRegionHandle(nx, ny) {
+  const c = regionCorners(region);
+  const pad = 0.035;
+  const pts = [
+    ["tl", c.tl],
+    ["tr", c.tr],
+    ["bl", c.bl],
+    ["br", c.br],
+    ["center", c.center],
+  ];
+  for (const [name, p] of pts) {
+    if (Math.hypot(nx - p.x, ny - p.y) <= pad) return name;
+  }
+  // Inside square → move
+  if (nx >= c.tl.x && nx <= c.br.x && ny >= c.tl.y && ny <= c.br.y) {
+    return "center";
+  }
+  return null;
+}
+
+function clientToNorm(clientX, clientY) {
+  const el = canvasRef.value;
+  if (!el) return { x: 0.5, y: 0.5 };
+  const rect = el.getBoundingClientRect();
+  const w = rect.width || 1;
+  const h = rect.height || 1;
+  return {
+    x: Math.min(1, Math.max(0, (clientX - rect.left) / w)),
+    y: Math.min(1, Math.max(0, (clientY - rect.top) / h)),
+  };
+}
+
+function endRegionDrag() {
+  if (!regionDrag) return;
+  regionDrag = null;
+  blockHostOrbit = false;
+  window.removeEventListener("pointermove", onRegionWindowMove);
+  window.removeEventListener("pointerup", onRegionWindowUp);
+  syncCursor();
+}
+
+function onRegionWindowMove(e) {
+  if (!regionDrag) return;
+  const n = clientToNorm(e.clientX, e.clientY);
+  applyRegionDrag(n.x, n.y);
+}
+
+function onRegionWindowUp() {
+  endRegionDrag();
+}
+
+function startRegionDrag(handle) {
+  if (!handle) return;
+  regionDrag = handle;
+  blockHostOrbit = true;
+  regionError.value = "";
+  window.addEventListener("pointermove", onRegionWindowMove);
+  window.addEventListener("pointerup", onRegionWindowUp);
+  syncCursor();
+}
+
+function confirmRegion() {
+  regionError.value = "";
+  const el = canvasRef.value;
+  if (!el) {
+    regionError.value = "Preview not ready.";
+    return;
+  }
+  const c = regionCorners(region);
+  const tlC = regionToCanvas(c.tl.x, c.tl.y, el);
+  const brC = regionToCanvas(c.br.x, c.br.y, el);
+  const tlHit = pickRoot(tlC.sx, tlC.sy);
+  const brHit = pickRoot(brC.sx, brC.sy);
+  if (!tlHit?.uv || !brHit?.uv) {
+    regionError.value =
+      "Square corners must sit on the mesh — rotate the view or move the square.";
+    return;
+  }
+  const textureUv = eyeUvFromCorners(
+    tlHit.uv[0],
+    tlHit.uv[1],
+    brHit.uv[0],
+    brHit.uv[1],
+  );
+  emit("region-confirm", { textureUv, region: { ...region } });
+}
+
 function onPointerDown(e) {
-  if (surfacePickActive.value) {
+  if (props.regionMode) {
     if (e.button === 2 || e.button === 1) {
       draggingOrbit = true;
       blockHostOrbit = false;
@@ -171,30 +293,34 @@ function onPointerDown(e) {
       return;
     }
     if (e.button !== 0) return;
-    if (props.uvAssignPhase === "refine") {
-      const hit = pickRoot(e.offsetX, e.offsetY);
-      if (hit?.uv) {
-        uvDragging = true;
-        blockHostOrbit = true;
-        session?.setAutoRotate?.(false);
-        queueSurfaceDrag(hit);
-        try {
-          canvasRef.value?.setPointerCapture?.(e.pointerId);
-        } catch {
-          /* ignore */
-        }
-        e.stopPropagation();
-        syncCursor();
-        return;
-      }
+    const n = eventToNorm(e);
+    const handle = hitOnRegionHandle(n.x, n.y);
+    if (handle) {
+      startRegionDrag(handle);
+      e.stopPropagation();
+      return;
     }
+    // Outside square: left-click does nothing (right-drag still orbits).
+    e.stopPropagation();
+    return;
+  }
+
+  if (props.placeMode) {
+    if (e.button === 2 || e.button === 1) {
+      draggingOrbit = true;
+      blockHostOrbit = false;
+      session?.host?.pointerDown?.(e.offsetX, e.offsetY, e.button);
+      return;
+    }
+    if (e.button !== 0) return;
     downPos = { x: e.offsetX, y: e.offsetY };
     e.stopPropagation();
     return;
   }
 
   if (surfaceDragActive.value && e.button === 0) {
-    const childHit = pickEditableChild(e.offsetX, e.offsetY);
+    const { sx, sy } = eventToCanvas(e);
+    const childHit = pickEditableChild(sx, sy);
     if (childHit?.instanceGuid) {
       surfaceDragging = true;
       dragGuid = childHit.instanceGuid;
@@ -202,8 +328,7 @@ function onPointerDown(e) {
       hoverChildGuid.value = dragGuid;
       session?.setAutoRotate?.(false);
       emit("select-child", dragGuid);
-      // Snap immediately if root is under the cursor
-      const rootHit = pickRoot(e.offsetX, e.offsetY);
+      const rootHit = pickRoot(sx, sy);
       if (rootHit) queueSurfaceDrag(rootHit);
       try {
         canvasRef.value?.setPointerCapture?.(e.pointerId);
@@ -218,51 +343,51 @@ function onPointerDown(e) {
 }
 
 function onPointerMove(e) {
-  if (surfacePickActive.value) {
+  if (props.regionMode) {
     if (draggingOrbit) {
       session?.host?.pointerMove?.(e.offsetX, e.offsetY);
       return;
     }
-    if (uvDragging) {
-      const rootHit = pickRoot(e.offsetX, e.offsetY);
-      if (rootHit) queueSurfaceDrag(rootHit);
+    return;
+  }
+
+  if (props.placeMode) {
+    if (draggingOrbit) {
+      session?.host?.pointerMove?.(e.offsetX, e.offsetY);
       return;
     }
-    const hit = pickRoot(e.offsetX, e.offsetY);
+    const { sx, sy } = eventToCanvas(e);
+    const hit = pickRoot(sx, sy);
     hoverHit.value = hit;
-    if (props.placeMode) emit("place-hover", hit);
+    emit("place-hover", hit);
     return;
   }
 
   if (surfaceDragging && dragGuid) {
-    const rootHit = pickRoot(e.offsetX, e.offsetY);
+    const { sx, sy } = eventToCanvas(e);
+    const rootHit = pickRoot(sx, sy);
     if (rootHit) queueSurfaceDrag(rootHit);
     return;
   }
 
   if (surfaceDragActive.value) {
-    const childHit = pickEditableChild(e.offsetX, e.offsetY);
+    const { sx, sy } = eventToCanvas(e);
+    const childHit = pickEditableChild(sx, sy);
     hoverChildGuid.value = childHit?.instanceGuid || null;
     syncCursor();
   }
 }
 
 function onPointerUp(e) {
-  if (uvDragging) {
-    if (dragRaf) {
-      cancelAnimationFrame(dragRaf);
-      dragRaf = 0;
+  if (props.regionMode) {
+    if (draggingOrbit) {
+      session?.host?.pointerUp?.();
+      draggingOrbit = false;
     }
-    flushSurfaceDrag();
-    uvDragging = false;
-    blockHostOrbit = false;
-    session?.setAutoRotate?.(!surfacePickActive.value);
-    emit("uv-assign-drag-end");
-    syncCursor();
     return;
   }
 
-  if (surfacePickActive.value) {
+  if (props.placeMode) {
     if (draggingOrbit) {
       session?.host?.pointerUp?.();
       draggingOrbit = false;
@@ -272,12 +397,9 @@ function onPointerUp(e) {
     const dist = Math.hypot(e.offsetX - downPos.x, e.offsetY - downPos.y);
     downPos = null;
     if (dist > 6) return;
-    const hit = pickRoot(e.offsetX, e.offsetY);
-    if (!hit) return;
-    if (props.placeMode) emit("place-commit", hit);
-    else if (props.uvAssignPhase === "tl" || props.uvAssignPhase === "br") {
-      emit("uv-assign-click", hit);
-    }
+    const { sx, sy } = eventToCanvas(e);
+    const hit = pickRoot(sx, sy);
+    if (hit) emit("place-commit", hit);
     return;
   }
 
@@ -299,15 +421,15 @@ function onPointerUp(e) {
 function onKeyDown(e) {
   if (e.key !== "Escape") return;
   if (props.placeMode) emit("place-cancel");
-  else if (uvAssignActive.value) emit("uv-assign-cancel");
+  else if (props.regionMode) emit("region-cancel");
 }
 
 function onContextMenu(e) {
-  if (surfacePickActive.value || surfaceDragging || uvDragging) e.preventDefault();
+  if (surfacePickActive.value || surfaceDragging) e.preventDefault();
 }
 
 function onPointerLeave() {
-  if (surfaceDragging || uvDragging) return;
+  if (surfaceDragging || regionDrag) return;
   hoverChildGuid.value = null;
   syncCursor();
 }
@@ -330,6 +452,7 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   window.removeEventListener("keydown", onKeyDown);
+  endRegionDrag();
   if (dragRaf) cancelAnimationFrame(dragRaf);
   session?.dispose();
   session = null;
@@ -345,11 +468,12 @@ watch(
 );
 
 watch(
-  () => [props.placeMode, props.uvAssignPhase],
+  () => [props.placeMode, props.regionMode],
   () => {
-    session?.setAutoRotate?.(!surfacePickActive.value && !surfaceDragging && !uvDragging);
+    session?.setAutoRotate?.(!surfacePickActive.value && !surfaceDragging);
     hoverHit.value = null;
     hoverChildGuid.value = null;
+    if (props.regionMode) resetRegion();
     syncCursor();
   },
 );
@@ -375,7 +499,7 @@ watch(
     class="preview"
     :class="{
       placing: placeMode,
-      'uv-assign': uvAssignActive,
+      'region-mode': regionMode,
       'surface-drag': surfaceDragActive,
     }"
   >
@@ -388,8 +512,8 @@ watch(
         ref="canvasRef"
         class="view"
         :class="{
-          place: placeMode || uvAssignPhase === 'tl' || uvAssignPhase === 'br',
-          grab: !!hoverChildGuid || surfaceDragging || uvAssignPhase === 'refine',
+          place: placeMode,
+          grab: !!hoverChildGuid || surfaceDragging,
         }"
         @pointerdown.capture="onPointerDown"
         @pointermove.capture="onPointerMove"
@@ -397,34 +521,48 @@ watch(
         @pointerleave="onPointerLeave"
         @contextmenu="onContextMenu"
       />
+
+      <div v-if="regionMode" class="region-layer" aria-hidden="true">
+        <div class="region-box" :style="regionStyle">
+          <button
+            type="button"
+            class="handle center"
+            title="Drag to move"
+            @pointerdown.stop.prevent="startRegionDrag('center')"
+          />
+          <button
+            v-for="h in ['tl', 'tr', 'bl', 'br']"
+            :key="h"
+            type="button"
+            class="handle corner"
+            :class="h"
+            title="Drag to resize"
+            @pointerdown.stop.prevent="startRegionDrag(h)"
+          />
+        </div>
+      </div>
+
       <div v-if="placeMode" class="place-banner">
         Place on surface · hover (+) · click to attach · Esc cancel · right-drag orbit
       </div>
-      <div v-else-if="uvAssignActive" class="place-banner uv">
-        <span>{{ uvBanner }}</span>
-        <button
-          v-if="uvAssignPhase === 'refine'"
-          type="button"
-          class="done"
-          @click.stop="emit('uv-assign-done')"
-        >
-          Done
+      <div v-else-if="regionMode" class="place-banner region">
+        <span>
+          Place the square over the eyes · drag center / corners · right-drag orbit
+        </span>
+        <button type="button" class="ban-btn" @click.stop="emit('region-cancel')">
+          Cancel
         </button>
+        <button type="button" class="ban-btn ok" @click.stop="confirmRegion">OK</button>
       </div>
       <div v-else-if="surfaceDragActive" class="place-banner drag">
         Sub edit · hover sub-object · drag along surface · right-drag orbit
       </div>
     </div>
+    <p v-if="regionError" class="err">{{ regionError }}</p>
     <p class="hint">
       <template v-if="placeMode">Aim at the root surface — sub-object aligns to the normal</template>
-      <template v-else-if="uvAssignPhase === 'tl'">
-        Click where the top-left of the eye pair should sit
-      </template>
-      <template v-else-if="uvAssignPhase === 'br'">
-        Click the bottom-right corner to set size and position
-      </template>
-      <template v-else-if="uvAssignPhase === 'refine'">
-        Drag on the surface to slide the eyes · open Assign again for scale / gap sliders
+      <template v-else-if="regionMode">
+        Orbit the mesh first if needed, then fit the square and press OK to choose a texture
       </template>
       <template v-else-if="surfaceDragActive">
         Drag the sub-object on the root surface (follows normals)
@@ -449,8 +587,8 @@ watch(
   border-color: rgba(59, 130, 246, 0.55);
   box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.25);
 }
-.preview.uv-assign {
-  border-color: rgba(250, 204, 21, 0.5);
+.preview.region-mode {
+  border-color: rgba(250, 204, 21, 0.55);
   box-shadow: 0 0 0 1px rgba(250, 204, 21, 0.22);
 }
 .preview.surface-drag {
@@ -501,6 +639,73 @@ span {
   cursor: grab;
 }
 
+.region-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: 12px;
+  overflow: hidden;
+}
+.region-box {
+  position: absolute;
+  border: 1.5px solid rgba(250, 204, 21, 0.95);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.35),
+    inset 0 0 0 999px rgba(250, 204, 21, 0.08);
+  pointer-events: none;
+}
+.handle {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  padding: 0;
+  border: 1.5px solid #fde68a;
+  background: rgba(15, 23, 42, 0.9);
+  pointer-events: auto;
+  cursor: grab;
+  box-sizing: border-box;
+}
+.handle:active {
+  cursor: grabbing;
+}
+.handle.center {
+  left: 50%;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(250, 204, 21, 0.85);
+  border-color: #fff8c5;
+}
+.handle.corner {
+  border-radius: 2px;
+}
+.handle.tl {
+  left: 0;
+  top: 0;
+  transform: translate(-50%, -50%);
+  cursor: nwse-resize;
+}
+.handle.tr {
+  right: 0;
+  top: 0;
+  transform: translate(50%, -50%);
+  cursor: nesw-resize;
+}
+.handle.bl {
+  left: 0;
+  bottom: 0;
+  transform: translate(-50%, 50%);
+  cursor: nesw-resize;
+}
+.handle.br {
+  right: 0;
+  bottom: 0;
+  transform: translate(50%, 50%);
+  cursor: nwse-resize;
+}
+
 .place-banner {
   position: absolute;
   left: 0.5rem;
@@ -516,30 +721,39 @@ span {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.45rem;
   flex-wrap: wrap;
 }
 .place-banner.drag {
   color: #a7f3d0;
 }
-.place-banner.uv {
+.place-banner.region {
   color: #fde68a;
   pointer-events: none;
 }
-.place-banner .done {
+.place-banner .ban-btn {
   pointer-events: auto;
   padding: 0.2rem 0.55rem;
   font-size: 0.68rem;
   border-radius: 6px;
-  border: 1px solid rgba(250, 204, 21, 0.45);
-  background: rgba(250, 204, 21, 0.18);
-  color: #fef3c7;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  color: #e5e7eb;
   cursor: pointer;
 }
+.place-banner .ban-btn.ok {
+  border-color: rgba(250, 204, 21, 0.55);
+  background: rgba(250, 204, 21, 0.22);
+  color: #fef3c7;
+}
 
-.hint {
+.hint,
+.err {
   margin: 0;
   font-size: 0.72rem;
   color: var(--ink-dim);
+}
+.err {
+  color: #f0a070;
 }
 </style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -3,6 +3,7 @@ import { SplineLathe } from "../../../tessellate/spline_lathe.mjs";
 import { tessellateBody } from "../lib/latheTessellate.js";
 import {
   rasterizeEyePairUvMap,
+  rasterizeEyePairUvMapAsync,
   normalizeEyeTexture,
   normalizeEyeUv,
   averageKnotColorHex,
@@ -137,6 +138,8 @@ function loadSpineBlock(block, fallbackKnots) {
 export function useSplineEditor() {
   /** Optional provider for procedural texture assets (from Texture editor / library). */
   let textureAssetsProvider = () => /** @type {Record<string, any>} */ ({});
+  /** Pre-baked UV atlas for async assign: { guid, map } kept for one tessellate pass. */
+  let pendingTextureMap = null;
 
   const state = reactive({
     assetGuid: newGuid(),
@@ -920,6 +923,13 @@ export function useSplineEditor() {
   }
 
   function resolveTextureMap(om) {
+    if (
+      pendingTextureMap &&
+      om?.textureAsset &&
+      om.textureAsset === pendingTextureMap.guid
+    ) {
+      return pendingTextureMap.map;
+    }
     if (!om) return null;
     const guid = om.textureAsset;
     if (!guid) return null;
@@ -939,6 +949,14 @@ export function useSplineEditor() {
 
   function setTextureAssetsProvider(fn) {
     textureAssetsProvider = typeof fn === "function" ? fn : () => ({});
+  }
+
+  function setPendingTextureMap(map, guid = null) {
+    if (!map || !guid) {
+      pendingTextureMap = null;
+      return;
+    }
+    pendingTextureMap = { map, guid };
   }
 
   /**
@@ -965,6 +983,54 @@ export function useSplineEditor() {
     };
     if (record) endGesture();
     if (record) state.status = "Assigned eye texture to mesh UVs (left + right).";
+    return true;
+  }
+
+  /**
+   * Bake UV atlas asynchronously (yields between steps), then assign + tessellate.
+   * @param {string} assetGuid
+   * @param {object} uv
+   * @param {{ onProgress?: (label:string)=>void, width?: number, height?: number }} [opts]
+   */
+  async function assignEyeTextureToRootAsync(assetGuid, uv, opts = {}) {
+    const onProgress = typeof opts.onProgress === "function" ? opts.onProgress : () => {};
+    const assets = textureAssetsProvider() || {};
+    const raw = assets[assetGuid];
+    if (!raw) {
+      state.status = "Texture asset not loaded — open it in Texture or import the project.";
+      return false;
+    }
+    const tex = raw.kind === "eye" || !raw.kind ? normalizeEyeTexture(raw) : raw;
+    const nextUv = normalizeEyeUv(uv || state.objectMaterial?.textureUv);
+    onProgress("Painting UV atlas…");
+    const map = await rasterizeEyePairUvMapAsync(tex, opts.width || 384, opts.height || 384, {
+      uv: nextUv,
+      background: meshBackgroundColor(),
+      onProgress: (step) => {
+        if (step === "left-eye") onProgress("Drawing left eye…");
+        else if (step === "right-eye") onProgress("Drawing right eye…");
+        else if (step === "readback") onProgress("Reading atlas pixels…");
+        else if (step === "background") onProgress("Filling atlas background…");
+      },
+    });
+    if (!map) return false;
+    setPendingTextureMap(map, assetGuid);
+    onProgress("Applying to mesh…");
+    await new Promise((r) => setTimeout(r, 0));
+    if (!assignEyeTextureToRoot(assetGuid, nextUv)) {
+      setPendingTextureMap(null);
+      return false;
+    }
+    onProgress("Updating 3D mesh…");
+    await new Promise((r) => {
+      if (typeof requestAnimationFrame === "function") requestAnimationFrame(() => r());
+      else setTimeout(r, 0);
+    });
+    try {
+      tessellate();
+    } finally {
+      setPendingTextureMap(null);
+    }
     return true;
   }
 
@@ -1430,6 +1496,8 @@ export function useSplineEditor() {
     snapshotState,
     setTextureAssetsProvider,
     assignEyeTextureToRoot,
+    assignEyeTextureToRootAsync,
+    setPendingTextureMap,
     clearAssignedTexture,
     attachFromProject,
     selectChild,
@@ -1442,7 +1510,6 @@ export function useSplineEditor() {
     addSymmetricTwin,
     undo,
     redo,
-    beginGesture,
     beginGesture,
     endGesture,
     commitToHistory,

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/assignRegion.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/assignRegion.js
@@ -1,0 +1,42 @@
+// ============================================================================
+// assignRegion.js — screen-space square for eye UV placement on the 3D preview.
+// ============================================================================
+
+/** @typedef {{ cx: number, cy: number, half: number }} AssignRegion */
+
+export const DEFAULT_ASSIGN_REGION = { cx: 0.5, cy: 0.42, half: 0.14 };
+
+export function clampAssignRegion(r, minHalf = 0.04, maxHalf = 0.45) {
+  const half = Math.min(maxHalf, Math.max(minHalf, Number(r?.half) || DEFAULT_ASSIGN_REGION.half));
+  let cx = Number(r?.cx);
+  let cy = Number(r?.cy);
+  if (!Number.isFinite(cx)) cx = DEFAULT_ASSIGN_REGION.cx;
+  if (!Number.isFinite(cy)) cy = DEFAULT_ASSIGN_REGION.cy;
+  cx = Math.min(1 - half, Math.max(half, cx));
+  cy = Math.min(1 - half, Math.max(half, cy));
+  return { cx, cy, half };
+}
+
+/** Normalized corners (y grows downward). */
+export function regionCorners(r) {
+  const reg = clampAssignRegion(r);
+  return {
+    tl: { x: reg.cx - reg.half, y: reg.cy - reg.half },
+    tr: { x: reg.cx + reg.half, y: reg.cy - reg.half },
+    bl: { x: reg.cx - reg.half, y: reg.cy + reg.half },
+    br: { x: reg.cx + reg.half, y: reg.cy + reg.half },
+    center: { x: reg.cx, y: reg.cy },
+  };
+}
+
+/**
+ * Map normalized overlay coords → canvas pixel coords used by raycast.
+ * @param {number} nx
+ * @param {number} ny
+ * @param {{ width: number, height: number }} canvas
+ */
+export function regionToCanvas(nx, ny, canvas) {
+  const w = canvas?.width || 1;
+  const h = canvas?.height || 1;
+  return { sx: nx * w, sy: ny * h };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -878,3 +878,92 @@ export function rasterizeEyePairUvMap(tex, width = 512, height = 512, opts = {})
     name: (tex?.name || "eye") + "-uv",
   };
 }
+
+function defaultYield() {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => resolve());
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
+
+/**
+ * Async UV atlas rasterize — yields between steps so the UI can show a loader.
+ * Same result as rasterizeEyePairUvMap in the browser; Node falls back to sync.
+ *
+ * @param {object} tex
+ * @param {number} [width]
+ * @param {number} [height]
+ * @param {{ background?: string, uv?: object, onProgress?: (step:string)=>void, yield?: ()=>Promise<void> }} [opts]
+ */
+export async function rasterizeEyePairUvMapAsync(tex, width = 512, height = 512, opts = {}) {
+  const onProgress = typeof opts.onProgress === "function" ? opts.onProgress : () => {};
+  const yieldFn = typeof opts.yield === "function" ? opts.yield : defaultYield;
+
+  if (typeof document === "undefined") {
+    onProgress("node");
+    return rasterizeEyePairUvMap(tex, width, height, opts);
+  }
+
+  const w = Math.max(64, width | 0);
+  const h = Math.max(64, height | 0);
+  const pair = normalizeEyePair(tex?.eyePair);
+  const uv = normalizeEyeUv(opts.uv || opts);
+  const centerU = uv.centerU;
+  const centerV = uv.centerV;
+  const scale = uv.scale;
+  const sepU =
+    uv.eyeSeparationU != null ? uv.eyeSeparationU : 0.1 + pair.distance * 0.08;
+  const eyeWU = (opts.eyeWidthU != null ? Number(opts.eyeWidthU) : 0.11) * scale;
+  const eyeHV = (opts.eyeHeightV != null ? Number(opts.eyeHeightV) : 0.13) * scale;
+  const bg = opts.background || "#e8e4dc";
+
+  onProgress("background");
+  await yieldFn();
+
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, w, h);
+
+  const cellW = Math.max(8, Math.round(eyeWU * w));
+  const cellH = Math.max(8, Math.round(eyeHV * h));
+  const left = layersWithEyeballColor(tex.layers || [], bg);
+  const right = layersWithEyeballColor(rightEyeLayers(tex), bg);
+
+  function blit(layers, uCenter) {
+    const x = Math.round(uCenter * w - cellW / 2);
+    const y = Math.round((1 - centerV) * h - cellH / 2);
+    const off = document.createElement("canvas");
+    off.width = cellW;
+    off.height = cellH;
+    const octx = off.getContext("2d");
+    octx.fillStyle = bg;
+    octx.fillRect(0, 0, cellW, cellH);
+    drawEyeLayers(octx, layers, cellW, cellH);
+    ctx.drawImage(off, x, y);
+  }
+
+  onProgress("left-eye");
+  await yieldFn();
+  blit(left, centerU - sepU / 2);
+
+  onProgress("right-eye");
+  await yieldFn();
+  blit(right, centerU + sepU / 2);
+
+  onProgress("readback");
+  await yieldFn();
+  const img = ctx.getImageData(0, 0, w, h);
+  onProgress("done");
+  return {
+    rgba: img.data,
+    w,
+    h,
+    name: (tex?.name || "eye") + "-uv",
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Replaces the previous two-click UV corner flow with a clearer assign workflow:

1. Orbit / pose the mesh in the 3D preview as usual.
2. **Assign to mesh** shows a yellow **square** on the preview — drag the **center** to move, **corner handles** to resize.
3. **OK** raycasts the square’s top-left / bottom-right onto lathe UVs, then opens the **texture chooser** dialog.
4. **Assign** runs a stepped UV bake (background → left eye → right eye → mesh update) with a **spinner / progress label** so the UI doesn’t feel frozen.

## Notes
- Square corners must land on the mesh surface (rotate or move the square if OK complains).
- Eye gap remains adjustable in the dialog; placement/scale come from the square.
- Atlas bake uses 384² async path during assign; later tessellates reuse the pre-baked map for that pass.

## Tests
- `node scripts/smoke-eye-texture.mjs`
- `node scripts/smoke-mesh-pick.mjs`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

