### PR TITLE
Persist pre-baked eye UV atlas on mesh save/reload

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -44,6 +44,10 @@ import {
   buildProjectDocument,
   validateProject,
 } from "../src/library/schema.js";
+import {
+  serializeTextureMap,
+  normalizeTextureMap,
+} from "../src/lib/texture/textureMapCodec.js";
 
 const eye = createDefaultEyeTexture({ name: "TestEye" });
 assert.equal(eye.kind, "eye");
@@ -294,22 +298,22 @@ const doc = buildProjectDocument({
   slug: "with-eye",
   projectKind: "mesh",
 });
-assert.equal(doc.schemaVersion, 10);
+assert.equal(doc.schemaVersion, 11);
 assert.equal(doc.projectKind, "mesh");
 assert.ok(doc.textureAssets[ser.assetGuid]);
 assert.equal(doc.objectMaterial.textureAssign, "eyePair");
 
 const mig = migrateProject(doc);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
-assert.equal(CURRENT_SCHEMA_VERSION, 10);
-assert.equal(mig.doc.schemaVersion, 10);
+assert.equal(CURRENT_SCHEMA_VERSION, 11);
+assert.equal(mig.doc.schemaVersion, 11);
 assert.equal(mig.doc.projectKind, "mesh");
 assert.ok(mig.doc.textureAssets[ser.assetGuid].layers.length >= 4);
 
 // Texture-only library entry validates without mesh profile
 const texOnly = {
   kind: "ranger.splineProject",
-  schemaVersion: 10,
+  schemaVersion: 11,
   projectKind: "texture",
   name: "Eyes only",
   textureAssets: { [ser.assetGuid]: ser },
@@ -360,8 +364,119 @@ const asyncMap = await rasterizeEyePairUvMapAsync(eye, 64, 64, {
 assert.equal(asyncMap.w, 64);
 assert.equal(asyncMap.rgba.length, 64 * 64 * 4);
 
+// Pre-baked atlas codec + project JSON round-trip (reload must keep pixels)
+const enc = serializeTextureMap(asyncMap);
+assert.equal(enc.encoding, "rgba8-base64");
+assert.equal(enc.w, 64);
+assert.equal(enc.h, 64);
+assert.ok(typeof enc.data === "string" && enc.data.length > 100);
+const dec = normalizeTextureMap(enc);
+assert.equal(dec.w, 64);
+assert.equal(dec.h, 64);
+assert.equal(dec.rgba.length, 64 * 64 * 4);
+for (let i = 0; i < dec.rgba.length; i++) {
+  assert.equal(dec.rgba[i], asyncMap.rgba[i], `pixel byte ${i}`);
+}
+
+const docWithBake = buildProjectDocument({
+  state: {
+    assetGuid: "root-bake",
+    curveType: 0,
+    pathSegments: 12,
+    angularSteps: 24,
+    revolutionDeg: 360,
+    tessellationMode: "rotation",
+    materialMode: 3,
+    symmetry: true,
+    viewMode: "profile",
+    spineSource: "profile",
+    knots: [
+      { id: "a", x: 0, y: -1, hx: 0, hy: 0, color: "#fff" },
+      { id: "b", x: 0.4, y: 1, hx: 0, hy: 0, color: "#fff" },
+    ],
+    segments: [
+      {
+        fromId: "a",
+        toId: "b",
+        pathType: "line",
+        roughness: 0.4,
+        metalness: 0,
+        opacity: 1,
+        texture: "gradient",
+        color: null,
+      },
+    ],
+    orbitKnots: [
+      { id: "o0", x: 1, y: 0, hx: 0, hy: 0.55, color: "#fff" },
+      { id: "o1", x: 0, y: 1, hx: -0.55, hy: 0, color: "#fff" },
+      { id: "o2", x: -1, y: 0, hx: 0, hy: -0.55, color: "#fff" },
+      { id: "o3", x: 0, y: -1, hx: 0.55, hy: 0, color: "#fff" },
+    ],
+    orbitSegments: [
+      { fromId: "o0", toId: "o1", pathType: "bezier", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+      { fromId: "o1", toId: "o2", pathType: "bezier", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+      { fromId: "o2", toId: "o3", pathType: "bezier", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+      { fromId: "o3", toId: "o0", pathType: "bezier", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+    ],
+    spineProfileKnots: [
+      { id: "s0", x: 0, y: -1, hx: 0, hy: 0, color: "#fff" },
+      { id: "s1", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+    ],
+    spineProfileSegments: [
+      { fromId: "s0", toId: "s1", pathType: "line", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+    ],
+    spineOrbitKnots: [
+      { id: "t0", x: 0, y: -1, hx: 0, hy: 0, color: "#fff" },
+      { id: "t1", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+    ],
+    spineOrbitSegments: [
+      { fromId: "t0", toId: "t1", pathType: "line", roughness: 0.4, metalness: 0, opacity: 1, texture: "gradient", color: null },
+    ],
+    placementNormal: { start: { x: 0, y: -1 }, end: { x: 0, y: 1 } },
+    embeddedAssets: {},
+    children: [],
+    textureAssets: { [ser.assetGuid]: ser },
+    projectKind: "mesh",
+    objectMaterial: {
+      color: null,
+      roughness: 0.4,
+      metalness: 0,
+      opacity: 1,
+      texture: "asset",
+      textureAsset: ser.assetGuid,
+      textureAssign: "eyePair",
+      textureUv: fromCorners,
+      textureMap: asyncMap,
+    },
+  },
+  name: "Baked eyes",
+  slug: "baked-eyes",
+  projectKind: "mesh",
+});
+assert.equal(docWithBake.schemaVersion, 11);
+assert.ok(docWithBake.objectMaterial.textureMap?.encoding === "rgba8-base64");
+assert.deepEqual(validateProject(docWithBake), []);
+const migBake = migrateProject(JSON.parse(JSON.stringify(docWithBake)));
+assert.equal(migBake.ok, true, migBake.errors?.join("; "));
+const restoredMap = normalizeTextureMap(migBake.doc.objectMaterial.textureMap);
+assert.ok(restoredMap);
+assert.equal(restoredMap.rgba[0], asyncMap.rgba[0]);
+assert.equal(
+  restoredMap.rgba[restoredMap.rgba.length - 1],
+  asyncMap.rgba[asyncMap.rgba.length - 1],
+);
+// v10 docs without textureMap still migrate
+const v10 = JSON.parse(JSON.stringify(doc));
+v10.schemaVersion = 10;
+delete v10.objectMaterial.textureMap;
+const mig10 = migrateProject(v10);
+assert.equal(mig10.ok, true, mig10.errors?.join("; "));
+assert.equal(mig10.doc.schemaVersion, 11);
+assert.equal(mig10.doc.objectMaterial.textureMap, null);
+
 console.log("smoke-eye-texture: ok", {
   schema: mig.doc.schemaVersion,
   projectKind: mig.doc.projectKind,
   layers: mig.doc.textureAssets[ser.assetGuid].layers.map((L) => L.type),
+  bakedBytes: enc.data.length,
 });

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -311,8 +311,8 @@ const v7 = {
 
 const mig = migrateProject(v7);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
-assert.equal(CURRENT_SCHEMA_VERSION, 10);
-assert.equal(mig.doc.schemaVersion, 10);
+assert.equal(CURRENT_SCHEMA_VERSION, 11);
+assert.equal(mig.doc.schemaVersion, 11);
 assert.equal(mig.doc.children[0].transform.surface, false);
 assert.equal(mig.doc.children[0].transform.z, 0);
 

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-placement-normal.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-placement-normal.mjs
@@ -121,7 +121,7 @@ const v5 = {
 const mig = migrateProject(v5);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
 assert.equal(mig.doc.schemaVersion, CURRENT_SCHEMA_VERSION);
-assert.equal(CURRENT_SCHEMA_VERSION, 10);
+assert.equal(CURRENT_SCHEMA_VERSION, 11);
 assert.deepEqual(mig.doc.placementNormal.start, { x: 0, y: -1 });
 assert.deepEqual(mig.doc.placementNormal.end, { x: 0, y: 1 });
 assert.equal(mig.doc.editor.tessellationMode, "rotation");

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
@@ -156,7 +156,7 @@ const v6 = {
 const mig = migrateProject(v6);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
 assert.equal(mig.doc.schemaVersion, CURRENT_SCHEMA_VERSION);
-assert.equal(CURRENT_SCHEMA_VERSION, 10);
+assert.equal(CURRENT_SCHEMA_VERSION, 11);
 assert.equal(mig.doc.editor.tessellationMode, "rotation");
 const errs = validateProject(mig.doc);
 assert.equal(errs.length, 0, errs.join("; "));

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -181,6 +181,9 @@ async function onAssignApply({ guid, uv, assets }) {
           textureUv: normalizeEyeUv(uv || assignRegionUv.value || state.objectMaterial?.textureUv),
         };
       }
+      if (!state.objectMaterial?.textureMap) {
+        state.status = "Assign warning: UV atlas bake missing from material — re-assign if eyes look wrong.";
+      }
       assignDialogOpen.value = false;
       assignRegionUv.value = null;
       state.status = `Eye texture assigned (${wantGuid.slice(0, 8)}…).`;

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -9,6 +9,7 @@ import {
   averageKnotColorHex,
   DEFAULT_EYE_UV,
 } from "../lib/texture/eyeTexture.js";
+import { normalizeTextureMap } from "../lib/texture/textureMapCodec.js";
 import { transformParts } from "../lib/meshTransform.js";
 import { evalSpan as evalPathSpan } from "../lib/pathSample.js";
 import { createEditHistory } from "../lib/editHistory.js";
@@ -72,6 +73,7 @@ function defaultObjectMaterial() {
     textureAsset: null,
     textureAssign: null,
     textureUv: { ...DEFAULT_EYE_UV },
+    textureMap: null,
   };
 }
 
@@ -140,6 +142,29 @@ export function useSplineEditor() {
   let textureAssetsProvider = () => /** @type {Record<string, any>} */ ({});
   /** Pre-baked UV atlas for async assign: { guid, map } kept for one tessellate pass. */
   let pendingTextureMap = null;
+  /** Survives undo history (which omits large textureMap blobs). guid → live atlas. */
+  const bakedAtlasByGuid = new Map();
+
+  function rememberBakedAtlas(guid, map) {
+    const g = String(guid || "").trim();
+    const live = normalizeTextureMap(map);
+    if (!g || !live) return;
+    bakedAtlasByGuid.set(g, live);
+  }
+
+  function forgetBakedAtlas(guid = null) {
+    if (guid == null) bakedAtlasByGuid.clear();
+    else bakedAtlasByGuid.delete(String(guid));
+  }
+
+  function atlasForMaterial(om) {
+    if (!om) return null;
+    const fromOm = normalizeTextureMap(om.textureMap);
+    if (fromOm) return fromOm;
+    const guid = om.textureAsset;
+    if (guid && bakedAtlasByGuid.has(guid)) return bakedAtlasByGuid.get(guid);
+    return null;
+  }
 
   const state = reactive({
     assetGuid: newGuid(),
@@ -244,6 +269,13 @@ export function useSplineEditor() {
     state.spineOrbitSegments = so.segments;
     state.placementNormal = normalizePlacementNormal(snap.placementNormal);
     state.objectMaterial = { ...defaultObjectMaterial(), ...(snap.objectMaterial || {}) };
+    // History omits textureMap; reattach the last bake for this asset guid.
+    if (!state.objectMaterial.textureMap && state.objectMaterial.textureAsset) {
+      const cached = bakedAtlasByGuid.get(state.objectMaterial.textureAsset);
+      if (cached) state.objectMaterial.textureMap = cached;
+    } else if (state.objectMaterial.textureMap && state.objectMaterial.textureAsset) {
+      rememberBakedAtlas(state.objectMaterial.textureAsset, state.objectMaterial.textureMap);
+    }
     state.embeddedAssets = {};
     for (const [guid, body] of Object.entries(snap.embeddedAssets || {})) {
       const bsp = loadSpineBlock(
@@ -527,6 +559,8 @@ export function useSplineEditor() {
 
   function resetDefaults() {
     commitToHistory("reset");
+    forgetBakedAtlas();
+    setPendingTextureMap(null);
     state.assetGuid = newGuid();
     state.knots = defaultKnots();
     state.segments = [];
@@ -930,6 +964,10 @@ export function useSplineEditor() {
       }
     }
     if (!om) return null;
+    // Prefer the pre-baked atlas persisted at assign / load time so reload
+    // matches what the user saw (textureUv alone can re-rasterize differently).
+    const baked = atlasForMaterial(om);
+    if (baked) return baked;
     const guid = om.textureAsset;
     if (!guid) return null;
     if (om.texture !== "asset" && om.textureAssign !== "eyePair") return null;
@@ -978,6 +1016,7 @@ export function useSplineEditor() {
     if (record) commitToHistory("assign-eye-texture");
     const prev = state.objectMaterial || defaultObjectMaterial();
     const nextUv = normalizeEyeUv(uv || prev.textureUv);
+    const baked = normalizeTextureMap(opts.map) || null;
     // Plain object replace — explicit fields so textureAsset always serializes.
     state.objectMaterial = {
       color: prev.color ?? null,
@@ -988,7 +1027,12 @@ export function useSplineEditor() {
       textureAsset: guid,
       textureAssign: "eyePair",
       textureUv: nextUv,
+      // Keep the exact atlas pixels from the assign bake (or prior bake).
+      textureMap: baked || atlasForMaterial({ textureAsset: guid, textureMap: prev.textureMap }) || null,
     };
+    if (state.objectMaterial.textureMap) {
+      rememberBakedAtlas(guid, state.objectMaterial.textureMap);
+    }
     if (record) state.status = "Assigned eye texture to mesh UVs (left + right).";
     return true;
   }
@@ -1024,7 +1068,7 @@ export function useSplineEditor() {
     setPendingTextureMap(map, assetGuid);
     onProgress("Applying to mesh…");
     await new Promise((r) => setTimeout(r, 0));
-    if (!assignEyeTextureToRoot(assetGuid, nextUv)) {
+    if (!assignEyeTextureToRoot(assetGuid, nextUv, { map })) {
       setPendingTextureMap(null);
       return false;
     }
@@ -1046,13 +1090,17 @@ export function useSplineEditor() {
 
   function clearAssignedTexture() {
     beginGesture("clear-texture");
+    const prevGuid = state.objectMaterial?.textureAsset;
     state.objectMaterial = {
       ...state.objectMaterial,
       texture: "gradient",
       textureAsset: null,
       textureAssign: null,
       textureUv: { ...DEFAULT_EYE_UV },
+      textureMap: null,
     };
+    forgetBakedAtlas(prevGuid);
+    setPendingTextureMap(null);
     endGesture();
     state.status = "Cleared assigned body texture.";
   }
@@ -1299,6 +1347,8 @@ export function useSplineEditor() {
 
   function applyProject(doc) {
     if (!doc?.profile?.knots) return false;
+    forgetBakedAtlas();
+    setPendingTextureMap(null);
     const ed = doc.editor || {};
     state.assetGuid = doc.assetGuid || newGuid();
     state.curveType = ed.curveType | 0;
@@ -1323,7 +1373,11 @@ export function useSplineEditor() {
           ? "eyePair"
           : doc.objectMaterial?.textureAssign || null,
       textureUv: normalizeEyeUv(doc.objectMaterial?.textureUv),
+      textureMap: normalizeTextureMap(doc.objectMaterial?.textureMap),
     };
+    if (state.objectMaterial.textureMap && state.objectMaterial.textureAsset) {
+      rememberBakedAtlas(state.objectMaterial.textureAsset, state.objectMaterial.textureMap);
+    }
     state.knots = doc.profile.knots.map((k) => ({ ...k }));
     state.segments = (doc.profile.segments || []).map((s) => ({
       ...s,
@@ -1407,6 +1461,8 @@ export function useSplineEditor() {
       textureAsset: m.textureAsset || null,
       textureAssign: m.textureAssign === "eyePair" ? "eyePair" : m.textureAssign || null,
       textureUv: normalizeEyeUv(m.textureUv),
+      // Omit textureMap from undo history — atlases are large; reload uses saved bake.
+      textureMap: null,
     };
   }
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/textureMapCodec.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/textureMapCodec.js
@@ -1,0 +1,86 @@
+// ============================================================================
+// textureMapCodec.js — persist UV atlases as base64 RGBA in project JSON.
+// ============================================================================
+
+/**
+ * @typedef {{ encoding: 'rgba8-base64', w: number, h: number, data: string, name?: string }} SerializedTextureMap
+ * @typedef {{ rgba: Uint8ClampedArray|Uint8Array|number[], w: number, h: number, name?: string }} TextureMap
+ */
+
+function bytesToBase64(bytes) {
+  const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(u8).toString("base64");
+  }
+  let s = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < u8.length; i += chunk) {
+    s += String.fromCharCode(...u8.subarray(i, i + chunk));
+  }
+  return btoa(s);
+}
+
+function base64ToBytes(b64) {
+  if (typeof Buffer !== "undefined") {
+    return new Uint8ClampedArray(Buffer.from(String(b64), "base64"));
+  }
+  const bin = atob(String(b64));
+  const out = new Uint8ClampedArray(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/**
+ * Encode a live atlas for project.json.
+ * @param {TextureMap|null|undefined} map
+ * @returns {SerializedTextureMap|null}
+ */
+export function serializeTextureMap(map) {
+  if (!map) return null;
+  const w = Math.max(1, map.w | 0);
+  const h = Math.max(1, map.h | 0);
+  const need = w * h * 4;
+  const src = map.rgba;
+  if (!src || src.length < need) return null;
+  const bytes = src instanceof Uint8Array ? src.subarray(0, need) : new Uint8Array(src).subarray(0, need);
+  return {
+    encoding: "rgba8-base64",
+    w,
+    h,
+    data: bytesToBase64(bytes),
+    name: map.name || undefined,
+  };
+}
+
+/**
+ * Decode a persisted atlas (or pass through an already-live map).
+ * @param {SerializedTextureMap|TextureMap|null|undefined} raw
+ * @returns {TextureMap|null}
+ */
+export function normalizeTextureMap(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const w = Math.max(1, Number(raw.w) | 0);
+  const h = Math.max(1, Number(raw.h) | 0);
+  const need = w * h * 4;
+
+  // Already live (in-memory after assign)
+  if (raw.rgba && raw.rgba.length >= need && !raw.data) {
+    const rgba =
+      raw.rgba instanceof Uint8ClampedArray
+        ? raw.rgba
+        : new Uint8ClampedArray(raw.rgba);
+    return { rgba, w, h, name: raw.name };
+  }
+
+  if (raw.encoding !== "rgba8-base64" || typeof raw.data !== "string" || !raw.data) {
+    return null;
+  }
+  const rgba = base64ToBytes(raw.data);
+  if (rgba.length < need) return null;
+  return {
+    rgba: rgba.length === need ? rgba : rgba.subarray(0, need),
+    w,
+    h,
+    name: raw.name,
+  };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -13,6 +13,7 @@ import {
   normalizeProjectKind,
 } from "./schema.js";
 import { normalizeEyeTexture, normalizeEyeUv } from "../lib/texture/eyeTexture.js";
+import { normalizeTextureMap, serializeTextureMap } from "../lib/texture/textureMapCodec.js";
 
 function defaultOrbitDoc() {
   const raw = SplineLathe.defaultOrbitKnots();
@@ -502,6 +503,28 @@ function normalizeV10(doc) {
   return v9;
 }
 
+function normalizeV11(doc) {
+  // Capture bake before v10 rewrite (normalizeV10 rebuilds objectMaterial without textureMap).
+  const incomingMap = doc?.objectMaterial?.textureMap;
+  const v10 = normalizeV10(doc);
+  v10.schemaVersion = 11;
+  const om = v10.objectMaterial || {};
+  const baked = normalizeTextureMap(incomingMap);
+  v10.objectMaterial = {
+    color: om.color ?? null,
+    roughness: Number(om.roughness ?? 0.4),
+    metalness: Number(om.metalness ?? 0),
+    opacity: Number(om.opacity ?? 1),
+    texture: om.texture || "gradient",
+    textureAsset: om.textureAsset || null,
+    textureAssign:
+      om.textureAssign === "eyePair" ? "eyePair" : om.textureAssign || null,
+    textureUv: normalizeEyeUv(om.textureUv),
+    textureMap: serializeTextureMap(baked),
+  };
+  return v10;
+}
+
 /** @type {Record<number, (doc: any) => any>} */
 const STEPS = {
   1(doc) {
@@ -540,6 +563,10 @@ const STEPS = {
   // 9 → 10: projectKind mesh|texture + objectMaterial.textureAsset assign
   10(doc) {
     return normalizeV10(doc);
+  },
+  // 10 → 11: persist pre-baked UV atlas (objectMaterial.textureMap)
+  11(doc) {
+    return normalizeV11(doc);
   },
 };
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -3,8 +3,11 @@
 // ============================================================================
 
 import { serializeEyeTexture, normalizeEyeUv } from "../lib/texture/eyeTexture.js";
+import { serializeTextureMap, normalizeTextureMap } from "../lib/texture/textureMapCodec.js";
 
-export const CURRENT_SCHEMA_VERSION = 10;
+export const CURRENT_SCHEMA_VERSION = 11;
+
+export { serializeTextureMap, normalizeTextureMap };
 
 export const SCHEMA_KIND = "ranger.splineProject";
 
@@ -95,13 +98,7 @@ function serializeBodyContent(body) {
     angularSteps: body.angularSteps | 0,
     revolutionDeg: body.revolutionDeg | 0,
     tessellationMode: body.tessellationMode === "torus" ? "torus" : "rotation",
-    objectMaterial: {
-      color: body.objectMaterial?.color ?? null,
-      roughness: Number(body.objectMaterial?.roughness ?? 0.4),
-      metalness: Number(body.objectMaterial?.metalness ?? 0),
-      opacity: Number(body.objectMaterial?.opacity ?? 1),
-      texture: body.objectMaterial?.texture || "gradient",
-    },
+    objectMaterial: serializeObjectMaterial(body.objectMaterial, { includeMap: false }),
     knots: (body.knots || []).map(serializeKnot),
     segments: (body.segments || []).map(serializeSegment),
     orbitKnots: (body.orbitKnots || []).map(serializeKnot),
@@ -155,6 +152,30 @@ function serializeTextureAsset(tex) {
     previewBackground: tex.previewBackground || "#6a8f6a",
     layers: tex.layers || [],
   };
+}
+
+/**
+ * Serialize objectMaterial for project JSON / embedded bodies.
+ * @param {object|null|undefined} om
+ * @param {{ includeMap?: boolean }} [opts] includeMap=true for root save (pre-baked UV atlas)
+ */
+export function serializeObjectMaterial(om, opts = {}) {
+  const includeMap = opts.includeMap !== false;
+  const out = {
+    color: om?.color ?? null,
+    roughness: Number(om?.roughness ?? 0.4),
+    metalness: Number(om?.metalness ?? 0),
+    opacity: Number(om?.opacity ?? 1),
+    texture: om?.texture || "gradient",
+    textureAsset: om?.textureAsset || null,
+    textureAssign:
+      om?.textureAssign === "eyePair" ? "eyePair" : om?.textureAssign || null,
+    textureUv: normalizeEyeUv(om?.textureUv),
+  };
+  if (includeMap) {
+    out.textureMap = serializeTextureMap(om?.textureMap);
+  }
+  return out;
 }
 
 /**
@@ -218,14 +239,15 @@ export function buildProjectDocument(opts) {
       spineSource: st.spineSource === "orbit" ? "orbit" : "profile",
     },
     objectMaterial: {
-      color: st.objectMaterial?.color ?? null,
-      roughness: Number(st.objectMaterial?.roughness ?? 0.4),
-      metalness: Number(st.objectMaterial?.metalness ?? 0),
-      opacity: Number(st.objectMaterial?.opacity ?? 1),
-      texture: texMode,
-      textureAsset: texAsset,
-      textureAssign: texAssign,
-      textureUv: normalizeEyeUv(st.objectMaterial?.textureUv),
+      ...serializeObjectMaterial(
+        {
+          ...(st.objectMaterial || {}),
+          texture: texMode,
+          textureAsset: texAsset,
+          textureAssign: texAssign,
+        },
+        { includeMap: true },
+      ),
     },
     profile: {
       knots: (st.knots || []).map(serializeKnot),
@@ -341,6 +363,16 @@ export function validateProject(doc) {
         }
         if (!Array.isArray(tex.layers)) errors.push(`textureAssets[${guid}].layers must be an array`);
       }
+    }
+  }
+  if (doc.schemaVersion >= 11 && doc.objectMaterial?.textureMap != null) {
+    const tm = doc.objectMaterial.textureMap;
+    if (typeof tm !== "object") {
+      errors.push("objectMaterial.textureMap must be an object or null");
+    } else if (tm.encoding !== "rgba8-base64") {
+      errors.push('objectMaterial.textureMap.encoding must be "rgba8-base64"');
+    } else if (!(tm.w > 0) || !(tm.h > 0) || typeof tm.data !== "string") {
+      errors.push("objectMaterial.textureMap needs w, h, and data");
     }
   }
   return errors;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Assigning eyes baked a UV atlas in memory, but save only kept `textureUv` params. On reload the atlas was **re-rasterized**, so eyes could land in a different place than at assign time.

## Fix
- Schema **v11**: `objectMaterial.textureMap` (`rgba8-base64` RGBA atlas) alongside `textureUv` / `textureAsset`.
- Assign stores the exact bake; `resolveTextureMap` prefers it over live re-paint.
- Undo history omits the large map; a guid-keyed cache reattaches it so edits don’t wipe placement.
- Smoke: encode/decode + document migrate round-trip.

Mesh vertex UVs stay regenerated from profile/orbit (deterministic); the durable piece is the **pre-baked atlas** that encodes eye placement.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

