### PR TITLE
Fix assign square OK when overlay is clearly on the mesh

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -6,7 +6,14 @@ import {
   raycastMeshParts,
   applyPreviewEuler,
   applyPreviewEulerInv,
+  approximateLatheUvFromPoint,
+  pickRootSurface,
 } from "../src/lib/meshPick.js";
+import {
+  eyeUvFromRegionSamples,
+  regionSamplePoints,
+  DEFAULT_ASSIGN_REGION,
+} from "../src/lib/assignRegion.js";
 import { migrateProject } from "../src/library/migrations.js";
 import { CURRENT_SCHEMA_VERSION } from "../src/library/schema.js";
 
@@ -47,6 +54,32 @@ const uvHit = raycastMeshParts([0, 0, 3], [0, 0, -1], uvParts);
 assert.ok(uvHit?.uv);
 assert.ok(Math.abs(uvHit.uv[0] - 0.5) < 0.05);
 assert.ok(Math.abs(uvHit.uv[1] - 0.5) < 0.05);
+
+const approx = approximateLatheUvFromPoint([0.5, 0, 0.5], [
+  { positions: [-1, -1, -1, 1, 1, 1] },
+]);
+assert.ok(approx && approx[0] >= 0 && approx[0] <= 1);
+
+const fromSamples = eyeUvFromRegionSamples(
+  [
+    [0.4, 0.7],
+    [0.6, 0.45],
+  ],
+  DEFAULT_ASSIGN_REGION,
+);
+assert.ok(fromSamples && fromSamples.scale > 0);
+assert.ok(regionSamplePoints(DEFAULT_ASSIGN_REGION, 3).length === 9);
+
+// pickRootSurface fills UV when vertex uvs are missing
+const pickView = {
+  cam: [0, 0, 4],
+  target: [0, 0, 0],
+  fovDeg: 45,
+  width: 400,
+  height: 400,
+};
+const noUvHit = pickRootSurface(200, 200, pickView, parts, 0, 0, null);
+assert.ok(noUvHit?.uv, "approximate UV on hit without vertex uvs");
 
 const tagged = [{ ...parts[0], instanceGuid: "child-a" }];
 const hitTagged = raycastMeshParts([0, 0, 3], [0, 0, -1], tagged);

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -8,6 +8,7 @@ import {
   applyPreviewEulerInv,
   approximateLatheUvFromPoint,
   pickRootSurface,
+  transformPartsByPreviewEuler,
 } from "../src/lib/meshPick.js";
 import {
   eyeUvFromRegionSamples,
@@ -99,6 +100,65 @@ const p = [1, 0, 0];
 const e = applyPreviewEuler(p, 0.12, 0.5);
 const back = applyPreviewEulerInv(e, 0.12, 0.5);
 assert.ok(Math.hypot(back[0] - 1, back[1], back[2]) < 1e-6);
+
+// Must match Three.js Euler XYZ (host entityTransform) — R = Rx * Ry
+{
+  const rx = 0.12;
+  const ry = 0.4;
+  const c1 = Math.cos(rx / 2);
+  const c2 = Math.cos(ry / 2);
+  const s1 = Math.sin(rx / 2);
+  const s2 = Math.sin(ry / 2);
+  const q = {
+    x: s1 * c2,
+    y: c1 * s2,
+    z: s1 * s2,
+    w: c1 * c2,
+  };
+  // z=0 simplifies Three.js XYZ quat
+  const qFull = {
+    x: s1 * c2 * 1 + c1 * s2 * 0,
+    y: c1 * s2 * 1 - s1 * c2 * 0,
+    z: c1 * c2 * 0 + s1 * s2 * 1,
+    w: c1 * c2 * 1 - s1 * s2 * 0,
+  };
+  void q;
+  const pt = [0.3, 0.7, -0.2];
+  const ours = applyPreviewEuler(pt, rx, ry);
+  const qx = qFull.x;
+  const qy = qFull.y;
+  const qz = qFull.z;
+  const qw = qFull.w;
+  const ix = qw * pt[0] + qy * pt[2] - qz * pt[1];
+  const iy = qw * pt[1] + qz * pt[0] - qx * pt[2];
+  const iz = qw * pt[2] + qx * pt[1] - qy * pt[0];
+  const iw = -qx * pt[0] - qy * pt[1] - qz * pt[2];
+  const three = [
+    ix * qw + iw * -qx + iy * -qz - iz * -qy,
+    iy * qw + iw * -qy + iz * -qx - ix * -qz,
+    iz * qw + iw * -qz + ix * -qy - iy * -qx,
+  ];
+  assert.ok(
+    Math.hypot(ours[0] - three[0], ours[1] - three[1], ours[2] - three[2]) < 1e-9,
+    "preview euler must match Three.js XYZ used by mesh host",
+  );
+}
+
+// Picking must succeed when the host has spun the mesh (yaw/tilt ≠ 0)
+{
+  const rx = 0.12;
+  const ry = 0.55;
+  const localHit = pickRootSurface(200, 200, view, uvParts, rx, ry, null);
+  assert.ok(localHit?.uv, "pick through inverse host yaw/tilt");
+  const worldParts = transformPartsByPreviewEuler(uvParts, rx, ry);
+  const { origin: oW, dir: dW } = rayFromCanvas(200, 200, view);
+  const worldHit = raycastMeshParts(oW, dW, worldParts);
+  assert.ok(worldHit?.uv, "world-space rotated parts still pickable");
+  assert.ok(
+    Math.hypot(localHit.uv[0] - worldHit.uv[0], localHit.uv[1] - worldHit.uv[1]) < 0.05,
+    "inverse-ray pick UV matches world-space rotated pick",
+  );
+}
 
 const v7 = {
   kind: "ranger.splineProject",

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -120,7 +120,8 @@ function startAssignRegion() {
   placePending.value = null;
   assignDialogOpen.value = false;
   assignRegionUv.value = null;
-  if (!state.rootMesh) tessellate();
+  // Ensure rootMesh (+ UVs) exist for ray picks under the square.
+  tessellate();
   assignRegionMode.value = true;
   state.status =
     "Assign — orbit the mesh, fit the yellow square over the eyes, then OK.";

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
@@ -11,9 +11,9 @@ import {
   DEFAULT_ASSIGN_REGION,
   clampAssignRegion,
   regionCorners,
-  regionToCanvas,
+  regionSamplePoints,
+  eyeUvFromRegionSamples,
 } from "../lib/assignRegion.js";
-import { eyeUvFromCorners } from "../lib/texture/eyeTexture.js";
 
 const props = defineProps({
   mesh: { type: Object, default: null },
@@ -258,30 +258,123 @@ function startRegionDrag(handle) {
   syncCursor();
 }
 
+/**
+ * Pick UV at a normalized overlay point (0–1 over the canvas box).
+ * NDC uses visual fraction, so sx = nx * view.width matches the stretched bitmap.
+ */
+function pickUvAtNorm(nx, ny) {
+  const view = getView();
+  if (!view) return null;
+
+  const rootParts = props.rootMesh?.parts;
+  const rootOnlyDisplay = (displayMesh.value?.parts || []).filter((p) => !p.instanceGuid);
+  const sx = nx * (view.width || 1);
+  const sy = ny * (view.height || 1);
+
+  const attempts = [];
+  if (rootParts?.length) {
+    attempts.push(
+      pickRootSurface(
+        sx,
+        sy,
+        view,
+        rootParts,
+        view.meshTilt,
+        view.meshAngle,
+        orientInv.value,
+      ),
+    );
+    // Sometimes placement-orient inverse disagrees — try authoring parts with euler only.
+    attempts.push(
+      pickRootSurface(sx, sy, view, rootParts, view.meshTilt, view.meshAngle, null),
+    );
+  }
+  if (rootOnlyDisplay.length) {
+    attempts.push(
+      pickRootSurface(sx, sy, view, rootOnlyDisplay, view.meshTilt, view.meshAngle, null),
+    );
+    attempts.push(
+      pickRootSurface(
+        sx,
+        sy,
+        view,
+        rootOnlyDisplay,
+        view.meshTilt,
+        view.meshAngle,
+        orientInv.value,
+      ),
+    );
+  }
+
+  for (const hit of attempts) {
+    if (hit?.uv) return hit.uv;
+  }
+  return null;
+}
+
 function confirmRegion() {
   regionError.value = "";
-  const el = canvasRef.value;
-  if (!el) {
+  if (!getView() || !canvasRef.value) {
     regionError.value = "Preview not ready.";
     return;
   }
-  const c = regionCorners(region);
-  const tlC = regionToCanvas(c.tl.x, c.tl.y, el);
-  const brC = regionToCanvas(c.br.x, c.br.y, el);
-  const tlHit = pickRoot(tlC.sx, tlC.sy);
-  const brHit = pickRoot(brC.sx, brC.sy);
-  if (!tlHit?.uv || !brHit?.uv) {
-    regionError.value =
-      "Square corners must sit on the mesh — rotate the view or move the square.";
+  if (!props.rootMesh?.parts?.length && !displayMesh.value?.parts?.length) {
+    regionError.value = "No mesh to pick — tessellate first.";
     return;
   }
-  const textureUv = eyeUvFromCorners(
-    tlHit.uv[0],
-    tlHit.uv[1],
-    brHit.uv[0],
-    brHit.uv[1],
-  );
-  emit("region-confirm", { textureUv, region: { ...region } });
+
+  const pts = regionSamplePoints(region, 5);
+  const samples = [];
+  let hitWithoutUv = false;
+  for (const p of pts) {
+    const uv = pickUvAtNorm(p.x, p.y);
+    if (uv) {
+      samples.push(uv);
+      continue;
+    }
+    // Detect geometric hit without UV for a clearer error
+    const view = getView();
+    const el = canvasRef.value;
+    const sx = p.x * (view.width || 1);
+    const sy = p.y * (view.height || 1);
+    const probe =
+      (props.rootMesh?.parts?.length &&
+        pickRootSurface(
+          sx,
+          sy,
+          view,
+          props.rootMesh.parts,
+          view.meshTilt,
+          view.meshAngle,
+          orientInv.value,
+        )) ||
+      pickRootSurface(
+        sx,
+        sy,
+        view,
+        (displayMesh.value?.parts || []).filter((q) => !q.instanceGuid),
+        view.meshTilt,
+        view.meshAngle,
+        null,
+      );
+    if (probe && !probe.uv) hitWithoutUv = true;
+  }
+
+  const uniq = [];
+  for (const uv of samples) {
+    if (!uniq.some((u) => Math.hypot(u[0] - uv[0], u[1] - uv[1]) < 1e-4)) {
+      uniq.push(uv);
+    }
+  }
+
+  const textureUv = eyeUvFromRegionSamples(uniq, region);
+  if (!textureUv) {
+    regionError.value = hitWithoutUv
+      ? "Mesh hit but has no UVs — tessellate the body and try again."
+      : "Could not hit the mesh under the square — orbit the face toward the camera, or shrink the square.";
+    return;
+  }
+  emit("region-confirm", { textureUv, region: { ...clampAssignRegion(region) } });
 }
 
 function onPointerDown(e) {
@@ -473,7 +566,11 @@ watch(
     session?.setAutoRotate?.(!surfacePickActive.value && !surfaceDragging);
     hoverHit.value = null;
     hoverChildGuid.value = null;
-    if (props.regionMode) resetRegion();
+    if (props.regionMode) {
+      resetRegion();
+      // Re-push so host entityTransform matches the frozen yaw used by picking.
+      pushDisplay();
+    }
     syncCursor();
   },
 );
@@ -508,54 +605,57 @@ watch(
       <span>{{ backendLabel }}</span>
     </header>
     <div class="view-wrap">
-      <canvas
-        ref="canvasRef"
-        class="view"
-        :class="{
-          place: placeMode,
-          grab: !!hoverChildGuid || surfaceDragging,
-        }"
-        @pointerdown.capture="onPointerDown"
-        @pointermove.capture="onPointerMove"
-        @pointerup.capture="onPointerUp"
-        @pointerleave="onPointerLeave"
-        @contextmenu="onContextMenu"
-      />
+      <!-- Stack keeps the region overlay pixel-aligned with the canvas box. -->
+      <div class="canvas-stack">
+        <canvas
+          ref="canvasRef"
+          class="view"
+          :class="{
+            place: placeMode,
+            grab: !!hoverChildGuid || surfaceDragging,
+          }"
+          @pointerdown.capture="onPointerDown"
+          @pointermove.capture="onPointerMove"
+          @pointerup.capture="onPointerUp"
+          @pointerleave="onPointerLeave"
+          @contextmenu="onContextMenu"
+        />
 
-      <div v-if="regionMode" class="region-layer" aria-hidden="true">
-        <div class="region-box" :style="regionStyle">
-          <button
-            type="button"
-            class="handle center"
-            title="Drag to move"
-            @pointerdown.stop.prevent="startRegionDrag('center')"
-          />
-          <button
-            v-for="h in ['tl', 'tr', 'bl', 'br']"
-            :key="h"
-            type="button"
-            class="handle corner"
-            :class="h"
-            title="Drag to resize"
-            @pointerdown.stop.prevent="startRegionDrag(h)"
-          />
+        <div v-if="regionMode" class="region-layer" aria-hidden="true">
+          <div class="region-box" :style="regionStyle">
+            <button
+              type="button"
+              class="handle center"
+              title="Drag to move"
+              @pointerdown.stop.prevent="startRegionDrag('center')"
+            />
+            <button
+              v-for="h in ['tl', 'tr', 'bl', 'br']"
+              :key="h"
+              type="button"
+              class="handle corner"
+              :class="h"
+              title="Drag to resize"
+              @pointerdown.stop.prevent="startRegionDrag(h)"
+            />
+          </div>
         </div>
-      </div>
 
-      <div v-if="placeMode" class="place-banner">
-        Place on surface · hover (+) · click to attach · Esc cancel · right-drag orbit
-      </div>
-      <div v-else-if="regionMode" class="place-banner region">
-        <span>
-          Place the square over the eyes · drag center / corners · right-drag orbit
-        </span>
-        <button type="button" class="ban-btn" @click.stop="emit('region-cancel')">
-          Cancel
-        </button>
-        <button type="button" class="ban-btn ok" @click.stop="confirmRegion">OK</button>
-      </div>
-      <div v-else-if="surfaceDragActive" class="place-banner drag">
-        Sub edit · hover sub-object · drag along surface · right-drag orbit
+        <div v-if="placeMode" class="place-banner">
+          Place on surface · hover (+) · click to attach · Esc cancel · right-drag orbit
+        </div>
+        <div v-else-if="regionMode" class="place-banner region">
+          <span>
+            Place the square over the eyes · drag center / corners · right-drag orbit
+          </span>
+          <button type="button" class="ban-btn" @click.stop="emit('region-cancel')">
+            Cancel
+          </button>
+          <button type="button" class="ban-btn ok" @click.stop="confirmRegion">OK</button>
+        </div>
+        <div v-else-if="surfaceDragActive" class="place-banner drag">
+          Sub edit · hover sub-object · drag along surface · right-drag orbit
+        </div>
       </div>
     </div>
     <p v-if="regionError" class="err">{{ regionError }}</p>
@@ -616,10 +716,13 @@ span {
 }
 
 .view-wrap {
-  position: relative;
   justify-self: center;
   width: 100%;
   max-width: 420px;
+}
+.canvas-stack {
+  position: relative;
+  width: 100%;
 }
 
 .view {
@@ -631,6 +734,7 @@ span {
   touch-action: none;
   cursor: crosshair;
   display: block;
+  vertical-align: top;
 }
 .view.place {
   cursor: copy;

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
@@ -260,7 +260,8 @@ function startRegionDrag(handle) {
 
 /**
  * Pick UV at a normalized overlay point (0–1 over the canvas box).
- * NDC uses visual fraction, so sx = nx * view.width matches the stretched bitmap.
+ * Uses host meshTilt/meshAngle so picks follow the editor object spin
+ * (WebMeshEditorHost entityTransform euler XYZ).
  */
 function pickUvAtNorm(nx, ny) {
   const view = getView();
@@ -270,43 +271,20 @@ function pickUvAtNorm(nx, ny) {
   const rootOnlyDisplay = (displayMesh.value?.parts || []).filter((p) => !p.instanceGuid);
   const sx = nx * (view.width || 1);
   const sy = ny * (view.height || 1);
+  const tilt = view.meshTilt;
+  const yaw = view.meshAngle;
 
-  const attempts = [];
+  // Primary: authoring root + placement orient + host yaw/tilt
   if (rootParts?.length) {
-    attempts.push(
-      pickRootSurface(
-        sx,
-        sy,
-        view,
-        rootParts,
-        view.meshTilt,
-        view.meshAngle,
-        orientInv.value,
-      ),
-    );
-    // Sometimes placement-orient inverse disagrees — try authoring parts with euler only.
-    attempts.push(
-      pickRootSurface(sx, sy, view, rootParts, view.meshTilt, view.meshAngle, null),
-    );
+    const hit = pickRootSurface(sx, sy, view, rootParts, tilt, yaw, orientInv.value);
+    if (hit?.uv) return hit.uv;
+    // Default placement normal is +Y (orient = I); still try without orientInv.
+    const hit2 = pickRootSurface(sx, sy, view, rootParts, tilt, yaw, null);
+    if (hit2?.uv) return hit2.uv;
   }
+  // Fallback: displayed root parts (already placement-oriented)
   if (rootOnlyDisplay.length) {
-    attempts.push(
-      pickRootSurface(sx, sy, view, rootOnlyDisplay, view.meshTilt, view.meshAngle, null),
-    );
-    attempts.push(
-      pickRootSurface(
-        sx,
-        sy,
-        view,
-        rootOnlyDisplay,
-        view.meshTilt,
-        view.meshAngle,
-        orientInv.value,
-      ),
-    );
-  }
-
-  for (const hit of attempts) {
+    const hit = pickRootSurface(sx, sy, view, rootOnlyDisplay, tilt, yaw, null);
     if (hit?.uv) return hit.uv;
   }
   return null;

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/assignRegion.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/assignRegion.js
@@ -2,6 +2,8 @@
 // assignRegion.js — screen-space square for eye UV placement on the 3D preview.
 // ============================================================================
 
+import { eyeUvFromCorners, normalizeEyeUv, unwrapUvPairU } from "./texture/eyeTexture.js";
+
 /** @typedef {{ cx: number, cy: number, half: number }} AssignRegion */
 
 export const DEFAULT_ASSIGN_REGION = { cx: 0.5, cy: 0.42, half: 0.14 };
@@ -30,13 +32,87 @@ export function regionCorners(r) {
 }
 
 /**
- * Map normalized overlay coords → canvas pixel coords used by raycast.
+ * Map normalized overlay coords → pick pixel coords.
  * @param {number} nx
  * @param {number} ny
- * @param {{ width: number, height: number }} canvas
+ * @param {{ width: number, height: number }} size
  */
-export function regionToCanvas(nx, ny, canvas) {
-  const w = canvas?.width || 1;
-  const h = canvas?.height || 1;
+export function regionToCanvas(nx, ny, size) {
+  const w = size?.width || 1;
+  const h = size?.height || 1;
   return { sx: nx * w, sy: ny * h };
+}
+
+/** Dense sample points inside the square (normalized). */
+export function regionSamplePoints(r, grid = 5) {
+  const reg = clampAssignRegion(r);
+  const c = regionCorners(reg);
+  const n = Math.max(2, grid | 0);
+  const pts = [];
+  for (let iy = 0; iy < n; iy++) {
+    for (let ix = 0; ix < n; ix++) {
+      const x = c.tl.x + ((c.br.x - c.tl.x) * ix) / (n - 1);
+      const y = c.tl.y + ((c.br.y - c.tl.y) * iy) / (n - 1);
+      pts.push({ x, y });
+    }
+  }
+  return pts;
+}
+
+/**
+ * Build textureUv from one or more UV samples under the screen square.
+ * Prefer AABB of samples; if only one sample, derive scale from region.half.
+ *
+ * @param {Array<[number, number]|{0:number,1:number}>} samples
+ * @param {AssignRegion} region
+ * @param {object} [opts]
+ */
+export function eyeUvFromRegionSamples(samples, region, opts = {}) {
+  const list = (samples || [])
+    .map((s) => {
+      const u = Number(s?.[0]);
+      const v = Number(s?.[1]);
+      if (!Number.isFinite(u) || !Number.isFinite(v)) return null;
+      return [u, v];
+    })
+    .filter(Boolean);
+  if (!list.length) return null;
+
+  const reg = clampAssignRegion(region);
+  if (list.length === 1) {
+    const scale = Math.min(
+      2.5,
+      Math.max(0.35, (reg.half / DEFAULT_ASSIGN_REGION.half) * (opts.baseScale || 1)),
+    );
+    return normalizeEyeUv({
+      centerU: list[0][0],
+      centerV: list[0][1],
+      scale,
+      eyeSeparationU: opts.eyeSeparationU != null ? opts.eyeSeparationU : 0.12 * scale,
+    });
+  }
+
+  // Unwrap U relative to the first sample so the AABB doesn't span the seam wrongly.
+  const u0 = list[0][0];
+  let uMin = Infinity;
+  let uMax = -Infinity;
+  let vMin = Infinity;
+  let vMax = -Infinity;
+  for (const [u, v] of list) {
+    const [lo, hi] = unwrapUvPairU(u0, u);
+    // unwrapUvPairU orders the pair; recover signed offset of u from u0
+    let uu = ((u % 1) + 1) % 1;
+    let base = ((u0 % 1) + 1) % 1;
+    let d = uu - base;
+    if (d > 0.5) uu -= 1;
+    if (d < -0.5) uu += 1;
+    uMin = Math.min(uMin, uu);
+    uMax = Math.max(uMax, uu);
+    vMin = Math.min(vMin, v);
+    vMax = Math.max(vMax, v);
+    void lo;
+    void hi;
+  }
+  // eyeUvFromCorners expects two corners; pass unwrapped extents
+  return eyeUvFromCorners(uMin, vMax, uMax, vMin, opts);
 }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/meshPick.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/meshPick.js
@@ -176,8 +176,33 @@ export function raycastMeshParts(origin, dir, parts) {
 }
 
 /**
+ * Approximate lathe UV from a hit point when vertex UVs are missing.
+ * u = angle around Y, v = normalized height in the part's Y range.
+ */
+export function approximateLatheUvFromPoint(point, parts) {
+  if (!point) return null;
+  let yMin = Infinity;
+  let yMax = -Infinity;
+  for (const part of parts || []) {
+    const pos = part.positions;
+    if (!pos?.length) continue;
+    for (let i = 1; i < pos.length; i += 3) {
+      const y = pos[i];
+      if (y < yMin) yMin = y;
+      if (y > yMax) yMax = y;
+    }
+  }
+  if (!Number.isFinite(yMin) || !Number.isFinite(yMax)) return null;
+  const span = Math.max(1e-6, yMax - yMin);
+  const u = ((Math.atan2(point[0], point[2]) / (Math.PI * 2)) + 1) % 1;
+  const v = Math.min(1, Math.max(0, (point[1] - yMin) / span));
+  return [u, v];
+}
+
+/**
  * Full pick: canvas → world ray → inverse preview euler → authoring ray → hit.
  * `orientInv` maps display(oriented) → authoring (3×3 row-major or null).
+ * If the hit has no vertex UVs, fills `uv` via approximateLatheUvFromPoint.
  */
 export function pickRootSurface(sx, sy, view, rootParts, meshTilt, meshAngle, orientInvMat) {
   const { origin, dir } = rayFromCanvas(sx, sy, view);
@@ -191,7 +216,11 @@ export function pickRootSurface(sx, sy, view, rootParts, meshTilt, meshAngle, or
     const tip = mulMat3(orientInvMat, add3(o1, dA));
     dA = normalize3(sub3(tip, oA));
   }
-  return raycastMeshParts(oA, dA, rootParts);
+  const hit = raycastMeshParts(oA, dA, rootParts);
+  if (hit && !hit.uv) {
+    hit.uv = approximateLatheUvFromPoint(hit.point, rootParts);
+  }
+  return hit;
 }
 
 function mulMat3(m, v) {

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/meshPick.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/meshPick.js
@@ -65,33 +65,64 @@ function mul3(a, s) {
   return [a[0] * s, a[1] * s, a[2] * s];
 }
 
-/** Rotate point by euler (rx, ry, 0) — matches preview entityTransform. */
+/**
+ * Rotate point by preview mesh euler (rx, ry, 0).
+ * Must match Three.js Object3D Euler order "XYZ" used by
+ * WebMeshEditorHost.entityTransform(..., tilt, yaw, 0): R = Rx * Ry
+ * (apply yaw around Y first, then tilt around X).
+ */
 export function applyPreviewEuler(p, rx, ry) {
   const cx = Math.cos(rx);
   const sx = Math.sin(rx);
   const cy = Math.cos(ry);
   const sy = Math.sin(ry);
-  // X then Y (XYZ euler with z=0)
-  let x = p[0];
-  let y = p[1] * cx - p[2] * sx;
-  let z = p[1] * sx + p[2] * cx;
-  const x2 = x * cy + z * sy;
-  const z2 = -x * sy + z * cy;
-  return [x2, y, z2];
+  // Y first
+  const x1 = p[0] * cy + p[2] * sy;
+  const y1 = p[1];
+  const z1 = -p[0] * sy + p[2] * cy;
+  // then X
+  return [x1, y1 * cx - z1 * sx, y1 * sx + z1 * cx];
 }
 
+/** Inverse of applyPreviewEuler (undo host mesh yaw/tilt into authoring space). */
 export function applyPreviewEulerInv(p, rx, ry) {
   const cx = Math.cos(rx);
   const sx = Math.sin(rx);
   const cy = Math.cos(ry);
   const sy = Math.sin(ry);
-  // inverse Y then inverse X
-  let x = p[0] * cy - p[2] * sy;
-  let y = p[1];
-  let z = p[0] * sy + p[2] * cy;
-  const y2 = y * cx + z * sx;
-  const z2 = -y * sx + z * cx;
-  return [x, y2, z2];
+  // Inv(Rx*Ry) = Ry^-1 * Rx^-1 → undo X, then undo Y
+  const x1 = p[0];
+  const y1 = p[1] * cx + p[2] * sx;
+  const z1 = -p[1] * sx + p[2] * cx;
+  return [x1 * cy - z1 * sy, y1, x1 * sy + z1 * cy];
+}
+
+/** Transform all part positions/normals by preview euler (world-space pick helper). */
+export function transformPartsByPreviewEuler(parts, rx, ry) {
+  return (parts || []).map((part) => {
+    const pos = part.positions;
+    const nrm = part.normals;
+    if (!pos?.length) return part;
+    const positions = new Array(pos.length);
+    for (let i = 0; i + 2 < pos.length; i += 3) {
+      const p = applyPreviewEuler([pos[i], pos[i + 1], pos[i + 2]], rx, ry);
+      positions[i] = p[0];
+      positions[i + 1] = p[1];
+      positions[i + 2] = p[2];
+    }
+    let normals = nrm;
+    if (nrm?.length) {
+      normals = new Array(nrm.length);
+      for (let i = 0; i + 2 < nrm.length; i += 3) {
+        const n = applyPreviewEuler([nrm[i], nrm[i + 1], nrm[i + 2]], rx, ry);
+        const L = Math.hypot(n[0], n[1], n[2]) || 1;
+        normals[i] = n[0] / L;
+        normals[i + 1] = n[1] / L;
+        normals[i + 2] = n[2] / L;
+      }
+    }
+    return { ...part, positions, normals };
+  });
 }
 
 /**
@@ -200,13 +231,17 @@ export function approximateLatheUvFromPoint(point, parts) {
 }
 
 /**
- * Full pick: canvas → world ray → inverse preview euler → authoring ray → hit.
- * `orientInv` maps display(oriented) → authoring (3×3 row-major or null).
+ * Full pick against root parts in authoring space.
+ * Accounts for the preview host mesh yaw/tilt (entityTransform euler XYZ) by
+ * inverse-rotating the camera ray into authoring space — same rotation the
+ * editor applies when the object spins / is frozen after orbit.
+ *
+ * `orientInv` maps placement-oriented display → authoring (3×3 row-major or null).
  * If the hit has no vertex UVs, fills `uv` via approximateLatheUvFromPoint.
  */
 export function pickRootSurface(sx, sy, view, rootParts, meshTilt, meshAngle, orientInvMat) {
   const { origin, dir } = rayFromCanvas(sx, sy, view);
-  // World (after euler) → pre-euler oriented space
+  // World (mesh rotated by host euler) → authoring / placement-oriented space
   const o1 = applyPreviewEulerInv(origin, meshTilt, meshAngle);
   const d1p = applyPreviewEulerInv(add3(origin, dir), meshTilt, meshAngle);
   let oA = o1;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The yellow assign square could sit visually on the mesh (including after spinning/orbiting in the preview), but **OK** still failed. Two issues:

1. Confirmation required both screen corners to return vertex UVs.
2. **Raycast euler did not match the host mesh rotation** — picks used `Ry*Rx`, but `WebMeshEditorHost.entityTransform` applies Three.js Euler **XYZ** (`R = Rx*Ry`). After the object spun, inverse rays missed the surface even when all four corners looked on-mesh.

## Fix
- Sample a **5×5 grid** under the square; one good UV sample is enough.
- Approximate lathe UVs when vertex UVs are missing.
- **Align `applyPreviewEuler` / `applyPreviewEulerInv` with Three.js XYZ** used by the preview host yaw/tilt.
- Smoke: Three.js parity + pick through non-zero yaw/tilt matches world-space rotated parts.
- Keep the region overlay pixel-aligned with the canvas stack; tessellate on assign enter.

## Tests
- `node scripts/smoke-mesh-pick.mjs`
- `node scripts/smoke-eye-texture.mjs`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

