### PR TITLE
Persist eye texture assignment (textureAsset) in saved mesh JSON

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-library-safe.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-library-safe.mjs
@@ -81,4 +81,44 @@ assert.equal(doc.projectKind, "texture");
 assert.ok(doc.textureAssets.g1, "textureAssets must be serialized into JSON doc");
 assert.equal(doc.textureAssets.g1.name, "Eye");
 
+// Repair: texture:"asset" without textureAsset but assets present → fill guid
+const broken = buildProjectDocument({
+  projectKind: "mesh",
+  name: "kivinen",
+  state: {
+    knots: [
+      { id: "a", x: 0.2, y: -0.5, hx: 0, hy: 0, color: "#fff" },
+      { id: "b", x: 0.3, y: 0.5, hx: 0, hy: 0, color: "#fff" },
+    ],
+    segments: [],
+    orbitKnots: [
+      { id: "o0", x: 1, y: 0, hx: 0, hy: 0, color: "#fff" },
+      { id: "o1", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+      { id: "o2", x: -1, y: 0, hx: 0, hy: 0, color: "#fff" },
+    ],
+    orbitSegments: [],
+    objectMaterial: {
+      color: "#b5b5b5",
+      roughness: 0.4,
+      metalness: 0,
+      opacity: 1,
+      texture: "asset",
+      textureAsset: null,
+      textureAssign: null,
+      textureUv: { centerU: 0.5, centerV: 0.58, scale: 1, eyeSeparationU: null },
+    },
+    textureAssets: {
+      g1: {
+        assetGuid: "g1",
+        name: "Eye",
+        kind: "eye",
+        layers: [{ id: "l1", type: "eyeball", name: "Eyeball", knots: [], segments: [] }],
+      },
+    },
+  },
+});
+assert.equal(broken.objectMaterial.textureAsset, "g1", "repair missing textureAsset on save");
+assert.equal(broken.objectMaterial.textureAssign, "eyePair");
+assert.equal(broken.objectMaterial.texture, "asset");
+
 console.log("smoke-library-safe: ok");

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -12,6 +12,7 @@ import AssignTextureDialog from "./components/AssignTextureDialog.vue";
 import { useSplineEditor } from "./composables/useSplineEditor.js";
 import { useTextureEditor } from "./composables/useTextureEditor.js";
 import { useLibrary } from "./composables/useLibrary.js";
+import { normalizeEyeUv } from "./lib/texture/eyeTexture.js";
 import * as api from "./library/api.js";
 
 const {
@@ -158,16 +159,32 @@ async function onAssignApply({ guid, uv, assets }) {
   try {
     await new Promise((r) => setTimeout(r, 0));
     mergeAssignAssets(assets);
+    const wantGuid = String(guid || "").trim();
+    if (!wantGuid || !tex.snapshotTextures()[wantGuid]) {
+      state.status = "Assign failed: texture asset not in editor after load.";
+      return;
+    }
     assignProgress.value = "Starting UV bake…";
-    const ok = await assignEyeTextureToRootAsync(guid, uv || assignRegionUv.value, {
+    const ok = await assignEyeTextureToRootAsync(wantGuid, uv || assignRegionUv.value, {
       onProgress: (label) => {
         assignProgress.value = label;
       },
     });
     if (ok) {
+      // Hard-verify persistence fields before closing the dialog.
+      if (state.objectMaterial?.textureAsset !== wantGuid) {
+        state.objectMaterial = {
+          ...state.objectMaterial,
+          texture: "asset",
+          textureAsset: wantGuid,
+          textureAssign: "eyePair",
+          textureUv: normalizeEyeUv(uv || assignRegionUv.value || state.objectMaterial?.textureUv),
+        };
+      }
       assignDialogOpen.value = false;
       assignRegionUv.value = null;
-      state.status = "Eye texture assigned.";
+      state.status = `Eye texture assigned (${wantGuid.slice(0, 8)}…).`;
+      tessellate();
     }
   } catch (err) {
     state.status = "Assign failed: " + (err.message || err);
@@ -851,10 +868,11 @@ onBeforeUnmount(() => {
       <LibraryPanel
         :lib="lib"
         project-kind="mesh"
+        :save-disabled="assignBusy"
         @refresh="refresh"
         @load="(slug) => load(slug, 'mesh')"
-        @save="() => save('mesh')"
-        @save-as="(name) => saveAs(name, 'mesh')"
+        @save="() => !assignBusy && save('mesh')"
+        @save-as="(name) => !assignBusy && saveAs(name, 'mesh')"
         @remove="(slug) => remove(slug, 'mesh')"
         @export="(name) => exportJson(name, 'mesh')"
         @import-file="(file) => importJsonFile(file, 'mesh')"

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/LibraryPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/LibraryPanel.vue
@@ -5,6 +5,8 @@ const props = defineProps({
   lib: { type: Object, required: true },
   /** mesh | texture — filters the saved list + picks identity slot */
   projectKind: { type: String, default: "mesh" },
+  /** Extra disable for Save / Save as (e.g. while UV assign is baking). */
+  saveDisabled: { type: Boolean, default: false },
 });
 
 const emit = defineEmits([
@@ -71,14 +73,14 @@ function metaLine(p) {
       <button
         type="button"
         class="primary"
-        :disabled="lib.busy"
+        :disabled="lib.busy || saveDisabled"
         @click="emit('save-as', slot.saveAsName, kind)"
       >
         Save as
       </button>
       <button
         type="button"
-        :disabled="lib.busy || !slot.slug"
+        :disabled="lib.busy || saveDisabled || !slot.slug"
         @click="emit('save', kind)"
       >
         Save

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -923,12 +923,11 @@ export function useSplineEditor() {
   }
 
   function resolveTextureMap(om) {
-    if (
-      pendingTextureMap &&
-      om?.textureAsset &&
-      om.textureAsset === pendingTextureMap.guid
-    ) {
-      return pendingTextureMap.map;
+    // Prefer the in-flight atlas from async assign (guid may be set on om in the same tick).
+    if (pendingTextureMap?.map && pendingTextureMap.guid) {
+      if (!om?.textureAsset || om.textureAsset === pendingTextureMap.guid) {
+        return pendingTextureMap.map;
+      }
     }
     if (!om) return null;
     const guid = om.textureAsset;
@@ -966,22 +965,30 @@ export function useSplineEditor() {
    * @param {{ recordHistory?: boolean }} [opts]
    */
   function assignEyeTextureToRoot(assetGuid, uv, opts = {}) {
-    if (!assetGuid) return false;
+    const guid = String(assetGuid || "").trim();
+    if (!guid) return false;
     const assets = textureAssetsProvider() || {};
-    if (!assets[assetGuid]) {
+    if (!assets[guid]) {
       state.status = "Texture asset not loaded — open it in Texture or import the project.";
       return false;
     }
     const record = opts.recordHistory !== false;
-    if (record) beginGesture("assign-eye-texture");
+    // Use a single history commit (not begin/end gesture) so a stuck open gesture
+    // cannot skip recording / leave objectMaterial half-updated.
+    if (record) commitToHistory("assign-eye-texture");
+    const prev = state.objectMaterial || defaultObjectMaterial();
+    const nextUv = normalizeEyeUv(uv || prev.textureUv);
+    // Plain object replace — explicit fields so textureAsset always serializes.
     state.objectMaterial = {
-      ...state.objectMaterial,
+      color: prev.color ?? null,
+      roughness: Number(prev.roughness ?? 0.4),
+      metalness: Number(prev.metalness ?? 0),
+      opacity: Number(prev.opacity ?? 1),
       texture: "asset",
-      textureAsset: assetGuid,
+      textureAsset: guid,
       textureAssign: "eyePair",
-      textureUv: normalizeEyeUv(uv || state.objectMaterial?.textureUv),
+      textureUv: nextUv,
     };
-    if (record) endGesture();
     if (record) state.status = "Assigned eye texture to mesh UVs (left + right).";
     return true;
   }
@@ -1389,6 +1396,20 @@ export function useSplineEditor() {
     return true;
   }
 
+  function snapshotObjectMaterial(om) {
+    const m = om || defaultObjectMaterial();
+    return {
+      color: m.color ?? null,
+      roughness: Number(m.roughness ?? 0.4),
+      metalness: Number(m.metalness ?? 0),
+      opacity: Number(m.opacity ?? 1),
+      texture: m.texture || "gradient",
+      textureAsset: m.textureAsset || null,
+      textureAssign: m.textureAssign === "eyePair" ? "eyePair" : m.textureAssign || null,
+      textureUv: normalizeEyeUv(m.textureUv),
+    };
+  }
+
   function snapshotState() {
     const embedded = {};
     for (const [guid, body] of Object.entries(state.embeddedAssets)) {
@@ -1400,7 +1421,7 @@ export function useSplineEditor() {
         angularSteps: body.angularSteps,
         revolutionDeg: body.revolutionDeg,
         tessellationMode: body.tessellationMode === "torus" ? "torus" : "rotation",
-        objectMaterial: { ...body.objectMaterial },
+        objectMaterial: snapshotObjectMaterial(body.objectMaterial),
         knots: body.knots.map((k) => ({ ...k })),
         segments: body.segments.map(mapSegSnapshot),
         orbitKnots: body.orbitKnots.map((k) => ({ ...k })),
@@ -1423,7 +1444,7 @@ export function useSplineEditor() {
       symmetry: state.symmetry,
       viewMode: state.viewMode,
       spineSource: state.spineSource,
-      objectMaterial: { ...state.objectMaterial },
+      objectMaterial: snapshotObjectMaterial(state.objectMaterial),
       knots: state.knots.map((k) => ({ ...k })),
       segments: state.segments.map(mapSegSnapshot),
       orbitKnots: state.orbitKnots.map((k) => ({ ...k })),

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -475,14 +475,28 @@ function normalizeV10(doc) {
   if (!kind) kind = !hasMesh && texN > 0 ? "texture" : "mesh";
   v9.projectKind = normalizeProjectKind(kind);
   const om = v9.objectMaterial || {};
+  const assetKeys = Object.keys(v9.textureAssets || {});
+  let textureAsset = om.textureAsset || null;
+  let textureAssign = om.textureAssign === "eyePair" ? "eyePair" : om.textureAssign || null;
+  let texture = om.texture || "gradient";
+  if (textureAsset && !(v9.textureAssets || {})[textureAsset]) {
+    textureAsset = assetKeys.length === 1 ? assetKeys[0] : null;
+  }
+  if (!textureAsset && assetKeys.length && (texture === "asset" || textureAssign === "eyePair")) {
+    textureAsset = assetKeys[0];
+    textureAssign = textureAssign || "eyePair";
+    texture = "asset";
+  }
+  if (textureAsset && !textureAssign) textureAssign = "eyePair";
+  if (textureAsset && texture !== "asset") texture = "asset";
   v9.objectMaterial = {
     color: om.color ?? null,
     roughness: Number(om.roughness ?? 0.4),
     metalness: Number(om.metalness ?? 0),
     opacity: Number(om.opacity ?? 1),
-    texture: om.texture || "gradient",
-    textureAsset: om.textureAsset || null,
-    textureAssign: om.textureAssign === "eyePair" ? "eyePair" : om.textureAssign || null,
+    texture,
+    textureAsset,
+    textureAssign,
     textureUv: normalizeEyeUv(om.textureUv),
   };
   return v9;

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -169,6 +169,30 @@ export function buildProjectDocument(opts) {
     embedded[guid] = serializeBodyContent(body);
   }
   const projectKind = normalizeProjectKind(opts.projectKind || st.projectKind || "mesh");
+  const textureAssets = {};
+  for (const [guid, tex] of Object.entries(st.textureAssets || {})) {
+    const s = serializeTextureAsset({ ...tex, assetGuid: tex.assetGuid || guid });
+    if (s) textureAssets[s.assetGuid] = s;
+  }
+  const assetKeys = Object.keys(textureAssets);
+  let texAsset = st.objectMaterial?.textureAsset || null;
+  let texAssign =
+    st.objectMaterial?.textureAssign === "eyePair"
+      ? "eyePair"
+      : st.objectMaterial?.textureAssign || null;
+  let texMode = st.objectMaterial?.texture || "gradient";
+  if (texAsset && !textureAssets[texAsset]) {
+    // Stale guid — fall back when there is exactly one embedded texture.
+    texAsset = assetKeys.length === 1 ? assetKeys[0] : null;
+  }
+  if (!texAsset && assetKeys.length && (texMode === "asset" || texAssign === "eyePair")) {
+    texAsset = assetKeys[0];
+    texAssign = texAssign || "eyePair";
+    texMode = "asset";
+  }
+  if (texAsset && !texAssign) texAssign = "eyePair";
+  if (texAsset && texMode !== "asset") texMode = "asset";
+
   return {
     kind: SCHEMA_KIND,
     schemaVersion: CURRENT_SCHEMA_VERSION,
@@ -198,12 +222,9 @@ export function buildProjectDocument(opts) {
       roughness: Number(st.objectMaterial?.roughness ?? 0.4),
       metalness: Number(st.objectMaterial?.metalness ?? 0),
       opacity: Number(st.objectMaterial?.opacity ?? 1),
-      texture: st.objectMaterial?.texture || "gradient",
-      textureAsset: st.objectMaterial?.textureAsset || null,
-      textureAssign:
-        st.objectMaterial?.textureAssign === "eyePair"
-          ? "eyePair"
-          : st.objectMaterial?.textureAssign || null,
+      texture: texMode,
+      textureAsset: texAsset,
+      textureAssign: texAssign,
       textureUv: normalizeEyeUv(st.objectMaterial?.textureUv),
     },
     profile: {
@@ -225,14 +246,7 @@ export function buildProjectDocument(opts) {
     placementNormal: serializePlacementNormal(st.placementNormal),
     embeddedAssets: embedded,
     children: (st.children || []).map(serializeChild),
-    textureAssets: (() => {
-      const out = {};
-      for (const [guid, tex] of Object.entries(st.textureAssets || {})) {
-        const s = serializeTextureAsset({ ...tex, assetGuid: tex.assetGuid || guid });
-        if (s) out[s.assetGuid] = s;
-      }
-      return out;
-    })(),
+    textureAssets,
   };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Saved mesh JSON looked like this after Assign → Save:

```json
"objectMaterial": {
  "texture": "asset",
  "textureAsset": null,
  "textureAssign": null,
  "textureUv": { "centerU": 0.5, "centerV": 0.58, ... }
}
```

`textureAssets` still contained the Eye, but without `textureAsset` / `textureAssign` the assignment does not reload.

## Fixes

1. **Assign writes explicit plain fields** (`texture`, `textureAsset`, `textureAssign`, `textureUv`) via a single history commit (avoids stuck `beginGesture` skipping the write path).
2. **Snapshot** serializes `objectMaterial` field-by-field.
3. **Save/load repair** — if `texture:"asset"` (or eyePair) but guid is missing/stale and exactly the embedded `textureAssets` can resolve it, fill `textureAsset` + `textureAssign:"eyePair"` (`buildProjectDocument` + migrate v10).
4. **After async assign**, App verifies `textureAsset` and re-applies if needed; library Save disabled while assign is busy.

## Test

```bash
cd gallery/game_engine/v2/mesh_editor/app && npm test
```

Includes a smoke that rebuilds the broken `kivinen`-style document and asserts the guid is repaired.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

