### PR TITLE
Fix slow mesh-editor object load (Vue deep reactivity + atlas copies)

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/package.json
+++ b/gallery/game_engine/v2/mesh_editor/app/package.json
@@ -9,7 +9,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node scripts/smoke-library-safe.mjs && node scripts/smoke-mesh-pick.mjs && node scripts/smoke-eye-texture.mjs"
+    "test": "node scripts/smoke-library-safe.mjs && node scripts/smoke-mesh-pick.mjs && node scripts/smoke-eye-texture.mjs && node scripts/smoke-mesh-map-share.mjs"
   },
   "dependencies": {
     "vue": "^3.5.13"

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-map-share.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-map-share.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * smoke-mesh-map-share.mjs — atlas must stay TypedArray + shared across parts.
+ */
+import assert from "node:assert/strict";
+import { tessellateBody } from "../src/lib/latheTessellate.js";
+import { defaultSpineKnots, defaultSpineSegments } from "../src/lib/spineLathe.js";
+import { SplineLathe } from "../../tessellate/spline_lathe.mjs";
+
+function uid() {
+  return "k" + Math.random().toString(36).slice(2, 9);
+}
+
+function knotsFrom(defaults) {
+  return defaults.map((k, i) => ({
+    id: uid(),
+    x: k.x,
+    y: k.y,
+    hx: k.hx,
+    hy: k.hy,
+    color: i % 2 ? "#7ecf6a" : "#6ec8ff",
+  }));
+}
+
+function openSegs(knots) {
+  const segs = [];
+  for (let i = 0; i < knots.length - 1; i++) {
+    segs.push({
+      fromId: knots[i].id,
+      toId: knots[i + 1].id,
+      color: null,
+      roughness: 0.4,
+      metalness: 0,
+      opacity: 1,
+      texture: "gradient",
+      textureData: null,
+      pathType: "bezier",
+    });
+  }
+  return segs;
+}
+
+function closedSegs(knots) {
+  const segs = [];
+  for (let i = 0; i < knots.length; i++) {
+    segs.push({
+      fromId: knots[i].id,
+      toId: knots[(i + 1) % knots.length].id,
+      color: null,
+      roughness: 0.4,
+      metalness: 0,
+      opacity: 1,
+      texture: "gradient",
+      textureData: null,
+      pathType: "bezier",
+    });
+  }
+  return segs;
+}
+
+const profile = knotsFrom(SplineLathe.defaultKnots());
+const orbit = knotsFrom(SplineLathe.defaultOrbitKnots());
+const spineP = defaultSpineKnots();
+const spineO = defaultSpineKnots();
+
+const W = 64;
+const H = 64;
+const atlas = new Uint8ClampedArray(W * H * 4);
+for (let i = 0; i < atlas.length; i += 4) {
+  atlas[i] = 200;
+  atlas[i + 1] = 40;
+  atlas[i + 2] = 40;
+  atlas[i + 3] = 255;
+}
+
+const body = {
+  knots: profile,
+  segments: openSegs(profile),
+  orbitKnots: orbit,
+  orbitSegments: closedSegs(orbit),
+  spineProfileKnots: spineP,
+  spineProfileSegments: defaultSpineSegments(spineP),
+  spineOrbitKnots: spineO,
+  spineOrbitSegments: defaultSpineSegments(spineO),
+  curveType: 0,
+  pathSegments: 8,
+  angularSteps: 16,
+  revolutionDeg: 360,
+  tessellationMode: "rotation",
+  objectMaterial: {
+    color: null,
+    roughness: 0.4,
+    metalness: 0,
+    opacity: 1,
+    texture: "asset",
+    textureAsset: "test-guid",
+    textureAssign: "eyePair",
+    textureMap: { rgba: atlas, w: W, h: H },
+  },
+};
+
+const mesh = tessellateBody(body, {
+  resolveTextureMap: (om) => om.textureMap,
+});
+
+assert.ok(mesh.parts.length >= 2, "expected multiple lathe parts");
+const first = mesh.parts[0].mapRgba;
+assert.ok(first instanceof Uint8Array, "mapRgba must stay TypedArray (no Array.from)");
+assert.equal(first.length, W * H * 4);
+
+for (const part of mesh.parts) {
+  assert.strictEqual(
+    part.mapRgba,
+    first,
+    "body atlas must be shared by reference across parts",
+  );
+  assert.equal(part.mapW, W);
+  assert.equal(part.mapH, H);
+}
+
+// Gradient-only body still uses TypedArray maps (not number[]).
+const plain = {
+  ...body,
+  objectMaterial: {
+    color: null,
+    roughness: 0.4,
+    metalness: 0,
+    opacity: 1,
+    texture: "gradient",
+    textureAsset: null,
+    textureAssign: null,
+    textureMap: null,
+  },
+};
+const plainMesh = tessellateBody(plain, {});
+assert.ok(plainMesh.parts.length >= 1);
+assert.ok(
+  plainMesh.parts[0].mapRgba instanceof Uint8Array,
+  "procedural maps should also be TypedArray",
+);
+
+console.log("[smoke-mesh-map-share] OK", {
+  parts: mesh.parts.length,
+  atlasBytes: first.byteLength,
+  shared: true,
+});

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
@@ -550,7 +550,9 @@ onBeforeUnmount(() => {
   session = null;
 });
 
-watch(displayMesh, () => pushDisplay(), { deep: true });
+// Identity-only: tessellate() replaces the mesh root. Deep watch would traverse
+// every position/normal/uv/index/mapRgba element (seconds on large atlases).
+watch(displayMesh, () => pushDisplay());
 
 watch(
   () => props.materialMode,

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -1,4 +1,4 @@
-import { reactive, computed, watch } from "vue";
+import { reactive, computed, watch, markRaw } from "vue";
 import { SplineLathe } from "../../../tessellate/spline_lathe.mjs";
 import { tessellateBody } from "../lib/latheTessellate.js";
 import {
@@ -137,6 +137,20 @@ function loadSpineBlock(block, fallbackKnots) {
   return { knots, segments: defaultSpineSegments(knots) };
 }
 
+/** Keep large atlas blobs out of Vue's deep Proxy graph. */
+function sealTextureMap(raw) {
+  const live = normalizeTextureMap(raw);
+  if (!live) return null;
+  const rgba =
+    live.rgba instanceof Uint8Array ? live.rgba : new Uint8ClampedArray(live.rgba);
+  return markRaw({
+    rgba,
+    w: live.w,
+    h: live.h,
+    name: live.name,
+  });
+}
+
 export function useSplineEditor() {
   /** Optional provider for procedural texture assets (from Texture editor / library). */
   let textureAssetsProvider = () => /** @type {Record<string, any>} */ ({});
@@ -147,7 +161,7 @@ export function useSplineEditor() {
 
   function rememberBakedAtlas(guid, map) {
     const g = String(guid || "").trim();
-    const live = normalizeTextureMap(map);
+    const live = sealTextureMap(map);
     if (!g || !live) return;
     bakedAtlasByGuid.set(g, live);
   }
@@ -159,7 +173,7 @@ export function useSplineEditor() {
 
   function atlasForMaterial(om) {
     if (!om) return null;
-    const fromOm = normalizeTextureMap(om.textureMap);
+    const fromOm = sealTextureMap(om.textureMap);
     if (fromOm) return fromOm;
     const guid = om.textureAsset;
     if (guid && bakedAtlasByGuid.has(guid)) return bakedAtlasByGuid.get(guid);
@@ -275,6 +289,9 @@ export function useSplineEditor() {
       if (cached) state.objectMaterial.textureMap = cached;
     } else if (state.objectMaterial.textureMap && state.objectMaterial.textureAsset) {
       rememberBakedAtlas(state.objectMaterial.textureAsset, state.objectMaterial.textureMap);
+      state.objectMaterial.textureMap = bakedAtlasByGuid.get(state.objectMaterial.textureAsset) || null;
+    } else {
+      state.objectMaterial.textureMap = sealTextureMap(state.objectMaterial.textureMap);
     }
     state.embeddedAssets = {};
     for (const [guid, body] of Object.entries(snap.embeddedAssets || {})) {
@@ -993,7 +1010,7 @@ export function useSplineEditor() {
       pendingTextureMap = null;
       return;
     }
-    pendingTextureMap = { map, guid };
+    pendingTextureMap = { map: sealTextureMap(map) || map, guid };
   }
 
   /**
@@ -1028,7 +1045,9 @@ export function useSplineEditor() {
       textureAssign: "eyePair",
       textureUv: nextUv,
       // Keep the exact atlas pixels from the assign bake (or prior bake).
-      textureMap: baked || atlasForMaterial({ textureAsset: guid, textureMap: prev.textureMap }) || null,
+      textureMap: sealTextureMap(
+        baked || atlasForMaterial({ textureAsset: guid, textureMap: prev.textureMap }),
+      ),
     };
     if (state.objectMaterial.textureMap) {
       rememberBakedAtlas(guid, state.objectMaterial.textureMap);
@@ -1109,7 +1128,9 @@ export function useSplineEditor() {
     const tessOpts = { resolveTextureMap };
     // Always assemble from ROOT + children (preview shows full object even when editing a child).
     const root = tessellateBody(rootBodySnapshot(), tessOpts);
-    state.rootMesh = { parts: root.parts.slice() };
+    // Mesh buffers are large and treated as immutable snapshots — keep them out of
+    // Vue's deep Proxy (deep watch / track on positions + atlas bytes is catastrophic).
+    state.rootMesh = markRaw({ parts: root.parts.slice() });
     // Spine / profile edits move the root surface — re-seat surface children on it.
     resnapSurfaceChildren(state.rootMesh.parts);
     const parts = root.parts.slice();
@@ -1133,7 +1154,7 @@ export function useSplineEditor() {
       }
     }
 
-    state.mesh = { parts };
+    state.mesh = markRaw({ parts });
     state.stats = {
       verts: totalV,
       tris: totalT,
@@ -1373,7 +1394,7 @@ export function useSplineEditor() {
           ? "eyePair"
           : doc.objectMaterial?.textureAssign || null,
       textureUv: normalizeEyeUv(doc.objectMaterial?.textureUv),
-      textureMap: normalizeTextureMap(doc.objectMaterial?.textureMap),
+      textureMap: sealTextureMap(doc.objectMaterial?.textureMap),
     };
     if (state.objectMaterial.textureMap && state.objectMaterial.textureAsset) {
       rememberBakedAtlas(state.objectMaterial.textureAsset, state.objectMaterial.textureMap);

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/latheTessellate.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/latheTessellate.js
@@ -52,6 +52,14 @@ function roughnessToShininess(r) {
   return lerp(280, 6, t);
 }
 
+/** Keep atlas pixels as a TypedArray; never widen to a number[]. */
+function asRgbaBytes(map) {
+  if (!map?.rgba || !map.rgba.length) return null;
+  const src = map.rgba;
+  if (src instanceof Uint8Array) return src;
+  return new Uint8Array(src);
+}
+
 function makeGradientRgba(hexA, hexB, w = 4, h = 64) {
   const A = hexToRgb(hexA);
   const B = hexToRgb(hexB);
@@ -248,6 +256,8 @@ export function tessellateBody(body, opts = {}) {
   ) {
     bodyMap = opts.resolveTextureMap(om);
   }
+  // One typed-array view for the body atlas — shared by every part (no Array.from).
+  const bodyMapBytes = bodyMap ? asRgbaBytes(bodyMap) : null;
 
   const parts = [];
   let totalV = 0;
@@ -255,6 +265,7 @@ export function tessellateBody(body, opts = {}) {
   for (const piece of pieces) {
     const style = resolveCombinedStyle(body, piece.profileSeg, piece.orbitSeg);
     const map = bodyMap || style.map;
+    const mapBytes = bodyMap ? bodyMapBytes : map ? asRgbaBytes(map) : null;
     parts.push({
       positions: piece.positions,
       normals: piece.normals,
@@ -264,7 +275,7 @@ export function tessellateBody(body, opts = {}) {
       shininess: style.shininess,
       reflectivity: style.reflectivity,
       opacity: style.opacity,
-      mapRgba: map ? Array.from(map.rgba) : null,
+      mapRgba: mapBytes,
       mapW: map ? map.w : 0,
       mapH: map ? map.h : 0,
     });

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/meshTransform.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/meshTransform.js
@@ -141,7 +141,8 @@ export function transformPart(part, xf, sharedCenter, pivot) {
     normals: normals || part.normals,
     indices: mirror ? reverseWinding(indices) : indices,
     uvs: part.uvs ? part.uvs.slice() : part.uvs,
-    mapRgba: part.mapRgba ? part.mapRgba.slice() : part.mapRgba,
+    // Share atlas bytes by reference (immutable for preview upload).
+    mapRgba: part.mapRgba,
   };
 }
 
@@ -217,7 +218,8 @@ function transformPartSurface(part, xf, pivot) {
     normals: normals || part.normals,
     indices,
     uvs: part.uvs ? part.uvs.slice() : part.uvs,
-    mapRgba: part.mapRgba ? part.mapRgba.slice() : part.mapRgba,
+    // Share atlas bytes by reference (immutable for preview upload).
+    mapRgba: part.mapRgba,
   };
 }
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/rangerPreview.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/rangerPreview.js
@@ -1,5 +1,22 @@
 /** Boot / drive WebMeshEditorHost for the 3D preview canvas. */
 
+/**
+ * Build a Ranger ES6 `buffer` (ArrayBuffer + DataView) from RGBA bytes.
+ * One memcpy — avoids host.bytesToBuffer's per-element loop.
+ * @param {Uint8Array|Uint8ClampedArray|ArrayLike<number>} rgba
+ */
+function toRangerBuffer(rgba) {
+  const src = rgba instanceof Uint8Array ? rgba : new Uint8Array(rgba);
+  const ab = new ArrayBuffer(src.byteLength);
+  new Uint8Array(ab).set(src);
+  ab._view = new DataView(ab);
+  return ab;
+}
+
+function hasMap(part) {
+  return !!(part?.mapRgba && part.mapRgba.length && part.mapW > 0 && part.mapH > 0);
+}
+
 export async function createPreviewSession(canvas, size = 420, opts = {}) {
   const bundleSource = await fetch("/ranger/mesh_editor.bundle.js").then((r) => r.text());
   const vfs = new window.RangerVFS();
@@ -64,26 +81,79 @@ export async function createPreviewSession(canvas, size = 420, opts = {}) {
     raf = 0;
   }
 
+  /**
+   * Upload each distinct atlas once (by object identity), then addPart geometry.
+   * Empty mapBytes + hasPartMap on the host applies the shared ThreeTexture.
+   */
   function pushMesh(mesh) {
     if (!mesh) return;
     host.setMaterialMode(lastMode | 0);
     if (mesh.parts && mesh.parts.length) {
       host.beginParts();
+      let currentMap = null;
+      const emptyMap = [];
+      const canShare =
+        typeof host.setPartMapBuffer === "function" && typeof host.clearPartMap === "function";
+
       for (const part of mesh.parts) {
-        const mapBytes = part.mapRgba && part.mapRgba.length ? part.mapRgba : [];
-        host.addPart(
-          part.positions,
-          part.normals,
-          part.uvs,
-          part.indices,
-          part.colorHex | 0,
-          part.shininess || 120,
-          part.opacity == null ? 1 : part.opacity,
-          part.reflectivity || 0,
-          mapBytes,
-          part.mapW | 0,
-          part.mapH | 0,
-        );
+        if (hasMap(part)) {
+          if (canShare) {
+            if (part.mapRgba !== currentMap) {
+              host.setPartMapBuffer(toRangerBuffer(part.mapRgba), part.mapW | 0, part.mapH | 0);
+              currentMap = part.mapRgba;
+            }
+            host.addPart(
+              part.positions,
+              part.normals,
+              part.uvs,
+              part.indices,
+              part.colorHex | 0,
+              part.shininess || 120,
+              part.opacity == null ? 1 : part.opacity,
+              part.reflectivity || 0,
+              emptyMap,
+              part.mapW | 0,
+              part.mapH | 0,
+            );
+          } else {
+            // Older host bundle: fall back to per-part upload (still TypedArray-safe).
+            const mapBytes =
+              part.mapRgba instanceof Uint8Array
+                ? part.mapRgba
+                : Array.from(part.mapRgba);
+            host.addPart(
+              part.positions,
+              part.normals,
+              part.uvs,
+              part.indices,
+              part.colorHex | 0,
+              part.shininess || 120,
+              part.opacity == null ? 1 : part.opacity,
+              part.reflectivity || 0,
+              mapBytes,
+              part.mapW | 0,
+              part.mapH | 0,
+            );
+          }
+        } else {
+          if (canShare && currentMap !== null) {
+            host.clearPartMap();
+            currentMap = null;
+          }
+          host.addPart(
+            part.positions,
+            part.normals,
+            part.uvs,
+            part.indices,
+            part.colorHex | 0,
+            part.shininess || 120,
+            part.opacity == null ? 1 : part.opacity,
+            part.reflectivity || 0,
+            emptyMap,
+            0,
+            0,
+          );
+        }
       }
       host.frame(0);
       blit();

--- a/gallery/game_engine/v2/mesh_editor/host/web_mesh_editor_host.rgr
+++ b/gallery/game_engine/v2/mesh_editor/host/web_mesh_editor_host.rgr
@@ -30,6 +30,9 @@ class WebMeshEditorHost {
     def angle:double 0.0
     def outBuf:buffer (buffer_alloc 0)
     def lastMatH:int 0
+    ; Shared RGBA atlas for the current beginParts batch (upload once, reuse on parts).
+    def partMapTex:ThreeTexture (new ThreeTexture)
+    def hasPartMap:boolean false
 
     fn setupGL:boolean (canvasId:string) {
         def ok:boolean (gl.init(canvasId))
@@ -147,7 +150,25 @@ class WebMeshEditorHost {
         return buf
     }
 
-    ; Add one lathed segment. mapBytes empty => no texture.
+    ; Clear the shared part map (call from beginParts / when switching atlases).
+    fn clearPartMap:void () {
+        hasPartMap = false
+    }
+
+    ; Upload an atlas once as a Ranger buffer (fast path from JS TypedArray→ArrayBuffer).
+    fn setPartMapBuffer:void (rgba:buffer w:int h:int) {
+        def tex:ThreeTexture (new ThreeTexture)
+        tex.setImage(rgba w h)
+        partMapTex = tex
+        hasPartMap = true
+    }
+
+    ; Legacy: convert [int]/Uint8-like arrays into the shared part map.
+    fn setPartMap:void (bytes:[int] w:int h:int) {
+        this.setPartMapBuffer((this.bytesToBuffer(bytes)) w h)
+    }
+
+    ; Add one lathed segment. Prefer hasPartMap when set; else mapBytes non-empty.
     fn addPart:void (positions:[double] normals:[double] uvs:[double] indices:[int] colorHex:int shininess:double opacity:double reflectivity:double mapBytes:[int] mapW:int mapH:int) {
         if (ready == false) {
             return
@@ -156,10 +177,14 @@ class WebMeshEditorHost {
         push host.geometries g
         def geoH:int (array_length host.geometries)
         def matH:int (this.buildPartMaterial(colorHex shininess opacity reflectivity))
-        if (((array_length mapBytes) > 0) && (mapW > 0) && (mapH > 0)) {
-            def tex:ThreeTexture (new ThreeTexture)
-            tex.setImage((this.bytesToBuffer(mapBytes)) mapW mapH)
-            (host.materialAt(matH)).setMap(tex)
+        if (hasPartMap) {
+            (host.materialAt(matH)).setMap(partMapTex)
+        } {
+            if (((array_length mapBytes) > 0) && (mapW > 0) && (mapH > 0)) {
+                def tex:ThreeTexture (new ThreeTexture)
+                tex.setImage((this.bytesToBuffer(mapBytes)) mapW mapH)
+                (host.materialAt(matH)).setMap(tex)
+            }
         }
         lastMatH = matH
         def meshH:int (host.meshNew(sceneH geoH matH))
@@ -169,6 +194,7 @@ class WebMeshEditorHost {
 
     fn beginParts:void () {
         this.clearParts()
+        this.clearPartMap()
     }
 
     fn setMaterialMode:void (mode:int) {

--- a/gallery/game_engine/v2/mesh_editor/smoke.mjs
+++ b/gallery/game_engine/v2/mesh_editor/smoke.mjs
@@ -97,10 +97,31 @@ for (let i = 0; i < pix.length; i += 3) {
 if (lit < 40) throw new Error("software preview produced too few lit pixels: " + lit);
 if (host.partCount() !== 2) throw new Error("expected 2 parts, got " + host.partCount());
 
+// Shared atlas path: upload once, apply to two parts without re-copying bytes.
+if (typeof host.setPartMapBuffer !== "function") {
+  throw new Error("host missing setPartMapBuffer");
+}
+const shared = new Uint8Array(8 * 8 * 4);
+for (let i = 0; i < shared.length; i += 4) {
+  shared[i] = 220;
+  shared[i + 1] = 80;
+  shared[i + 2] = 40;
+  shared[i + 3] = 255;
+}
+const ab = shared.buffer.slice(shared.byteOffset, shared.byteOffset + shared.byteLength);
+ab._view = new DataView(ab);
+host.beginParts();
+host.setPartMapBuffer(ab, 8, 8);
+host.addPart(mid.positions, mid.normals, mid.uvs, mid.indices, 0xffffff, 120, 1, 0, [], 8, 8);
+host.addPart(top.positions, top.normals, top.uvs, top.indices, 0xffffff, 120, 1, 0, [], 8, 8);
+host.frame(16);
+if (host.partCount() !== 2) throw new Error("shared-map expected 2 parts, got " + host.partCount());
+
 console.log("[mesh-editor smoke] OK", {
   fullVerts: (full.positions.length / 3) | 0,
   orbitVerts: (viaOrbit.positions.length / 3) | 0,
   orbitMaxAbsDiff: maxAbs,
   parts: host.partCount(),
   litPixels: lit,
+  sharedMap: true,
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Loading a mesh project with a baked UV atlas stalled for several seconds. Chrome profiles showed most time in Vue `track` / `get` / `traverse` and Ranger `bytesToBuffer`, not in `tessellateBody`.

Root causes:
1. `tessellateBody` did `Array.from(map.rgba)` **per part**, turning a TypedArray atlas into huge `number[]` copies.
2. `state.mesh` lived inside a deep `reactive()` object, and `Preview3D` watched it with `{ deep: true }`, so Vue walked every vertex and pixel.
3. Each part re-uploaded the same atlas through `bytesToBuffer` (element-by-element).

## Fix

1. Remove `{ deep: true }` — `tessellate()` replaces the mesh root by identity.
2. `markRaw()` mesh / rootMesh / textureMap atlases so they stay out of Vue’s Proxy graph.
3. Keep `mapRgba` as a shared TypedArray (no `Array.from`); child transforms share the reference.
4. Host: `setPartMapBuffer` / `clearPartMap`; preview uploads each distinct atlas once per batch via a single memcpy into a Ranger buffer.

## Tests

- `node build-host.mjs && node smoke.mjs` (includes shared-map path)
- `npm test` in `app/` (adds `smoke-mesh-map-share.mjs`)

Follow-up (not in this PR): separate `updateTexture()` from full `tessellate()` when only atlas pixels change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e760c237-1550-4846-8e36-6c280a4e94b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e760c237-1550-4846-8e36-6c280a4e94b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

