### PR TITLE
Fix texture assign save/load roundtrip (UV + bake)

### DIFF
--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-eye-texture.mjs
@@ -47,6 +47,7 @@ import {
 import {
   serializeTextureMap,
   normalizeTextureMap,
+  rgbaSourceToBytes,
 } from "../src/lib/texture/textureMapCodec.js";
 
 const eye = createDefaultEyeTexture({ name: "TestEye" });
@@ -514,6 +515,116 @@ assert.equal(mig10.doc.objectMaterial.textureMap, null);
     "Save must persist textureMap bake",
   );
   assert.ok(saveDoc.objectMaterial.textureMap.data.length > 100);
+}
+
+// ---------------------------------------------------------------------------
+// Assign → save → load identity: textureUv + atlas pixels must not drift.
+// Mirrors Save as / create: live TypedArray in state must survive JSON I/O.
+// ---------------------------------------------------------------------------
+{
+  const assignUv = normalizeEyeUv({
+    centerU: 0.27,
+    centerV: 0.61,
+    scale: 1.15,
+    eyeSeparationU: 0.13,
+  });
+  // Distinct pattern so reload cannot accidentally match a solid re-bake bg.
+  const liveRgba = new Uint8ClampedArray(32 * 32 * 4);
+  for (let i = 0; i < liveRgba.length; i += 4) {
+    liveRgba[i] = (i * 3) & 255;
+    liveRgba[i + 1] = (i * 5) & 255;
+    liveRgba[i + 2] = (i * 7) & 255;
+    liveRgba[i + 3] = 255;
+  }
+  const liveMap = { rgba: liveRgba, w: 32, h: 32, name: "eye-uv" };
+
+  const editorState = {
+    ...docWithBake,
+    objectMaterial: {
+      ...docWithBake.objectMaterial,
+      texture: "asset",
+      textureAsset: ser.assetGuid,
+      textureAssign: "eyePair",
+      textureUv: assignUv,
+      textureMap: liveMap,
+    },
+    textureAssets: { [ser.assetGuid]: ser },
+    knots: docWithBake.profile.knots,
+    segments: docWithBake.profile.segments,
+    orbitKnots: docWithBake.orbit.knots,
+    orbitSegments: docWithBake.orbit.segments,
+    spineProfileKnots: docWithBake.spineProfile.knots,
+    spineProfileSegments: docWithBake.spineProfile.segments,
+    spineOrbitKnots: docWithBake.spineOrbit.knots,
+    spineOrbitSegments: docWithBake.spineOrbit.segments,
+    placementNormal: docWithBake.placementNormal,
+    embeddedAssets: {},
+    children: [],
+    editor: docWithBake.editor,
+  };
+
+  // Correct client path (save / saveAs after fix): build doc, then JSON wire.
+  const savedDoc = buildProjectDocument({
+    state: editorState,
+    name: "Roundtrip eyes",
+    slug: "roundtrip-eyes",
+    projectKind: "mesh",
+  });
+  assert.ok(savedDoc.objectMaterial.textureMap?.data, "bake must be base64 before wire");
+  assert.deepEqual(savedDoc.objectMaterial.textureUv, assignUv, "textureUv saved as assigned");
+
+  const wire = JSON.parse(JSON.stringify(savedDoc));
+  const loaded = migrateProject(wire);
+  assert.equal(loaded.ok, true, loaded.errors?.join("; "));
+  assert.deepEqual(
+    loaded.doc.objectMaterial.textureUv,
+    assignUv,
+    "textureUv must match after load",
+  );
+  const loadedMap = normalizeTextureMap(loaded.doc.objectMaterial.textureMap);
+  assert.ok(loadedMap, "textureMap must survive save→load");
+  assert.equal(loadedMap.w, 32);
+  assert.equal(loadedMap.h, 32);
+  assert.equal(loadedMap.rgba.length, liveRgba.length);
+  for (let i = 0; i < liveRgba.length; i++) {
+    assert.equal(loadedMap.rgba[i], liveRgba[i], `pixel byte ${i} drifted`);
+  }
+
+  // Regression: raw create body { name, state } with TypedArray — JSON kills
+  // .length; codec must still recover so server buildProjectDocument keeps bake.
+  const createBody = JSON.parse(
+    JSON.stringify({
+      name: "Create raw state",
+      projectKind: "mesh",
+      state: editorState,
+    }),
+  );
+  assert.equal(
+    Array.isArray(createBody.state.objectMaterial.textureMap.rgba),
+    false,
+    "TypedArray becomes plain object on the wire",
+  );
+  assert.equal(
+    createBody.state.objectMaterial.textureMap.rgba.length,
+    undefined,
+    "revived rgba has no .length",
+  );
+  const recovered = rgbaSourceToBytes(createBody.state.objectMaterial.textureMap.rgba, 32 * 32 * 4);
+  assert.ok(recovered, "rgbaSourceToBytes recovers JSON-revived TypedArray");
+  const fromRawState = buildProjectDocument({
+    state: createBody.state,
+    name: createBody.name,
+    projectKind: createBody.projectKind,
+  });
+  assert.ok(
+    fromRawState.objectMaterial.textureMap?.encoding === "rgba8-base64",
+    "create {state} path must not drop bake after JSON revive",
+  );
+  assert.deepEqual(fromRawState.objectMaterial.textureUv, assignUv);
+  const rawRound = normalizeTextureMap(fromRawState.objectMaterial.textureMap);
+  for (let i = 0; i < liveRgba.length; i++) {
+    assert.equal(rawRound.rgba[i], liveRgba[i], `create-path pixel ${i}`);
+  }
 }
 
 console.log("smoke-eye-texture: ok", {

--- a/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
+++ b/gallery/game_engine/v2/mesh_editor/app/scripts/smoke-mesh-pick.mjs
@@ -159,14 +159,13 @@ assert.ok(regionSamplePoints(DEFAULT_ASSIGN_REGION, 3).length === 9);
   assert.ok(pinned);
   assert.ok(Math.abs(pinned.centerU - 0.25) < 1e-9, "centerHit pins U to front");
   assert.ok(Math.abs(pinned.centerV - 0.55) < 1e-9, "centerHit pins V");
-  // Front face: character left = higher U (toward −X), right = lower U (toward +X)
+  // Blit placement: character left = lower U, right = higher U (see eyeTexture.js).
   {
     const sep = 0.12;
     const cu = 0.25;
-    const leftU = ((cu + sep / 2) % 1 + 1) % 1;
-    const rightU = ((cu - sep / 2) % 1 + 1) % 1;
-    assert.ok(leftU > rightU, "left eye at higher U than right on front face");
-    assert.ok(Math.abs(leftU - 0.5) < Math.abs(rightU - 0.5), "left nearer −X");
+    const leftU = ((cu - sep / 2) % 1 + 1) % 1;
+    const rightU = ((cu + sep / 2) % 1 + 1) % 1;
+    assert.ok(leftU < rightU, "left eye at lower U than right");
   }
 }
 

--- a/gallery/game_engine/v2/mesh_editor/app/src/composables/useLibrary.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/composables/useLibrary.js
@@ -145,11 +145,16 @@ export function useLibrary({ snapshotState, applyProject, tessellate }) {
     }
     beginBusy();
     try {
-      const created = await api.createProject({
-        name: n,
+      // Build the document on the client first (same as save/exportJson) so
+      // textureMap TypedArrays become rgba8-base64 before fetch JSON.stringify.
+      // Posting raw editor state drops the bake: TypedArrays revive as
+      // `{ "0": n, … }` without .length and serializeTextureMap returns null.
+      const doc = buildProjectDocument({
         state: snapshotState(k),
+        name: n,
         projectKind: k,
       });
+      const created = await api.createProject(doc);
       slot.slug = created.slug;
       slot.name = created.name;
       slot.saveAsName = created.name;

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/eyeTexture.js
@@ -905,10 +905,9 @@ export function rasterizeEyePairUvMap(tex, width = 512, height = 512, opts = {})
   const left = tintSclera ? layersWithEyeballColor(leftRaw, bg) : leftRaw;
   const right = tintSclera ? layersWithEyeballColor(rightRaw, bg) : rightRaw;
 
-  // Front (+Z, u≈0.25): character left = higher U (toward −X / screen-left from +Z).
-  // Character right = lower U (toward +X / screen-right).
-  blitEyeCellToAtlas(ctx, left, centerU + sepU / 2, centerV, cellW, cellH, bg);
-  blitEyeCellToAtlas(ctx, right, centerU - sepU / 2, centerV, cellW, cellH, bg);
+  // Character left eye = lower U; right = higher U (matches live assign on screen).
+  blitEyeCellToAtlas(ctx, left, centerU - sepU / 2, centerV, cellW, cellH, bg);
+  blitEyeCellToAtlas(ctx, right, centerU + sepU / 2, centerV, cellW, cellH, bg);
 
   const img = ctx.getImageData(0, 0, w, h);
   return {
@@ -980,12 +979,11 @@ export async function rasterizeEyePairUvMapAsync(tex, width = 512, height = 512,
 
   onProgress("left-eye");
   await yieldFn();
-  // Front (+Z): character left = higher U; right = lower U (see rasterizeEyePairUvMap).
-  blitEyeCellToAtlas(ctx, left, centerU + sepU / 2, centerV, cellW, cellH, bg);
+  blitEyeCellToAtlas(ctx, left, centerU - sepU / 2, centerV, cellW, cellH, bg);
 
   onProgress("right-eye");
   await yieldFn();
-  blitEyeCellToAtlas(ctx, right, centerU - sepU / 2, centerV, cellW, cellH, bg);
+  blitEyeCellToAtlas(ctx, right, centerU + sepU / 2, centerV, cellW, cellH, bg);
 
   onProgress("readback");
   await yieldFn();

--- a/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/textureMapCodec.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/lib/texture/textureMapCodec.js
@@ -31,7 +31,40 @@ function base64ToBytes(b64) {
 }
 
 /**
- * Encode a live atlas for project.json.
+ * Coerce live / JSON-revived RGBA into a byte view of length >= need.
+ * JSON.stringify turns TypedArrays into `{ "0": n, "1": n, ... }` without
+ * `.length` — `new Uint8Array(that)` is empty, so we recover index-by-index.
+ * @param {unknown} src
+ * @param {number} need
+ * @returns {Uint8Array|null}
+ */
+export function rgbaSourceToBytes(src, need) {
+  const n = Math.max(0, need | 0);
+  if (!src || n <= 0) return null;
+  if (ArrayBuffer.isView(src)) {
+    const u8 = new Uint8Array(src.buffer, src.byteOffset, src.byteLength);
+    return u8.length >= n ? u8.subarray(0, n) : null;
+  }
+  if (Array.isArray(src)) {
+    if (src.length < n) return null;
+    return Uint8Array.from(src.slice(0, n));
+  }
+  if (typeof src === "object") {
+    let len = typeof src.length === "number" && Number.isFinite(src.length) ? src.length | 0 : -1;
+    if (len < 0) {
+      len = 0;
+      while (typeof src[len] === "number") len++;
+    }
+    if (len < n) return null;
+    const out = new Uint8Array(n);
+    for (let i = 0; i < n; i++) out[i] = src[i] & 255;
+    return out;
+  }
+  return null;
+}
+
+/**
+ * Encode a live atlas for project JSON.
  * @param {TextureMap|null|undefined} map
  * @returns {SerializedTextureMap|null}
  */
@@ -40,9 +73,8 @@ export function serializeTextureMap(map) {
   const w = Math.max(1, map.w | 0);
   const h = Math.max(1, map.h | 0);
   const need = w * h * 4;
-  const src = map.rgba;
-  if (!src || src.length < need) return null;
-  const bytes = src instanceof Uint8Array ? src.subarray(0, need) : new Uint8Array(src).subarray(0, need);
+  const bytes = rgbaSourceToBytes(map.rgba, need);
+  if (!bytes) return null;
   return {
     encoding: "rgba8-base64",
     w,
@@ -63,13 +95,17 @@ export function normalizeTextureMap(raw) {
   const h = Math.max(1, Number(raw.h) | 0);
   const need = w * h * 4;
 
-  // Already live (in-memory after assign)
-  if (raw.rgba && raw.rgba.length >= need && !raw.data) {
-    const rgba =
-      raw.rgba instanceof Uint8ClampedArray
-        ? raw.rgba
-        : new Uint8ClampedArray(raw.rgba);
-    return { rgba, w, h, name: raw.name };
+  // Already live (in-memory after assign), or JSON-revived TypedArray shape.
+  if (raw.rgba && !raw.data) {
+    const bytes = rgbaSourceToBytes(raw.rgba, need);
+    if (bytes) {
+      return {
+        rgba: new Uint8ClampedArray(bytes),
+        w,
+        h,
+        name: raw.name,
+      };
+    }
   }
 
   if (raw.encoding !== "rgba8-base64" || typeof raw.data !== "string" || !raw.data) {

--- a/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
+++ b/gallery/game_engine/v2/mesh_editor/app/src/library/migrations.js
@@ -475,11 +475,19 @@ function normalizeV10(doc) {
     doc.projectKind === "texture" || doc.projectKind === "mesh" ? doc.projectKind : null;
   if (!kind) kind = !hasMesh && texN > 0 ? "texture" : "mesh";
   v9.projectKind = normalizeProjectKind(kind);
+  // v3 whitelist rebuilds objectMaterial without texture* fields — always prefer
+  // the pre-chain document so load does not reset assign UV / asset guid.
+  const incomingOm = doc.objectMaterial || {};
   const om = v9.objectMaterial || {};
   const assetKeys = Object.keys(v9.textureAssets || {});
-  let textureAsset = om.textureAsset || null;
-  let textureAssign = om.textureAssign === "eyePair" ? "eyePair" : om.textureAssign || null;
-  let texture = om.texture || "gradient";
+  let textureAsset = incomingOm.textureAsset || om.textureAsset || null;
+  let textureAssign =
+    incomingOm.textureAssign === "eyePair"
+      ? "eyePair"
+      : incomingOm.textureAssign ||
+        (om.textureAssign === "eyePair" ? "eyePair" : om.textureAssign) ||
+        null;
+  let texture = incomingOm.texture || om.texture || "gradient";
   if (textureAsset && !(v9.textureAssets || {})[textureAsset]) {
     textureAsset = assetKeys.length === 1 ? assetKeys[0] : null;
   }
@@ -492,14 +500,14 @@ function normalizeV10(doc) {
   if (textureAsset && !textureAssign) textureAssign = "eyePair";
   if (textureAsset && texture !== "asset") texture = "asset";
   v9.objectMaterial = {
-    color: om.color ?? null,
-    roughness: Number(om.roughness ?? 0.4),
-    metalness: Number(om.metalness ?? 0),
-    opacity: Number(om.opacity ?? 1),
+    color: incomingOm.color ?? om.color ?? null,
+    roughness: Number(incomingOm.roughness ?? om.roughness ?? 0.4),
+    metalness: Number(incomingOm.metalness ?? om.metalness ?? 0),
+    opacity: Number(incomingOm.opacity ?? om.opacity ?? 1),
     texture,
     textureAsset,
     textureAssign,
-    textureUv: normalizeEyeUv(om.textureUv),
+    textureUv: normalizeEyeUv(incomingOm.textureUv ?? om.textureUv),
   };
   return v9;
 }
@@ -507,6 +515,7 @@ function normalizeV10(doc) {
 function normalizeV11(doc) {
   // Capture bake before v10 rewrite (normalizeV10 rebuilds objectMaterial without textureMap).
   const incomingMap = doc?.objectMaterial?.textureMap;
+  const incomingUv = doc?.objectMaterial?.textureUv;
   const v10 = normalizeV10(doc);
   v10.schemaVersion = 11;
   const om = v10.objectMaterial || {};
@@ -520,7 +529,8 @@ function normalizeV11(doc) {
     textureAsset: om.textureAsset || null,
     textureAssign:
       om.textureAssign === "eyePair" ? "eyePair" : om.textureAssign || null,
-    textureUv: normalizeEyeUv(om.textureUv),
+    // Prefer pre-chain UV (same reason as textureMap capture above).
+    textureUv: normalizeEyeUv(incomingUv != null ? incomingUv : om.textureUv),
     textureMap: serializeTextureMap(baked),
   };
   return v10;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Renderissä silmät näyttivät oikeilta, mutta tallennus/lataus vaihtoi parametreja.

### Juurisyyt
1. **Save as / create** lähetti raa’an editor state -objektin. `JSON.stringify` muuttaa `Uint8ClampedArray`-atlasen muotoon `{ "0": n, … }` ilman `.length` → `serializeTextureMap` palautti `null` → bake katosi → lataus re-rasteroi eri parametreilla.
2. **`migrateProject`** ajaa aina nykyisen schema-normalizerin; v3 whitelist rakentaa `objectMaterial` uudelleen ilman `textureUv`/`textureAsset` → jokainen lataus nollasi UV:n defaulteihin (`centerU: 0.25` jne.).
3. **#490 L/R-swap** ei vastannut live-renderiä (käyttäjä: tekstuuri kääntyi ylösalaisin) — palautettu.

### Korjaukset
- `saveAs` rakentaa dokumentin clientillä ennen POSTia (kuten Save/export).
- `rgbaSourceToBytes` palauttaa JSON-revived TypedArray-muodon.
- `normalizeV10`/`V11` lukevat texture*-kentät alkuperäisestä dokumentista ennen ketjua.
- L/R blit takaisin: left = `centerU - sep/2`, right = `centerU + sep/2`.
- Smoke: assign → save → load vertaa `textureUv` + pikselit; regressio create `{state}` -polulle.

`npm test` mesh_editorissä vihreä.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-693f8270-56dc-4eed-8ae8-310f4db4a582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

