### PR TITLE
Fix eye UV assign placement + corner markers, drop autorotate

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -327,8 +327,13 @@ assert.equal(normalizeEyeUv({ centerU: 0.4, eyeSeparationU: 0.14 }).eyeSeparatio
 const fromCorners = eyeUvFromCorners(0.35, 0.7, 0.65, 0.45);
 assert.ok(Math.abs(fromCorners.centerU - 0.5) < 1e-6);
 assert.ok(Math.abs(fromCorners.centerV - 0.575) < 1e-6);
-assert.ok(fromCorners.scale > 0.5);
+assert.ok(fromCorners.scale > 0.5 && fromCorners.scale < 3);
 assert.ok(fromCorners.eyeSeparationU > 0.02);
+// Tall UV rect must not explode scale past what width can hold
+const tall = eyeUvFromCorners(0.4, 0.9, 0.6, 0.2);
+assert.ok(tall.scale <= tall.eyeSeparationU / 0.01); // sanity
+assert.ok(tall.scale < 2.5, "scale fits width+height, not height-only");
+assert.ok(tall.eyeSeparationU >= 0.04);
 assert.deepEqual(unwrapUvPairU(0.9, 0.1)[0] <= unwrapUvPairU(0.9, 0.1)[1], true);
 const moved = eyeUvMoveCenter(fromCorners, 0.42, 0.55);
 assert.ok(Math.abs(moved.centerU - 0.42) < 1e-9);

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -15,6 +15,7 @@ import {
   regionSamplePoints,
   DEFAULT_ASSIGN_REGION,
 } from "../src/lib/assignRegion.js";
+import { latheProfileWithOrbit } from "../src/lib/pathSample.js";
 import { migrateProject } from "../src/library/migrations.js";
 import { CURRENT_SCHEMA_VERSION } from "../src/library/schema.js";
 
@@ -51,10 +52,26 @@ const uvParts = [
     indices: [0, 1, 2, 0, 2, 3],
   },
 ];
-const uvHit = raycastMeshParts([0, 0, 3], [0, 0, -1], uvParts);
+const uvHit = raycastMeshParts([0.25, -0.25, 3], [0, 0, -1], uvParts);
 assert.ok(uvHit?.uv);
