### PR TITLE
Fix wrong eye on mesh save and atlas body tint

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -326,6 +326,13 @@ const uv = rasterizeEyePairUvMap(eye, 64, 64, {
 assert.ok(uv && uv.w === 64 && uv.h === 64 && uv.rgba.length === 64 * 64 * 4);
 assert.equal(averageKnotColorHex([{ color: "#ff0000" }, { color: "#0000ff" }]), "#800080");
 assert.equal(averageKnotColorHex([], ""), "");
+// Atlas fill must use mesh tint — never texture previewBackground green
+assert.notEqual(eye.previewBackground, "#c8a070");
+assert.equal(
+  averageKnotColorHex([{ color: "#c8a070" }, { color: "#c8a070" }]),
+  "#c8a070",
+  "mesh/segment tint for atlas bg",
+);
 assert.equal(normalizeEyeUv({ scale: 99 }).scale, 3);
 assert.equal(normalizeEyeUv({ centerU: 0.4, eyeSeparationU: 0.14 }).eyeSeparationU, 0.14);
 

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-library-safe.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-library-safe.mjs
@@ -122,7 +122,6 @@ assert.equal(broken.objectMaterial.textureAssign, "eyePair");
 assert.equal(broken.objectMaterial.texture, "asset");
 
 // Mesh save must not embed every open Texture-editor eye — only the assigned one.
-// (Otherwise assign picker showed "Eye · egghead" for each unused embed.)
 const meshEgg = buildProjectDocument({
   projectKind: "mesh",
   name: "egghead",
@@ -201,16 +200,115 @@ const texProj = buildProjectDocument({
 });
 assert.equal(Object.keys(texProj.textureAssets).length, 2);
 
+// Multiple open eyes + missing textureAsset must NOT invent assetKeys[0] (wrong eye).
+const ambiguous = buildProjectDocument({
+  projectKind: "mesh",
+  name: "egghead",
+  state: {
+    knots: [
+      { id: "a", x: 0.2, y: -0.5, hx: 0, hy: 0, color: "#fff" },
+      { id: "b", x: 0.3, y: 0.5, hx: 0, hy: 0, color: "#fff" },
+    ],
+    segments: [],
+    orbitKnots: [
+      { id: "o0", x: 1, y: 0, hx: 0, hy: 0, color: "#fff" },
+      { id: "o1", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+      { id: "o2", x: -1, y: 0, hx: 0, hy: 0, color: "#fff" },
+    ],
+    orbitSegments: [],
+    objectMaterial: {
+      color: "#9a9a9a",
+      roughness: 0.4,
+      metalness: 0,
+      opacity: 1,
+      texture: "asset",
+      textureAsset: null,
+      textureAssign: "eyePair",
+    },
+    textureAssets: {
+      wrong: {
+        assetGuid: "wrong",
+        name: "Eye",
+        kind: "eye",
+        layers: [{ id: "l1", type: "eyeball", name: "Eyeball", knots: [], segments: [] }],
+      },
+      right: {
+        assetGuid: "right",
+        name: "Eye",
+        kind: "eye",
+        layers: [{ id: "l2", type: "eyeball", name: "Eyeball", knots: [], segments: [] }],
+      },
+    },
+  },
+});
+assert.equal(ambiguous.objectMaterial.textureAsset, null, "do not guess among multiple eyes");
+assert.equal(Object.keys(ambiguous.textureAssets).length, 0, "mesh embeds nothing without a guid");
+
+// Assigned guid kept; unassigned open eyes pruned from mesh save
+const assigned = buildProjectDocument({
+  projectKind: "mesh",
+  name: "egghead",
+  state: {
+    knots: [
+      { id: "a", x: 0.2, y: -0.5, hx: 0, hy: 0, color: "#fff" },
+      { id: "b", x: 0.3, y: 0.5, hx: 0, hy: 0, color: "#fff" },
+    ],
+    segments: [],
+    orbitKnots: [
+      { id: "o0", x: 1, y: 0, hx: 0, hy: 0, color: "#fff" },
+      { id: "o1", x: 0, y: 1, hx: 0, hy: 0, color: "#fff" },
+      { id: "o2", x: -1, y: 0, hx: 0, hy: 0, color: "#fff" },
+    ],
+    orbitSegments: [],
+    objectMaterial: {
+      color: "#9a9a9a",
+      roughness: 0.4,
+      metalness: 0,
+      opacity: 1,
+      texture: "asset",
+      textureAsset: "right",
+      textureAssign: "eyePair",
+    },
+    textureAssets: {
+      wrong: {
+        assetGuid: "wrong",
+        name: "Eye",
+        kind: "eye",
+        layers: [{ id: "l1", type: "eyeball", name: "Eyeball", knots: [], segments: [] }],
+      },
+      right: {
+        assetGuid: "right",
+        name: "Eye",
+        kind: "eye",
+        layers: [{ id: "l2", type: "eyeball", name: "Eyeball", knots: [], segments: [] }],
+      },
+    },
+  },
+});
+assert.equal(assigned.objectMaterial.textureAsset, "right");
+assert.ok(assigned.textureAssets.right);
+assert.equal(assigned.textureAssets.wrong, undefined);
+
 // Assign picker filter: only projectKind===texture (mesh embeds must not appear)
 {
   const projects = [
-    { slug: "egghead", name: "egghead", projectKind: "mesh", textureCount: 2, textures: [
-      { assetGuid: "keep-me", name: "Eye" },
-      { assetGuid: "extra-open", name: "Eye" },
-    ]},
-    { slug: "eyes", name: "Eyes", projectKind: "texture", textureCount: 1, textures: [
-      { assetGuid: "tex1", name: "Eye" },
-    ]},
+    {
+      slug: "egghead",
+      name: "egghead",
+      projectKind: "mesh",
+      textureCount: 2,
+      textures: [
+        { assetGuid: "keep-me", name: "Eye" },
+        { assetGuid: "extra-open", name: "Eye" },
+      ],
+    },
+    {
+      slug: "eyes",
+      name: "Eyes",
+      projectKind: "texture",
+      textureCount: 1,
+      textures: [{ assetGuid: "tex1", name: "Eye" }],
+    },
   ];
   const forPicker = projects.filter((p) => p.projectKind === "texture");
   assert.equal(forPicker.length, 1);

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -115,7 +115,7 @@ const { lib, refresh, load, save, saveAs, remove, exportJson, importJsonFile } =
 });
 
 const loadedTextures = computed(() => Object.values(texState.textures || {}));
-/** Saved texture-library entries only — mesh projects may embed textureAssets for assign, but must not appear in the texture picker. */
+/** Saved texture-library entries only — mesh embeds must not appear in the picker. */
 const libraryTextureProjects = computed(() =>
   (lib.projects || []).filter((p) => !p.error && p.projectKind === "texture"),
 );

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -968,10 +968,27 @@ export function useSplineEditor() {
   }
 
   function meshBackgroundColor() {
-    // Prefer profile knot (vertex) colors so the UV atlas matches the painted mesh.
-    const fromKnots = averageKnotColorHex(state.knots, "");
+    // Atlas non-eye fill must match the mesh body — never the Texture editor's
+    // previewBackground (green #6a8f6a). Prefer the same signals tessellation uses.
+    const om = state.objectMaterial?.color;
+    if (om && String(om).replace("#", "").length >= 6) return String(om);
+
+    const segSwatches = [];
+    for (const s of state.segments || []) {
+      if (s?.color) segSwatches.push({ color: s.color });
+    }
+    for (const s of state.orbitSegments || []) {
+      if (s?.color) segSwatches.push({ color: s.color });
+    }
+    if (segSwatches.length) {
+      const fromSegs = averageKnotColorHex(segSwatches, "");
+      if (fromSegs) return fromSegs;
+    }
+
+    const knots = [...(state.knots || []), ...(state.orbitKnots || [])];
+    const fromKnots = averageKnotColorHex(knots, "");
     if (fromKnots) return fromKnots;
-    return state.objectMaterial?.color || "#e8e4dc";
+    return "#e8e4dc";
   }
 
   function resolveTextureMap(om) {

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -483,7 +483,8 @@ function normalizeV10(doc) {
   if (textureAsset && !(v9.textureAssets || {})[textureAsset]) {
     textureAsset = assetKeys.length === 1 ? assetKeys[0] : null;
   }
-  if (!textureAsset && assetKeys.length && (texture === "asset" || textureAssign === "eyePair")) {
+  // Never guess among multiple embeds — that saved the wrong eye on mesh projects.
+  if (!textureAsset && assetKeys.length === 1 && (texture === "asset" || textureAssign === "eyePair")) {
     textureAsset = assetKeys[0];
     textureAssign = textureAssign || "eyePair";
     texture = "asset";

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -224,10 +224,11 @@ export function buildProjectDocument(opts) {
       : st.objectMaterial?.textureAssign || null;
   let texMode = st.objectMaterial?.texture || "gradient";
   if (texAsset && !textureAssets[texAsset]) {
-    // Stale guid — fall back when there is exactly one embedded texture.
+    // Stale guid — only auto-repair when there is exactly one embed (never guess among many).
     texAsset = assetKeys.length === 1 ? assetKeys[0] : null;
   }
-  if (!texAsset && assetKeys.length && (texMode === "asset" || texAssign === "eyePair")) {
+  // Only invent a guid when the mesh clearly wants an asset and there is exactly one candidate.
+  if (!texAsset && assetKeys.length === 1 && (texMode === "asset" || texAssign === "eyePair")) {
     texAsset = assetKeys[0];
     texAssign = texAssign || "eyePair";
     texMode = "asset";
@@ -235,8 +236,7 @@ export function buildProjectDocument(opts) {
   if (texAsset && !texAssign) texAssign = "eyePair";
   if (texAsset && texMode !== "asset") texMode = "asset";
 
-  // Mesh saves only keep textures actually assigned to the mesh — not every eye
-  // open in the Texture editor (those leaked into the assign picker as "Eye · meshName").
+  // Mesh saves only keep textures actually assigned — not every eye open in Texture editor.
   if (projectKind === "mesh") {
     const keep = collectReferencedTextureGuids({
       ...st,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problems
1. Mesh save could pick the **wrong eye** when several were open in the Texture editor (`textureAsset = assetKeys[0]`).
2. After assign, the whole body filled with the **texture preview green** (or other wrong tint) instead of the character’s objectMaterial / segment / vertex colors.
3. Mesh names like “egghead” still leaked into the assign texture list (same root cause as #486).

## Fixes
- Only auto-repair `textureAsset` when there is **exactly one** embedded texture; never guess among many.
- Mesh documents embed **only the assigned** texture asset.
- Atlas background tint order: `objectMaterial.color` → segment colors → knot colors (never Texture `previewBackground`).
- Assign picker lists only `projectKind === "texture"` projects.

Supersedes the intent of #486 (picker + prune) and adds the wrong-eye / body-tint fixes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

