### PR TITLE
Fix eye placement on the wrong side of the lathe

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -146,6 +146,28 @@ assert.ok(regionSamplePoints(DEFAULT_ASSIGN_REGION, 3).length === 9);
     Math.abs(placed.centerV - 0.6666666666666666) < 1e-6,
     "default mid-face V stays high (not inverted to ~0.33)",
   );
+  // Pin to center hit even if corners drift toward the sides/back
+  const drifted = [
+    [0.05, 0.7],
+    [0.45, 0.7],
+    [0.45, 0.4],
+    [0.05, 0.4],
+  ];
+  const pinned = eyeUvFromRegionSamples(drifted, DEFAULT_ASSIGN_REGION, {
+    centerHit: [0.25, 0.55],
+  });
+  assert.ok(pinned);
+  assert.ok(Math.abs(pinned.centerU - 0.25) < 1e-9, "centerHit pins U to front");
+  assert.ok(Math.abs(pinned.centerV - 0.55) < 1e-9, "centerHit pins V");
+  // Front face: character left = higher U (toward −X), right = lower U (toward +X)
+  {
+    const sep = 0.12;
+    const cu = 0.25;
+    const leftU = ((cu + sep / 2) % 1 + 1) % 1;
+    const rightU = ((cu - sep / 2) % 1 + 1) % 1;
+    assert.ok(leftU > rightU, "left eye at higher U than right on front face");
+    assert.ok(Math.abs(leftU - 0.5) < Math.abs(rightU - 0.5), "left nearer −X");
+  }
 }
 
 // pickRootSurface fills UV when vertex uvs are missing

--- a/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
+++ b/gallery/game_engine/v2/mesh_editor/app/src/components/Preview3D.vue
@@ -342,16 +342,18 @@ function confirmRegion() {
     return;
   }
 
-  // Prefer the four square corners (matches the yellow overlay); fall back to a grid.
+  // Prefer the square center (face aimed at), then corners for scale/gap.
   const c = regionCorners(region);
+  const centerHit = pickUvAtNorm(c.center.x, c.center.y);
   const cornerPts = [c.tl, c.tr, c.br, c.bl];
   let samples = [];
   for (const p of cornerPts) {
     const uv = pickUvAtNorm(p.x, p.y);
     if (uv) samples.push(uv);
   }
