### PR TITLE
Show library texture projects in the assign dropdown

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-library-safe.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-library-safe.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import { resolveSafeProjectDir, PROJECT_SLUG_RE } from "../src/library/safePath.mjs";
 import { createEditHistory } from "../src/lib/editHistory.js";
 import { buildProjectDocument } from "../src/library/schema.js";
+import { buildAssignTextureSources } from "../src/lib/assignTextureSources.js";
 
 const root = path.join(os.tmpdir(), "mesh-editor-lib-test");
 
@@ -319,6 +320,59 @@ assert.equal(assigned.textureAssets.wrong, undefined);
   }
   assert.deepEqual(labels, ["Eye · Eyes"]);
   assert.ok(!labels.some((l) => l.includes("egghead")), "mesh name must not leak into texture list");
+}
+
+// Dropdown must list library eyes even when the same guid is open in the editor
+{
+  const library = [
+    {
+      slug: "neutral_eyes",
+      name: "neutral_eyes",
+      projectKind: "texture",
+      textureCount: 1,
+      textures: [{ assetGuid: "g-neutral", name: "Eye" }],
+    },
+    {
+      slug: "evil_eyes",
+      name: "evil_eyes",
+      projectKind: "texture",
+      textureCount: 1,
+      textures: [{ assetGuid: "g-evil", name: "Eye" }],
+    },
+    {
+      slug: "eye_normal",
+      name: "eye_normal",
+      projectKind: "texture",
+      textureCount: 1,
+      textures: [{ assetGuid: "g-normal", name: "Eye" }],
+    },
+  ];
+  // Same guids open in editor (previously hid every library row)
+  const loaded = [
+    { assetGuid: "g-neutral", name: "Eye" },
+    { assetGuid: "g-evil", name: "Eye" },
+    { assetGuid: "orphan-open", name: "Eye" },
+  ];
+  const rows = buildAssignTextureSources(loaded, library);
+  const labels = rows.map((r) => r.label);
+  assert.equal(rows.filter((r) => r.kind === "library").length, 3, "all 3 library eyes listed");
+  assert.ok(labels.includes("Eye · neutral_eyes"));
+  assert.ok(labels.includes("Eye · evil_eyes"));
+  assert.ok(labels.includes("Eye · eye_normal"));
+  assert.equal(rows.filter((r) => r.kind === "loaded").length, 1, "only orphan open eye");
+  assert.ok(labels.some((l) => l.startsWith("Eye (open · orphan-o")));
+  // Mesh projects still excluded
+  const withMesh = buildAssignTextureSources(loaded, [
+    ...library,
+    {
+      slug: "egghead",
+      name: "egghead",
+      projectKind: "mesh",
+      textureCount: 1,
+      textures: [{ assetGuid: "g-mesh", name: "Eye" }],
+    },
+  ]);
+  assert.ok(!withMesh.some((r) => String(r.label).includes("egghead")));
 }
 
 console.log("smoke-library-safe: ok");

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/AssignTextureDialog.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/AssignTextureDialog.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, nextTick, reactive, ref, watch } from "vue";
 import { DEFAULT_EYE_UV, normalizeEyeUv } from "../lib/texture/eyeTexture.js";
