### PR TITLE
Harden library API; separate mesh/texture save identity

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/package.json
+++ b/gallery/game_engine/v2/mesh_editor/app/package.json
@@ -8,7 +8,8 @@
     "prebuild": "node ../tessellate/build.mjs && node ../build-host.mjs && node scripts/sync-public.mjs",
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node scripts/smoke-library-safe.mjs && node scripts/smoke-mesh-pick.mjs && node scripts/smoke-eye-texture.mjs"
   },
   "dependencies": {
     "vue": "^3.5.13"

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-library-safe.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-library-safe.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import path from "node:path";
+import os from "node:os";
+import { resolveSafeProjectDir, PROJECT_SLUG_RE } from "../src/library/safePath.mjs";
+import { createEditHistory } from "../src/lib/editHistory.js";
+import { buildProjectDocument } from "../src/library/schema.js";
+
+const root = path.join(os.tmpdir(), "mesh-editor-lib-test");
+
+assert.ok(PROJECT_SLUG_RE.test("tall-vase"));
+assert.ok(PROJECT_SLUG_RE.test("a"));
+assert.equal(PROJECT_SLUG_RE.test("../etc"), false);
+assert.equal(PROJECT_SLUG_RE.test("foo/bar"), false);
+assert.equal(PROJECT_SLUG_RE.test(""), false);
+
+const ok = resolveSafeProjectDir(root, "my-project");
+assert.equal(ok.slug, "my-project");
+assert.ok(ok.dir.startsWith(path.resolve(root) + path.sep));
+assert.ok(ok.file.endsWith(`${path.sep}project.json`));
+
+for (const bad of ["../x", "..", "a/b", "a\\b", "UPPER", "has space", ".hidden", ""]) {
+  assert.throws(() => resolveSafeProjectDir(root, bad), /Invalid project slug/);
+}
+
+// Encoded traversal that becomes ".." after decode would still fail pattern
+assert.throws(() => resolveSafeProjectDir(root, decodeURIComponent("%2e%2e")), /Invalid/);
+
+// History limit: both object and legacy number forms
+const hObj = createEditHistory({ limit: 3 });
+for (let i = 0; i < 5; i++) hObj.push({ i }, "n");
+assert.equal(hObj.canUndo(), true);
+// Drain past — only 3 kept
+let n = 0;
+let cur = { i: 99 };
+while (hObj.canUndo()) {
+  cur = hObj.undo(cur);
+  n += 1;
+}
+assert.equal(n, 3);
+
+const hNum = createEditHistory(2);
+hNum.push({ a: 1 });
+hNum.push({ a: 2 });
+hNum.push({ a: 3 });
+n = 0;
+cur = { a: 0 };
+while (hNum.canUndo()) {
+  cur = hNum.undo(cur);
+  n += 1;
+}
+assert.equal(n, 2);
+
+// Texture kind snapshot must keep textureAssets in the document
+const doc = buildProjectDocument({
+  projectKind: "texture",
+  name: "Eyes",
+  state: {
+    knots: [
+      { id: "a", x: 0.2, y: -0.5, hx: 0, hy: 0, color: "#fff" },
+      { id: "b", x: 0.3, y: 0.5, hx: 0, hy: 0, color: "#fff" },
+    ],
+    segments: [],
+    orbitKnots: [
+      { id: "o0", x: 1, y: 0, hx: 0, hy: 0, color: "#fff" },
+      { id: "o1", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+      { id: "o2", x: -1, y: 0, hx: 0, hy: 0, color: "#fff" },
+    ],
+    orbitSegments: [],
+    textureAssets: {
+      g1: {
+        assetGuid: "g1",
+        name: "Eye",
+        kind: "eye",
+        layers: [{ id: "l1", type: "eyeball", name: "Eyeball", knots: [], segments: [] }],
+      },
+    },
+  },
+});
+assert.equal(doc.projectKind, "texture");
+assert.ok(doc.textureAssets.g1, "textureAssets must be serialized into JSON doc");
+assert.equal(doc.textureAssets.g1.name, "Eye");
+
+console.log("smoke-library-safe: ok");

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -80,16 +80,22 @@ const assignRegionUv = ref(null);
 
 setTextureAssetsProvider(() => tex.snapshotTextures());
 
-function snapshotState() {
+function snapshotState(kind) {
+  const k = kind === "texture" ? "texture" : "mesh";
   return {
     ...snapshotMeshState(),
     textureAssets: tex.snapshotTextures(),
-    projectKind: workspace.value === "texture" ? "texture" : "mesh",
+    projectKind: k,
   };
 }
 
-function applyProject(doc) {
-  const kind = doc?.projectKind === "texture" ? "texture" : "mesh";
+function applyProject(doc, kindHint) {
+  const kind =
+    kindHint === "texture" || kindHint === "mesh"
+      ? kindHint
+      : doc?.projectKind === "texture"
+        ? "texture"
+        : "mesh";
   workspace.value = kind;
   if (doc?.profile?.knots?.length >= 2) {
     applyMeshProject(doc);
@@ -163,6 +169,8 @@ async function onAssignApply({ guid, uv, assets }) {
       assignRegionUv.value = null;
       state.status = "Eye texture assigned.";
     }
+  } catch (err) {
+    state.status = "Assign failed: " + (err.message || err);
   } finally {
     assignBusy.value = false;
     assignProgress.value = "";
@@ -304,6 +312,7 @@ function onRedo() {
 }
 
 function onKeyDown(e) {
+  if (isEditableTarget(e.target)) return;
   const mod = e.metaKey || e.ctrlKey;
   if (!mod) return;
   const key = e.key.toLowerCase();
@@ -316,6 +325,15 @@ function onKeyDown(e) {
     if (workspace.value === "texture") tex.redo();
     else onRedo();
   }
+}
+
+function isEditableTarget(target) {
+  if (!target || typeof target !== "object") return false;
+  const el = /** @type {HTMLElement} */ (target);
+  const tag = el.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (el.isContentEditable) return true;
+  return !!el.closest?.("input, textarea, select, [contenteditable='true']");
 }
 
 const placePending = ref(null); // { slug, mode, symmetric, doc }
@@ -834,12 +852,12 @@ onBeforeUnmount(() => {
         :lib="lib"
         project-kind="mesh"
         @refresh="refresh"
-        @load="load"
-        @save="save"
-        @save-as="saveAs"
-        @remove="remove"
-        @export="exportJson"
-        @import-file="importJsonFile"
+        @load="(slug) => load(slug, 'mesh')"
+        @save="() => save('mesh')"
+        @save-as="(name) => saveAs(name, 'mesh')"
+        @remove="(slug) => remove(slug, 'mesh')"
+        @export="(name) => exportJson(name, 'mesh')"
+        @import-file="(file) => importJsonFile(file, 'mesh')"
       />
     </main>
 
@@ -926,12 +944,12 @@ onBeforeUnmount(() => {
         :lib="lib"
         project-kind="texture"
         @refresh="refresh"
-        @load="load"
-        @save="save"
-        @save-as="saveAs"
-        @remove="remove"
-        @export="exportJson"
-        @import-file="importJsonFile"
+        @load="(slug) => load(slug, 'texture')"
+        @save="() => save('texture')"
+        @save-as="(name) => saveAs(name, 'texture')"
+        @remove="(slug) => remove(slug, 'texture')"
+        @export="(name) => exportJson(name, 'texture')"
+        @import-file="(file) => importJsonFile(file, 'texture')"
       />
     </main>
     <AssignTextureDialog

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/LibraryPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/LibraryPanel.vue
@@ -3,7 +3,7 @@ import { ref, computed } from "vue";
 
 const props = defineProps({
   lib: { type: Object, required: true },
-  /** mesh | texture — filters the saved list */
+  /** mesh | texture — filters the saved list + picks identity slot */
   projectKind: { type: String, default: "mesh" },
 });
 
@@ -19,20 +19,26 @@ const emit = defineEmits([
 
 const fileRef = ref(null);
 
+const kind = computed(() => (props.projectKind === "texture" ? "texture" : "mesh"));
+
+const slot = computed(() =>
+  kind.value === "texture" ? props.lib.texture : props.lib.mesh,
+);
+
 const filtered = computed(() => {
-  const kind = props.projectKind === "texture" ? "texture" : "mesh";
+  const k = kind.value;
   return (props.lib.projects || []).filter((p) => {
     if (p.error) return true;
     const pk = p.projectKind === "texture" ? "texture" : "mesh";
-    return pk === kind;
+    return pk === k;
   });
 });
 
-const kindLabel = computed(() => (props.projectKind === "texture" ? "textures" : "meshes"));
+const kindLabel = computed(() => (kind.value === "texture" ? "textures" : "meshes"));
 
 function onFile(ev) {
   const f = ev.target.files?.[0];
-  if (f) emit("import-file", f);
+  if (f) emit("import-file", f, kind.value);
   ev.target.value = "";
 }
 
@@ -57,18 +63,23 @@ function metaLine(p) {
 
     <div class="save-row">
       <input
-        v-model="lib.saveAsName"
+        v-model="slot.saveAsName"
         type="text"
-        :placeholder="projectKind === 'texture' ? 'Name (e.g. eyes)' : 'Name (e.g. tall vase)'"
-        @keyup.enter="emit('save-as', lib.saveAsName)"
+        :placeholder="kind === 'texture' ? 'Name (e.g. eyes)' : 'Name (e.g. tall vase)'"
+        @keyup.enter="emit('save-as', slot.saveAsName, kind)"
       />
-      <button type="button" class="primary" :disabled="lib.busy" @click="emit('save-as', lib.saveAsName)">
+      <button
+        type="button"
+        class="primary"
+        :disabled="lib.busy"
+        @click="emit('save-as', slot.saveAsName, kind)"
+      >
         Save as
       </button>
       <button
         type="button"
-        :disabled="lib.busy || !lib.currentSlug"
-        @click="emit('save')"
+        :disabled="lib.busy || !slot.slug"
+        @click="emit('save', kind)"
       >
         Save
       </button>
@@ -76,14 +87,14 @@ function metaLine(p) {
 
     <div class="row-actions">
       <button type="button" :disabled="lib.busy" @click="emit('refresh')">Refresh</button>
-      <button type="button" @click="emit('export', lib.saveAsName)">Export JSON</button>
+      <button type="button" @click="emit('export', slot.saveAsName, kind)">Export JSON</button>
       <button type="button" @click="fileRef?.click()">Import JSON</button>
       <input ref="fileRef" type="file" accept="application/json,.json" hidden @change="onFile" />
     </div>
 
-    <p v-if="lib.currentSlug" class="current">
-      Editing <strong>{{ lib.currentName }}</strong>
-      <span class="slug">{{ lib.currentSlug }}</span>
+    <p v-if="slot.slug" class="current">
+      Editing <strong>{{ slot.name }}</strong>
+      <span class="slug">{{ slot.slug }}</span>
     </p>
 
     <ul class="list">
@@ -91,9 +102,14 @@ function metaLine(p) {
       <li
         v-for="p in filtered"
         :key="p.slug"
-        :class="{ active: p.slug === lib.currentSlug, bad: !!p.error }"
+        :class="{ active: p.slug === slot.slug, bad: !!p.error }"
       >
-        <button type="button" class="open" :disabled="!!p.error" @click="emit('load', p.slug)">
+        <button
+          type="button"
+          class="open"
+          :disabled="!!p.error"
+          @click="emit('load', p.slug, kind)"
+        >
           <strong>{{ p.name || p.slug }}</strong>
           <span>{{ metaLine(p) }}</span>
         </button>
@@ -102,7 +118,7 @@ function metaLine(p) {
           class="danger"
           title="Delete"
           :disabled="lib.busy"
-          @click="emit('remove', p.slug)"
+          @click="emit('remove', p.slug, kind)"
         >
           ×
         </button>

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useLibrary.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useLibrary.js
@@ -1,139 +1,200 @@
 import { reactive, onMounted } from "vue";
 import * as api from "../library/api.js";
-import { buildProjectDocument } from "../library/schema.js";
+import { buildProjectDocument, normalizeProjectKind } from "../library/schema.js";
 import { migrateProject } from "../library/migrations.js";
 
+const MAX_IMPORT_BYTES = 8 * 1024 * 1024;
+
+function emptyIdentity() {
+  return { slug: null, name: "", saveAsName: "" };
+}
+
+/**
+ * Local project library. Mesh and texture workspaces keep separate current-document
+ * identities so Save cannot rewrite a mesh project as texture (or vice versa).
+ *
+ * @param {{
+ *   snapshotState: (kind: 'mesh'|'texture') => object,
+ *   applyProject: (doc: object, kind: 'mesh'|'texture') => void,
+ *   tessellate: () => void,
+ * }} opts
+ */
 export function useLibrary({ snapshotState, applyProject, tessellate }) {
   const lib = reactive({
     available: false,
     root: "",
     schemaVersion: 0,
     projects: [],
-    currentSlug: null,
-    currentName: "",
+    mesh: emptyIdentity(),
+    texture: emptyIdentity(),
     status: "",
     busy: false,
-    saveAsName: "",
+    busyCount: 0,
   });
 
-  async function refresh() {
+  let refreshGen = 0;
+
+  function beginBusy() {
+    lib.busyCount += 1;
     lib.busy = true;
+  }
+
+  function endBusy() {
+    lib.busyCount = Math.max(0, lib.busyCount - 1);
+    lib.busy = lib.busyCount > 0;
+  }
+
+  function identity(kind) {
+    return kind === "texture" ? lib.texture : lib.mesh;
+  }
+
+  function normalizeKind(kind) {
+    return kind === "texture" ? "texture" : "mesh";
+  }
+
+  async function refresh() {
+    const gen = ++refreshGen;
+    beginBusy();
     try {
       const data = await api.listLibrary();
+      if (gen !== refreshGen) return;
       lib.available = true;
       lib.root = data.root || "";
       lib.schemaVersion = data.schemaVersion || 0;
       lib.projects = data.projects || [];
       lib.status = `${lib.projects.length} projects · ${lib.root}`;
     } catch (err) {
+      if (gen !== refreshGen) return;
       lib.available = false;
       lib.projects = [];
       lib.status = "Local library API offline (use npm run dev). " + (err.message || "");
     } finally {
-      lib.busy = false;
+      endBusy();
     }
   }
 
-  async function load(slug) {
-    lib.busy = true;
+  async function load(slug, kindHint) {
+    beginBusy();
     try {
       const doc = await api.loadProject(slug);
-      applyProject(doc);
-      tessellate();
-      lib.currentSlug = doc.slug;
-      lib.currentName = doc.name;
-      lib.saveAsName = doc.name;
-      lib.status = `Loaded ${doc.slug}`;
+      const kind = normalizeKind(kindHint || doc.projectKind);
+      applyProject(doc, kind);
+      if (kind === "mesh") tessellate();
+      const slot = identity(kind);
+      slot.slug = doc.slug;
+      slot.name = doc.name;
+      slot.saveAsName = doc.name;
+      lib.status = `Loaded ${doc.slug} (${kind})`;
       await refresh();
     } catch (err) {
       lib.status = "Load failed: " + (err.message || err);
     } finally {
-      lib.busy = false;
+      endBusy();
     }
   }
 
-  async function save() {
-    if (!lib.currentSlug) {
-      return saveAs(lib.saveAsName || lib.currentName || "Untitled spline");
+  async function save(kind) {
+    const k = normalizeKind(kind);
+    const slot = identity(k);
+    if (!slot.slug) {
+      return saveAs(slot.saveAsName || slot.name || "Untitled", k);
     }
-    lib.busy = true;
+    beginBusy();
     try {
+      const prev = await api.loadProject(slot.slug).catch(() => null);
+      if (prev && normalizeProjectKind(prev.projectKind) !== k) {
+        lib.status =
+          `“${slot.slug}” is a ${prev.projectKind} project — use Save as to create a new ${k} entry.`;
+        return;
+      }
       const doc = buildProjectDocument({
-        state: snapshotState(),
-        name: lib.currentName || lib.saveAsName || "Untitled spline",
-        id: undefined,
-        slug: lib.currentSlug,
+        state: snapshotState(k),
+        name: slot.name || slot.saveAsName || "Untitled",
+        slug: slot.slug,
+        projectKind: k,
       });
-      // Keep stable id from disk if present
-      const existing = lib.projects.find((p) => p.slug === lib.currentSlug);
-      if (existing?.id) doc.id = existing.id;
-      const prev = await api.loadProject(lib.currentSlug).catch(() => null);
       if (prev?.id) {
         doc.id = prev.id;
         doc.createdAt = prev.createdAt;
+      } else {
+        const existing = lib.projects.find((p) => p.slug === slot.slug);
+        if (existing?.id) doc.id = existing.id;
       }
-      doc.slug = lib.currentSlug;
-      doc.name = lib.currentName || doc.name;
-      const saved = await api.saveProject(lib.currentSlug, doc);
-      lib.currentName = saved.name;
-      lib.status = `Saved ${saved.slug}`;
+      doc.slug = slot.slug;
+      doc.name = slot.name || doc.name;
+      doc.projectKind = k;
+      const saved = await api.saveProject(slot.slug, doc);
+      slot.name = saved.name;
+      slot.saveAsName = saved.name;
+      lib.status = `Saved ${saved.slug} (${k})`;
       await refresh();
     } catch (err) {
       lib.status = "Save failed: " + (err.message || err);
     } finally {
-      lib.busy = false;
+      endBusy();
     }
   }
 
-  async function saveAs(name) {
-    const n = String(name || lib.saveAsName || "Untitled spline").trim();
+  async function saveAs(name, kind) {
+    const k = normalizeKind(kind);
+    const slot = identity(k);
+    const n = String(name || slot.saveAsName || slot.name || "Untitled").trim();
     if (!n) {
       lib.status = "Enter a name to save.";
       return;
     }
-    lib.busy = true;
+    beginBusy();
     try {
       const created = await api.createProject({
         name: n,
-        state: snapshotState(),
+        state: snapshotState(k),
+        projectKind: k,
       });
-      lib.currentSlug = created.slug;
-      lib.currentName = created.name;
-      lib.saveAsName = created.name;
-      lib.status = `Created ${created.slug}`;
+      slot.slug = created.slug;
+      slot.name = created.name;
+      slot.saveAsName = created.name;
+      lib.status = `Created ${created.slug} (${k})`;
       await refresh();
     } catch (err) {
       lib.status = "Save As failed: " + (err.message || err);
     } finally {
-      lib.busy = false;
+      endBusy();
     }
   }
 
-  async function remove(slug) {
+  async function remove(slug, kind) {
     if (!slug) return;
     if (!confirm(`Delete local project “${slug}”?`)) return;
-    lib.busy = true;
+    beginBusy();
     try {
       await api.deleteProject(slug);
-      if (lib.currentSlug === slug) {
-        lib.currentSlug = null;
-        lib.currentName = "";
+      for (const k of ["mesh", "texture"]) {
+        const slot = identity(k);
+        if (slot.slug === slug) {
+          slot.slug = null;
+          slot.name = "";
+          slot.saveAsName = "";
+        }
       }
+      void kind;
       lib.status = `Deleted ${slug}`;
       await refresh();
     } catch (err) {
       lib.status = "Delete failed: " + (err.message || err);
     } finally {
-      lib.busy = false;
+      endBusy();
     }
   }
 
   /** Fallback when API is offline: download JSON. */
-  function exportJson(name) {
+  function exportJson(name, kind) {
+    const k = normalizeKind(kind);
+    const slot = identity(k);
     const doc = buildProjectDocument({
-      state: snapshotState(),
-      name: name || lib.currentName || "spline",
-      slug: lib.currentSlug || undefined,
+      state: snapshotState(k),
+      name: name || slot.name || slot.saveAsName || "spline",
+      slug: slot.slug || undefined,
+      projectKind: k,
     });
     const blob = new Blob([JSON.stringify(doc, null, 2)], { type: "application/json" });
     const a = document.createElement("a");
@@ -144,22 +205,53 @@ export function useLibrary({ snapshotState, applyProject, tessellate }) {
     lib.status = "Downloaded " + a.download;
   }
 
-  async function importJsonFile(file) {
-    const text = await file.text();
-    const raw = JSON.parse(text);
-    const mig = migrateProject(raw);
-    if (!mig.ok) {
-      lib.status = "Import invalid: " + mig.errors.join("; ");
-      return;
-    }
-    if (lib.available) {
-      const created = await api.createProject(mig.doc);
-      await load(created.slug);
-    } else {
-      applyProject(mig.doc);
-      tessellate();
-      lib.currentName = mig.doc.name;
-      lib.status = "Imported into editor (API offline — not written to disk).";
+  async function importJsonFile(file, kindHint) {
+    beginBusy();
+    try {
+      if (!file) {
+        lib.status = "No file selected.";
+        return;
+      }
+      if (file.size > MAX_IMPORT_BYTES) {
+        lib.status = `Import too large (max ${MAX_IMPORT_BYTES / (1024 * 1024)} MB).`;
+        return;
+      }
+      let text;
+      try {
+        text = await file.text();
+      } catch (err) {
+        lib.status = "Could not read file: " + (err.message || err);
+        return;
+      }
+      let raw;
+      try {
+        raw = JSON.parse(text);
+      } catch (err) {
+        lib.status = "Invalid JSON: " + (err.message || err);
+        return;
+      }
+      const mig = migrateProject(raw);
+      if (!mig.ok) {
+        lib.status = "Import invalid: " + mig.errors.join("; ");
+        return;
+      }
+      const kind = normalizeKind(kindHint || mig.doc.projectKind);
+      mig.doc.projectKind = kind;
+      if (lib.available) {
+        const created = await api.createProject(mig.doc);
+        await load(created.slug, kind);
+      } else {
+        applyProject(mig.doc, kind);
+        if (kind === "mesh") tessellate();
+        const slot = identity(kind);
+        slot.name = mig.doc.name;
+        slot.saveAsName = mig.doc.name;
+        lib.status = "Imported into editor (API offline — not written to disk).";
+      }
+    } catch (err) {
+      lib.status = "Import failed: " + (err.message || err);
+    } finally {
+      endBusy();
     }
   }
 
@@ -176,5 +268,6 @@ export function useLibrary({ snapshotState, applyProject, tessellate }) {
     remove,
     exportJson,
     importJsonFile,
+    identity,
   };
 }

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/usePathEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/usePathEditor.js
@@ -41,7 +41,7 @@ export function usePathEditor(opts = {}) {
     history: { past: 0, future: 0, canUndo: false, canRedo: false },
   });
 
-  const history = createEditHistory(48);
+  const history = createEditHistory({ limit: 48 });
 
   function refreshHistoryFlags() {
     const info = history.info();

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -1028,9 +1028,12 @@ export function useSplineEditor() {
     });
     try {
       tessellate();
-    } finally {
+    } catch (err) {
       setPendingTextureMap(null);
+      state.status = "Tessellate after assign failed: " + (err.message || err);
+      return false;
     }
+    setPendingTextureMap(null);
     return true;
   }
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/editHistory.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/editHistory.js
@@ -6,7 +6,13 @@
  * Lightweight history stack (no Zustand). Snapshots are plain JSON-safe clones.
  * Call push() *before* a mutating edit with the current (pre-edit) shape.
  */
-export function createEditHistory({ limit = 80 } = {}) {
+export function createEditHistory(opts = {}) {
+  const limit =
+    typeof opts === "number"
+      ? opts
+      : Number.isFinite(opts?.limit)
+        ? opts.limit
+        : 80;
   /** @type {{ label: string, data: any }[]} */
   let past = [];
   /** @type {{ label: string, data: any }[]} */

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/safePath.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/safePath.mjs
@@ -1,0 +1,39 @@
+// ============================================================================
+// safePath.mjs — keep library project paths inside the library root.
+// ============================================================================
+
+import path from "node:path";
+
+/** Lowercase slug: letter/digit start, then [a-z0-9_-], max 64 chars. */
+export const PROJECT_SLUG_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+/**
+ * Resolve `<root>/<slug>` only if slug is safe and the path stays under root.
+ * @param {string} root
+ * @param {string} slug
+ * @returns {{ dir: string, file: string, slug: string }}
+ */
+export function resolveSafeProjectDir(root, slug) {
+  if (typeof slug !== "string" || !slug) {
+    throw new Error("Invalid project slug");
+  }
+  if (
+    slug.includes("\0") ||
+    slug.includes("/") ||
+    slug.includes("\\") ||
+    slug.includes("..") ||
+    !PROJECT_SLUG_RE.test(slug)
+  ) {
+    throw new Error("Invalid project slug");
+  }
+  const rootPath = path.resolve(root);
+  const candidate = path.resolve(rootPath, slug);
+  if (candidate === rootPath || !candidate.startsWith(rootPath + path.sep)) {
+    throw new Error("Invalid project slug");
+  }
+  return {
+    slug,
+    dir: candidate,
+    file: path.join(candidate, "project.json"),
+  };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/vite-plugin-library.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/vite-plugin-library.mjs
@@ -20,6 +20,7 @@ import {
   slugify,
   validateProject,
 } from "./src/library/schema.js";
+import { resolveSafeProjectDir } from "./src/library/safePath.mjs";
 
 const HERE = path.dirname(url.fileURLToPath(import.meta.url));
 const DEFAULT_ROOT = path.resolve(HERE, "../library/projects");
@@ -153,9 +154,13 @@ export function splineLibraryPlugin() {
 
           const m = urlPath.match(/^\/api\/library\/([^/]+)\/?$/);
           if (m) {
-            const slug = decodeURIComponent(m[1]);
-            const dir = path.join(root, slug);
-            const file = path.join(dir, "project.json");
+            let safe;
+            try {
+              safe = resolveSafeProjectDir(root, decodeURIComponent(m[1]));
+            } catch {
+              return sendJson(res, 400, { error: "Invalid project slug" });
+            }
+            const { slug, dir, file } = safe;
 
             if (req.method === "GET") {
               if (!fs.existsSync(file)) return sendJson(res, 404, { error: "not found" });
@@ -180,7 +185,12 @@ export function splineLibraryPlugin() {
             }
 
             if (req.method === "DELETE") {
-              if (!fs.existsSync(dir)) return sendJson(res, 404, { error: "not found" });
+              // Only delete an existing project.json folder under root.
+              if (!fs.existsSync(file) || !fs.existsSync(dir)) {
+                return sendJson(res, 404, { error: "not found" });
+              }
+              const st = fs.statSync(dir);
+              if (!st.isDirectory()) return sendJson(res, 400, { error: "not a project folder" });
               fs.rmSync(dir, { recursive: true, force: true });
               return sendJson(res, 200, { ok: true, slug });
             }
@@ -201,6 +211,7 @@ export function splineLibraryPlugin() {
                 name: body.name,
                 description: body.description,
                 tags: body.tags,
+                projectKind: body.projectKind || body.state.projectKind,
               });
             } else {
               return sendJson(res, 400, { error: "expected project document or { name, state }" });
@@ -208,9 +219,15 @@ export function splineLibraryPlugin() {
             const errors = validateProject(doc);
             if (errors.length) return sendJson(res, 422, { error: "invalid", errors });
             doc.slug = uniqueSlug(root, body.slug || doc.slug || doc.name);
+            let safeCreate;
+            try {
+              safeCreate = resolveSafeProjectDir(root, doc.slug);
+            } catch {
+              return sendJson(res, 400, { error: "Invalid project slug" });
+            }
             doc.updatedAt = nowIso();
             if (!doc.createdAt) doc.createdAt = doc.updatedAt;
-            writeJson(path.join(root, doc.slug, "project.json"), doc);
+            writeJson(safeCreate.file, doc);
             return sendJson(res, 201, doc);
           }
 

--- a/gallery/game_engine/v2/mesh_editor/app/vite.config.js
+++ b/gallery/game_engine/v2/mesh_editor/app/vite.config.js
@@ -15,7 +15,8 @@ export default defineConfig({
   },
   server: {
     port: 5177,
-    host: true,
+    // Bind localhost only — library API can DELETE project folders.
+    host: "localhost",
   },
   build: {
     outDir: "dist",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the critical/high items from the mesh editor code review (path traversal, shared library identity, shortcuts, history limit, async errors, busy races). Also ensures texture saves keep `textureAssets` under an explicit `projectKind`.

## Changes

1. **Path traversal** — `safePath.mjs` + library middleware: strict slug regex, reject `..`/`/`/`\\`, `path.resolve` must stay under library root. DELETE only removes a folder that contains `project.json`. Vite server bound to `localhost`.
2. **Mesh vs texture identity** — `lib.mesh` / `lib.texture` slots (`slug`, `name`, `saveAsName`). Save refuses to overwrite a project of the other kind (Save as instead). Snapshot/load/export pass explicit kind so texture JSON keeps `textureAssets`.
3. **Ctrl/Cmd+Z** — skipped when focus is in input/textarea/select/contenteditable.
4. **History** — `createEditHistory({ limit: 48 })`; also accepts a bare number for safety.
5. **Errors / busy** — JSON import try/catch + size limit; assign texture catch; busy refcount + refresh generation guard.
6. **Tests** — `npm test` runs `smoke-library-safe` (+ existing mesh/eye smokes).

## Not in this PR

- Full App.vue / useSplineEditor split (review item 6–7)
- 3D Preview roll handle (separate request)

## Test

```bash
cd gallery/game_engine/v2/mesh_editor/app && npm test
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