-assert.ok(Math.abs(uvHit.uv[0] - 0.5) < 0.05);
-assert.ok(Math.abs(uvHit.uv[1] - 0.5) < 0.05);
+assert.ok(uvHit.uv[0] > 0.5 && uvHit.uv[0] < 0.8, `u=${uvHit.uv[0]}`);
+assert.ok(uvHit.uv[1] > 0.2 && uvHit.uv[1] < 0.5, `v=${uvHit.uv[1]}`);
+
+// Seam face: U wraps 0.95 → 0.05 across a short 3D edge
+const seamParts = [
+  {
+    positions: [0.98, 0, 0.1, 0.98, 0, -0.1, 0.99, 0.2, 0],
+    normals: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+    uvs: [0.95, 0.4, 0.05, 0.4, 0.95, 0.6],
+    indices: [0, 1, 2],
+  },
+];
+const seamHit = raycastMeshParts([2, 0.05, 0], [-1, 0, 0], seamParts);
+assert.ok(seamHit?.uv, "seam triangle hit");
+assert.ok(
+  seamHit.uv[0] > 0.85 || seamHit.uv[0] < 0.15,
+  `seam U stays near wrap, got ${seamHit.uv[0]}`,
+);
 
 const approx = approximateLatheUvFromPoint([0.5, 0, 0.5], [
   { positions: [-1, -1, -1, 1, 1, 1] },
@@ -70,6 +87,51 @@ const fromSamples = eyeUvFromRegionSamples(
 );
 assert.ok(fromSamples && fromSamples.scale > 0);
 assert.ok(regionSamplePoints(DEFAULT_ASSIGN_REGION, 3).length === 9);
+
+// Simple closed lathe: front (+Z) hit must be u≈0.25; region AABB center tracks the hit UV.
+{
+  const profile = [
+    { x: 0.4, y: -1, tx: 0, ty: 1, segmentIndex: 0 },
+    { x: 0.55, y: -0.2, tx: 0, ty: 1, segmentIndex: 0 },
+    { x: 0.5, y: 0.4, tx: 0, ty: 1, segmentIndex: 0 },
+    { x: 0.35, y: 1, tx: 0, ty: 1, segmentIndex: 0 },
+  ];
+  const steps = 24;
+  const orbit = [];
+  for (let i = 0; i < steps; i++) {
+    const a = (i / steps) * Math.PI * 2;
+    orbit.push({ x: Math.cos(a), y: Math.sin(a), segmentIndex: 0 });
+  }
+  const mesh = latheProfileWithOrbit(profile, orbit, true);
+  const latheParts = [
+    {
+      positions: mesh.positions,
+      normals: mesh.normals,
+      uvs: mesh.uvs,
+      indices: mesh.indices,
+    },
+  ];
+  const front = raycastMeshParts([0, 0.4, 3], [0, 0, -1], latheParts);
+  assert.ok(front?.uv, "lathe front hit has UV");
+  assert.ok(Math.abs(front.uv[0] - 0.25) < 1e-6, `front u≈0.25 got ${front.uv[0]}`);
+  const plusX = raycastMeshParts([3, 0.4, 0], [-1, 0, 0], latheParts);
+  assert.ok(plusX?.uv && Math.abs(plusX.uv[0]) < 1e-6, `+X u≈0 got ${plusX?.uv?.[0]}`);
+  const patch = [
+    [front.uv[0] - 0.05, front.uv[1] + 0.08],
+    [front.uv[0] + 0.05, front.uv[1] + 0.08],
+    [front.uv[0] + 0.05, front.uv[1] - 0.08],
+    [front.uv[0] - 0.05, front.uv[1] - 0.08],
+  ];
+  const placed = eyeUvFromRegionSamples(patch, DEFAULT_ASSIGN_REGION);
+  assert.ok(placed, "region samples → textureUv");
+  assert.ok(Math.abs(placed.centerU - front.uv[0]) < 1e-6, "centerU tracks front");
+  assert.ok(Math.abs(placed.centerV - front.uv[1]) < 1e-6, "centerV tracks front");
+  // Host sampleTex / GL upload: v=0 → buffer row 0 — atlas Y must not flip.
+  assert.ok(
+    Math.abs(placed.centerV - 0.6666666666666666) < 1e-6,
+    "default mid-face V stays high (not inverted to ~0.33)",
+  );
+}
 
 // pickRootSurface fills UV when vertex uvs are missing
 const pickView = {

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
@@ -14,6 +14,7 @@ import {
   regionSamplePoints,
   eyeUvFromRegionSamples,
 } from "../lib/assignRegion.js";
+import { cubeSizeForView, makeSurfaceNormalCubePart } from "../lib/debugCube.js";
 
 const props = defineProps({
   mesh: { type: Object, default: null },
@@ -88,9 +89,75 @@ const regionStyle = computed(() => {
   };
 });
 
+/** Blue corner markers from the latest region raycasts (display-space parts). */
+let cornerMarkerParts = [];
+let markerRaf = 0;
+
 function pushDisplay() {
   if (!session) return;
-  if (displayMesh.value) session.setMesh(displayMesh.value);
+  const base = displayMesh.value;
+  if (!base) return;
+  if (props.regionMode && cornerMarkerParts.length) {
+    session.setMesh({ parts: [...(base.parts || []), ...cornerMarkerParts] });
+  } else {
+    session.setMesh(base);
+  }
+}
+
+/**
+ * Full surface hit at normalized overlay coords (for UV + corner markers).
+ * Prefer display-space root parts so marker cubes share the pushed mesh space.
+ */
+function pickHitAtNorm(nx, ny) {
+  const view = getView();
+  if (!view) return null;
+  const sx = nx * (view.width || 1);
+  const sy = ny * (view.height || 1);
+  const tilt = view.meshTilt;
+  const yaw = view.meshAngle;
+  const rootOnlyDisplay = (displayMesh.value?.parts || []).filter((p) => !p.instanceGuid);
+  if (rootOnlyDisplay.length) {
+    const hit = pickRootSurface(sx, sy, view, rootOnlyDisplay, tilt, yaw, null);
+    if (hit) return hit;
+  }
+  const rootParts = props.rootMesh?.parts;
+  if (rootParts?.length) {
+    const hit = pickRootSurface(sx, sy, view, rootParts, tilt, yaw, orientInv.value);
+    if (hit) return hit;
+    return pickRootSurface(sx, sy, view, rootParts, tilt, yaw, null);
+  }
+  return null;
+}
+
+function refreshCornerMarkers() {
+  if (!props.regionMode || !session) {
+    cornerMarkerParts = [];
+    return;
+  }
+  const view = getView();
+  if (!view) {
+    cornerMarkerParts = [];
+    return;
+  }
+  const edge = cubeSizeForView(view, 0.02);
+  const c = regionCorners(region);
+  const pts = [c.tl, c.tr, c.br, c.bl];
+  const parts = [];
+  for (const p of pts) {
+    const hit = pickHitAtNorm(p.x, p.y);
+    if (!hit?.point || !hit?.normal) continue;
+    parts.push(makeSurfaceNormalCubePart(hit.point, hit.normal, edge, 0x3b82f6));
+  }
+  cornerMarkerParts = parts;
+  pushDisplay();
+}
+
+function scheduleCornerMarkers() {
+  if (markerRaf) return;
+  markerRaf = requestAnimationFrame(() => {
+    markerRaf = 0;
+    refreshCornerMarkers();
+  });
 }
 
 function getView() {
@@ -185,16 +252,18 @@ function resetRegion() {
   Object.assign(region, clampAssignRegion(DEFAULT_ASSIGN_REGION));
   regionError.value = "";
   regionDrag = null;
+  scheduleCornerMarkers();
 }
 
 function applyRegionDrag(nx, ny) {
   if (!regionDrag) return;
   if (regionDrag === "center") {
     Object.assign(region, clampAssignRegion({ cx: nx, cy: ny, half: region.half }));
-    return;
+  } else {
+    const half = Math.max(Math.abs(nx - region.cx), Math.abs(ny - region.cy));
+    Object.assign(region, clampAssignRegion({ cx: region.cx, cy: region.cy, half }));
   }
-  const half = Math.max(Math.abs(nx - region.cx), Math.abs(ny - region.cy));
-  Object.assign(region, clampAssignRegion({ cx: region.cx, cy: region.cy, half }));
+  scheduleCornerMarkers();
 }
 
 function hitOnRegionHandle(nx, ny) {
@@ -258,36 +327,8 @@ function startRegionDrag(handle) {
   syncCursor();
 }
 
-/**
- * Pick UV at a normalized overlay point (0–1 over the canvas box).
- * Uses host meshTilt/meshAngle so picks follow the editor object spin
- * (WebMeshEditorHost entityTransform euler XYZ).
- */
 function pickUvAtNorm(nx, ny) {
-  const view = getView();
-  if (!view) return null;
-
-  const rootParts = props.rootMesh?.parts;
-  const rootOnlyDisplay = (displayMesh.value?.parts || []).filter((p) => !p.instanceGuid);
-  const sx = nx * (view.width || 1);
-  const sy = ny * (view.height || 1);
-  const tilt = view.meshTilt;
-  const yaw = view.meshAngle;
-
-  // Primary: authoring root + placement orient + host yaw/tilt
-  if (rootParts?.length) {
-    const hit = pickRootSurface(sx, sy, view, rootParts, tilt, yaw, orientInv.value);
-    if (hit?.uv) return hit.uv;
-    // Default placement normal is +Y (orient = I); still try without orientInv.
-    const hit2 = pickRootSurface(sx, sy, view, rootParts, tilt, yaw, null);
-    if (hit2?.uv) return hit2.uv;
-  }
-  // Fallback: displayed root parts (already placement-oriented)
-  if (rootOnlyDisplay.length) {
-    const hit = pickRootSurface(sx, sy, view, rootOnlyDisplay, tilt, yaw, null);
-    if (hit?.uv) return hit.uv;
-  }
-  return null;
+  return pickHitAtNorm(nx, ny)?.uv || null;
 }
 
 function confirmRegion() {
@@ -301,41 +342,20 @@ function confirmRegion() {
     return;
   }
 
-  const pts = regionSamplePoints(region, 5);
-  const samples = [];
-  let hitWithoutUv = false;
-  for (const p of pts) {
+  // Prefer the four square corners (matches the yellow overlay); fall back to a grid.
+  const c = regionCorners(region);
+  const cornerPts = [c.tl, c.tr, c.br, c.bl];
+  let samples = [];
+  for (const p of cornerPts) {
     const uv = pickUvAtNorm(p.x, p.y);
-    if (uv) {
-      samples.push(uv);
-      continue;
+    if (uv) samples.push(uv);
+  }
+  if (samples.length < 2) {
+    samples = [];
+    for (const p of regionSamplePoints(region, 5)) {
+      const uv = pickUvAtNorm(p.x, p.y);
+      if (uv) samples.push(uv);
     }
-    // Detect geometric hit without UV for a clearer error
-    const view = getView();
-    const el = canvasRef.value;
-    const sx = p.x * (view.width || 1);
-    const sy = p.y * (view.height || 1);
-    const probe =
-      (props.rootMesh?.parts?.length &&
-        pickRootSurface(
-          sx,
-          sy,
-          view,
-          props.rootMesh.parts,
-          view.meshTilt,
-          view.meshAngle,
-          orientInv.value,
-        )) ||
-      pickRootSurface(
-        sx,
-        sy,
-        view,
-        (displayMesh.value?.parts || []).filter((q) => !q.instanceGuid),
-        view.meshTilt,
-        view.meshAngle,
-        null,
-      );
-    if (probe && !probe.uv) hitWithoutUv = true;
   }
 
   const uniq = [];
@@ -347,9 +367,8 @@ function confirmRegion() {
 
   const textureUv = eyeUvFromRegionSamples(uniq, region);
   if (!textureUv) {
-    regionError.value = hitWithoutUv
-      ? "Mesh hit but has no UVs — tessellate the body and try again."
-      : "Could not hit the mesh under the square — orbit the face toward the camera, or shrink the square.";
+    regionError.value =
+      "Could not hit the mesh under the square — orbit the face toward the camera, or shrink the square.";
     return;
   }
   emit("region-confirm", { textureUv, region: { ...clampAssignRegion(region) } });
@@ -454,6 +473,7 @@ function onPointerUp(e) {
     if (draggingOrbit) {
       session?.host?.pointerUp?.();
       draggingOrbit = false;
+      scheduleCornerMarkers();
     }
     return;
   }
@@ -483,7 +503,7 @@ function onPointerUp(e) {
     surfaceDragging = false;
     dragGuid = null;
     blockHostOrbit = false;
-    session?.setAutoRotate?.(!surfacePickActive.value);
+    session?.setAutoRotate?.(false);
     emit("surface-drag-end");
     syncCursor();
   }
@@ -513,7 +533,7 @@ onMounted(async () => {
     backendLabel.value = session.useGL ? "Ranger Three · WebGL" : "Ranger Three · software";
     pushDisplay();
     session.setMaterialMode(props.materialMode);
-    session.setAutoRotate?.(true);
+    session.setAutoRotate?.(false);
   } catch (err) {
     backendLabel.value = "preview failed";
     console.error(err);
@@ -525,6 +545,7 @@ onBeforeUnmount(() => {
   window.removeEventListener("keydown", onKeyDown);
   endRegionDrag();
   if (dragRaf) cancelAnimationFrame(dragRaf);
+  if (markerRaf) cancelAnimationFrame(markerRaf);
   session?.dispose();
   session = null;
 });
@@ -541,12 +562,14 @@ watch(
 watch(
   () => [props.placeMode, props.regionMode],
   () => {
-    session?.setAutoRotate?.(!surfacePickActive.value && !surfaceDragging);
+    session?.setAutoRotate?.(false);
     hoverHit.value = null;
     hoverChildGuid.value = null;
     if (props.regionMode) {
       resetRegion();
-      // Re-push so host entityTransform matches the frozen yaw used by picking.
+      scheduleCornerMarkers();
+    } else {
+      cornerMarkerParts = [];
       pushDisplay();
     }
     syncCursor();
@@ -624,7 +647,7 @@ watch(
         </div>
         <div v-else-if="regionMode" class="place-banner region">
           <span>
-            Place the square over the eyes · drag center / corners · right-drag orbit
+            Fit the square · blue cubes = raycast corners · right-drag orbit · no autorotate
           </span>
           <button type="button" class="ban-btn" @click.stop="emit('region-cancel')">
             Cancel

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/debugCube.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/debugCube.js
@@ -1,0 +1,133 @@
+// ============================================================================
+// debugCube.js — small solid cube mesh parts for preview markers.
+// ============================================================================
+
+/**
+ * World-space cube size ≈ `screenFraction` of the preview frame height.
+ * @param {{ cam:number[], target:number[], fovDeg:number }} view
+ * @param {number} [screenFraction=0.02]
+ */
+export function cubeSizeForView(view, screenFraction = 0.02) {
+  if (!view?.cam || !view?.target) return 0.08;
+  const dx = view.cam[0] - view.target[0];
+  const dy = view.cam[1] - view.target[1];
+  const dz = view.cam[2] - view.target[2];
+  const dist = Math.hypot(dx, dy, dz) || 3;
+  const fov = ((view.fovDeg || 45) * Math.PI) / 180;
+  const frameH = 2 * dist * Math.tan(fov / 2);
+  return Math.max(0.015, frameH * screenFraction);
+}
+
+/**
+ * Axis-aligned cube centered at (cx,cy,cz) with half-extent `half`.
+ * @returns {{ positions:number[], normals:number[], uvs:number[], indices:number[], colorHex:number, shininess:number, opacity:number, reflectivity:number }}
+ */
+export function makeAxisCubePart(cx, cy, cz, half, colorHex = 0x3b82f6) {
+  const h = Math.max(1e-4, half);
+  const x0 = cx - h;
+  const x1 = cx + h;
+  const y0 = cy - h;
+  const y1 = cy + h;
+  const z0 = cz - h;
+  const z1 = cz + h;
+  // 6 faces × 4 verts (unique per face for flat normals)
+  const faces = [
+    // +Z
+    [
+      [x0, y0, z1],
+      [x1, y0, z1],
+      [x1, y1, z1],
+      [x0, y1, z1],
+      [0, 0, 1],
+    ],
+    // -Z
+    [
+      [x1, y0, z0],
+      [x0, y0, z0],
+      [x0, y1, z0],
+      [x1, y1, z0],
+      [0, 0, -1],
+    ],
+    // +Y
+    [
+      [x0, y1, z1],
+      [x1, y1, z1],
+      [x1, y1, z0],
+      [x0, y1, z0],
+      [0, 1, 0],
+    ],
+    // -Y
+    [
+      [x0, y0, z0],
+      [x1, y0, z0],
+      [x1, y0, z1],
+      [x0, y0, z1],
+      [0, -1, 0],
+    ],
+    // +X
+    [
+      [x1, y0, z1],
+      [x1, y0, z0],
+      [x1, y1, z0],
+      [x1, y1, z1],
+      [1, 0, 0],
+    ],
+    // -X
+    [
+      [x0, y0, z0],
+      [x0, y0, z1],
+      [x0, y1, z1],
+      [x0, y1, z0],
+      [-1, 0, 0],
+    ],
+  ];
+  const positions = [];
+  const normals = [];
+  const uvs = [];
+  const indices = [];
+  let vi = 0;
+  for (const f of faces) {
+    const n = f[4];
+    for (let i = 0; i < 4; i++) {
+      const p = f[i];
+      positions.push(p[0], p[1], p[2]);
+      normals.push(n[0], n[1], n[2]);
+      uvs.push(i === 1 || i === 2 ? 1 : 0, i >= 2 ? 1 : 0);
+    }
+    indices.push(vi, vi + 1, vi + 2, vi, vi + 2, vi + 3);
+    vi += 4;
+  }
+  return {
+    positions,
+    normals,
+    uvs,
+    indices,
+    colorHex: colorHex | 0,
+    shininess: 40,
+    opacity: 1,
+    reflectivity: 0,
+  };
+}
+
+/**
+ * Cube sitting on a surface hit: center pushed out along the normal.
+ * @param {[number,number,number]} point
+ * @param {[number,number,number]} normal
+ * @param {number} edge World edge length
+ * @param {number} [colorHex]
+ */
+export function makeSurfaceNormalCubePart(point, normal, edge, colorHex = 0x3b82f6) {
+  const half = edge / 2;
+  const nx = Number(normal?.[0]) || 0;
+  const ny = Number(normal?.[1]) || 1;
+  const nz = Number(normal?.[2]) || 0;
+  const L = Math.hypot(nx, ny, nz) || 1;
+  const ux = nx / L;
+  const uy = ny / L;
+  const uz = nz / L;
+  // Sit just outside the surface so the cube is visible
+  const cx = point[0] + ux * half * 1.15;
+  const cy = point[1] + uy * half * 1.15;
+  const cz = point[2] + uz * half * 1.15;
+  return makeAxisCubePart(cx, cy, cz, half, colorHex);
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/meshPick.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/meshPick.js
@@ -188,10 +188,41 @@ export function raycastMeshParts(origin, dir, parts) {
         const bu = hitT.u;
         const bv = hitT.v;
         const bw = 1 - bu - bv;
-        const u =
-          bw * uvs[ia * 2] + bu * uvs[ib * 2] + bv * uvs[ic * 2];
-        const v =
-          bw * uvs[ia * 2 + 1] + bu * uvs[ib * 2 + 1] + bv * uvs[ic * 2 + 1];
+        let u0 = uvs[ia * 2];
+        let u1 = uvs[ib * 2];
+        let u2 = uvs[ic * 2];
+        const v0 = uvs[ia * 2 + 1];
+        const v1 = uvs[ib * 2 + 1];
+        const v2 = uvs[ic * 2 + 1];
+        // Closed lathe seam: UV jumps ~1 across a short 3D edge. Unwrap only then
+        // (not for a large UV island that legitimately spans 0→1).
+        const pairs = [
+          [u0, u1, i0, i1],
+          [u0, u2, i0, i2],
+          [u1, u2, i1, i2],
+        ];
+        let seam = false;
+        for (const [ua, ub, pa, pb] of pairs) {
+          if (Math.abs(ua - ub) <= 0.5) continue;
+          const plen = Math.hypot(
+            pos[pa] - pos[pb],
+            pos[pa + 1] - pos[pb + 1],
+            pos[pa + 2] - pos[pb + 2],
+          );
+          if (plen < 1.25) {
+            seam = true;
+            break;
+          }
+        }
+        if (seam) {
+          if (u1 - u0 > 0.5) u1 -= 1;
+          else if (u1 - u0 < -0.5) u1 += 1;
+          if (u2 - u0 > 0.5) u2 -= 1;
+          else if (u2 - u0 < -0.5) u2 += 1;
+        }
+        let u = bw * u0 + bu * u1 + bv * u2;
+        u = ((u % 1) + 1) % 1;
+        const v = bw * v0 + bu * v1 + bv * v2;
         uv = [u, v];
       }
       best = {
@@ -225,7 +256,8 @@ export function approximateLatheUvFromPoint(point, parts) {
   }
   if (!Number.isFinite(yMin) || !Number.isFinite(yMax)) return null;
   const span = Math.max(1e-6, yMax - yMin);
-  const u = ((Math.atan2(point[0], point[2]) / (Math.PI * 2)) + 1) % 1;
+  // Lathe u=0 at +X (pathSample: col0 → orbit (1,0) → position x=r, z=0).
+  const u = ((Math.atan2(point[2], point[0]) / (Math.PI * 2)) + 1) % 1;
   const v = Math.min(1, Math.max(0, (point[1] - yMin) / span));
   return [u, v];
 }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/rangerPreview.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/rangerPreview.js
@@ -111,8 +111,9 @@ export async function createPreviewSession(canvas, size = 420, opts = {}) {
     }
   }
 
-  function setAutoRotate(on) {
-    host.setAutoRotate?.(!!on);
+  function setAutoRotate(_on) {
+    // Autorotate removed — always keep the mesh fixed for stable UV picks.
+    host.setAutoRotate?.(false);
   }
 
   function getView() {

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -730,6 +730,7 @@ export function unwrapUvPairU(u1, u2) {
 /**
  * Build eye-pair textureUv from two mesh UV corners (top-left then bottom-right).
  * Lathe: u around orbit, v along profile (higher v = higher on mesh).
+ * Scale is fit so the pair footprint stays inside the UV rect (not height-only).
  */
 export function eyeUvFromCorners(u1, v1, u2, v2, opts = {}) {
   const [uLo, uHi] = unwrapUvPairU(u1, u2);
@@ -743,20 +744,20 @@ export function eyeUvFromCorners(u1, v1, u2, v2, opts = {}) {
   const height = Math.max(0.02, vHi - vLo);
   const eyeWU = opts.eyeWidthU != null ? Number(opts.eyeWidthU) : EYE_UV_FOOTPRINT.eyeWidthU;
   const eyeHV = opts.eyeHeightV != null ? Number(opts.eyeHeightV) : EYE_UV_FOOTPRINT.eyeHeightV;
-  const scaleH = height / (eyeHV || 0.13);
+  const minSep = 0.04;
   const preferSep =
     opts.eyeSeparationU != null && Number.isFinite(Number(opts.eyeSeparationU))
       ? Number(opts.eyeSeparationU)
       : null;
-  let scale;
-  let eyeSeparationU;
-  if (preferSep != null) {
-    scale = (scaleH + width / (preferSep + eyeWU)) / 2;
-    eyeSeparationU = preferSep;
-  } else {
-    scale = scaleH;
-    eyeSeparationU = Math.min(0.45, Math.max(0.04, width - eyeWU * scale));
-  }
+  const sepHint = preferSep != null ? preferSep : Math.min(0.2, Math.max(minSep, width * 0.45));
+  const scaleV = height / (eyeHV || 0.13);
+  const scaleU = width / (eyeWU + sepHint);
+  // Fit inside the picked rect — height-only scale blew past and collapsed the gap.
+  const scale = Math.min(scaleV, scaleU);
+  const eyeSeparationU =
+    preferSep != null
+      ? preferSep
+      : Math.min(0.45, Math.max(minSep, width - eyeWU * scale));
   let centerU = (uLo + uHi) / 2;
   centerU = ((centerU % 1) + 1) % 1;
   const centerV = (vLo + vHi) / 2;
@@ -856,7 +857,8 @@ export function rasterizeEyePairUvMap(tex, width = 512, height = 512, opts = {})
 
   function blit(layers, uCenter) {
     const x = Math.round(uCenter * w - cellW / 2);
-    const y = Math.round((1 - centerV) * h - cellH / 2);
+    // Host samples atlas with v=0 at buffer row 0 (no V flip on upload).
+    const y = Math.round(centerV * h - cellH / 2);
     const off = document.createElement("canvas");
     off.width = cellW;
     off.height = cellH;
@@ -867,6 +869,8 @@ export function rasterizeEyePairUvMap(tex, width = 512, height = 512, opts = {})
     ctx.drawImage(off, x, y);
   }
 
+  // Screen-left on a front-facing lathe is higher U when viewing from +X/+Z;
+  // character "left" eye still uses lower U in atlas convention (centerU - sep/2).
   blit(left, centerU - sepU / 2);
   blit(right, centerU + sepU / 2);
 
@@ -937,7 +941,8 @@ export async function rasterizeEyePairUvMapAsync(tex, width = 512, height = 512,
 
   function blit(layers, uCenter) {
     const x = Math.round(uCenter * w - cellW / 2);
-    const y = Math.round((1 - centerV) * h - cellH / 2);
+    // Host samples atlas with v=0 at buffer row 0 (no V flip on upload).
+    const y = Math.round(centerV * h - cellH / 2);
     const off = document.createElement("canvas");
     off.width = cellW;
     off.height = cellH;

--- a/gallery/game_engine/v2/mesh_editor/host/web_mesh_editor_host.rgr
+++ b/gallery/game_engine/v2/mesh_editor/host/web_mesh_editor_host.rgr
@@ -26,8 +26,8 @@ class WebMeshEditorHost {
     def camH:int 0
     def meshHs:[int]
     def matMode:int 3
-    def autoRotate:boolean true
-    def angle:double 0.4
+    def autoRotate:boolean false
+    def angle:double 0.0
     def outBuf:buffer (buffer_alloc 0)
     def lastMatH:int 0
 
@@ -183,7 +183,8 @@ class WebMeshEditorHost {
     }
 
     fn setAutoRotate:void (on:boolean) {
-        autoRotate = on
+        ; Autorotate removed — always off so UV / assign picks stay stable.
+        autoRotate = false
     }
 
     ; View state for JS surface picking (camera + mesh yaw/tilt).
@@ -223,7 +224,6 @@ class WebMeshEditorHost {
 
     fn pointerDown:void (x:double y:double button:int) {
         controls.pointerDown(x y button)
-        autoRotate = false
     }
     fn pointerMove:void (x:double y:double) {
         controls.pointerMove(x y)
@@ -233,20 +233,18 @@ class WebMeshEditorHost {
     }
     fn wheel:void (delta:double) {
         controls.wheel(delta)
-        autoRotate = false
     }
 
     fn frame:void (dtMs:double) {
         if (ready == false) {
             return
         }
-        if (autoRotate) {
-            angle = (angle + (dtMs * 0.0009))
-            def i:int 0
-            while (i < (array_length meshHs)) {
-                host.entityTransform((itemAt meshHs i) 0.0 0.0 0.0 0.12 angle 0.0 1.0 1.0 1.0)
-                i = (i + 1)
-            }
+        ; Keep mesh yaw/tilt fixed (no autorotate). Re-assert transform each frame
+        ; so newly added parts stay aligned after beginParts/addPart.
+        def i:int 0
+        while (i < (array_length meshHs)) {
+            host.entityTransform((itemAt meshHs i) 0.0 0.0 0.0 0.12 angle 0.0 1.0 1.0 1.0)
+            i = (i + 1)
         }
         controls.applyToCamera()
         if (useGL) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Assigning eyes via the 3D square put them in the wrong place even on a simple lathe with the default region. Autorotate also made UV picks unstable.

## Root causes

1. **Atlas V flip** — `rasterizeEyePairUvMap` placed eyes at `(1 - centerV)`, but the host samples with **v=0 at buffer row 0** (software `sampleTex` and WebGL upload). Eyes appeared vertically inverted.
2. **Closed lathe seam U** — barycentric UV lerp across the u wrap (~0.98↔0.02) averaged to ~0.5. Unwrap only when `|Δu|>0.5` **and** the 3D edge is short.
3. **Scale from height only** — tall UV AABBs exploded scale (clamped to 3) and collapsed eye gap. Now `scale = min(scaleV, scaleU)`.
4. **Approximate lathe U** — `atan2(x,z)` disagreed with lathe `u=0` at +X; switched to `atan2(z,x)`.

## Also

- Preview **autorotate removed** (host + JS session always keep mesh fixed).
- **Four blue cubes** (~2% of frame) at square-corner raycast hits along surface normals while placing the region.

## Tests

- `node scripts/smoke-eye-texture.mjs`
- `node scripts/smoke-mesh-pick.mjs` (includes simple lathe front-hit → region center tracking)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