+  if (centerHit) samples.unshift(centerHit);
   if (samples.length < 2) {
-    samples = [];
+    samples = centerHit ? [centerHit] : [];
     for (const p of regionSamplePoints(region, 5)) {
       const uv = pickUvAtNorm(p.x, p.y);
       if (uv) samples.push(uv);
@@ -365,7 +367,9 @@ function confirmRegion() {
     }
   }
 
-  const textureUv = eyeUvFromRegionSamples(uniq, region);
+  const textureUv = eyeUvFromRegionSamples(uniq, region, {
+    centerHit: centerHit || undefined,
+  });
   if (!textureUv) {
     regionError.value =
       "Could not hit the mesh under the square — orbit the face toward the camera, or shrink the square.";

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/assignRegion.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/assignRegion.js
@@ -2,7 +2,7 @@
 // assignRegion.js — screen-space square for eye UV placement on the 3D preview.
 // ============================================================================
 
-import { eyeUvFromCorners, normalizeEyeUv, unwrapUvPairU } from "./texture/eyeTexture.js";
+import { eyeUvFromCorners, normalizeEyeUv } from "./texture/eyeTexture.js";
 
 /** @typedef {{ cx: number, cy: number, half: number }} AssignRegion */
 
@@ -61,11 +61,12 @@ export function regionSamplePoints(r, grid = 5) {
 
 /**
  * Build textureUv from one or more UV samples under the screen square.
- * Prefer AABB of samples; if only one sample, derive scale from region.half.
+ * Prefer AABB of samples for scale/gap; pin center to opts.centerHit when given
+ * so corner rays that graze the sides/back do not drag placement off the face.
  *
  * @param {Array<[number, number]|{0:number,1:number}>} samples
  * @param {AssignRegion} region
- * @param {object} [opts]
+ * @param {{ centerHit?: [number, number], baseScale?: number, eyeSeparationU?: number }} [opts]
  */
 export function eyeUvFromRegionSamples(samples, region, opts = {}) {
   const list = (samples || [])
@@ -79,7 +80,13 @@ export function eyeUvFromRegionSamples(samples, region, opts = {}) {
   if (!list.length) return null;
 
   const reg = clampAssignRegion(region);
-  if (list.length === 1) {
+  const centerHit = opts.centerHit;
+  const hasCenter =
+    Array.isArray(centerHit) &&
+    Number.isFinite(Number(centerHit[0])) &&
+    Number.isFinite(Number(centerHit[1]));
+
+  if (list.length === 1 && !hasCenter) {
     const scale = Math.min(
       2.5,
       Math.max(0.35, (reg.half / DEFAULT_ASSIGN_REGION.half) * (opts.baseScale || 1)),
@@ -97,14 +104,12 @@ export function eyeUvFromRegionSamples(samples, region, opts = {}) {
   }
 
   // Unwrap U relative to the first sample so the AABB doesn't span the seam wrongly.
-  const u0 = list[0][0];
+  const u0 = hasCenter ? Number(centerHit[0]) : list[0][0];
   let uMin = Infinity;
   let uMax = -Infinity;
   let vMin = Infinity;
   let vMax = -Infinity;
   for (const [u, v] of list) {
-    const [lo, hi] = unwrapUvPairU(u0, u);
-    // unwrapUvPairU orders the pair; recover signed offset of u from u0
     let uu = ((u % 1) + 1) % 1;
     let base = ((u0 % 1) + 1) % 1;
     let d = uu - base;
@@ -114,9 +119,19 @@ export function eyeUvFromRegionSamples(samples, region, opts = {}) {
     uMax = Math.max(uMax, uu);
     vMin = Math.min(vMin, v);
     vMax = Math.max(vMax, v);
-    void lo;
-    void hi;
   }
-  // eyeUvFromCorners expects two corners; pass unwrapped extents
-  return eyeUvFromCorners(uMin, vMax, uMax, vMin, opts);
+  if (!Number.isFinite(uMin)) {
+    uMin = u0;
+    uMax = u0;
+    vMin = hasCenter ? Number(centerHit[1]) : list[0][1];
+    vMax = vMin;
+  }
+  const fromBox = eyeUvFromCorners(uMin, vMax, uMax, vMin, opts);
+  if (!hasCenter) return fromBox;
+  // Pin pair center to the square's center hit (the face the user aimed at).
+  return normalizeEyeUv({
+    ...fromBox,
+    centerU: ((Number(centerHit[0]) % 1) + 1) % 1,
+    centerV: Math.min(1, Math.max(0, Number(centerHit[1]))),
+  });
 }

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -686,7 +686,8 @@ export function rasterizeEyeTexture(tex, width, height) {
 
 /** Default UV placement for eye-pair assignment on a lathe mesh. */
 export const DEFAULT_EYE_UV = {
-  centerU: 0.5,
+  /** Front face of unit lathe (+Z) is u≈0.25 — not 0.5 (−X side). */
+  centerU: 0.25,
   centerV: 0.58,
   /** Uniform size multiplier for both eyes. */
   scale: 1,
@@ -904,9 +905,10 @@ export function rasterizeEyePairUvMap(tex, width = 512, height = 512, opts = {})
   const left = tintSclera ? layersWithEyeballColor(leftRaw, bg) : leftRaw;
   const right = tintSclera ? layersWithEyeballColor(rightRaw, bg) : rightRaw;
 
-  // Character left eye = lower U; right = higher U.
-  blitEyeCellToAtlas(ctx, left, centerU - sepU / 2, centerV, cellW, cellH, bg);
-  blitEyeCellToAtlas(ctx, right, centerU + sepU / 2, centerV, cellW, cellH, bg);
+  // Front (+Z, u≈0.25): character left = higher U (toward −X / screen-left from +Z).
+  // Character right = lower U (toward +X / screen-right).
+  blitEyeCellToAtlas(ctx, left, centerU + sepU / 2, centerV, cellW, cellH, bg);
+  blitEyeCellToAtlas(ctx, right, centerU - sepU / 2, centerV, cellW, cellH, bg);
 
   const img = ctx.getImageData(0, 0, w, h);
   return {
@@ -978,11 +980,12 @@ export async function rasterizeEyePairUvMapAsync(tex, width = 512, height = 512,
 
   onProgress("left-eye");
   await yieldFn();
-  blitEyeCellToAtlas(ctx, left, centerU - sepU / 2, centerV, cellW, cellH, bg);
+  // Front (+Z): character left = higher U; right = lower U (see rasterizeEyePairUvMap).
+  blitEyeCellToAtlas(ctx, left, centerU + sepU / 2, centerV, cellW, cellH, bg);
 
   onProgress("right-eye");
   await yieldFn();
-  blitEyeCellToAtlas(ctx, right, centerU + sepU / 2, centerV, cellW, cellH, bg);
+  blitEyeCellToAtlas(ctx, right, centerU - sepU / 2, centerV, cellW, cellH, bg);
 
   onProgress("readback");
   await yieldFn();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Eyes still landed on the wrong side of the 3D lathe (wrong cheeks / off the aimed face), including after save.

## Causes
1. **Left/right U swap** — on the front face (+Z, `u≈0.25`), character left is **higher** U (toward −X), but the atlas painted left at lower U.
2. **Default `centerU` was 0.5** (−X side), not the front.
3. Region assign used only square **corners**; a wide square could drag the UV AABB onto the sides/back.

## Fix
- Paint character left at `centerU + sep/2`, right at `centerU - sep/2`.
- Default `centerU = 0.25` (front).
- Pin pair center to the square’s **center** ray hit; corners only drive scale/gap.

Re-assign eyes after merging (old baked atlases keep the previous L/R placement).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

