### PR TITLE
Keep mesh names out of the texture assign picker

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-library-safe.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-library-safe.mjs
@@ -121,4 +121,106 @@ assert.equal(broken.objectMaterial.textureAsset, "g1", "repair missing textureAs
 assert.equal(broken.objectMaterial.textureAssign, "eyePair");
 assert.equal(broken.objectMaterial.texture, "asset");
 
+// Mesh save must not embed every open Texture-editor eye — only the assigned one.
+// (Otherwise assign picker showed "Eye · egghead" for each unused embed.)
+const meshEgg = buildProjectDocument({
+  projectKind: "mesh",
+  name: "egghead",
+  state: {
+    knots: [
+      { id: "a", x: 0.2, y: -0.5, hx: 0, hy: 0, color: "#fff" },
+      { id: "b", x: 0.3, y: 0.5, hx: 0, hy: 0, color: "#fff" },
+    ],
+    segments: [],
+    orbitKnots: [
+      { id: "o0", x: 1, y: 0, hx: 0, hy: 0, color: "#fff" },
+      { id: "o1", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+      { id: "o2", x: -1, y: 0, hx: 0, hy: 0, color: "#fff" },
+    ],
+    orbitSegments: [],
+    objectMaterial: {
+      color: null,
+      roughness: 0.4,
+      metalness: 0,
+      opacity: 1,
+      texture: "asset",
+      textureAsset: "keep-me",
+      textureAssign: "eyePair",
+    },
+    textureAssets: {
+      "keep-me": {
+        assetGuid: "keep-me",
+        name: "Eye",
+        kind: "eye",
+        layers: [{ id: "l1", type: "eyeball", name: "Eyeball", knots: [], segments: [] }],
+      },
+      "extra-open": {
+        assetGuid: "extra-open",
+        name: "Eye",
+        kind: "eye",
+        layers: [{ id: "l2", type: "eyeball", name: "Eyeball", knots: [], segments: [] }],
+      },
+    },
+  },
+});
+assert.ok(meshEgg.textureAssets["keep-me"], "assigned eye kept");
+assert.equal(meshEgg.textureAssets["extra-open"], undefined, "unassigned open eye not embedded");
+assert.equal(Object.keys(meshEgg.textureAssets).length, 1);
+
+// Texture projects still keep all assets
+const texProj = buildProjectDocument({
+  projectKind: "texture",
+  name: "Eyes pack",
+  state: {
+    knots: [
+      { id: "a", x: 0.2, y: -0.5, hx: 0, hy: 0, color: "#fff" },
+      { id: "b", x: 0.3, y: 0.5, hx: 0, hy: 0, color: "#fff" },
+    ],
+    segments: [],
+    orbitKnots: [
+      { id: "o0", x: 1, y: 0, hx: 0, hy: 0, color: "#fff" },
+      { id: "o1", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+      { id: "o2", x: -1, y: 0, hx: 0, hy: 0, color: "#fff" },
+    ],
+    orbitSegments: [],
+    textureAssets: {
+      a: {
+        assetGuid: "a",
+        name: "Eye A",
+        kind: "eye",
+        layers: [{ id: "l1", type: "eyeball", name: "Eyeball", knots: [], segments: [] }],
+      },
+      b: {
+        assetGuid: "b",
+        name: "Eye B",
+        kind: "eye",
+        layers: [{ id: "l2", type: "eyeball", name: "Eyeball", knots: [], segments: [] }],
+      },
+    },
+  },
+});
+assert.equal(Object.keys(texProj.textureAssets).length, 2);
+
+// Assign picker filter: only projectKind===texture (mesh embeds must not appear)
+{
+  const projects = [
+    { slug: "egghead", name: "egghead", projectKind: "mesh", textureCount: 2, textures: [
+      { assetGuid: "keep-me", name: "Eye" },
+      { assetGuid: "extra-open", name: "Eye" },
+    ]},
+    { slug: "eyes", name: "Eyes", projectKind: "texture", textureCount: 1, textures: [
+      { assetGuid: "tex1", name: "Eye" },
+    ]},
+  ];
+  const forPicker = projects.filter((p) => p.projectKind === "texture");
+  assert.equal(forPicker.length, 1);
+  assert.equal(forPicker[0].slug, "eyes");
+  const labels = [];
+  for (const p of forPicker) {
+    for (const t of p.textures) labels.push(`${t.name} · ${p.name}`);
+  }
+  assert.deepEqual(labels, ["Eye · Eyes"]);
+  assert.ok(!labels.some((l) => l.includes("egghead")), "mesh name must not leak into texture list");
+}
+
 console.log("smoke-library-safe: ok");

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -115,11 +115,9 @@ const { lib, refresh, load, save, saveAs, remove, exportJson, importJsonFile } =
 });
 
 const loadedTextures = computed(() => Object.values(texState.textures || {}));
-/** Saved texture projects + any project that embeds textureAssets (legacy mesh saves). */
+/** Saved texture-library entries only — mesh projects may embed textureAssets for assign, but must not appear in the texture picker. */
 const libraryTextureProjects = computed(() =>
-  (lib.projects || []).filter(
-    (p) => !p.error && (p.projectKind === "texture" || (p.textureCount || 0) > 0),
-  ),
+  (lib.projects || []).filter((p) => !p.error && p.projectKind === "texture"),
 );
 
 /** Orbit first, then place a square on the mesh, then pick a texture. */

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/AssignTextureDialog.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/AssignTextureDialog.vue
@@ -47,6 +47,8 @@ const sources = computed(() => {
 
   for (const p of props.libraryProjects || []) {
     if (p.error) continue;
+    // Mesh projects often embed a copy of the assigned eye for reload — never list them here.
+    if (p.projectKind && p.projectKind !== "texture") continue;
     const texList = Array.isArray(p.textures) ? p.textures : [];
     if (texList.length) {
       for (const t of texList) {
@@ -64,7 +66,7 @@ const sources = computed(() => {
       continue;
     }
     const texN = p.textureCount || 0;
-    if (p.projectKind === "texture" || texN > 0) {
+    if (texN > 0 || p.projectKind === "texture") {
       rows.push({
         key: `lib:${p.slug}:`,
         label: `${p.name || p.slug}${texN ? ` · ${texN} tex` : ""} (saved)`,

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -178,6 +178,27 @@ export function serializeObjectMaterial(om, opts = {}) {
   return out;
 }
 
+function collectReferencedTextureGuids(st) {
+  const guids = new Set();
+  const add = (g) => {
+    if (g) guids.add(String(g));
+  };
+  const scanSegs = (segs) => {
+    for (const s of segs || []) add(s?.textureAsset);
+  };
+  const scanBody = (body) => {
+    if (!body) return;
+    add(body.objectMaterial?.textureAsset);
+    scanSegs(body.segments);
+    scanSegs(body.orbitSegments);
+    scanSegs(body.spineProfileSegments);
+    scanSegs(body.spineOrbitSegments);
+  };
+  scanBody(st);
+  for (const body of Object.values(st.embeddedAssets || {})) scanBody(body);
+  return guids;
+}
+
 /**
  * Build a current-version project document from the live editor state.
  */
@@ -214,6 +235,20 @@ export function buildProjectDocument(opts) {
   if (texAsset && !texAssign) texAssign = "eyePair";
   if (texAsset && texMode !== "asset") texMode = "asset";
 
+  // Mesh saves only keep textures actually assigned to the mesh — not every eye
+  // open in the Texture editor (those leaked into the assign picker as "Eye · meshName").
+  if (projectKind === "mesh") {
+    const keep = collectReferencedTextureGuids({
+      ...st,
+      objectMaterial: {
+        ...(st.objectMaterial || {}),
+        textureAsset: texAsset,
+      },
+    });
+    for (const guid of Object.keys(textureAssets)) {
+      if (!keep.has(guid)) delete textureAssets[guid];
+    }
+  }
   return {
     kind: SCHEMA_KIND,
     schemaVersion: CURRENT_SCHEMA_VERSION,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
After saving a mesh (e.g. “egghead”), the Assign texture dropdown showed **Eye · egghead** (often twice). The mesh object name was leaking into the texture picker.

## Cause
1. Mesh Save embedded **every** eye open in the Texture editor into `textureAssets`.
2. The assign picker treated any library entry with `textureCount > 0` as a texture source — including mesh projects — and listed each embedded eye as `Eye · {meshName}`.

## Fix
- Picker / `libraryTextureProjects`: only `projectKind === "texture"`.
- Mesh `buildProjectDocument`: keep only texture assets referenced by the mesh (assigned guid), not all open editor eyes.
- Texture projects still save the full asset set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