+import { buildAssignTextureSources } from "../lib/assignTextureSources.js";
 import * as api from "../library/api.js";
 
 const props = defineProps({
@@ -29,55 +30,9 @@ const uv = reactive({
 const status = ref("");
 const resolving = ref(false);
 
-const sources = computed(() => {
-  const rows = [];
-  const seen = new Set();
-
-  for (const t of props.loadedTextures || []) {
-    if (!t?.assetGuid || seen.has(t.assetGuid)) continue;
-    seen.add(t.assetGuid);
-    rows.push({
-      key: `loaded:${t.assetGuid}`,
-      label: `${t.name || "Texture"} (open in editor)`,
-      kind: "loaded",
-      guid: t.assetGuid,
-      slug: null,
-    });
-  }
-
-  for (const p of props.libraryProjects || []) {
-    if (p.error) continue;
-    // Mesh projects often embed a copy of the assigned eye for reload — never list them here.
-    if (p.projectKind && p.projectKind !== "texture") continue;
-    const texList = Array.isArray(p.textures) ? p.textures : [];
-    if (texList.length) {
-      for (const t of texList) {
-        if (!t?.assetGuid) continue;
-        if (seen.has(t.assetGuid)) continue;
-        seen.add(t.assetGuid);
-        rows.push({
-          key: `lib:${p.slug}:${t.assetGuid}`,
-          label: `${t.name || "Texture"} · ${p.name || p.slug}`,
-          kind: "library",
-          guid: t.assetGuid,
-          slug: p.slug,
-        });
-      }
-      continue;
-    }
-    const texN = p.textureCount || 0;
-    if (texN > 0 || p.projectKind === "texture") {
-      rows.push({
-        key: `lib:${p.slug}:`,
-        label: `${p.name || p.slug}${texN ? ` · ${texN} tex` : ""} (saved)`,
-        kind: "library",
-        guid: null,
-        slug: p.slug,
-      });
-    }
-  }
-  return rows;
-});
+const sources = computed(() =>
+  buildAssignTextureSources(props.loadedTextures, props.libraryProjects),
+);
 
 function resetFromProps() {
   const next = normalizeEyeUv(props.initialUv || DEFAULT_EYE_UV);

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/assignTextureSources.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/assignTextureSources.js
@@ -1,0 +1,77 @@
+// ============================================================================
+// assignTextureSources.js — options for the Assign eye-texture dropdown.
+// ============================================================================
+
+/**
+ * Build dropdown rows: saved texture-library projects first, then editor-only assets.
+ * Library rows are never hidden just because the same guid is open in the editor.
+ *
+ * @param {Array<{ assetGuid?: string, name?: string }>} loadedTextures
+ * @param {Array<{
+ *   error?: string,
+ *   projectKind?: string,
+ *   slug?: string,
+ *   name?: string,
+ *   textureCount?: number,
+ *   textures?: Array<{ assetGuid?: string, name?: string }>
+ * }>} libraryProjects
+ * @returns {Array<{ key: string, label: string, kind: string, guid: string|null, slug: string|null }>}
+ */
+export function buildAssignTextureSources(loadedTextures, libraryProjects) {
+  const rows = [];
+  const seenGuid = new Set();
+  const seenKey = new Set();
+
+  for (const p of libraryProjects || []) {
+    if (p?.error) continue;
+    if (p.projectKind && p.projectKind !== "texture") continue;
+    const texList = Array.isArray(p.textures) ? p.textures : [];
+    let added = 0;
+    for (const t of texList) {
+      const guid = t?.assetGuid ? String(t.assetGuid) : "";
+      const key = guid ? `lib:${p.slug}:${guid}` : `lib:${p.slug}:`;
+      if (seenKey.has(key)) continue;
+      seenKey.add(key);
+      rows.push({
+        key,
+        label: `${t?.name || "Texture"} · ${p.name || p.slug}`,
+        kind: "library",
+        guid: guid || null,
+        slug: p.slug || null,
+      });
+      if (guid) seenGuid.add(guid);
+      added += 1;
+    }
+    if (!added && (p.projectKind === "texture" || (p.textureCount || 0) > 0)) {
+      const key = `lib:${p.slug}:`;
+      if (!seenKey.has(key)) {
+        seenKey.add(key);
+        const texN = p.textureCount || 0;
+        rows.push({
+          key,
+          label: `${p.name || p.slug}${texN ? ` · ${texN} tex` : ""} (saved)`,
+          kind: "library",
+          guid: null,
+          slug: p.slug || null,
+        });
+      }
+    }
+  }
+
+  for (const t of loadedTextures || []) {
+    const guid = t?.assetGuid ? String(t.assetGuid) : "";
+    if (!guid || seenGuid.has(guid)) continue;
+    seenGuid.add(guid);
+    const key = `loaded:${guid}`;
+    if (seenKey.has(key)) continue;
+    seenKey.add(key);
+    rows.push({
+      key,
+      label: `${t.name || "Texture"} (open · ${guid.slice(0, 8)}…)`,
+      kind: "loaded",
+      guid,
+      slug: null,
+    });
+  }
+  return rows;
+}

--- a/gallery/game_engine/v2/mesh_editor/app/vite-plugin-library.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/vite-plugin-library.mjs
@@ -69,10 +69,10 @@ function listProjects(root) {
       const d = mig.doc;
       const projectKind = d.projectKind === "texture" ? "texture" : "mesh";
       const textureAssets = d.textureAssets || {};
-      const textures = Object.values(textureAssets).map((t) => ({
-        assetGuid: t.assetGuid,
-        name: t.name || "Texture",
-        kind: t.kind || "eye",
+      const textures = Object.entries(textureAssets).map(([guid, t]) => ({
+        assetGuid: t?.assetGuid || guid,
+        name: t?.name || "Texture",
+        kind: t?.kind || "eye",
       }));
       const textureCount = textures.length;
       out.push({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Assign dropdown showed only duplicate **Eye (open in editor)** rows. Library entries (`neutral_eyes`, `evil_eyes`, `eye_normal`) never appeared.

## Cause
Dropdown built loaded editor textures first, then skipped any library texture whose `assetGuid` was already open. Loading/saving eyes put those guids in the editor, so every library row was filtered out. Two default/open eyes with the same name looked like duplicates.

## Fix
- List **library texture projects first** (always), labeled `Eye · {projectName}`.
- Only then list editor-only assets not already offered by the library, with a short guid suffix.
- Library list API fills `assetGuid` from the `textureAssets` map key when missing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

