### PR TITLE
fix(deps): bump brace-expansion@2 to 2.1.2 (Dependabot #125)

### DIFF
--- a/ranger-vscode-extension/client/package.json
+++ b/ranger-vscode-extension/client/package.json
@@ -16,6 +16,6 @@
   },
   "overrides": {
     "minimatch": "^5.1.9",
-    "brace-expansion": "^2.0.3"
+    "brace-expansion": "^2.1.2"
   }
 }

--- a/ranger-vscode-extension/package-lock.json
+++ b/ranger-vscode-extension/package-lock.json
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ranger-vscode-extension/package.json
+++ b/ranger-vscode-extension/package.json
@@ -119,7 +119,7 @@
     "picomatch": "^2.3.2",
     "ajv@6": "6.15.0",
     "brace-expansion@1": "1.1.16",
-    "brace-expansion@2": "2.0.3",
+    "brace-expansion@2": "2.1.2",
     "minimatch@3": "3.1.5",
     "minimatch@5": "5.1.9",
     "minimatch@9": "9.0.9"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes Dependabot alert **#125** (`brace-expansion`: DoS via exponential-time expansion of consecutive non-expanding `{}` groups — [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) / CVE-2026-13149).

The previous security override incorrectly pinned `brace-expansion@2` to **2.0.3**, which is still in the affected range (`>= 2.0.0, < 2.1.2`). This updates the override to the patched **2.1.2** release and refreshes `ranger-vscode-extension/package-lock.json`.

## Changes

- `ranger-vscode-extension/package.json`: `overrides.brace-expansion@2` → `2.1.2`
- `ranger-vscode-extension/client/package.json`: override range → `^2.1.2`
- Lockfile now resolves `@typescript-eslint/typescript-estree`'s nested `brace-expansion` to `2.1.2`

## Verification

- All locked `brace-expansion` versions are patched: `1.1.16`, `2.1.2`, `5.0.7`
- `npm audit` reports **0 vulnerabilities** in `ranger-vscode-extension` (root, client, and server)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56711a18-ccac-4f39-a6b1-f9d7c1218a37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56711a18-ccac-4f39-a6b1-f9d7c1218a37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

