### PR TITLE
Eye emotion poses: topology tags + morph-compatible rig (schema v12)

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -194,6 +194,11 @@ Use **Add** to insert more knots.
 the same knot topology so emotions can morph. Compatible textures share
 `topologyKey`. Design: [`docs/EYE_EMOTION_RIG.md`](./docs/EYE_EMOTION_RIG.md).
 
+**Anim preview (mesh toolbar):** after **Assign to mesh**, use **Anim preview**
+to pick an animation class (currently **Emotion**) and morph From → To. If the
+texture has no targets yet, **Seed demo emotions** builds procedural variants
+for testing; the 3D preview re-bakes the UV atlas as you drag Morph.
+
 ## Shading base
 
 Teapot-inspired modes exercised against Ranger Three:

--- a/gallery/game_engine/v2/mesh_editor/README.md
+++ b/gallery/game_engine/v2/mesh_editor/README.md
@@ -189,6 +189,11 @@ Eye paths default to a **4-knot circle** (same κ ≈ 0.552 as Mesh Orbit). Tool
 recomputes Bezier handles after moving a **point** (not while dragging handles).
 Use **Add** to insert more knots.
 
+**Emotion poses (schema v12):** each eye texture has `partClass: "eye"`, an
+`emotion` tag, a `topologyKey` fingerprint, and optional `poses[]` snapshots of
+the same knot topology so emotions can morph. Compatible textures share
+`topologyKey`. Design: [`docs/EYE_EMOTION_RIG.md`](./docs/EYE_EMOTION_RIG.md).
+
 ## Shading base
 
 Teapot-inspired modes exercised against Ranger Three:

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -27,6 +27,7 @@ import {
 import {
   PART_CLASS_EYE,
   EYE_EMOTION_TAGS,
+  ANIM_CLASS_EMOTION,
   normalizeEmotionTag,
   eyeTopologyKey,
   defaultEyeTopologyKey,
@@ -40,6 +41,11 @@ import {
   upsertEyePose,
   eyeLibraryTags,
   compileEyeRig,
+  listAnimClassesForPart,
+  listAnimTargets,
+  ensureDemoAnimTargets,
+  morphTextureAnim,
+  getPoseForTarget,
 } from "../src/lib/texture/eyeEmotion.js";
 import {
   clampAssignRegion,
@@ -593,6 +599,33 @@ assert.equal(mig10.doc.objectMaterial.textureMap, null);
   assert.equal(migratedEye.emotion, "neutral");
   assert.ok(typeof migratedEye.topologyKey === "string");
   assert.ok(Array.isArray(migratedEye.poses));
+
+  // Animation class + demo targets + morphTextureAnim (preview path)
+  const classes = listAnimClassesForPart(PART_CLASS_EYE);
+  assert.ok(classes.some((c) => c.id === ANIM_CLASS_EMOTION));
+  const demoTex = createDefaultEyeTexture({ name: "DemoAnim" });
+  const seeded = ensureDemoAnimTargets(demoTex);
+  assert.ok(seeded.includes("neutral"));
+  assert.ok(seeded.includes("angry"));
+  assert.ok(seeded.includes("sad"));
+  assert.equal(listAnimTargets(demoTex, ANIM_CLASS_EMOTION).length, seeded.length);
+  assert.ok(getPoseForTarget(demoTex, ANIM_CLASS_EMOTION, "angry")?.animClass === "emotion");
+  const morphed = morphTextureAnim(demoTex, {
+    animClass: ANIM_CLASS_EMOTION,
+    from: "neutral",
+    to: "angry",
+    t: 0.5,
+  });
+  assert.ok(morphed);
+  const lidY0 = getPoseForTarget(demoTex, "emotion", "neutral").layers.eyelid.knots[0].y;
+  const lidY1 = getPoseForTarget(demoTex, "emotion", "angry").layers.eyelid.knots[0].y;
+  const midY = findLayer(morphed, "eyelid").knots[0].y;
+  assert.ok(Math.abs(midY - (lidY0 + lidY1) * 0.5) < 1e-6);
+  // Source layers unchanged by morphTextureAnim
+  assert.ok(
+    Math.abs(findLayer(demoTex, "eyelid").knots[0].y - lidY0) < 1e-6 ||
+      findLayer(demoTex, "eyelid").enabled === false,
+  );
 }
 
 // Save path: buildProjectDocument must keep bake when state carries a live map

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -25,6 +25,23 @@ import {
   layersWithEyeballColor,
 } from "../src/lib/texture/eyeTexture.js";
 import {
+  PART_CLASS_EYE,
+  EYE_EMOTION_TAGS,
+  normalizeEmotionTag,
+  eyeTopologyKey,
+  defaultEyeTopologyKey,
+  areEyeTexturesCompatible,
+  listCompatibleEyeTextures,
+  captureEyePose,
+  applyEyePose,
+  interpolateEyePose,
+  interpolateKnot,
+  validateEyePoseTopology,
+  upsertEyePose,
+  eyeLibraryTags,
+  compileEyeRig,
+} from "../src/lib/texture/eyeEmotion.js";
+import {
   clampAssignRegion,
   regionCorners,
   DEFAULT_ASSIGN_REGION,
@@ -298,22 +315,22 @@ const doc = buildProjectDocument({
   slug: "with-eye",
   projectKind: "mesh",
 });
-assert.equal(doc.schemaVersion, 11);
+assert.equal(doc.schemaVersion, CURRENT_SCHEMA_VERSION);
 assert.equal(doc.projectKind, "mesh");
 assert.ok(doc.textureAssets[ser.assetGuid]);
 assert.equal(doc.objectMaterial.textureAssign, "eyePair");
 
 const mig = migrateProject(doc);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
-assert.equal(CURRENT_SCHEMA_VERSION, 11);
-assert.equal(mig.doc.schemaVersion, 11);
+assert.equal(CURRENT_SCHEMA_VERSION, 12);
+assert.equal(mig.doc.schemaVersion, 12);
 assert.equal(mig.doc.projectKind, "mesh");
 assert.ok(mig.doc.textureAssets[ser.assetGuid].layers.length >= 4);
 
 // Texture-only library entry validates without mesh profile
 const texOnly = {
   kind: "ranger.splineProject",
-  schemaVersion: 11,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   projectKind: "texture",
   name: "Eyes only",
   textureAssets: { [ser.assetGuid]: ser },
@@ -460,7 +477,7 @@ const docWithBake = buildProjectDocument({
   slug: "baked-eyes",
   projectKind: "mesh",
 });
-assert.equal(docWithBake.schemaVersion, 11);
+assert.equal(docWithBake.schemaVersion, CURRENT_SCHEMA_VERSION);
 assert.ok(docWithBake.objectMaterial.textureMap?.encoding === "rgba8-base64");
 assert.deepEqual(validateProject(docWithBake), []);
 const migBake = migrateProject(JSON.parse(JSON.stringify(docWithBake)));
@@ -478,8 +495,105 @@ v10.schemaVersion = 10;
 delete v10.objectMaterial.textureMap;
 const mig10 = migrateProject(v10);
 assert.equal(mig10.ok, true, mig10.errors?.join("; "));
-assert.equal(mig10.doc.schemaVersion, 11);
+assert.equal(mig10.doc.schemaVersion, CURRENT_SCHEMA_VERSION);
 assert.equal(mig10.doc.objectMaterial.textureMap, null);
+
+// --- Emotion poses / topology compatibility (schema v12) ---
+{
+  assert.equal(normalizeEmotionTag(" Angry!! "), "angry");
+  assert.ok(EYE_EMOTION_TAGS.includes("neutral"));
+  assert.equal(eye.partClass, PART_CLASS_EYE);
+  assert.equal(eye.emotion, "neutral");
+  assert.equal(eye.topologyKey, defaultEyeTopologyKey());
+  assert.ok(eye.topologyKey.startsWith("eye:v1/eyeball:4c"));
+  assert.ok(eye.topologyKey.includes("eyelid:3o:fill=above:clip=eyeball"));
+
+  const tags = eyeLibraryTags({ emotion: "sad", topologyKey: eye.topologyKey });
+  assert.ok(tags.includes("part:eye"));
+  assert.ok(tags.includes("emotion:sad"));
+  assert.ok(tags.some((t) => t.startsWith("topo:")));
+
+  const neutral = captureEyePose(eye, { emotion: "neutral", name: "Neutral", id: "pose_neutral" });
+  assert.ok(neutral);
+  assert.equal(neutral.layers.eyeball.knots.length, 4);
+  assert.equal(neutral.layers.eyelid.knots.length, 3);
+  assert.deepEqual(validateEyePoseTopology(eye, neutral), { ok: true, errors: [] });
+
+  // Mutate eyelid into an "angry" shape (same knot count)
+  const lid = findLayer(eye, "eyelid");
+  lid.enabled = true;
+  lid.knots[0].y += 0.12;
+  lid.knots[1].y -= 0.08;
+  lid.knots[2].y += 0.12;
+  const angry = captureEyePose(eye, { emotion: "angry", name: "Angry", id: "pose_angry" });
+  upsertEyePose(eye, neutral);
+  upsertEyePose(eye, angry);
+  assert.equal(eye.poses.length, 2);
+  assert.equal(eye.activePoseId, "pose_angry");
+
+  const mid = interpolateEyePose(neutral, angry, 0.5);
+  assert.ok(mid);
+  assert.equal(mid.layers.eyelid.knots.length, 3);
+  const k0 = interpolateKnot(neutral.layers.eyelid.knots[0], angry.layers.eyelid.knots[0], 0.5);
+  assert.ok(Math.abs(mid.layers.eyelid.knots[0].y - k0.y) < 1e-9);
+
+  applyEyePose(eye, neutral);
+  assert.equal(eye.emotion, "neutral");
+  assert.ok(Math.abs(findLayer(eye, "eyelid").knots[0].y - neutral.layers.eyelid.knots[0].y) < 1e-9);
+
+  const twin = createDefaultEyeTexture({ name: "Twin" });
+  assert.ok(areEyeTexturesCompatible(eye, twin));
+  // Break topology: drop a pupil knot → incompatible
+  const broken = createDefaultEyeTexture({ name: "Broken" });
+  const pupil = findLayer(broken, "pupil");
+  pupil.knots.pop();
+  broken.topologyKey = eyeTopologyKey(broken);
+  assert.equal(areEyeTexturesCompatible(eye, broken), false);
+  assert.equal(listCompatibleEyeTextures([twin, broken], eye).length, 1);
+
+  // Incompatible pose is dropped on normalize
+  const badPose = {
+    id: "pose_bad",
+    emotion: "happy",
+    layers: { eyeball: { knots: [{ x: 0, y: 0, hx: 0, hy: 0 }] } },
+  };
+  const round = normalizeEyeTexture(serializeEyeTexture(eye));
+  assert.equal(round.poses.length, 2);
+  assert.equal(round.partClass, "eye");
+  assert.ok(round.topologyKey);
+  const dropped = normalizeEyeTexture({
+    ...serializeEyeTexture(eye),
+    poses: [...serializeEyeTexture(eye).poses, badPose],
+  });
+  assert.equal(dropped.poses.length, 2, "bad topology pose dropped");
+
+  const rig = compileEyeRig(eye, { samplesPerSpan: 8 });
+  assert.ok(rig);
+  assert.equal(rig.topologyKey, eye.topologyKey);
+  const eb = rig.layers.find((L) => L.role === "eyeball");
+  assert.ok(eb.poses.pose_neutral instanceof Float32Array);
+  assert.ok(eb.poses.pose_angry.length > 8);
+  assert.equal(eb.poses.pose_neutral.length, eb.poses.pose_angry.length);
+
+  // v11 → v12 migration fills emotion fields
+  const v11doc = JSON.parse(JSON.stringify(doc));
+  v11doc.schemaVersion = 11;
+  for (const t of Object.values(v11doc.textureAssets)) {
+    delete t.partClass;
+    delete t.emotion;
+    delete t.topologyKey;
+    delete t.poses;
+    delete t.activePoseId;
+  }
+  const mig12 = migrateProject(v11doc);
+  assert.equal(mig12.ok, true, mig12.errors?.join("; "));
+  assert.equal(mig12.doc.schemaVersion, 12);
+  const migratedEye = mig12.doc.textureAssets[ser.assetGuid];
+  assert.equal(migratedEye.partClass, "eye");
+  assert.equal(migratedEye.emotion, "neutral");
+  assert.ok(typeof migratedEye.topologyKey === "string");
+  assert.ok(Array.isArray(migratedEye.poses));
+}
 
 // Save path: buildProjectDocument must keep bake when state carries a live map
 {

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -326,8 +326,8 @@ const v7 = {
 
 const mig = migrateProject(v7);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
-assert.equal(CURRENT_SCHEMA_VERSION, 11);
-assert.equal(mig.doc.schemaVersion, 11);
+assert.equal(CURRENT_SCHEMA_VERSION, 12);
+assert.equal(mig.doc.schemaVersion, 12);
 assert.equal(mig.doc.children[0].transform.surface, false);
 assert.equal(mig.doc.children[0].transform.z, 0);
 

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-placement-normal.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-placement-normal.mjs
@@ -121,7 +121,7 @@ const v5 = {
 const mig = migrateProject(v5);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
 assert.equal(mig.doc.schemaVersion, CURRENT_SCHEMA_VERSION);
-assert.equal(CURRENT_SCHEMA_VERSION, 11);
+assert.equal(CURRENT_SCHEMA_VERSION, 12);
 assert.deepEqual(mig.doc.placementNormal.start, { x: 0, y: -1 });
 assert.deepEqual(mig.doc.placementNormal.end, { x: 0, y: 1 });
 assert.equal(mig.doc.editor.tessellationMode, "rotation");

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-torus.mjs
@@ -157,7 +157,7 @@ const v6 = {
 const mig = migrateProject(v6);
 assert.equal(mig.ok, true, mig.errors?.join("; "));
 assert.equal(mig.doc.schemaVersion, CURRENT_SCHEMA_VERSION);
-assert.equal(CURRENT_SCHEMA_VERSION, 11);
+assert.equal(CURRENT_SCHEMA_VERSION, 12);
 assert.equal(mig.doc.editor.tessellationMode, "rotation");
 const errs = validateProject(mig.doc);
 assert.equal(errs.length, 0, errs.join("; "));

--- a/gallery/game_engine/v2/mesh_editor/app/src/App.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/App.vue
@@ -9,10 +9,15 @@ import ChildrenPanel from "./components/ChildrenPanel.vue";
 import TextureLayerPanel from "./components/TextureLayerPanel.vue";
 import TexturePreview from "./components/TexturePreview.vue";
 import AssignTextureDialog from "./components/AssignTextureDialog.vue";
+import TextureAnimPanel from "./components/TextureAnimPanel.vue";
 import { useSplineEditor } from "./composables/useSplineEditor.js";
 import { useTextureEditor } from "./composables/useTextureEditor.js";
 import { useLibrary } from "./composables/useLibrary.js";
 import { normalizeEyeUv } from "./lib/texture/eyeTexture.js";
+import {
+  ANIM_CLASS_EMOTION,
+  ensureDemoAnimTargets,
+} from "./lib/texture/eyeEmotion.js";
 import * as api from "./library/api.js";
 
 const {
@@ -55,6 +60,7 @@ const {
   activePlacementNormal,
   setTextureAssetsProvider,
   assignEyeTextureToRootAsync,
+  previewAssignedAnimMorph,
   clearAssignedTexture,
 } = useSplineEditor();
 
@@ -78,8 +84,19 @@ const assignProgress = ref("");
 const assignRegionMode = ref(false);
 /** UV derived from the confirmed square (fed into the texture dialog). */
 const assignRegionUv = ref(null);
+const animMorphBusy = ref(false);
+/** Coalesce slider morph rebakes to one in-flight pass. */
+let animMorphQueued = null;
+let animMorphRunning = false;
 
 setTextureAssetsProvider(() => tex.snapshotTextures());
+
+/** Live assigned eye texture (editor object — poses mutate here). */
+const assignedTexture = computed(() => {
+  const guid = state.objectMaterial?.textureAsset;
+  if (!guid) return null;
+  return texState.textures[guid] || null;
+});
 
 function snapshotState(kind) {
   const k = kind === "texture" ? "texture" : "mesh";
@@ -200,6 +217,63 @@ function onClearAssignedTexture() {
   assignRegionUv.value = null;
   clearAssignedTexture();
   tessellate();
+}
+
+function persistSeededPoses(seeded) {
+  const guid = state.objectMaterial?.textureAsset;
+  const live = guid ? texState.textures[guid] : null;
+  if (!live || !seeded) return;
+  live.poses = seeded.poses;
+  live.topologyKey = seeded.topologyKey;
+  live.emotion = seeded.emotion || live.emotion;
+  live.partClass = seeded.partClass || live.partClass;
+}
+
+function onSeedAnimTargets({ animClass } = {}) {
+  const live = assignedTexture.value;
+  if (!live) {
+    state.status = "Assign an eye texture before seeding anim targets.";
+    return;
+  }
+  const cls = animClass || ANIM_CLASS_EMOTION;
+  if (cls === ANIM_CLASS_EMOTION) {
+    const targets = ensureDemoAnimTargets(live);
+    state.status = `Seeded emotion targets: ${targets.join(", ")}`;
+  }
+}
+
+async function runAnimMorph(opts) {
+  const finalPass = !!opts.finalPass;
+  animMorphBusy.value = true;
+  try {
+    await previewAssignedAnimMorph({
+      animClass: opts.animClass || ANIM_CLASS_EMOTION,
+      from: opts.from,
+      to: opts.to,
+      t: opts.t,
+      width: finalPass ? 384 : 256,
+      height: finalPass ? 384 : 256,
+      seedDemo: false,
+      mutateSource: persistSeededPoses,
+    });
+  } finally {
+    animMorphBusy.value = false;
+  }
+}
+
+async function onAnimMorph(opts) {
+  animMorphQueued = opts;
+  if (animMorphRunning) return;
+  animMorphRunning = true;
+  try {
+    while (animMorphQueued) {
+      const next = animMorphQueued;
+      animMorphQueued = null;
+      await runAnimMorph(next);
+    }
+  } finally {
+    animMorphRunning = false;
+  }
 }
 
 const materials = [
@@ -689,6 +763,13 @@ onBeforeUnmount(() => {
       >
         Clear texture
       </button>
+      <TextureAnimPanel
+        :texture="assignedTexture"
+        :disabled="!state.objectMaterial?.textureAsset || assignBusy"
+        :busy="animMorphBusy"
+        @seed="onSeedAnimTargets"
+        @morph="onAnimMorph"
+      />
       <div class="mats">
         <span>Shading base</span>
         <div class="mat-row">

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/TextureAnimPanel.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/TextureAnimPanel.vue
@@ -1,0 +1,269 @@
+<script setup>
+/**
+ * Mesh-side animation class preview: pick class (e.g. emotion), from/to targets,
+ * and morph 0…1. Re-bakes the assigned eye atlas into the 3D preview.
+ */
+import { computed, ref, watch } from "vue";
+import {
+  ANIM_CLASS_EMOTION,
+  listAnimClassesForPart,
+  listAnimTargets,
+  ensureDemoAnimTargets,
+  PART_CLASS_EYE,
+} from "../lib/texture/eyeEmotion.js";
+
+const props = defineProps({
+  /** Assigned texture asset (live editor object), or null */
+  texture: { type: Object, default: null },
+  disabled: { type: Boolean, default: false },
+  busy: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["morph", "seed"]);
+
+const animClass = ref(ANIM_CLASS_EMOTION);
+const fromTarget = ref("neutral");
+const toTarget = ref("angry");
+const morphT = ref(0);
+const scrubbing = ref(false);
+
+const classes = computed(() =>
+  listAnimClassesForPart(props.texture?.partClass || PART_CLASS_EYE),
+);
+
+const targets = computed(() => {
+  if (!props.texture) return [];
+  return listAnimTargets(props.texture, animClass.value);
+});
+
+const hasTargets = computed(() => targets.value.length >= 2);
+
+const classLabel = computed(() => {
+  const c = classes.value.find((x) => x.id === animClass.value);
+  return c?.label || animClass.value;
+});
+
+watch(
+  targets,
+  (list) => {
+    if (!list.length) return;
+    if (!list.includes(fromTarget.value)) fromTarget.value = list[0];
+    if (!list.includes(toTarget.value)) {
+      toTarget.value = list.find((t) => t !== fromTarget.value) || list[0];
+    }
+  },
+  { immediate: true },
+);
+
+function emitMorph(finalPass = false) {
+  emit("morph", {
+    animClass: animClass.value,
+    from: fromTarget.value,
+    to: toTarget.value,
+    t: morphT.value,
+    finalPass,
+  });
+}
+
+function onSliderInput() {
+  scrubbing.value = true;
+  emitMorph(false);
+}
+
+function onSliderChange() {
+  scrubbing.value = false;
+  emitMorph(true);
+}
+
+function onSeed() {
+  emit("seed", { animClass: animClass.value });
+}
+
+function swap() {
+  const a = fromTarget.value;
+  fromTarget.value = toTarget.value;
+  toTarget.value = a;
+  emitMorph(true);
+}
+
+function jump(t) {
+  morphT.value = t;
+  emitMorph(true);
+}
+
+/** Expose ensure for parent if needed */
+defineExpose({ ensureDemoAnimTargets, targets, animClass });
+</script>
+
+<template>
+  <div class="anim-panel" :class="{ dim: disabled }">
+    <div class="anim-head">
+      <span class="anim-title">Anim preview</span>
+      <span class="anim-sub">{{ classLabel }} A → B</span>
+    </div>
+
+    <p v-if="!texture" class="anim-hint">Assign an eye texture to enable morph preview.</p>
+    <template v-else>
+      <label class="field">
+        Class
+        <select v-model="animClass" :disabled="disabled || busy">
+          <option v-for="c in classes" :key="c.id" :value="c.id">{{ c.label }}</option>
+        </select>
+      </label>
+
+      <div v-if="!hasTargets" class="anim-seed">
+        <p class="anim-hint">
+          No {{ classLabel.toLowerCase() }} targets on this texture yet.
+        </p>
+        <button
+          type="button"
+          class="primary"
+          :disabled="disabled || busy"
+          title="Create procedural emotion targets from the current eye for testing"
+          @click="onSeed"
+        >
+          Seed demo emotions
+        </button>
+      </div>
+
+      <template v-else>
+        <div class="anim-row">
+          <label class="field">
+            From
+            <select v-model="fromTarget" :disabled="disabled || busy" @change="emitMorph(true)">
+              <option v-for="t in targets" :key="'f-' + t" :value="t">{{ t }}</option>
+            </select>
+          </label>
+          <button
+            type="button"
+            class="swap"
+            title="Swap from/to"
+            :disabled="disabled || busy"
+            @click="swap"
+          >
+            ↔
+          </button>
+          <label class="field">
+            To
+            <select v-model="toTarget" :disabled="disabled || busy" @change="emitMorph(true)">
+              <option v-for="t in targets" :key="'t-' + t" :value="t">{{ t }}</option>
+            </select>
+          </label>
+        </div>
+
+        <label class="field morph">
+          Morph
+          <input
+            v-model.number="morphT"
+            type="range"
+            min="0"
+            max="1"
+            step="0.02"
+            :disabled="disabled || busy"
+            @input="onSliderInput"
+            @change="onSliderChange"
+          />
+          <span class="morph-val">{{ Math.round(morphT * 100) }}%</span>
+        </label>
+
+        <div class="anim-jumps">
+          <button type="button" :disabled="disabled || busy" @click="jump(0)">A</button>
+          <button type="button" :disabled="disabled || busy" @click="jump(0.5)">½</button>
+          <button type="button" :disabled="disabled || busy" @click="jump(1)">B</button>
+          <button
+            type="button"
+            :disabled="disabled || busy"
+            title="Add/refresh procedural emotion targets"
+            @click="onSeed"
+          >
+            Reseed
+          </button>
+        </div>
+      </template>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.anim-panel {
+  margin-top: 0.65rem;
+  padding: 0.65rem 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+.anim-panel.dim {
+  opacity: 0.55;
+}
+.anim-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+.anim-title {
+  font-weight: 600;
+  font-size: 0.92rem;
+}
+.anim-sub {
+  color: var(--ink-dim);
+  font-size: 0.78rem;
+}
+.anim-hint {
+  margin: 0;
+  color: var(--ink-dim);
+  font-size: 0.8rem;
+  line-height: 1.35;
+}
+.anim-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0.35rem;
+  align-items: end;
+}
+.swap {
+  padding: 0.35rem 0.45rem;
+  margin-bottom: 0.05rem;
+}
+.morph {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  gap: 0.25rem 0.5rem;
+  align-items: center;
+}
+.morph input[type="range"] {
+  grid-column: 1 / -1;
+  width: 100%;
+}
+.morph-val {
+  font-variant-numeric: tabular-nums;
+  color: var(--ink-dim);
+  font-size: 0.8rem;
+  justify-self: end;
+}
+.anim-jumps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+.anim-jumps button {
+  padding: 0.3rem 0.55rem;
+  font-size: 0.8rem;
+}
+.anim-seed {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  align-items: flex-start;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.78rem;
+  color: var(--ink-dim);
+}
+</style>

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useSplineEditor.js
@@ -9,6 +9,14 @@ import {
   averageKnotColorHex,
   DEFAULT_EYE_UV,
 } from "../lib/texture/eyeTexture.js";
+import {
+  ANIM_CLASS_EMOTION,
+  ensureDemoAnimTargets,
+  listAnimTargets,
+  morphTextureAnim,
+  normalizeAnimClassId,
+  normalizeAnimTarget,
+} from "../lib/texture/eyeEmotion.js";
 import { normalizeTextureMap } from "../lib/texture/textureMapCodec.js";
 import { transformParts } from "../lib/meshTransform.js";
 import { evalSpan as evalPathSpan } from "../lib/pathSample.js";
@@ -1125,6 +1133,105 @@ export function useSplineEditor() {
     return true;
   }
 
+  /**
+   * Live-preview an animation-class morph (e.g. emotion A→B) on the assigned
+   * eye texture by re-baking the UV atlas. Does not alter authoring layers.
+   *
+   * @param {{
+   *   animClass?: string,
+   *   from: string,
+   *   to: string,
+   *   t?: number,
+   *   width?: number,
+   *   height?: number,
+   *   seedDemo?: boolean,
+   *   mutateSource?: (tex: object) => void,
+   * }} opts
+   * mutateSource — optional hook to persist seeded poses into the texture store
+   */
+  async function previewAssignedAnimMorph(opts = {}) {
+    const guid = String(state.objectMaterial?.textureAsset || "").trim();
+    if (!guid) {
+      state.status = "Assign an eye texture before anim morph preview.";
+      return false;
+    }
+    const assets = textureAssetsProvider() || {};
+    const raw = assets[guid];
+    if (!raw) {
+      state.status = "Assigned texture is not loaded in the Texture editor.";
+      return false;
+    }
+    const live = raw.kind === "eye" || !raw.kind ? normalizeEyeTexture(raw) : raw;
+    if (live.kind !== "eye") {
+      state.status = "Anim morph preview currently supports eye textures only.";
+      return false;
+    }
+
+    const animClass = normalizeAnimClassId(opts.animClass || ANIM_CLASS_EMOTION);
+    if (opts.seedDemo !== false && animClass === ANIM_CLASS_EMOTION) {
+      const before = listAnimTargets(live, animClass).length;
+      ensureDemoAnimTargets(live);
+      if (listAnimTargets(live, animClass).length > before && typeof opts.mutateSource === "function") {
+        opts.mutateSource(live);
+      } else if (listAnimTargets(live, animClass).length > before) {
+        // Best-effort: copy poses onto the provider's live object if same ref.
+        if (raw.poses !== live.poses) {
+          raw.poses = live.poses;
+          raw.topologyKey = live.topologyKey;
+        }
+      }
+    }
+
+    const from = normalizeAnimTarget(opts.from);
+    const to = normalizeAnimTarget(opts.to);
+    const t = Math.min(1, Math.max(0, Number(opts.t) || 0));
+    const targets = listAnimTargets(live, animClass);
+    if (!targets.includes(from) || !targets.includes(to)) {
+      state.status = `Missing ${animClass} targets (need “${from}” and “${to}”). Seed demo poses or capture poses first.`;
+      return false;
+    }
+
+    const morphed = morphTextureAnim(live, { animClass, from, to, t });
+    if (!morphed) {
+      state.status = "Could not morph poses — check topology match.";
+      return false;
+    }
+
+    const nextUv = normalizeEyeUv(state.objectMaterial?.textureUv);
+    const map = await rasterizeEyePairUvMapAsync(
+      morphed,
+      opts.width || 256,
+      opts.height || 256,
+      {
+        uv: nextUv,
+        background: meshBackgroundColor(),
+      },
+    );
+    if (!map) return false;
+
+    setPendingTextureMap(map, guid);
+    const prev = state.objectMaterial || defaultObjectMaterial();
+    state.objectMaterial = {
+      ...prev,
+      texture: "asset",
+      textureAsset: guid,
+      textureAssign: "eyePair",
+      textureUv: nextUv,
+      textureMap: sealTextureMap(map),
+    };
+    rememberBakedAtlas(guid, state.objectMaterial.textureMap);
+    try {
+      tessellate();
+    } catch (err) {
+      setPendingTextureMap(null);
+      state.status = "Tessellate after anim morph failed: " + (err.message || err);
+      return false;
+    }
+    setPendingTextureMap(null);
+    state.status = `Anim ${animClass}: ${from} → ${to} (${Math.round(t * 100)}%)`;
+    return true;
+  }
+
   function clearAssignedTexture() {
     beginGesture("clear-texture");
     const prevGuid = state.objectMaterial?.textureAsset;
@@ -1621,6 +1728,7 @@ export function useSplineEditor() {
     setTextureAssetsProvider,
     assignEyeTextureToRoot,
     assignEyeTextureToRootAsync,
+    previewAssignedAnimMorph,
     setPendingTextureMap,
     clearAssignedTexture,
     attachFromProject,

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeEmotion.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeEmotion.js
@@ -45,6 +45,48 @@ export const EYE_EMOTION_TAGS = Object.freeze([
 
 const EMOTION_SET = new Set(EYE_EMOTION_TAGS);
 
+/** Animation class id for facial emotion (targets = emotion tags). */
+export const ANIM_CLASS_EMOTION = "emotion";
+
+/**
+ * Registry of animation classes. Each class has named targets that morph
+ * within the same topology. Future: blink, gaze, phoneme, …
+ * @type {Record<string, { id: string, label: string, partClasses: string[], targets: readonly string[] }>}
+ */
+export const ANIM_CLASS_DEFS = Object.freeze({
+  [ANIM_CLASS_EMOTION]: Object.freeze({
+    id: ANIM_CLASS_EMOTION,
+    label: "Emotion",
+    partClasses: Object.freeze([PART_CLASS_EYE]),
+    targets: EYE_EMOTION_TAGS,
+  }),
+});
+
+/**
+ * @param {string} [partClass]
+ * @returns {Array<{ id: string, label: string, partClasses: string[], targets: readonly string[] }>}
+ */
+export function listAnimClassesForPart(partClass = PART_CLASS_EYE) {
+  const pc = partClass || PART_CLASS_EYE;
+  return Object.values(ANIM_CLASS_DEFS).filter((c) => c.partClasses.includes(pc));
+}
+
+/** @param {unknown} raw */
+export function normalizeAnimClassId(raw) {
+  const s = String(raw ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32);
+  return s || ANIM_CLASS_EMOTION;
+}
+
+/** @param {unknown} raw */
+export function normalizeAnimTarget(raw) {
+  return normalizeEmotionTag(raw);
+}
+
 /**
  * Normalize an emotion tag: lowercase slug, empty → "neutral".
  * @param {unknown} raw
@@ -101,6 +143,8 @@ export function eyeLibraryTags(opts = {}) {
  * @typedef {{
  *   id: string,
  *   name: string,
+ *   animClass: string,
+ *   target: string,
  *   emotion: string,
  *   tags: string[],
  *   layers: Partial<Record<EyeLayerRole, EyeLayerPose>>,
@@ -279,17 +323,26 @@ export function applyLayerPose(layer, pose) {
 }
 
 /**
- * Capture a named emotion pose from the texture's working layers.
+ * Capture a named pose from the texture's working layers.
  * @param {object} tex
- * @param {{ emotion?: string, name?: string, id?: string, tags?: string[] }} [opts]
+ * @param {{
+ *   emotion?: string,
+ *   target?: string,
+ *   animClass?: string,
+ *   name?: string,
+ *   id?: string,
+ *   tags?: string[],
+ * }} [opts]
  * @returns {EyePose|null}
  */
 export function captureEyePose(tex, opts = {}) {
   if (!tex?.layers?.length) return null;
-  const emotion = normalizeEmotionTag(opts.emotion ?? tex.emotion);
+  const animClass = normalizeAnimClassId(opts.animClass ?? ANIM_CLASS_EMOTION);
+  const target = normalizeAnimTarget(opts.target ?? opts.emotion ?? tex.emotion);
+  const emotion = animClass === ANIM_CLASS_EMOTION ? target : normalizeEmotionTag(opts.emotion ?? tex.emotion);
   const name =
     String(opts.name || "").trim() ||
-    emotion.charAt(0).toUpperCase() + emotion.slice(1);
+    target.charAt(0).toUpperCase() + target.slice(1);
   /** @type {Partial<Record<EyeLayerRole, EyeLayerPose>>} */
   const layers = {};
   for (const role of EYE_LAYER_TYPES) {
@@ -299,11 +352,13 @@ export function captureEyePose(tex, opts = {}) {
   }
   const tags = Array.isArray(opts.tags)
     ? opts.tags.map(normalizeEmotionTag).filter(Boolean)
-    : [emotion];
-  if (!tags.includes(emotion)) tags.unshift(emotion);
+    : [target];
+  if (!tags.includes(target)) tags.unshift(target);
   return {
     id: opts.id || poseId(),
     name,
+    animClass,
+    target,
     emotion,
     tags,
     layers,
@@ -325,9 +380,252 @@ export function applyEyePose(tex, pose) {
     if (!L) return false;
     if (!applyLayerPose(L, layerPose)) return false;
   }
-  tex.emotion = normalizeEmotionTag(pose.emotion);
+  const animClass = normalizeAnimClassId(pose.animClass);
+  const target = normalizeAnimTarget(pose.target ?? pose.emotion);
+  tex.emotion = animClass === ANIM_CLASS_EMOTION ? target : normalizeEmotionTag(pose.emotion);
   tex.activePoseId = pose.id || tex.activePoseId || null;
   return true;
+}
+
+/**
+ * @param {EyePose} pose
+ * @returns {{ animClass: string, target: string }}
+ */
+export function poseAnimRef(pose) {
+  const animClass = normalizeAnimClassId(pose?.animClass);
+  const target = normalizeAnimTarget(pose?.target ?? pose?.emotion);
+  return { animClass, target };
+}
+
+/**
+ * List targets present on a texture for one animation class.
+ * @param {object} tex
+ * @param {string} [animClass]
+ * @returns {string[]}
+ */
+export function listAnimTargets(tex, animClass = ANIM_CLASS_EMOTION) {
+  const cls = normalizeAnimClassId(animClass);
+  const found = new Set();
+  for (const p of tex?.poses || []) {
+    const ref = poseAnimRef(p);
+    if (ref.animClass === cls) found.add(ref.target);
+  }
+  return [...found];
+}
+
+/**
+ * @param {object} tex
+ * @param {string} animClass
+ * @param {string} target
+ * @returns {EyePose|null}
+ */
+export function getPoseForTarget(tex, animClass, target) {
+  const cls = normalizeAnimClassId(animClass);
+  const tgt = normalizeAnimTarget(target);
+  for (const p of tex?.poses || []) {
+    const ref = poseAnimRef(p);
+    if (ref.animClass === cls && ref.target === tgt) return p;
+  }
+  return null;
+}
+
+function clonePoseLayers(layers) {
+  /** @type {Partial<Record<EyeLayerRole, EyeLayerPose>>} */
+  const out = {};
+  for (const [role, lp] of Object.entries(layers || {})) {
+    out[role] = {
+      knots: (lp.knots || []).map((k) => ({
+        x: k.x,
+        y: k.y,
+        hx: k.hx,
+        hy: k.hy,
+      })),
+      ...(lp.enabled === false ? { enabled: false } : { enabled: true }),
+      ...(Number.isFinite(Number(lp.opacity)) ? { opacity: Number(lp.opacity) } : {}),
+    };
+  }
+  return out;
+}
+
+function offsetKnots(knots, fn) {
+  return (knots || []).map((k, i) => {
+    const d = fn(k, i) || {};
+    return {
+      x: k.x + (Number(d.x) || 0),
+      y: k.y + (Number(d.y) || 0),
+      hx: k.hx + (Number(d.hx) || 0),
+      hy: k.hy + (Number(d.hy) || 0),
+    };
+  });
+}
+
+function scaleKnotsAbout(knots, cx, cy, sx, sy) {
+  return (knots || []).map((k) => ({
+    x: cx + (k.x - cx) * sx,
+    y: cy + (k.y - cy) * sy,
+    hx: k.hx * sx,
+    hy: k.hy * sy,
+  }));
+}
+
+/**
+ * Procedural emotion variants from a base pose (same topology) for preview testing.
+ * @param {EyePose} base
+ * @param {string} target
+ * @returns {EyePose}
+ */
+export function deriveDemoEmotionPose(base, target) {
+  const tgt = normalizeAnimTarget(target);
+  const layers = clonePoseLayers(base.layers);
+  const lid = layers.eyelid;
+  const eyeball = layers.eyeball;
+  const iris = layers.iris;
+  const pupil = layers.pupil;
+
+  if (lid?.knots?.length >= 3) {
+    if (tgt === "angry") {
+      lid.enabled = true;
+      lid.knots = offsetKnots(lid.knots, (_k, i) => {
+        if (i === 0 || i === 2) return { y: 0.14, hy: -0.04 };
+        return { y: -0.06, hy: 0.02 };
+      });
+    } else if (tgt === "sad") {
+      lid.enabled = true;
+      lid.knots = offsetKnots(lid.knots, (_k, i) => {
+        if (i === 0 || i === 2) return { y: -0.04 };
+        return { y: 0.1, hy: 0.04 };
+      });
+    } else if (tgt === "happy") {
+      lid.enabled = true;
+      lid.knots = offsetKnots(lid.knots, (_k, i) => {
+        if (i === 1) return { y: -0.1, hy: -0.02 };
+        return { y: 0.02 };
+      });
+    } else if (tgt === "surprised") {
+      lid.enabled = true;
+      lid.knots = offsetKnots(lid.knots, (_k, i) => {
+        if (i === 1) return { y: 0.22, hy: 0.06 };
+        return { y: 0.1 };
+      });
+    } else if (tgt === "sleepy") {
+      lid.enabled = true;
+      lid.knots = offsetKnots(lid.knots, () => ({ y: -0.16, hy: -0.03 }));
+    } else if (tgt === "fear") {
+      lid.enabled = true;
+      lid.knots = offsetKnots(lid.knots, (_k, i) => {
+        if (i === 1) return { y: 0.18 };
+        return { y: 0.08, hx: 0.02 };
+      });
+    } else if (tgt === "disgust") {
+      lid.enabled = true;
+      lid.knots = offsetKnots(lid.knots, (_k, i) => {
+        if (i === 0) return { y: 0.1 };
+        if (i === 2) return { y: -0.02 };
+        return { y: -0.08 };
+      });
+    } else if (tgt === "wink") {
+      lid.enabled = true;
+      lid.knots = offsetKnots(lid.knots, () => ({ y: -0.22 }));
+    } else {
+      // neutral / unknown — keep base; ensure eyelid visibility matches base
+    }
+  }
+
+  if (eyeball?.knots?.length >= 3 && (tgt === "surprised" || tgt === "fear")) {
+    const cx =
+      eyeball.knots.reduce((s, k) => s + k.x, 0) / eyeball.knots.length;
+    const cy =
+      eyeball.knots.reduce((s, k) => s + k.y, 0) / eyeball.knots.length;
+    eyeball.knots = scaleKnotsAbout(eyeball.knots, cx, cy, 1.02, 1.12);
+  }
+  if (eyeball?.knots?.length >= 3 && (tgt === "angry" || tgt === "sleepy")) {
+    const cx =
+      eyeball.knots.reduce((s, k) => s + k.x, 0) / eyeball.knots.length;
+    const cy =
+      eyeball.knots.reduce((s, k) => s + k.y, 0) / eyeball.knots.length;
+    eyeball.knots = scaleKnotsAbout(eyeball.knots, cx, cy, 1.0, 0.9);
+  }
+  if (iris?.knots?.length && (tgt === "surprised" || tgt === "fear")) {
+    const cx = iris.knots.reduce((s, k) => s + k.x, 0) / iris.knots.length;
+    const cy = iris.knots.reduce((s, k) => s + k.y, 0) / iris.knots.length;
+    iris.knots = scaleKnotsAbout(iris.knots, cx, cy, 0.92, 0.92);
+    if (pupil?.knots?.length) {
+      pupil.knots = scaleKnotsAbout(pupil.knots, cx, cy, 0.9, 0.9);
+    }
+  }
+
+  return {
+    id: `demo_${ANIM_CLASS_EMOTION}_${tgt}`,
+    name: tgt.charAt(0).toUpperCase() + tgt.slice(1),
+    animClass: ANIM_CLASS_EMOTION,
+    target: tgt,
+    emotion: tgt,
+    tags: [tgt, "demo"],
+    layers,
+  };
+}
+
+/**
+ * Ensure demo emotion targets exist on the texture (for A→B preview testing).
+ * Captures current layers as the base (usually neutral) when missing.
+ * @param {object} tex
+ * @param {{ targets?: string[], baseTarget?: string }} [opts]
+ * @returns {string[]} targets now available
+ */
+export function ensureDemoAnimTargets(tex, opts = {}) {
+  if (!tex?.layers?.length) return [];
+  if (!Array.isArray(tex.poses)) tex.poses = [];
+  const targets = Array.isArray(opts.targets) && opts.targets.length
+    ? opts.targets.map(normalizeAnimTarget)
+    : ["neutral", "happy", "sad", "angry", "surprised", "sleepy"];
+  const baseTarget = normalizeAnimTarget(opts.baseTarget || "neutral");
+
+  let base = getPoseForTarget(tex, ANIM_CLASS_EMOTION, baseTarget);
+  if (!base) {
+    base = captureEyePose(tex, {
+      animClass: ANIM_CLASS_EMOTION,
+      target: baseTarget,
+      emotion: baseTarget,
+      id: `demo_${ANIM_CLASS_EMOTION}_${baseTarget}`,
+      name: baseTarget.charAt(0).toUpperCase() + baseTarget.slice(1),
+      tags: [baseTarget, "demo"],
+    });
+    if (base) upsertEyePose(tex, base);
+  }
+
+  for (const tgt of targets) {
+    if (getPoseForTarget(tex, ANIM_CLASS_EMOTION, tgt)) continue;
+    if (tgt === baseTarget) continue;
+    upsertEyePose(tex, deriveDemoEmotionPose(base, tgt));
+  }
+  tex.topologyKey = eyeTopologyKey(tex);
+  return listAnimTargets(tex, ANIM_CLASS_EMOTION);
+}
+
+/**
+ * Build a cloned eye texture with layers morphed between two anim targets.
+ * Does not mutate the source texture.
+ * @param {object} tex
+ * @param {{ animClass?: string, from: string, to: string, t?: number }} opts
+ * @returns {object|null}
+ */
+export function morphTextureAnim(tex, opts) {
+  if (!tex) return null;
+  const animClass = normalizeAnimClassId(opts.animClass);
+  const fromT = normalizeAnimTarget(opts.from);
+  const toT = normalizeAnimTarget(opts.to);
+  const t = Math.min(1, Math.max(0, Number(opts.t) || 0));
+  const from = getPoseForTarget(tex, animClass, fromT);
+  const to = getPoseForTarget(tex, animClass, toT);
+  if (!from || !to) return null;
+  const mid = interpolateEyePose(from, to, t);
+  if (!mid) return null;
+  mid.animClass = animClass;
+  mid.target = t < 0.5 ? fromT : toT;
+  const clone = JSON.parse(JSON.stringify(tex));
+  if (!applyEyePose(clone, mid)) return null;
+  clone.emotion = mid.emotion;
+  return clone;
 }
 
 /**
@@ -374,10 +672,15 @@ export function interpolateEyePose(from, to, t) {
     row.opacity = oa + (ob - oa) * u;
     layers[role] = row;
   }
+  const fromRef = poseAnimRef(from);
+  const toRef = poseAnimRef(to);
+  const emotion = u < 0.5 ? fromRef.target : toRef.target;
   return {
     id: `morph_${from.id || "a"}_${to.id || "b"}`,
-    name: `${from.name || from.emotion}→${to.name || to.emotion}`,
-    emotion: u < 0.5 ? normalizeEmotionTag(from.emotion) : normalizeEmotionTag(to.emotion),
+    name: `${from.name || fromRef.target}→${to.name || toRef.target}`,
+    animClass: fromRef.animClass || toRef.animClass || ANIM_CLASS_EMOTION,
+    target: emotion,
+    emotion,
     tags: ["morph"],
     layers,
   };
@@ -425,7 +728,9 @@ export function validateEyePoseTopology(tex, pose) {
  */
 export function normalizeEyePose(raw, tex) {
   if (!raw || typeof raw !== "object") return null;
-  const emotion = normalizeEmotionTag(raw.emotion);
+  const animClass = normalizeAnimClassId(raw.animClass);
+  const target = normalizeAnimTarget(raw.target ?? raw.emotion);
+  const emotion = animClass === ANIM_CLASS_EMOTION ? target : normalizeEmotionTag(raw.emotion ?? target);
   /** @type {Partial<Record<EyeLayerRole, EyeLayerPose>>} */
   const layers = {};
   const src = raw.layers && typeof raw.layers === "object" ? raw.layers : {};
@@ -440,17 +745,26 @@ export function normalizeEyePose(raw, tex) {
     }
   }
   if (!Object.keys(layers).length && tex) {
-    const captured = captureEyePose(tex, { emotion, name: raw.name, id: raw.id, tags: raw.tags });
+    const captured = captureEyePose(tex, {
+      animClass,
+      target,
+      emotion,
+      name: raw.name,
+      id: raw.id,
+      tags: raw.tags,
+    });
     return captured;
   }
   if (!Object.keys(layers).length) return null;
   const tags = Array.isArray(raw.tags)
     ? raw.tags.map(normalizeEmotionTag).filter(Boolean)
-    : [emotion];
-  if (!tags.includes(emotion)) tags.unshift(emotion);
+    : [target];
+  if (!tags.includes(target)) tags.unshift(target);
   return {
     id: typeof raw.id === "string" && raw.id ? raw.id : poseId(),
-    name: String(raw.name || "").trim() || emotion.charAt(0).toUpperCase() + emotion.slice(1),
+    name: String(raw.name || "").trim() || target.charAt(0).toUpperCase() + target.slice(1),
+    animClass,
+    target,
     emotion,
     tags,
     layers,
@@ -485,42 +799,55 @@ export function normalizeEyePoses(tex, rawPoses) {
  * @returns {object[]}
  */
 export function serializeEyePoses(poses) {
-  return (poses || []).map((p) => ({
-    id: p.id,
-    name: p.name,
-    emotion: normalizeEmotionTag(p.emotion),
-    tags: Array.isArray(p.tags) ? p.tags.map(normalizeEmotionTag) : [normalizeEmotionTag(p.emotion)],
-    layers: Object.fromEntries(
-      Object.entries(p.layers || {}).map(([role, lp]) => [
-        role,
-        {
-          knots: (lp.knots || []).map((k) => ({
-            x: Number(k.x) || 0,
-            y: Number(k.y) || 0,
-            hx: Number(k.hx) || 0,
-            hy: Number(k.hy) || 0,
-          })),
-          ...(lp.enabled === false ? { enabled: false } : {}),
-          ...(Number.isFinite(Number(lp.opacity))
-            ? { opacity: Math.min(1, Math.max(0, Number(lp.opacity))) }
-            : {}),
-        },
-      ]),
-    ),
-  }));
+  return (poses || []).map((p) => {
+    const ref = poseAnimRef(p);
+    return {
+      id: p.id,
+      name: p.name,
+      animClass: ref.animClass,
+      target: ref.target,
+      emotion: normalizeEmotionTag(p.emotion ?? ref.target),
+      tags: Array.isArray(p.tags)
+        ? p.tags.map(normalizeEmotionTag)
+        : [ref.target],
+      layers: Object.fromEntries(
+        Object.entries(p.layers || {}).map(([role, lp]) => [
+          role,
+          {
+            knots: (lp.knots || []).map((k) => ({
+              x: Number(k.x) || 0,
+              y: Number(k.y) || 0,
+              hx: Number(k.hx) || 0,
+              hy: Number(k.hy) || 0,
+            })),
+            ...(lp.enabled === false ? { enabled: false } : {}),
+            ...(Number.isFinite(Number(lp.opacity))
+              ? { opacity: Math.min(1, Math.max(0, Number(lp.opacity))) }
+              : {}),
+          },
+        ]),
+      ),
+    };
+  });
 }
 
 /**
- * Upsert a pose into tex.poses (by id, or by emotion if id missing).
+ * Upsert a pose into tex.poses (by id, else by animClass+target).
  * @param {object} tex
  * @param {EyePose} pose
  */
 export function upsertEyePose(tex, pose) {
   if (!tex || !pose) return;
   if (!Array.isArray(tex.poses)) tex.poses = [];
-  const i = tex.poses.findIndex(
-    (p) => p.id === pose.id || (!pose.id && p.emotion === pose.emotion),
-  );
+  const ref = poseAnimRef(pose);
+  pose.animClass = ref.animClass;
+  pose.target = ref.target;
+  if (!pose.emotion) pose.emotion = ref.target;
+  const i = tex.poses.findIndex((p) => {
+    if (pose.id && p.id === pose.id) return true;
+    const pr = poseAnimRef(p);
+    return pr.animClass === ref.animClass && pr.target === ref.target;
+  });
   if (i >= 0) tex.poses[i] = pose;
   else tex.poses.push(pose);
   tex.activePoseId = pose.id;

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeEmotion.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeEmotion.js
@@ -1,0 +1,627 @@
+// ============================================================================
+// eyeEmotion.js — emotion tags, topology fingerprint, pose capture/morph.
+// Authoring helpers for eye vector rigs; runtime compile is sampled buffers.
+// ============================================================================
+
+import { samplePath } from "../pathModel.js";
+
+/** Part class for eye assets (future: mouth, brow, …). */
+export const PART_CLASS_EYE = "eye";
+
+/** Topology fingerprint schema version (bump when key format changes). */
+export const EYE_TOPOLOGY_VERSION = 1;
+
+/** Layer roles — kept local to avoid a circular import with eyeTexture.js. */
+const EYE_LAYER_TYPES = ["eyeball", "iris", "pupil", "reflection", "eyelid"];
+const EYE_DEFAULT_ORDER = EYE_LAYER_TYPES;
+const EYE_CLIP_PARENT = {
+  eyeball: null,
+  iris: "eyeball",
+  pupil: "iris",
+  reflection: "eyeball",
+  eyelid: "eyeball",
+};
+
+function findLayer(texOrLayers, typeOrId) {
+  const layers = Array.isArray(texOrLayers) ? texOrLayers : texOrLayers?.layers || [];
+  return layers.find((L) => L.id === typeOrId || L.type === typeOrId) || null;
+}
+
+/**
+ * Canonical emotion tags for eyes. Custom strings are allowed; prefer these
+ * for library search and morph pickers.
+ */
+export const EYE_EMOTION_TAGS = Object.freeze([
+  "neutral",
+  "happy",
+  "sad",
+  "angry",
+  "surprised",
+  "sleepy",
+  "wink",
+  "fear",
+  "disgust",
+]);
+
+const EMOTION_SET = new Set(EYE_EMOTION_TAGS);
+
+/**
+ * Normalize an emotion tag: lowercase slug, empty → "neutral".
+ * @param {unknown} raw
+ * @returns {string}
+ */
+export function normalizeEmotionTag(raw) {
+  const s = String(raw ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32);
+  return s || "neutral";
+}
+
+/** @param {string} tag */
+export function isCanonicalEyeEmotion(tag) {
+  return EMOTION_SET.has(normalizeEmotionTag(tag));
+}
+
+/**
+ * Library / project search tags for an eye pose or texture.
+ * @param {{ emotion?: string, topologyKey?: string, partClass?: string }} opts
+ * @returns {string[]}
+ */
+export function eyeLibraryTags(opts = {}) {
+  const part = opts.partClass || PART_CLASS_EYE;
+  const emotion = normalizeEmotionTag(opts.emotion);
+  const tags = [`part:${part}`, `emotion:${emotion}`];
+  if (opts.topologyKey) tags.push(`topo:${opts.topologyKey}`);
+  return tags;
+}
+
+/**
+ * @typedef {"eyeball"|"iris"|"pupil"|"reflection"|"eyelid"} EyeLayerRole
+ * @typedef {{ x: number, y: number, hx: number, hy: number }} BezierKnotPose
+ * @typedef {{
+ *   role: EyeLayerRole,
+ *   knotCount: number,
+ *   closed: boolean,
+ *   fillSide: "above"|"below"|null,
+ *   clipTo: EyeLayerRole|null,
+ * }} EyeLayerTopology
+ * @typedef {{
+ *   partClass: string,
+ *   version: number,
+ *   layers: EyeLayerTopology[],
+ * }} EyeTopology
+ * @typedef {{
+ *   knots: BezierKnotPose[],
+ *   opacity?: number,
+ *   enabled?: boolean,
+ * }} EyeLayerPose
+ * @typedef {{
+ *   id: string,
+ *   name: string,
+ *   emotion: string,
+ *   tags: string[],
+ *   layers: Partial<Record<EyeLayerRole, EyeLayerPose>>,
+ * }} EyePose
+ */
+
+function poseId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return `pose_${crypto.randomUUID().slice(0, 8)}`;
+  }
+  return "pose_" + Math.random().toString(36).slice(2, 10);
+}
+
+/**
+ * Stable layer order for topology: default draw order, then any extras.
+ * @param {object[]} layers
+ * @returns {object[]}
+ */
+function orderedLayers(layers) {
+  const list = Array.isArray(layers) ? layers.slice() : [];
+  const byType = new Map();
+  for (const L of list) {
+    if (L?.type && !byType.has(L.type)) byType.set(L.type, L);
+  }
+  const out = [];
+  for (const role of EYE_DEFAULT_ORDER) {
+    if (byType.has(role)) out.push(byType.get(role));
+  }
+  for (const L of list) {
+    if (L?.type && !EYE_DEFAULT_ORDER.includes(L.type) && byType.get(L.type) === L) {
+      out.push(L);
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract permanent topology from an eye texture (or layer stack).
+ * @param {object} texOrLayers
+ * @returns {EyeTopology}
+ */
+export function eyeTopology(texOrLayers) {
+  const layers = Array.isArray(texOrLayers) ? texOrLayers : texOrLayers?.layers || [];
+  const topoLayers = [];
+  for (const L of orderedLayers(layers)) {
+    const role = EYE_LAYER_TYPES.includes(L.type) ? L.type : null;
+    if (!role) continue;
+    const closed = role !== "eyelid" && L.closed !== false;
+    const fillSide =
+      role === "eyelid" ? (L.fillSide === "below" ? "below" : "above") : null;
+    const clipRaw = L.clipTo ?? EYE_CLIP_PARENT[role] ?? null;
+    const clipTo = EYE_LAYER_TYPES.includes(clipRaw) ? clipRaw : null;
+    topoLayers.push({
+      role,
+      knotCount: (L.knots || []).length | 0,
+      closed,
+      fillSide,
+      clipTo,
+    });
+  }
+  return {
+    partClass: PART_CLASS_EYE,
+    version: EYE_TOPOLOGY_VERSION,
+    layers: topoLayers,
+  };
+}
+
+/**
+ * Compact fingerprint used for morph compatibility.
+ * @param {object|EyeTopology} texOrTopo
+ * @returns {string}
+ */
+export function eyeTopologyKey(texOrTopo) {
+  const topo =
+    texOrTopo?.partClass && Array.isArray(texOrTopo.layers) && texOrTopo.version != null
+      ? texOrTopo
+      : eyeTopology(texOrTopo);
+  const parts = [`${topo.partClass}:v${topo.version}`];
+  for (const L of topo.layers) {
+    let s = `${L.role}:${L.knotCount}${L.closed ? "c" : "o"}`;
+    if (L.fillSide) s += `:fill=${L.fillSide}`;
+    if (L.clipTo) s += `:clip=${L.clipTo}`;
+    parts.push(s);
+  }
+  return parts.join("/");
+}
+
+/**
+ * Default topology key for a freshly created eye (4× closed + 3-knot eyelid).
+ * @returns {string}
+ */
+export function defaultEyeTopologyKey() {
+  // Match createDefaultEyeTexture layer structure without allocating a full tex.
+  const fake = {
+    layers: EYE_DEFAULT_ORDER.map((role) => ({
+      type: role,
+      closed: role !== "eyelid",
+      fillSide: role === "eyelid" ? "above" : null,
+      clipTo: EYE_CLIP_PARENT[role],
+      knots: new Array(role === "eyelid" ? 3 : 4).fill(null),
+    })),
+  };
+  return eyeTopologyKey(fake);
+}
+
+/**
+ * @param {object} a
+ * @param {object} b
+ * @returns {boolean}
+ */
+export function areEyeTexturesCompatible(a, b) {
+  if (!a || !b) return false;
+  const ka = a.kind == null || a.kind === "eye" ? PART_CLASS_EYE : a.kind;
+  const kb = b.kind == null || b.kind === "eye" ? PART_CLASS_EYE : b.kind;
+  if (ka !== PART_CLASS_EYE || kb !== PART_CLASS_EYE) return false;
+  return eyeTopologyKey(a) === eyeTopologyKey(b);
+}
+
+/**
+ * Filter library texture entries / eye assets that can morph with `ref`.
+ * @param {Iterable<object>} textures
+ * @param {object} ref
+ * @returns {object[]}
+ */
+export function listCompatibleEyeTextures(textures, ref) {
+  const out = [];
+  for (const t of textures || []) {
+    if (areEyeTexturesCompatible(ref, t)) out.push(t);
+  }
+  return out;
+}
+
+/**
+ * Snapshot animatable knot poses from a layer.
+ * @param {object} layer
+ * @returns {EyeLayerPose}
+ */
+export function captureLayerPose(layer) {
+  const knots = (layer?.knots || []).map((k) => ({
+    x: Number(k.x) || 0,
+    y: Number(k.y) || 0,
+    hx: Number(k.hx) || 0,
+    hy: Number(k.hy) || 0,
+  }));
+  /** @type {EyeLayerPose} */
+  const pose = { knots };
+  if (layer?.enabled === false) pose.enabled = false;
+  else pose.enabled = true;
+  const op = Number(layer?.opacity);
+  if (Number.isFinite(op)) pose.opacity = Math.min(1, Math.max(0, op));
+  return pose;
+}
+
+/**
+ * Write pose knots into an existing layer (preserve ids / segments / color).
+ * @param {object} layer
+ * @param {EyeLayerPose} pose
+ * @returns {boolean} false if knot counts differ
+ */
+export function applyLayerPose(layer, pose) {
+  if (!layer || !pose?.knots) return false;
+  if ((layer.knots || []).length !== pose.knots.length) return false;
+  for (let i = 0; i < layer.knots.length; i++) {
+    const src = pose.knots[i];
+    const dst = layer.knots[i];
+    dst.x = Number(src.x) || 0;
+    dst.y = Number(src.y) || 0;
+    dst.hx = Number(src.hx) || 0;
+    dst.hy = Number(src.hy) || 0;
+  }
+  if (pose.enabled != null) layer.enabled = !!pose.enabled;
+  if (pose.opacity != null && Number.isFinite(Number(pose.opacity))) {
+    layer.opacity = Math.min(1, Math.max(0, Number(pose.opacity)));
+  }
+  return true;
+}
+
+/**
+ * Capture a named emotion pose from the texture's working layers.
+ * @param {object} tex
+ * @param {{ emotion?: string, name?: string, id?: string, tags?: string[] }} [opts]
+ * @returns {EyePose|null}
+ */
+export function captureEyePose(tex, opts = {}) {
+  if (!tex?.layers?.length) return null;
+  const emotion = normalizeEmotionTag(opts.emotion ?? tex.emotion);
+  const name =
+    String(opts.name || "").trim() ||
+    emotion.charAt(0).toUpperCase() + emotion.slice(1);
+  /** @type {Partial<Record<EyeLayerRole, EyeLayerPose>>} */
+  const layers = {};
+  for (const role of EYE_LAYER_TYPES) {
+    const L = findLayer(tex, role);
+    if (!L) continue;
+    layers[role] = captureLayerPose(L);
+  }
+  const tags = Array.isArray(opts.tags)
+    ? opts.tags.map(normalizeEmotionTag).filter(Boolean)
+    : [emotion];
+  if (!tags.includes(emotion)) tags.unshift(emotion);
+  return {
+    id: opts.id || poseId(),
+    name,
+    emotion,
+    tags,
+    layers,
+  };
+}
+
+/**
+ * Apply a pose onto working layers. Returns false if topology mismatches.
+ * @param {object} tex
+ * @param {EyePose} pose
+ * @returns {boolean}
+ */
+export function applyEyePose(tex, pose) {
+  if (!tex || !pose?.layers) return false;
+  for (const role of EYE_LAYER_TYPES) {
+    const layerPose = pose.layers[role];
+    if (!layerPose) continue;
+    const L = findLayer(tex, role);
+    if (!L) return false;
+    if (!applyLayerPose(L, layerPose)) return false;
+  }
+  tex.emotion = normalizeEmotionTag(pose.emotion);
+  tex.activePoseId = pose.id || tex.activePoseId || null;
+  return true;
+}
+
+/**
+ * @param {BezierKnotPose} a
+ * @param {BezierKnotPose} b
+ * @param {number} t
+ * @returns {BezierKnotPose}
+ */
+export function interpolateKnot(a, b, t) {
+  const u = Number(t) || 0;
+  return {
+    x: a.x + (b.x - a.x) * u,
+    y: a.y + (b.y - a.y) * u,
+    hx: a.hx + (b.hx - a.hx) * u,
+    hy: a.hy + (b.hy - a.hy) * u,
+  };
+}
+
+/**
+ * Linear morph between two poses (same topology required).
+ * @param {EyePose} from
+ * @param {EyePose} to
+ * @param {number} t 0…1
+ * @returns {EyePose|null}
+ */
+export function interpolateEyePose(from, to, t) {
+  if (!from?.layers || !to?.layers) return null;
+  const u = Math.min(1, Math.max(0, Number(t) || 0));
+  /** @type {Partial<Record<EyeLayerRole, EyeLayerPose>>} */
+  const layers = {};
+  for (const role of EYE_LAYER_TYPES) {
+    const a = from.layers[role];
+    const b = to.layers[role];
+    if (!a && !b) continue;
+    if (!a || !b || a.knots.length !== b.knots.length) return null;
+    const knots = a.knots.map((k, i) => interpolateKnot(k, b.knots[i], u));
+    /** @type {EyeLayerPose} */
+    const row = { knots };
+    const ea = a.enabled !== false;
+    const eb = b.enabled !== false;
+    row.enabled = u < 0.5 ? ea : eb;
+    const oa = Number.isFinite(Number(a.opacity)) ? Number(a.opacity) : 1;
+    const ob = Number.isFinite(Number(b.opacity)) ? Number(b.opacity) : 1;
+    row.opacity = oa + (ob - oa) * u;
+    layers[role] = row;
+  }
+  return {
+    id: `morph_${from.id || "a"}_${to.id || "b"}`,
+    name: `${from.name || from.emotion}→${to.name || to.emotion}`,
+    emotion: u < 0.5 ? normalizeEmotionTag(from.emotion) : normalizeEmotionTag(to.emotion),
+    tags: ["morph"],
+    layers,
+  };
+}
+
+/**
+ * Validate pose knot counts against texture topology.
+ * @param {object} tex
+ * @param {EyePose} pose
+ * @returns {{ ok: boolean, errors: string[] }}
+ */
+export function validateEyePoseTopology(tex, pose) {
+  const errors = [];
+  if (!pose?.layers) {
+    return { ok: false, errors: ["pose missing layers"] };
+  }
+  const topo = eyeTopology(tex);
+  const byRole = new Map(topo.layers.map((L) => [L.role, L]));
+  for (const role of EYE_LAYER_TYPES) {
+    const layerPose = pose.layers[role];
+    const expect = byRole.get(role);
+    if (!layerPose && !expect) continue;
+    if (!layerPose) {
+      errors.push(`pose missing layer "${role}"`);
+      continue;
+    }
+    if (!expect) {
+      errors.push(`texture missing layer "${role}" for pose`);
+      continue;
+    }
+    if (layerPose.knots.length !== expect.knotCount) {
+      errors.push(
+        `${role}: pose has ${layerPose.knots.length} knots, topology expects ${expect.knotCount}`,
+      );
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Normalize a stored pose blob.
+ * @param {any} raw
+ * @param {object} [tex] optional texture for topology fill / validation
+ * @returns {EyePose|null}
+ */
+export function normalizeEyePose(raw, tex) {
+  if (!raw || typeof raw !== "object") return null;
+  const emotion = normalizeEmotionTag(raw.emotion);
+  /** @type {Partial<Record<EyeLayerRole, EyeLayerPose>>} */
+  const layers = {};
+  const src = raw.layers && typeof raw.layers === "object" ? raw.layers : {};
+  for (const role of EYE_LAYER_TYPES) {
+    const block = src[role];
+    if (!block) continue;
+    if (Array.isArray(block.knots)) {
+      layers[role] = captureLayerPose(block);
+    } else if (Array.isArray(block)) {
+      // Allow shorthand: layers.eyeball = [{x,y,hx,hy}, …]
+      layers[role] = captureLayerPose({ knots: block });
+    }
+  }
+  if (!Object.keys(layers).length && tex) {
+    const captured = captureEyePose(tex, { emotion, name: raw.name, id: raw.id, tags: raw.tags });
+    return captured;
+  }
+  if (!Object.keys(layers).length) return null;
+  const tags = Array.isArray(raw.tags)
+    ? raw.tags.map(normalizeEmotionTag).filter(Boolean)
+    : [emotion];
+  if (!tags.includes(emotion)) tags.unshift(emotion);
+  return {
+    id: typeof raw.id === "string" && raw.id ? raw.id : poseId(),
+    name: String(raw.name || "").trim() || emotion.charAt(0).toUpperCase() + emotion.slice(1),
+    emotion,
+    tags,
+    layers,
+  };
+}
+
+/**
+ * Normalize poses[] on an eye texture; drop incompatible entries.
+ * @param {object} tex
+ * @param {any[]} rawPoses
+ * @returns {EyePose[]}
+ */
+export function normalizeEyePoses(tex, rawPoses) {
+  if (!Array.isArray(rawPoses)) return [];
+  const out = [];
+  const seen = new Set();
+  for (const raw of rawPoses) {
+    const pose = normalizeEyePose(raw, tex);
+    if (!pose) continue;
+    const check = validateEyePoseTopology(tex, pose);
+    if (!check.ok) continue;
+    if (seen.has(pose.id)) pose.id = poseId();
+    seen.add(pose.id);
+    out.push(pose);
+  }
+  return out;
+}
+
+/**
+ * Serialize poses for project JSON (no knot ids).
+ * @param {EyePose[]} poses
+ * @returns {object[]}
+ */
+export function serializeEyePoses(poses) {
+  return (poses || []).map((p) => ({
+    id: p.id,
+    name: p.name,
+    emotion: normalizeEmotionTag(p.emotion),
+    tags: Array.isArray(p.tags) ? p.tags.map(normalizeEmotionTag) : [normalizeEmotionTag(p.emotion)],
+    layers: Object.fromEntries(
+      Object.entries(p.layers || {}).map(([role, lp]) => [
+        role,
+        {
+          knots: (lp.knots || []).map((k) => ({
+            x: Number(k.x) || 0,
+            y: Number(k.y) || 0,
+            hx: Number(k.hx) || 0,
+            hy: Number(k.hy) || 0,
+          })),
+          ...(lp.enabled === false ? { enabled: false } : {}),
+          ...(Number.isFinite(Number(lp.opacity))
+            ? { opacity: Math.min(1, Math.max(0, Number(lp.opacity))) }
+            : {}),
+        },
+      ]),
+    ),
+  }));
+}
+
+/**
+ * Upsert a pose into tex.poses (by id, or by emotion if id missing).
+ * @param {object} tex
+ * @param {EyePose} pose
+ */
+export function upsertEyePose(tex, pose) {
+  if (!tex || !pose) return;
+  if (!Array.isArray(tex.poses)) tex.poses = [];
+  const i = tex.poses.findIndex(
+    (p) => p.id === pose.id || (!pose.id && p.emotion === pose.emotion),
+  );
+  if (i >= 0) tex.poses[i] = pose;
+  else tex.poses.push(pose);
+  tex.activePoseId = pose.id;
+  tex.emotion = pose.emotion;
+}
+
+/**
+ * Sample a pose layer to a flat Float32Array of xy pairs (closed rings drop
+ * duplicate last point if samplePath includes it — we keep samples as returned).
+ * @param {EyeLayerPose} layerPose
+ * @param {{ closed: boolean, samplesPerSpan?: number, segments?: object[] }} opts
+ * @returns {Float32Array}
+ */
+export function sampleLayerPose(layerPose, opts) {
+  const knots = (layerPose?.knots || []).map((k, i) => ({
+    id: `s${i}`,
+    x: k.x,
+    y: k.y,
+    hx: k.hx,
+    hy: k.hy,
+    color: "#fff",
+  }));
+  const segments = opts.segments || [];
+  const pts = samplePath(knots, segments, {
+    closed: !!opts.closed,
+    samplesPerSpan: opts.samplesPerSpan ?? 16,
+  });
+  const out = new Float32Array(pts.length * 2);
+  for (let i = 0; i < pts.length; i++) {
+    out[i * 2] = pts[i].x;
+    out[i * 2 + 1] = pts[i].y;
+  }
+  return out;
+}
+
+/**
+ * Compile authoring poses → runtime-ish sampled buffers (CPU preview / GPU prep).
+ * Does not triangulate yet; callers can share one index buffer per layer later.
+ *
+ * @param {object} tex
+ * @param {{ samplesPerSpan?: number, poseIds?: string[] }} [opts]
+ * @returns {{
+ *   topologyKey: string,
+ *   partClass: string,
+ *   layers: Array<{
+ *     role: string,
+ *     closed: boolean,
+ *     clipTo: string|null,
+ *     fillSide: string|null,
+ *     poses: Record<string, Float32Array>,
+ *   }>,
+ *   emotions: Record<string, string>,
+ * } | null}
+ */
+export function compileEyeRig(tex, opts = {}) {
+  if (!tex?.layers?.length) return null;
+  const samplesPerSpan = opts.samplesPerSpan ?? 16;
+  const topo = eyeTopology(tex);
+  const key = eyeTopologyKey(topo);
+  const poseList =
+    Array.isArray(tex.poses) && tex.poses.length
+      ? tex.poses
+      : [captureEyePose(tex, { emotion: tex.emotion || "neutral", name: "Current" })].filter(
+          Boolean,
+        );
+  const selected = opts.poseIds
+    ? poseList.filter((p) => opts.poseIds.includes(p.id) || opts.poseIds.includes(p.emotion))
+    : poseList;
+
+  /** @type {Record<string, string>} */
+  const emotions = {};
+  const layers = [];
+
+  for (const tLayer of topo.layers) {
+    const live = findLayer(tex, tLayer.role);
+    const poseBufs = {};
+    for (const pose of selected) {
+      const lp = pose.layers?.[tLayer.role];
+      if (!lp) continue;
+      const check = lp.knots.length === tLayer.knotCount;
+      if (!check) continue;
+      poseBufs[pose.id] = sampleLayerPose(lp, {
+        closed: tLayer.closed,
+        samplesPerSpan,
+        segments: live?.segments || [],
+      });
+      emotions[pose.id] = pose.emotion;
+    }
+    layers.push({
+      role: tLayer.role,
+      closed: tLayer.closed,
+      clipTo: tLayer.clipTo,
+      fillSide: tLayer.fillSide,
+      poses: poseBufs,
+    });
+  }
+
+  return {
+    topologyKey: key,
+    partClass: PART_CLASS_EYE,
+    layers,
+    emotions,
+  };
+}

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -14,6 +14,13 @@ import {
   pathCentroid,
 } from "../pathModel.js";
 import { newGuid } from "../assetClone.js";
+import {
+  PART_CLASS_EYE,
+  normalizeEmotionTag,
+  eyeTopologyKey,
+  normalizeEyePoses,
+  serializeEyePoses,
+} from "./eyeEmotion.js";
 
 /** Default radii for “Restore to circle” (and createEyeLayer closed parts). */
 export const EYE_CIRCLE_RADII = {
@@ -146,10 +153,12 @@ export function createDefaultEyeTexture({ name = "Eye" } = {}) {
   // Optional eyelid starts disabled — user can enable
   const lid = layers.find((l) => l.type === "eyelid");
   if (lid) lid.enabled = false;
-  return {
+  const tex = {
     assetGuid: newGuid(),
     name,
     kind: "eye",
+    partClass: PART_CLASS_EYE,
+    emotion: "neutral",
     width: 256,
     height: 256,
     /** Background at mesh assign time comes from vertex colors; preview uses this fallback. */
@@ -159,7 +168,12 @@ export function createDefaultEyeTexture({ name = "Eye" } = {}) {
     /** Independent right-eye stack when eyePair.linked === false. */
     rightLayers: null,
     eyePair: { ...DEFAULT_EYE_PAIR },
+    /** Emotion pose snapshots (same topology as `layers`). */
+    poses: [],
+    activePoseId: null,
   };
+  tex.topologyKey = eyeTopologyKey(tex);
+  return tex;
 }
 
 export function normalizeEyePair(raw) {
@@ -383,17 +397,29 @@ function normalizeLayerRow(L) {
 
 export function serializeEyeTexture(tex) {
   const pair = normalizeEyePair(tex.eyePair);
+  const layers = (tex.layers || []).map(serializeLayerRow);
+  const topologyKey = eyeTopologyKey({ layers });
+  const poses = serializeEyePoses(normalizeEyePoses({ layers }, tex.poses));
+  const activePoseId =
+    typeof tex.activePoseId === "string" && poses.some((p) => p.id === tex.activePoseId)
+      ? tex.activePoseId
+      : null;
   const out = {
     assetGuid: tex.assetGuid,
     name: tex.name || "Eye",
     kind: "eye",
+    partClass: PART_CLASS_EYE,
+    emotion: normalizeEmotionTag(tex.emotion),
+    topologyKey,
     width: Number(tex.width) || 256,
     height: Number(tex.height) || 256,
     backgroundFrom: tex.backgroundFrom === "solid" ? "solid" : "vertexColors",
     previewBackground: tex.previewBackground || "#6a8f6a",
-    layers: (tex.layers || []).map(serializeLayerRow),
+    layers,
     eyePair: pair,
     rightLayers: null,
+    poses,
+    activePoseId,
   };
   if (!pair.linked && Array.isArray(tex.rightLayers) && tex.rightLayers.length) {
     out.rightLayers = tex.rightLayers.map(serializeLayerRow);
@@ -412,10 +438,19 @@ export function normalizeEyeTexture(raw) {
     rightLayers = raw.rightLayers.map(normalizeLayerRow);
   }
   if (pair.editSide === "both") pair.linked = true;
+  const draft = { layers };
+  const poses = normalizeEyePoses(draft, raw.poses);
+  const activePoseId =
+    typeof raw.activePoseId === "string" && poses.some((p) => p.id === raw.activePoseId)
+      ? raw.activePoseId
+      : null;
   return {
     assetGuid: raw.assetGuid || base.assetGuid,
     name: raw.name || base.name,
     kind: "eye",
+    partClass: PART_CLASS_EYE,
+    emotion: normalizeEmotionTag(raw.emotion),
+    topologyKey: eyeTopologyKey(draft),
     width: Number(raw.width) || 256,
     height: Number(raw.height) || 256,
     backgroundFrom: raw.backgroundFrom === "solid" ? "solid" : "vertexColors",
@@ -423,6 +458,8 @@ export function normalizeEyeTexture(raw) {
     layers,
     rightLayers,
     eyePair: pair,
+    poses,
+    activePoseId,
   };
 }
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -526,6 +526,24 @@ function normalizeV11(doc) {
   return v10;
 }
 
+function normalizeV12(doc) {
+  // Re-normalize eye textures so partClass / emotion / topologyKey / poses exist.
+  const v11 = normalizeV11(doc);
+  v11.schemaVersion = 12;
+  const src = doc.textureAssets || v11.textureAssets || {};
+  const textureAssets = {};
+  for (const [guid, raw] of Object.entries(src)) {
+    const tex = normalizeEyeTexture({
+      ...raw,
+      assetGuid: raw?.assetGuid || guid,
+      kind: raw?.kind || "eye",
+    });
+    textureAssets[tex.assetGuid] = tex;
+  }
+  v11.textureAssets = textureAssets;
+  return v11;
+}
+
 /** @type {Record<number, (doc: any) => any>} */
 const STEPS = {
   1(doc) {
@@ -568,6 +586,10 @@ const STEPS = {
   // 10 → 11: persist pre-baked UV atlas (objectMaterial.textureMap)
   11(doc) {
     return normalizeV11(doc);
+  },
+  // 11 → 12: eye emotion poses + topologyKey / partClass tags
+  12(doc) {
+    return normalizeV12(doc);
   },
 };
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/schema.js
@@ -5,7 +5,7 @@
 import { serializeEyeTexture, normalizeEyeUv } from "../lib/texture/eyeTexture.js";
 import { serializeTextureMap, normalizeTextureMap } from "../lib/texture/textureMapCodec.js";
 
-export const CURRENT_SCHEMA_VERSION = 11;
+export const CURRENT_SCHEMA_VERSION = 12;
 
 export { serializeTextureMap, normalizeTextureMap };
 
@@ -408,6 +408,24 @@ export function validateProject(doc) {
       errors.push('objectMaterial.textureMap.encoding must be "rgba8-base64"');
     } else if (!(tm.w > 0) || !(tm.h > 0) || typeof tm.data !== "string") {
       errors.push("objectMaterial.textureMap needs w, h, and data");
+    }
+  }
+  if (doc.schemaVersion >= 12 && doc.textureAssets) {
+    for (const [guid, tex] of Object.entries(doc.textureAssets)) {
+      if (!tex || typeof tex !== "object") continue;
+      if (tex.kind != null && tex.kind !== "eye") continue;
+      if (tex.poses != null && !Array.isArray(tex.poses)) {
+        errors.push(`textureAssets[${guid}].poses must be an array`);
+      }
+      if (tex.partClass != null && tex.partClass !== "eye") {
+        errors.push(`textureAssets[${guid}].partClass must be "eye" for eye textures`);
+      }
+      if (tex.topologyKey != null && typeof tex.topologyKey !== "string") {
+        errors.push(`textureAssets[${guid}].topologyKey must be a string`);
+      }
+      if (tex.emotion != null && typeof tex.emotion !== "string") {
+        errors.push(`textureAssets[${guid}].emotion must be a string`);
+      }
     }
   }
   return errors;

--- a/gallery/game_engine/v2/mesh_editor/docs/EYE_EMOTION_RIG.md
+++ b/gallery/game_engine/v2/mesh_editor/docs/EYE_EMOTION_RIG.md
@@ -177,9 +177,38 @@ reactive knot trees or WASM bindings every frame.
 | `interpolateEyePose(a, b, t)` | CPU morph (preview / bake) |
 | `compileEyeRig(tex, opts)` | Sampled buffers for runtime |
 
+## Animation classes (generalized states)
+
+Emotion is one **animation class**; a class has named **targets** that morph
+inside the same topology:
+
+```text
+animClass: "emotion"
+  targets: neutral | happy | sad | angry | …
+```
+
+Later classes (same machinery, different targets):
+
+```text
+animClass: "blink"   → open | closed
+animClass: "gaze"    → center | left | right
+```
+
+Each pose stores `animClass` + `target` (`emotion` kept as alias when
+`animClass === "emotion"`). Registry: `ANIM_CLASS_DEFS` in `eyeEmotion.js`.
+
+## Mesh preview testing (Assign → A→B)
+
+1. **Assign to mesh** (existing square + texture dialog).
+2. In the mesh toolbar **Anim preview** panel:
+   - **Seed demo emotions** — procedural targets from the current eye
+   - Pick class / From / To and drag **Morph** 0…1
+3. Preview re-bakes the UV atlas (`previewAssignedAnimMorph`) so the 3D view
+   updates. Authoring `layers` stay unchanged; only the assigned atlas morphs.
+
 ## Out of scope (follow-ups)
 
-- UI for pose list / emotion picker in the Texture sector
-- GPU offscreen eye framebuffer → mesh UV
+- Full pose list / capture UI in the Texture sector
+- GPU offscreen eye framebuffer / vertex-shader morph (no atlas rebake)
 - Per-eye blink / gaze overrides on top of shared emotion
 - Asymmetric in/out handles (`inHandle` / `outHandle`) if C1 symmetry is too limiting

--- a/gallery/game_engine/v2/mesh_editor/docs/EYE_EMOTION_RIG.md
+++ b/gallery/game_engine/v2/mesh_editor/docs/EYE_EMOTION_RIG.md
@@ -1,0 +1,185 @@
+# Eye emotion rig — design
+
+How eye textures become a small **animatable vector rig** with tagged
+emotion poses that morph A → B when topology matches.
+
+Authoring lives in the mesh editor (`kind: "eye"`). Runtime compiles poses to
+sampled geometry / GPU buffers (see § Runtime). This doc is the contract for
+tags, topology, and pose data.
+
+## Goals
+
+1. Tag each eye pose with a clear **emotion** (`angry`, `sad`, …).
+2. Morph only between poses that share the same **topology** (same knot counts /
+   closedness / clip graph per layer role).
+3. Keep `partClass: "eye"` so later body parts (`mouth`, `brow`, …) can use the
+   same library machinery with their own tag vocabularies and topology keys.
+4. Separate **authoring JSON** (knots, ids, clipTo) from **runtime buffers**.
+
+## Asset layers (already authored)
+
+| Role | Shape | Default knots |
+|------|--------|----------------|
+| `eyeball` | closed Bézier | 4 |
+| `iris` | closed, clip → eyeball | 4 |
+| `pupil` | closed, clip → iris | 4 |
+| `reflection` | closed, clip → eyeball | 4 |
+| `eyelid` | open, fill above/below, clip → eyeball | 3 (2 segments) |
+
+Left/right pair: one rig, right eye mirrored when `eyePair.linked` (no separate
+pose stack required for morph).
+
+## Topology vs pose
+
+**Topology** (stable within a morph family):
+
+- layer roles + draw order
+- knot count and order per role
+- closed / open, `fillSide`, `clipTo`
+- materials / colours (not morphed by default)
+
+**Pose** (animatable):
+
+- knot `{ x, y, hx, hy }` per stable index
+- optional `opacity` / `enabled`
+
+Knot correspondence is by **role + index**, never by random knot ids:
+
+```text
+angry.eyeball[i]  ↔  sad.eyeball[i]
+```
+
+Handles (`hx`, `hy`) interpolate with positions so curvature does not pop.
+
+## Tags
+
+### Part class
+
+```text
+partClass: "eye" | "mouth" | "brow" | …
+```
+
+Only assets with the same `partClass` are candidates for a shared picker /
+morph family. Mouth/brow will define their own roles and emotion (or phoneme)
+lists later.
+
+### Emotion tags (`partClass: "eye"`)
+
+Canonical set (extensible; custom strings allowed):
+
+| Tag | Intent |
+|-----|--------|
+| `neutral` | Rest / idle |
+| `happy` | Raised lids, soft curves |
+| `sad` | Inner brows down, lids heavy |
+| `angry` | Outer lids down, sharper shape |
+| `surprised` | Wide open |
+| `sleepy` | Heavy lids |
+| `wink` | One side override later |
+| `fear` | Wide + tense |
+| `disgust` | Squint / squeeze |
+
+Project / library list tags (search):
+
+```text
+part:eye
+emotion:<tag>
+topo:<topologyKey>
+```
+
+Example: `["part:eye", "emotion:angry", "topo:eye:v1/…"]`.
+
+### Topology key
+
+Computed from layer roles (see `eyeTopologyKey()` in
+`app/src/lib/texture/eyeEmotion.js`):
+
+```text
+eye:v1/eyeball:4c/iris:4c:clip=eyeball/pupil:4c:clip=iris/reflection:4c:clip=eyeball/eyelid:3o:fill=above:clip=eyeball
+```
+
+Two eye textures are **morph-compatible** iff their topology keys are equal.
+Colours and emotion tags may differ.
+
+## Authoring document shape (schema v12+)
+
+On each `textureAssets[*]` with `kind: "eye"`:
+
+```js
+{
+  kind: "eye",
+  partClass: "eye",
+  topologyKey: "eye:v1/…",   // derived on normalize/save
+  emotion: "neutral",        // tag of the working layers / active pose
+  layers: [ /* editable working copy */ ],
+  eyePair: { distance, linked, editSide },
+  poses: [
+    {
+      id: "pose_…",
+      name: "Angry",
+      emotion: "angry",
+      tags: ["angry"],         // optional extras
+      layers: {
+        eyeball: { knots: [/* length = topology */], opacity: 1 },
+        iris: { knots: […] },
+        pupil: { knots: […] },
+        reflection: { knots: […] },
+        eyelid: { knots: [/* 3 */], opacity: 1, enabled: true }
+      }
+    }
+  ],
+  activePoseId: "pose_…" | null
+}
+```
+
+Working `layers` remain the editor source of truth for the current pose.
+Capturing a pose snapshots knot poses from those layers; applying a pose
+writes knots back (ids / segments preserved).
+
+## Morph pipeline (authoring → runtime)
+
+```text
+Eye texture JSON
+  ├── poses (emotion-tagged, same topology)
+  └── working layers
+          │
+          ▼ compileEyeRig()
+  topology check → sample Bézier at fixed t → triangulate once
+          │
+          ▼
+  CompiledEyeRig { indices, poses: Float32Array per emotion, clip graph }
+          │
+          ▼ EyeAnimator (from, to, uMorph)
+          ▼ GPU mix(from, to, eased t)
+```
+
+Recommended runtime (later): fixed sampling (~16/segment), vertex-shader morph,
+stencil/clip from `clipTo`, left/right as mirrored instances. Do not push Vue-
+reactive knot trees or WASM bindings every frame.
+
+## Editor constraints (to keep morphs valid)
+
+- Adding/removing knots on a layer regenerates `topologyKey` and marks
+  poses with a different key as incompatible (drop or re-capture).
+- Prefer editing within a locked topology once a pose set exists.
+- Do not author self-intersecting or inverted eye outlines for poses in the
+  same family.
+
+## Compatibility helpers
+
+| Helper | Role |
+|--------|------|
+| `eyeTopologyKey(tex)` | Fingerprint for morph family |
+| `areEyeTexturesCompatible(a, b)` | Same partClass + topologyKey |
+| `listCompatibleEyeTextures(lib, ref)` | Library filter |
+| `captureEyePose(tex, { emotion, name })` | Snapshot working layers |
+| `applyEyePose(tex, pose)` | Write pose into working layers |
+| `interpolateEyePose(a, b, t)` | CPU morph (preview / bake) |
+| `compileEyeRig(tex, opts)` | Sampled buffers for runtime |
+
+## Out of scope (follow-ups)
+
+- UI for pose list / emotion picker in the Texture sector
+- GPU offscreen eye framebuffer → mesh UV
+- Per-eye blink / gaze overrides on top of shared emotion
+- Asymmetric in/out handles (`inHandle` / `outHandle`) if C1 symmetry is too limiting

--- a/gallery/game_engine/v2/mesh_editor/library/README.md
+++ b/gallery/game_engine/v2/mesh_editor/library/README.md
@@ -52,6 +52,11 @@ copy or symlink selected folders into a tracked tree, or temporarily force-add.
 - v10 adds `projectKind` (`mesh` | `texture`) so the library list filters by
   workspace, plus optional `objectMaterial.textureAsset` / `textureAssign`
   (`eyePair`) to map a saved eye texture onto lathe UVs (both eyes).
+- v11 persists a pre-baked UV atlas on `objectMaterial.textureMap`.
+- v12 extends `kind: "eye"` textures with emotion-rig fields: `partClass`,
+  `emotion`, `topologyKey`, `poses[]`, `activePoseId`. Poses share one topology
+  so emotion A can morph to B; see
+  [`docs/EYE_EMOTION_RIG.md`](../docs/EYE_EMOTION_RIG.md).
 
 When you change the document shape, bump the version and add a step; old folders
 keep working.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Eye emotion morph: **texture ↔ texture** peers (same `topologyKey`), testable in Texture editor and in 3D after assign.

### Texture editor

1. Tag eyes with emotions (`neutral`, `angry`, …)
2. Morph 0…1 toward a compatible peer in the texture preview

### 3D preview (optimized)

After **Assign to mesh**:

1. Pre-bake UV atlases for A and B once
2. Scrub Morph → **lerp atlas pixels** (no Bézier re-raster)
3. Hot-swap map via `updatePartMapBuffer` / `gpu_update_texture`
4. **No tessellate / UV rebuild**

### Key pieces

- `atlasMorph.js` — `lerpAtlas`
- `ThreeTexture.needsUpdate` → `gpu_update_texture`
- Host `updatePartMapBuffer` (stable `partMapTex` instance)
- `Preview3D.updateAtlas` / `rangerPreview.updateSharedMap`

### Test plan

- [x] `npm test` in `mesh_editor/app`
- [x] `node smoke.mjs` (includes atlas hot-swap)
- [ ] Manual: two tagged eyes → Texture morph → Assign → 3D morph scrub

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7a486d2-7037-4316-93e5-5f38ff67c13e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7a486d2-7037-4316-93e5-5f38ff67c13e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

