### PR TITLE
Fix eye texture save bake + closed-lathe UV seam

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -474,6 +474,41 @@ assert.equal(mig10.ok, true, mig10.errors?.join("; "));
 assert.equal(mig10.doc.schemaVersion, 11);
 assert.equal(mig10.doc.objectMaterial.textureMap, null);
 
+// Save path: buildProjectDocument must keep bake when state carries a live map
+{
+  const saveDoc = buildProjectDocument({
+    state: {
+      ...docWithBake,
+      // Simulate editor snapshotState({ includeMap: true }) — live rgba map
+      objectMaterial: {
+        ...docWithBake.objectMaterial,
+        textureMap: asyncMap,
+      },
+      textureAssets: { [ser.assetGuid]: ser },
+      knots: docWithBake.profile.knots,
+      segments: docWithBake.profile.segments,
+      orbitKnots: docWithBake.orbit.knots,
+      orbitSegments: docWithBake.orbit.segments,
+      spineProfileKnots: docWithBake.spineProfile.knots,
+      spineProfileSegments: docWithBake.spineProfile.segments,
+      spineOrbitKnots: docWithBake.spineOrbit.knots,
+      spineOrbitSegments: docWithBake.spineOrbit.segments,
+      placementNormal: docWithBake.placementNormal,
+      embeddedAssets: {},
+      children: [],
+      editor: docWithBake.editor,
+    },
+    name: "Save bake",
+    slug: "save-bake",
+    projectKind: "mesh",
+  });
+  assert.ok(
+    saveDoc.objectMaterial.textureMap?.encoding === "rgba8-base64",
+    "Save must persist textureMap bake",
+  );
+  assert.ok(saveDoc.objectMaterial.textureMap.data.length > 100);
+}
+
 console.log("smoke-eye-texture: ok", {
   schema: mig.doc.schemaVersion,
   projectKind: mig.doc.projectKind,

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -115,7 +115,22 @@ assert.ok(regionSamplePoints(DEFAULT_ASSIGN_REGION, 3).length === 9);
   assert.ok(front?.uv, "lathe front hit has UV");
   assert.ok(Math.abs(front.uv[0] - 0.25) < 1e-6, `front u≈0.25 got ${front.uv[0]}`);
   const plusX = raycastMeshParts([3, 0.4, 0], [-1, 0, 0], latheParts);
-  assert.ok(plusX?.uv && Math.abs(plusX.uv[0]) < 1e-6, `+X u≈0 got ${plusX?.uv?.[0]}`);
+  // Seam column duplicates col0 at u=1; hit may land on u≈0 or u≈1 (same atlas edge).
+  assert.ok(
+    plusX?.uv && (plusX.uv[0] < 1e-6 || plusX.uv[0] > 1 - 1e-6),
+    `+X u≈0 or 1 got ${plusX?.uv?.[0]}`,
+  );
+  // Wrap faces must not span the atlas: max |Δu| on any edge < 0.5
+  {
+    const { uvs, indices, vertCols, steps } = mesh;
+    assert.equal(vertCols, steps + 1, "closed lathe has seam column");
+    let maxDu = 0;
+    for (let i = 0; i < indices.length; i += 3) {
+      const us = [0, 1, 2].map((k) => uvs[indices[i + k] * 2]);
+      maxDu = Math.max(maxDu, Math.abs(us[0] - us[1]), Math.abs(us[0] - us[2]), Math.abs(us[1] - us[2]));
+    }
+    assert.ok(maxDu < 0.5 + 1e-9, `seam faces must not cross atlas, maxΔu=${maxDu}`);
+  }
   const patch = [
     [front.uv[0] - 0.05, front.uv[1] + 0.08],
     [front.uv[0] + 0.05, front.uv[1] + 0.08],

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
@@ -52,7 +52,8 @@ const mesh = latheProfileAsTorusOnSpine(
 
 assert.equal(mesh.rows, profile.length);
 assert.equal(mesh.steps, orbit.length);
-assert.equal(mesh.positions.length, profile.length * orbit.length * 3);
+assert.equal(mesh.vertCols, orbit.length + 1, "closed torus has seam UV column");
+assert.equal(mesh.positions.length, profile.length * mesh.vertCols * 3);
 
 // Outer radius should be ~1 (unit torus)
 let maxR = 0;

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -84,7 +84,7 @@ setTextureAssetsProvider(() => tex.snapshotTextures());
 function snapshotState(kind) {
   const k = kind === "texture" ? "texture" : "mesh";
   return {
-    ...snapshotMeshState(),
+    ...snapshotMeshState({ includeMap: true }),
     textureAssets: tex.snapshotTextures(),
     projectKind: k,
   };

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -248,7 +248,8 @@ export function useSplineEditor() {
         spineOrbitKnots: state.spineOrbitKnots,
         spineOrbitSegments: state.spineOrbitSegments.map(mapSegSnapshot),
         placementNormal: normalizePlacementNormal(state.placementNormal),
-        objectMaterial: state.objectMaterial,
+        // Strip textureMap — TypedArray JSON would explode undo memory; cache reattaches.
+        objectMaterial: snapshotObjectMaterial(state.objectMaterial),
         embeddedAssets: state.embeddedAssets,
         children: state.children,
         selectedId: state.selectedId,
@@ -1471,8 +1472,9 @@ export function useSplineEditor() {
     return true;
   }
 
-  function snapshotObjectMaterial(om) {
+  function snapshotObjectMaterial(om, opts = {}) {
     const m = om || defaultObjectMaterial();
+    const includeMap = !!opts.includeMap;
     return {
       color: m.color ?? null,
       roughness: Number(m.roughness ?? 0.4),
@@ -1482,12 +1484,16 @@ export function useSplineEditor() {
       textureAsset: m.textureAsset || null,
       textureAssign: m.textureAssign === "eyePair" ? "eyePair" : m.textureAssign || null,
       textureUv: normalizeEyeUv(m.textureUv),
-      // Omit textureMap from undo history — atlases are large; reload uses saved bake.
-      textureMap: null,
+      // Undo history omits the atlas (large); Save/Export must include it.
+      textureMap: includeMap
+        ? sealTextureMap(m.textureMap) ||
+          (m.textureAsset ? bakedAtlasByGuid.get(m.textureAsset) || null : null)
+        : null,
     };
   }
 
-  function snapshotState() {
+  function snapshotState(opts = {}) {
+    const includeMap = !!opts.includeMap;
     const embedded = {};
     for (const [guid, body] of Object.entries(state.embeddedAssets)) {
       embedded[guid] = {
@@ -1498,7 +1504,7 @@ export function useSplineEditor() {
         angularSteps: body.angularSteps,
         revolutionDeg: body.revolutionDeg,
         tessellationMode: body.tessellationMode === "torus" ? "torus" : "rotation",
-        objectMaterial: snapshotObjectMaterial(body.objectMaterial),
+        objectMaterial: snapshotObjectMaterial(body.objectMaterial, { includeMap }),
         knots: body.knots.map((k) => ({ ...k })),
         segments: body.segments.map(mapSegSnapshot),
         orbitKnots: body.orbitKnots.map((k) => ({ ...k })),
@@ -1521,7 +1527,7 @@ export function useSplineEditor() {
       symmetry: state.symmetry,
       viewMode: state.viewMode,
       spineSource: state.spineSource,
-      objectMaterial: snapshotObjectMaterial(state.objectMaterial),
+      objectMaterial: snapshotObjectMaterial(state.objectMaterial, { includeMap }),
       knots: state.knots.map((k) => ({ ...k })),
       segments: state.segments.map(mapSegSnapshot),
       orbitKnots: state.orbitKnots.map((k) => ({ ...k })),

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/pathSample.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/pathSample.js
@@ -201,10 +201,14 @@ export function sampleClosedPath(knots, segments, samplesPerSpan, curveType = 0)
 /**
  * Revolve a sampled open profile around Y using orbit direction samples (ox, oy).
  * Returns a single mesh buffer (all profile rows × orbit cols) plus rowSeg meta.
+ *
+ * Closed meshes emit an extra seam column (duplicate of col 0 at u=1) so wrap
+ * faces interpolate (steps-1)/steps → 1 instead of crossing the whole atlas.
  */
 export function latheProfileWithOrbit(profilePts, orbitPts, closed) {
   const rows = profilePts.length;
   const steps = orbitPts.length;
+  const vertCols = closed ? steps + 1 : steps;
   const positions = [];
   const normals = [];
   const uvs = [];
@@ -230,6 +234,7 @@ export function latheProfileWithOrbit(profilePts, orbitPts, closed) {
       pnx = -pnx;
       pny = -pny;
     }
+    const v = rows <= 1 ? 0 : row / (rows - 1);
 
     for (let col = 0; col < steps; col++) {
       const o = orbitPts[col];
@@ -240,30 +245,38 @@ export function latheProfileWithOrbit(profilePts, orbitPts, closed) {
       const nst = olen < 1e-9 ? 0 : st / olen;
       positions.push(radius * ct, yy, radius * st);
       normals.push(pnx * nct, pny, pnx * nst);
-      uvs.push(col / steps, rows <= 1 ? 0 : row / (rows - 1));
+      uvs.push(col / steps, v);
+    }
+    if (closed) {
+      const base = positions.length - steps * 3;
+      positions.push(positions[base], positions[base + 1], positions[base + 2]);
+      normals.push(normals[base], normals[base + 1], normals[base + 2]);
+      uvs.push(1, v);
     }
   }
 
   for (let r = 0; r < rows - 1; r++) {
     const colMax = closed ? steps : steps - 1;
     for (let c = 0; c < colMax; c++) {
-      const cNext = c + 1 >= steps ? 0 : c + 1;
-      const a = r * steps + c;
-      const b = r * steps + cNext;
-      const cc = (r + 1) * steps + cNext;
-      const d = (r + 1) * steps + c;
+      const cNext = c + 1;
+      const a = r * vertCols + c;
+      const b = r * vertCols + cNext;
+      const cc = (r + 1) * vertCols + cNext;
+      const d = (r + 1) * vertCols + c;
       indices.push(a, d, b, b, d, cc);
     }
   }
 
-  return { positions, normals, uvs, indices, rowSeg, colSeg, rows, steps };
+  return { positions, normals, uvs, indices, rowSeg, colSeg, rows, steps, vertCols };
 }
 
 /**
  * Split a full lathe mesh into profileSeg × orbitSeg parts (own buffers).
  */
 export function splitLatheBySegments(mesh, numProfileSegs, numOrbitSegs, closed) {
-  const { positions, normals, uvs, indices, rowSeg, colSeg, rows, steps } = mesh;
+  const { positions, normals, uvs, rowSeg, colSeg, rows, steps } = mesh;
+  const vertCols =
+    mesh.vertCols || (closed ? steps + 1 : steps);
   const out = [];
 
   for (let pi = 0; pi < numProfileSegs; pi++) {
@@ -277,11 +290,11 @@ export function splitLatheBySegments(mesh, numProfileSegs, numOrbitSegs, closed)
         const colMax = closed ? steps : steps - 1;
         for (let c = 0; c < colMax; c++) {
           if ((colSeg[c] | 0) !== oi) continue;
-          const cNext = c + 1 >= steps ? 0 : c + 1;
-          const a = r * steps + c;
-          const b = r * steps + cNext;
-          const cc = (r + 1) * steps + cNext;
-          const d = (r + 1) * steps + c;
+          const cNext = c + 1;
+          const a = r * vertCols + c;
+          const b = r * vertCols + cNext;
+          const cc = (r + 1) * vertCols + cNext;
+          const d = (r + 1) * vertCols + c;
           faces.push(a, d, b, b, d, cc);
         }
       }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/spineLathe.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/spineLathe.js
@@ -137,6 +137,7 @@ export function buildSpineFrames(centers) {
 export function latheProfileWithOrbitOnSpine(profilePts, orbitPts, closed, spineProfile, spineOrbit) {
   const rows = profilePts.length;
   const steps = orbitPts.length;
+  const vertCols = closed ? steps + 1 : steps;
   const positions = [];
   const normals = [];
   const uvs = [];
@@ -200,6 +201,7 @@ export function latheProfileWithOrbitOnSpine(profilePts, orbitPts, closed, spine
       N: { x: 1, y: 0, z: 0 },
       B: { x: 0, y: 0, z: 1 },
     };
+    const v = rows <= 1 ? 0 : row / (rows - 1);
 
     for (let col = 0; col < steps; col++) {
       const o = orbitPts[col];
@@ -221,23 +223,29 @@ export function latheProfileWithOrbitOnSpine(profilePts, orbitPts, closed, spine
       const nz = fr.N.z * (pnx * nct) + fr.T.z * pny + fr.B.z * (pnx * nst);
       const nl = Math.hypot(nx, ny, nz) || 1;
       normals.push(nx / nl, ny / nl, nz / nl);
-      uvs.push(col / steps, rows <= 1 ? 0 : row / (rows - 1));
+      uvs.push(col / steps, v);
+    }
+    if (closed) {
+      const base = positions.length - steps * 3;
+      positions.push(positions[base], positions[base + 1], positions[base + 2]);
+      normals.push(normals[base], normals[base + 1], normals[base + 2]);
+      uvs.push(1, v);
     }
   }
 
   for (let r = 0; r < rows - 1; r++) {
     const colMax = closed ? steps : steps - 1;
     for (let c = 0; c < colMax; c++) {
-      const cNext = c + 1 >= steps ? 0 : c + 1;
-      const a = r * steps + c;
-      const b = r * steps + cNext;
-      const cc = (r + 1) * steps + cNext;
-      const d = (r + 1) * steps + c;
+      const cNext = c + 1;
+      const a = r * vertCols + c;
+      const b = r * vertCols + cNext;
+      const cc = (r + 1) * vertCols + cNext;
+      const d = (r + 1) * vertCols + c;
       indices.push(a, d, b, b, d, cc);
     }
   }
 
-  return { positions, normals, uvs, indices, rowSeg, colSeg, rows, steps };
+  return { positions, normals, uvs, indices, rowSeg, colSeg, rows, steps, vertCols };
 }
 
 /**
@@ -278,6 +286,7 @@ export function latheProfileAsTorusOnSpine(
 ) {
   const rows = profilePts.length;
   const steps = orbitPts.length;
+  const vertCols = closed ? steps + 1 : steps;
   const positions = [];
   const normals = [];
   const uvs = [];
@@ -337,6 +346,8 @@ export function latheProfileAsTorusOnSpine(
       pny = -pny;
     }
 
+    const v = rows <= 1 ? 0 : row / (rows - 1);
+
     for (let col = 0; col < steps; col++) {
       const fr = frames[col] || {
         C: centers[col] || { x: 0, y: 0, z: 0 },
@@ -355,21 +366,27 @@ export function latheProfileAsTorusOnSpine(
       const nz = fr.N.z * pnx + fr.B.z * pny;
       const nl = Math.hypot(nx, ny, nz) || 1;
       normals.push(nx / nl, ny / nl, nz / nl);
-      uvs.push(col / steps, rows <= 1 ? 0 : row / (rows - 1));
+      uvs.push(col / steps, v);
+    }
+    if (closed) {
+      const base = positions.length - steps * 3;
+      positions.push(positions[base], positions[base + 1], positions[base + 2]);
+      normals.push(normals[base], normals[base + 1], normals[base + 2]);
+      uvs.push(1, v);
     }
   }
 
   for (let r = 0; r < rows - 1; r++) {
     const colMax = closed ? steps : steps - 1;
     for (let c = 0; c < colMax; c++) {
-      const cNext = c + 1 >= steps ? 0 : c + 1;
-      const a = r * steps + c;
-      const b = r * steps + cNext;
-      const cc = (r + 1) * steps + cNext;
-      const d = (r + 1) * steps + c;
+      const cNext = c + 1;
+      const a = r * vertCols + c;
+      const b = r * vertCols + cNext;
+      const cc = (r + 1) * vertCols + cNext;
+      const d = (r + 1) * vertCols + c;
       indices.push(a, d, b, b, d, cc);
     }
   }
 
-  return { positions, normals, uvs, indices, rowSeg, colSeg, rows, steps };
+  return { positions, normals, uvs, indices, rowSeg, colSeg, rows, steps, vertCols };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context
After #483 (persist bake) + #484 (perf/`markRaw`), eyes still looked wrong after save/reload: one eye stretched to a thin line along the seam, placement off.

## Root causes
1. **Save never wrote `textureMap`** — undo snapshot stripped the atlas, and Save reused that path (`textureMap: null`), so reload re-baked from params.
2. **Closed lathe UV seam** — wrap faces connected `u≈1 → u=0`, so the GPU interpolated across the whole atlas on a thin +X strip (classic stretch artifact).

## Fix
- Save/Export: `snapshotState({ includeMap: true })` keeps the bake; undo still strips it (cache reattaches).
- Closed lathes (`pathSample` / `spineLathe` / torus): emit a duplicate seam column at `u=1` so wrap faces stay continuous.
- Smokes: max |Δu| on edges &lt; 0.5; Save document retains `rgba8-base64` bake.

No rewrite of #483/#484 needed — this builds cleanly on current `master`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

