### PR TITLE
Fix upside-down eyes, missing white sclera, and one-eye cobra assign

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -22,6 +22,7 @@ import {
   eyeUvFromCorners,
   eyeUvMoveCenter,
   unwrapUvPairU,
+  layersWithEyeballColor,
 } from "../src/lib/texture/eyeTexture.js";
 import {
   clampAssignRegion,
@@ -329,11 +330,20 @@ assert.ok(Math.abs(fromCorners.centerU - 0.5) < 1e-6);
 assert.ok(Math.abs(fromCorners.centerV - 0.575) < 1e-6);
 assert.ok(fromCorners.scale > 0.5 && fromCorners.scale < 3);
 assert.ok(fromCorners.eyeSeparationU > 0.02);
+// Eyes must stay separated (not collapsed into one disc)
+assert.ok(
+  fromCorners.eyeSeparationU >= fromCorners.scale * 0.11 * 1.1,
+  "gap at least ~eye width so both eyes show",
+);
 // Tall UV rect must not explode scale past what width can hold
 const tall = eyeUvFromCorners(0.4, 0.9, 0.6, 0.2);
 assert.ok(tall.scale <= tall.eyeSeparationU / 0.01); // sanity
 assert.ok(tall.scale < 2.5, "scale fits width+height, not height-only");
 assert.ok(tall.eyeSeparationU >= 0.04);
+// Sclera tint helper still available, but atlas default keeps authored white
+const tinted = layersWithEyeballColor(eye.layers, "#00ff00");
+assert.equal(tinted.find((L) => L.type === "eyeball")?.color, "#00ff00");
+assert.equal(eye.layers.find((L) => L.type === "eyeball")?.color, "#f2f0ea");
 assert.deepEqual(unwrapUvPairU(0.9, 0.1)[0] <= unwrapUvPairU(0.9, 0.1)[1], true);
 const moved = eyeUvMoveCenter(fromCorners, 0.42, 0.55);
 assert.ok(Math.abs(moved.centerU - 0.42) < 1e-9);

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -330,16 +330,16 @@ assert.ok(Math.abs(fromCorners.centerU - 0.5) < 1e-6);
 assert.ok(Math.abs(fromCorners.centerV - 0.575) < 1e-6);
 assert.ok(fromCorners.scale > 0.5 && fromCorners.scale < 3);
 assert.ok(fromCorners.eyeSeparationU > 0.02);
-// Eyes must stay separated (not collapsed into one disc)
-assert.ok(
-  fromCorners.eyeSeparationU >= fromCorners.scale * 0.11 * 1.1,
-  "gap at least ~eye width so both eyes show",
-);
+assert.ok(fromCorners.eyeSeparationU <= 0.16 + 1e-9, "pair gap capped for one face");
+// Wide UV span (cobra-like cheeks) must NOT pin eyes to the U edges
+const wide = eyeUvFromCorners(0.05, 0.7, 0.55, 0.45);
+assert.ok(wide.eyeSeparationU <= 0.16 + 1e-9, `sep capped, got ${wide.eyeSeparationU}`);
+assert.ok(wide.eyeSeparationU < 0.45, "must not use full rect width as gap");
+assert.ok(wide.eyeSeparationU >= 0.05, "eyes still separated");
 // Tall UV rect must not explode scale past what width can hold
 const tall = eyeUvFromCorners(0.4, 0.9, 0.6, 0.2);
-assert.ok(tall.scale <= tall.eyeSeparationU / 0.01); // sanity
 assert.ok(tall.scale < 2.5, "scale fits width+height, not height-only");
-assert.ok(tall.eyeSeparationU >= 0.04);
+assert.ok(tall.eyeSeparationU >= 0.04 && tall.eyeSeparationU <= 0.16 + 1e-9);
 // Sclera tint helper still available, but atlas default keeps authored white
 const tinted = layersWithEyeballColor(eye.layers, "#00ff00");
 assert.equal(tinted.find((L) => L.type === "eyeball")?.color, "#00ff00");

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/assignRegion.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/assignRegion.js
@@ -84,11 +84,15 @@ export function eyeUvFromRegionSamples(samples, region, opts = {}) {
       2.5,
       Math.max(0.35, (reg.half / DEFAULT_ASSIGN_REGION.half) * (opts.baseScale || 1)),
     );
+    const sep =
+      opts.eyeSeparationU != null
+        ? opts.eyeSeparationU
+        : Math.min(0.16, Math.max(0.05, 0.12 * scale));
     return normalizeEyeUv({
       centerU: list[0][0],
       centerV: list[0][1],
       scale,
-      eyeSeparationU: opts.eyeSeparationU != null ? opts.eyeSeparationU : 0.12 * scale,
+      eyeSeparationU: sep,
     });
   }
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -730,7 +730,9 @@ export function unwrapUvPairU(u1, u2) {
 /**
  * Build eye-pair textureUv from two mesh UV corners (top-left then bottom-right).
  * Lathe: u around orbit, v along profile (higher v = higher on mesh).
- * Scale is fit so the pair footprint stays inside the UV rect (not height-only).
+ * Scale fits the pair inside the UV rect. Separation is capped so both eyes
+ * stay on the same face — using the full rect width as gap pinned eyes to the
+ * U edges (often around the sides/back of a lathe → only one eye visible).
  */
 export function eyeUvFromCorners(u1, v1, u2, v2, opts = {}) {
   const [uLo, uHi] = unwrapUvPairU(u1, u2);
@@ -744,22 +746,26 @@ export function eyeUvFromCorners(u1, v1, u2, v2, opts = {}) {
   const height = Math.max(0.02, vHi - vLo);
   const eyeWU = opts.eyeWidthU != null ? Number(opts.eyeWidthU) : EYE_UV_FOOTPRINT.eyeWidthU;
   const eyeHV = opts.eyeHeightV != null ? Number(opts.eyeHeightV) : EYE_UV_FOOTPRINT.eyeHeightV;
-  const minSep = 0.04;
+  const minSep = 0.05;
+  /** ~58° of orbit — keeps a pair on one cheek of a closed lathe. */
+  const maxSep = opts.maxSeparationU != null ? Number(opts.maxSeparationU) : 0.16;
   const preferSep =
     opts.eyeSeparationU != null && Number.isFinite(Number(opts.eyeSeparationU))
       ? Number(opts.eyeSeparationU)
       : null;
-  // Gap ≈ half the rect so both eyes sit inside; then scale to fit width+height.
-  const sepHint =
-    preferSep != null ? preferSep : Math.min(0.35, Math.max(minSep, width * 0.5));
+  const sepTarget =
+    preferSep != null
+      ? preferSep
+      : Math.min(maxSep, Math.max(minSep, width * 0.38));
   const scaleV = height / (eyeHV || 0.13);
-  const scaleU = width / (eyeWU + sepHint);
+  const scaleU = Math.max(0.05, (width - sepTarget) / (eyeWU || 0.11));
   const scale = Math.min(scaleV, scaleU);
   const eyeW = eyeWU * scale;
+  // Final gap: at least a bit over one eye, but never wider than maxSep / rect.
   const eyeSeparationU =
     preferSep != null
       ? preferSep
-      : Math.min(0.45, Math.max(eyeW * 1.15, width - eyeW));
+      : Math.min(maxSep, Math.max(eyeW * 1.2, Math.min(sepTarget, width - eyeW)));
   let centerU = (uLo + uHi) / 2;
   centerU = ((centerU % 1) + 1) % 1;
   const centerV = (vLo + vHi) / 2;
@@ -815,11 +821,11 @@ export function layersWithEyeballColor(layers, color) {
  * Blit one eye cell into the UV atlas.
  * Host samples with v=0 at buffer row 0; canvas authoring has Y-up content at the
  * top of the cell — flip vertically so the reflection sits toward higher mesh V.
+ * Also draws at u±1 so a cell that straddles the 0/1 seam still appears.
  */
 export function blitEyeCellToAtlas(ctx, layers, uCenter, centerV, cellW, cellH, bg) {
   const w = ctx.canvas.width;
   const h = ctx.canvas.height;
-  const x = Math.round(uCenter * w - cellW / 2);
   const y = Math.round(centerV * h - cellH / 2);
   const off = document.createElement("canvas");
   off.width = cellW;
@@ -828,11 +834,20 @@ export function blitEyeCellToAtlas(ctx, layers, uCenter, centerV, cellW, cellH, 
   octx.fillStyle = bg;
   octx.fillRect(0, 0, cellW, cellH);
   drawEyeLayers(octx, layers, cellW, cellH);
-  ctx.save();
-  ctx.translate(x, y + cellH);
-  ctx.scale(1, -1);
-  ctx.drawImage(off, 0, 0);
-  ctx.restore();
+  const u0 = ((Number(uCenter) % 1) + 1) % 1;
+  const xMain = Math.round(u0 * w - cellW / 2);
+  // Only wrap-copy when the cell crosses the atlas edge (avoids seam streaks).
+  const us =
+    xMain < 0 || xMain + cellW > w ? [u0 - 1, u0, u0 + 1] : [u0];
+  for (const u of us) {
+    const x = Math.round(u * w - cellW / 2);
+    if (x + cellW <= 0 || x >= w) continue;
+    ctx.save();
+    ctx.translate(x, y + cellH);
+    ctx.scale(1, -1);
+    ctx.drawImage(off, 0, 0);
+    ctx.restore();
+  }
 }
 
 /**

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -749,15 +749,17 @@ export function eyeUvFromCorners(u1, v1, u2, v2, opts = {}) {
     opts.eyeSeparationU != null && Number.isFinite(Number(opts.eyeSeparationU))
       ? Number(opts.eyeSeparationU)
       : null;
-  const sepHint = preferSep != null ? preferSep : Math.min(0.2, Math.max(minSep, width * 0.45));
+  // Gap ≈ half the rect so both eyes sit inside; then scale to fit width+height.
+  const sepHint =
+    preferSep != null ? preferSep : Math.min(0.35, Math.max(minSep, width * 0.5));
   const scaleV = height / (eyeHV || 0.13);
   const scaleU = width / (eyeWU + sepHint);
-  // Fit inside the picked rect — height-only scale blew past and collapsed the gap.
   const scale = Math.min(scaleV, scaleU);
+  const eyeW = eyeWU * scale;
   const eyeSeparationU =
     preferSep != null
       ? preferSep
-      : Math.min(0.45, Math.max(minSep, width - eyeWU * scale));
+      : Math.min(0.45, Math.max(eyeW * 1.15, width - eyeW));
   let centerU = (uLo + uHi) / 2;
   centerU = ((centerU % 1) + 1) % 1;
   const centerV = (vLo + vHi) / 2;
@@ -797,7 +799,11 @@ export function averageKnotColorHex(knots, fallback = "#e8e4dc") {
   return `#${to(r)}${to(g)}${to(b)}`;
 }
 
-/** Clone layers with eyeball fill remapped (UV project uses mesh/vertex tint as sclera). */
+/**
+ * Clone layers with eyeball fill remapped.
+ * Optional — UV atlas keeps authored sclera by default so white eyeballs stay visible
+ * against a mesh-tinted background.
+ */
 export function layersWithEyeballColor(layers, color) {
   if (!color) return layers || [];
   return (layers || []).map((L) =>
@@ -806,8 +812,33 @@ export function layersWithEyeballColor(layers, color) {
 }
 
 /**
+ * Blit one eye cell into the UV atlas.
+ * Host samples with v=0 at buffer row 0; canvas authoring has Y-up content at the
+ * top of the cell — flip vertically so the reflection sits toward higher mesh V.
+ */
+export function blitEyeCellToAtlas(ctx, layers, uCenter, centerV, cellW, cellH, bg) {
+  const w = ctx.canvas.width;
+  const h = ctx.canvas.height;
+  const x = Math.round(uCenter * w - cellW / 2);
+  const y = Math.round(centerV * h - cellH / 2);
+  const off = document.createElement("canvas");
+  off.width = cellW;
+  off.height = cellH;
+  const octx = off.getContext("2d");
+  octx.fillStyle = bg;
+  octx.fillRect(0, 0, cellW, cellH);
+  drawEyeLayers(octx, layers, cellW, cellH);
+  ctx.save();
+  ctx.translate(x, y + cellH);
+  ctx.scale(1, -1);
+  ctx.drawImage(off, 0, 0);
+  ctx.restore();
+}
+
+/**
  * Rasterize left+right eyes into a UV atlas.
- * Background defaults to mesh/vertex tint (not pure white) so the atlas blends.
+ * Background defaults to mesh/vertex tint so non-eye UV areas match the body.
+ * Eyeball sclera keeps its authored color (usually white/cream).
  * Lathe UVs: u around orbit, v along profile.
  *
  * @returns {{ rgba: Uint8ClampedArray|number[], w: number, h: number, name: string } | null}
@@ -825,6 +856,8 @@ export function rasterizeEyePairUvMap(tex, width = 512, height = 512, opts = {})
   const eyeWU = (opts.eyeWidthU != null ? Number(opts.eyeWidthU) : 0.11) * scale;
   const eyeHV = (opts.eyeHeightV != null ? Number(opts.eyeHeightV) : 0.13) * scale;
   const bg = opts.background || "#e8e4dc";
+  // tintSclera: legacy option — paint eyeball with mesh bg (hides white sclera).
+  const tintSclera = opts.tintSclera === true;
 
   if (typeof document === "undefined") {
     // Node smoke: solid bg map (assignment path is browser/WebGL).
@@ -851,28 +884,14 @@ export function rasterizeEyePairUvMap(tex, width = 512, height = 512, opts = {})
 
   const cellW = Math.max(8, Math.round(eyeWU * w));
   const cellH = Math.max(8, Math.round(eyeHV * h));
-  // Eyeball sclera follows mesh/vertex tint so the UV patch is not a white disc.
-  const left = layersWithEyeballColor(tex.layers || [], bg);
-  const right = layersWithEyeballColor(rightEyeLayers(tex), bg);
+  const leftRaw = tex.layers || [];
+  const rightRaw = rightEyeLayers(tex);
+  const left = tintSclera ? layersWithEyeballColor(leftRaw, bg) : leftRaw;
+  const right = tintSclera ? layersWithEyeballColor(rightRaw, bg) : rightRaw;
 
-  function blit(layers, uCenter) {
-    const x = Math.round(uCenter * w - cellW / 2);
-    // Host samples atlas with v=0 at buffer row 0 (no V flip on upload).
-    const y = Math.round(centerV * h - cellH / 2);
-    const off = document.createElement("canvas");
-    off.width = cellW;
-    off.height = cellH;
-    const octx = off.getContext("2d");
-    octx.fillStyle = bg;
-    octx.fillRect(0, 0, cellW, cellH);
-    drawEyeLayers(octx, layers, cellW, cellH);
-    ctx.drawImage(off, x, y);
-  }
-
-  // Screen-left on a front-facing lathe is higher U when viewing from +X/+Z;
-  // character "left" eye still uses lower U in atlas convention (centerU - sep/2).
-  blit(left, centerU - sepU / 2);
-  blit(right, centerU + sepU / 2);
+  // Character left eye = lower U; right = higher U.
+  blitEyeCellToAtlas(ctx, left, centerU - sepU / 2, centerV, cellW, cellH, bg);
+  blitEyeCellToAtlas(ctx, right, centerU + sepU / 2, centerV, cellW, cellH, bg);
 
   const img = ctx.getImageData(0, 0, w, h);
   return {
@@ -936,30 +955,19 @@ export async function rasterizeEyePairUvMapAsync(tex, width = 512, height = 512,
 
   const cellW = Math.max(8, Math.round(eyeWU * w));
   const cellH = Math.max(8, Math.round(eyeHV * h));
-  const left = layersWithEyeballColor(tex.layers || [], bg);
-  const right = layersWithEyeballColor(rightEyeLayers(tex), bg);
-
-  function blit(layers, uCenter) {
-    const x = Math.round(uCenter * w - cellW / 2);
-    // Host samples atlas with v=0 at buffer row 0 (no V flip on upload).
-    const y = Math.round(centerV * h - cellH / 2);
-    const off = document.createElement("canvas");
-    off.width = cellW;
-    off.height = cellH;
-    const octx = off.getContext("2d");
-    octx.fillStyle = bg;
-    octx.fillRect(0, 0, cellW, cellH);
-    drawEyeLayers(octx, layers, cellW, cellH);
-    ctx.drawImage(off, x, y);
-  }
+  const tintSclera = opts.tintSclera === true;
+  const leftRaw = tex.layers || [];
+  const rightRaw = rightEyeLayers(tex);
+  const left = tintSclera ? layersWithEyeballColor(leftRaw, bg) : leftRaw;
+  const right = tintSclera ? layersWithEyeballColor(rightRaw, bg) : rightRaw;
 
   onProgress("left-eye");
   await yieldFn();
-  blit(left, centerU - sepU / 2);
+  blitEyeCellToAtlas(ctx, left, centerU - sepU / 2, centerV, cellW, cellH, bg);
 
   onProgress("right-eye");
   await yieldFn();
-  blit(right, centerU + sepU / 2);
+  blitEyeCellToAtlas(ctx, right, centerU + sepU / 2, centerV, cellW, cellH, bg);
 
   onProgress("readback");
   await yieldFn();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After UV assign:
- Eyes appear **upside down** (reflection/glint at the bottom).
- **White sclera** missing — iris sits on mesh color (eyeball was tinted to atlas background).
- On wide heads (cobra), often **only one eye** shows — the other was pinned to the far U edge / back of the lathe.

## Fixes

1. **Upright blit** — flip each eye cell vertically when writing the UV atlas (`v=0` is buffer row 0).
2. **Keep authored sclera** — do not remap eyeball fill to mesh background by default (atlas clear still uses vertex/knot average).
3. **Cap `eyeSeparationU` (~0.16)** — stop using the full region U width as the gap so both eyes stay on the front face.
4. **Seam wrap** — only duplicate an eye cell across u±1 when it actually crosses the atlas edge.

## Tests

- `node scripts/smoke-eye-texture.mjs`
- `node scripts/smoke-mesh-pick.mjs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

