### PR TITLE
compiler: drop dead SourceCode constructor arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Duplicate serializer extension when one file is reached by two import spellings** — a file imported as both `Child.rgr` and `domain/Child.rgr` was expanded twice, and with `@serialize(true)` the second expansion produced `method with the same name and parameter signature declared earlier` pointing at generated code. Fixed since 3.1.1 was published, released here; covered by a regression test.
 
+- **`SourceCode` constructed with three arguments in `ng_CodeNode.rgr`** — `SourceCode` takes a single `code_str`, but `vref1`, `vref2`, `newStr`, `newBool` and nine sibling factories passed `(name 0 (strlen name))` or `("" 0 0)`, copying the shape of the adjacent `new CodeNode(code 0 ...)`. JavaScript discards the extra arguments, so this was invisible until the TypeScript API bundle was type checked, where it produced all 13 of the `TS2554: Expected 1 arguments, but got 3` errors that `build:dist:module` reported. Dropping the dead arguments makes `tsc` clean, so the step is `&&`-chained again and a real type error blocks the build instead of scrolling past
+
 - **`file_mtime` C++ backend** — added missing `cpp` template in `Lang.rgr` (`stat()` + ms, matching es6 `mtimeMs`); fixes `game_runtime.rgr` hot-reload compile for `game_sdl` native binary
 
 - **`TSLexer` UTF-8 / native C++ tokenization** — code-unit length vs byte `charAt` mismatch after multi-byte characters (e.g. em dash in comments) no longer desyncs the lexer; fixes native SDL parse failures on [`invaders.game.tsx`](./gallery/game_engine/scripting/invaders.game.tsx) and similar scripts

--- a/bin/output.js
+++ b/bin/output.js
@@ -2901,7 +2901,7 @@ class CodeNode  {
   };
 }
 CodeNode.vref1 = function(name) {
-  const code = new SourceCode(name, 0, name.length);
+  const code = new SourceCode(name);
   const newNode = new CodeNode(code, 0, name.length);
   newNode.vref = name;
   newNode.value_type = 11;
@@ -2910,7 +2910,7 @@ CodeNode.vref1 = function(name) {
   return newNode;
 };
 CodeNode.vref2 = function(name, typeName) {
-  const code = new SourceCode(name, 0, name.length);
+  const code = new SourceCode(name);
   const newNode = new CodeNode(code, 0, name.length);
   newNode.vref = name;
   newNode.type_name = typeName;
@@ -2920,7 +2920,7 @@ CodeNode.vref2 = function(name, typeName) {
   return newNode;
 };
 CodeNode.newStr = function(name) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.string_value = name;
   newNode.value_type = 4;
@@ -2928,7 +2928,7 @@ CodeNode.newStr = function(name) {
   return newNode;
 };
 CodeNode.newBool = function(value) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.boolean_value = value;
   newNode.value_type = 5;
@@ -2936,7 +2936,7 @@ CodeNode.newBool = function(value) {
   return newNode;
 };
 CodeNode.newInt = function(value) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.int_value = value;
   newNode.value_type = 3;
@@ -2944,7 +2944,7 @@ CodeNode.newInt = function(value) {
   return newNode;
 };
 CodeNode.newDouble = function(value) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.double_value = value;
   newNode.value_type = 2;
@@ -2952,7 +2952,7 @@ CodeNode.newDouble = function(value) {
   return newNode;
 };
 CodeNode.op = function(opName) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.expression = true;
   const opNode = CodeNode.vref1(opName);
@@ -2960,7 +2960,7 @@ CodeNode.op = function(opName) {
   return newNode;
 };
 CodeNode.op2 = function(opName, param1) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.expression = true;
   const opNode = CodeNode.vref1(opName);
@@ -2969,7 +2969,7 @@ CodeNode.op2 = function(opName, param1) {
   return newNode;
 };
 CodeNode.op3 = function(opName, list) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.expression = true;
   const opNode = CodeNode.vref1(opName);
@@ -2981,7 +2981,7 @@ CodeNode.op3 = function(opName, list) {
   return newNode;
 };
 CodeNode.fromList = function(list) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.expression = true;
   for ( let i = 0; i < list.length; i++) {
@@ -2992,20 +2992,20 @@ CodeNode.fromList = function(list) {
   return newNode;
 };
 CodeNode.expressionNode = function() {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.expression = true;
   return newNode;
 };
 CodeNode.blockNode = function() {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.is_block_node = true;
   newNode.expression = true;
   return newNode;
 };
 CodeNode.blockFromList = function(list) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.is_block_node = true;
   newNode.expression = true;

--- a/compiler/ng_CodeNode.rgr
+++ b/compiler/ng_CodeNode.rgr
@@ -261,7 +261,7 @@ class CodeNode {
   }
 
   static fn vref1:CodeNode (name:string) {
-    def code (new SourceCode( name 0 (strlen name)))
+    def code (new SourceCode( name))
     def newNode@(lives):CodeNode (new CodeNode (code 0 (strlen name)))
     newNode.vref = name
     newNode.value_type = RangerNodeType.VRef
@@ -271,7 +271,7 @@ class CodeNode {
   }
 
   static fn vref2:CodeNode (name:string typeName:string) {
-    def code (new SourceCode( name 0 (strlen name)))
+    def code (new SourceCode( name))
     def newNode@(lives):CodeNode (new CodeNode (code 0 (strlen name)))
     newNode.vref = name
     newNode.type_name = typeName
@@ -282,7 +282,7 @@ class CodeNode {
   }
 
   static fn newStr:CodeNode (name:string) {
-    def code (new SourceCode( "" 0 0))
+    def code (new SourceCode( ""))
     def newNode@(lives):CodeNode (new CodeNode (code 0 0))
     newNode.string_value = name
     newNode.value_type = RangerNodeType.String
@@ -291,7 +291,7 @@ class CodeNode {
   }
 
   static fn newBool:CodeNode (value:boolean) {
-    def code (new SourceCode( "" 0 0))
+    def code (new SourceCode( ""))
     def newNode@(lives):CodeNode (new CodeNode (code 0 0))
     newNode.boolean_value = value
     newNode.value_type = RangerNodeType.Boolean
@@ -300,7 +300,7 @@ class CodeNode {
   }
 
   static fn newInt:CodeNode (value:int) {
-    def code (new SourceCode( "" 0 0))
+    def code (new SourceCode( ""))
     def newNode@(lives):CodeNode (new CodeNode (code 0 0))
     newNode.int_value = value
     newNode.value_type = RangerNodeType.Integer
@@ -309,7 +309,7 @@ class CodeNode {
   }
 
   static fn newDouble:CodeNode (value:double) {
-    def code (new SourceCode( "" 0 0))
+    def code (new SourceCode( ""))
     def newNode@(lives):CodeNode (new CodeNode (code 0 0))
     newNode.double_value = value
     newNode.value_type = RangerNodeType.Double
@@ -318,7 +318,7 @@ class CodeNode {
   }
 
   static fn op:CodeNode ( opName:string ) {
-    def code (new SourceCode( "" 0 0))
+    def code (new SourceCode( ""))
     def newNode@(lives):CodeNode (new CodeNode (code 0 0))
     newNode.expression = true
     def opNode (r.vref opName)
@@ -327,7 +327,7 @@ class CodeNode {
   }
 
   static fn op2:CodeNode ( opName:string param1@(strong):CodeNode ) {
-    def code (new SourceCode( "" 0 0))
+    def code (new SourceCode( ""))
     def newNode@(lives):CodeNode (new CodeNode (code 0 0))
     newNode.expression = true
     def opNode (r.vref opName)
@@ -337,7 +337,7 @@ class CodeNode {
   }
 
   static fn op3:CodeNode ( opName:string list:[CodeNode] ) {
-    def code (new SourceCode( "" 0 0))
+    def code (new SourceCode( ""))
     def newNode@(lives):CodeNode (new CodeNode (code 0 0))
     newNode.expression = true
     def opNode (r.vref opName)
@@ -349,7 +349,7 @@ class CodeNode {
   }
 
   static fn fromList:CodeNode ( list:[CodeNode] ) {
-    def code (new SourceCode( "" 0 0))
+    def code (new SourceCode( ""))
     def newNode@(lives):CodeNode (new CodeNode (code 0 0))
     newNode.expression = true
     for list item@(lives):CodeNode i {
@@ -360,14 +360,14 @@ class CodeNode {
   }
   
   static fn expressionNode:CodeNode () {
-    def code (new SourceCode( "" 0 0))
+    def code (new SourceCode( ""))
     def newNode@(lives):CodeNode (new CodeNode (code 0 0))
     newNode.expression = true
     return newNode
   }
   
   static fn blockNode:CodeNode () {
-    def code (new SourceCode( "" 0 0))
+    def code (new SourceCode( ""))
     def newNode@(lives):CodeNode (new CodeNode (code 0 0))
     newNode.is_block_node = true
     newNode.expression = true
@@ -375,7 +375,7 @@ class CodeNode {
   }
   
   static fn blockFromList:CodeNode ( list:[CodeNode] ) {
-    def code (new SourceCode( "" 0 0))
+    def code (new SourceCode( ""))
     def newNode@(lives):CodeNode (new CodeNode (code 0 0))
     newNode.is_block_node = true
     newNode.expression = true

--- a/dist/api.js
+++ b/dist/api.js
@@ -3219,7 +3219,7 @@ class CodeNode {
     }
     ;
     static vref1(name) {
-        const code = new SourceCode(name, 0, name.length);
+        const code = new SourceCode(name);
         const newNode = new CodeNode(code, 0, name.length);
         newNode.vref = name;
         newNode.value_type = 11;
@@ -3229,7 +3229,7 @@ class CodeNode {
     }
     ;
     static vref2(name, typeName) {
-        const code = new SourceCode(name, 0, name.length);
+        const code = new SourceCode(name);
         const newNode = new CodeNode(code, 0, name.length);
         newNode.vref = name;
         newNode.type_name = typeName;
@@ -3240,7 +3240,7 @@ class CodeNode {
     }
     ;
     static newStr(name) {
-        const code = new SourceCode("", 0, 0);
+        const code = new SourceCode("");
         const newNode = new CodeNode(code, 0, 0);
         newNode.string_value = name;
         newNode.value_type = 4;
@@ -3249,7 +3249,7 @@ class CodeNode {
     }
     ;
     static newBool(value) {
-        const code = new SourceCode("", 0, 0);
+        const code = new SourceCode("");
         const newNode = new CodeNode(code, 0, 0);
         newNode.boolean_value = value;
         newNode.value_type = 5;
@@ -3258,7 +3258,7 @@ class CodeNode {
     }
     ;
     static newInt(value) {
-        const code = new SourceCode("", 0, 0);
+        const code = new SourceCode("");
         const newNode = new CodeNode(code, 0, 0);
         newNode.int_value = value;
         newNode.value_type = 3;
@@ -3267,7 +3267,7 @@ class CodeNode {
     }
     ;
     static newDouble(value) {
-        const code = new SourceCode("", 0, 0);
+        const code = new SourceCode("");
         const newNode = new CodeNode(code, 0, 0);
         newNode.double_value = value;
         newNode.value_type = 2;
@@ -3276,7 +3276,7 @@ class CodeNode {
     }
     ;
     static op(opName) {
-        const code = new SourceCode("", 0, 0);
+        const code = new SourceCode("");
         const newNode = new CodeNode(code, 0, 0);
         newNode.expression = true;
         const opNode = CodeNode.vref1(opName);
@@ -3285,7 +3285,7 @@ class CodeNode {
     }
     ;
     static op2(opName, param1) {
-        const code = new SourceCode("", 0, 0);
+        const code = new SourceCode("");
         const newNode = new CodeNode(code, 0, 0);
         newNode.expression = true;
         const opNode = CodeNode.vref1(opName);
@@ -3295,7 +3295,7 @@ class CodeNode {
     }
     ;
     static op3(opName, list) {
-        const code = new SourceCode("", 0, 0);
+        const code = new SourceCode("");
         const newNode = new CodeNode(code, 0, 0);
         newNode.expression = true;
         const opNode = CodeNode.vref1(opName);
@@ -3309,7 +3309,7 @@ class CodeNode {
     }
     ;
     static fromList(list) {
-        const code = new SourceCode("", 0, 0);
+        const code = new SourceCode("");
         const newNode = new CodeNode(code, 0, 0);
         newNode.expression = true;
         for (let i = 0; i < list.length; i++) {
@@ -3322,14 +3322,14 @@ class CodeNode {
     }
     ;
     static expressionNode() {
-        const code = new SourceCode("", 0, 0);
+        const code = new SourceCode("");
         const newNode = new CodeNode(code, 0, 0);
         newNode.expression = true;
         return newNode;
     }
     ;
     static blockNode() {
-        const code = new SourceCode("", 0, 0);
+        const code = new SourceCode("");
         const newNode = new CodeNode(code, 0, 0);
         newNode.is_block_node = true;
         newNode.expression = true;
@@ -3337,7 +3337,7 @@ class CodeNode {
     }
     ;
     static blockFromList(list) {
-        const code = new SourceCode("", 0, 0);
+        const code = new SourceCode("");
         const newNode = new CodeNode(code, 0, 0);
         newNode.is_block_node = true;
         newNode.expression = true;

--- a/dist/rgrc.js
+++ b/dist/rgrc.js
@@ -2901,7 +2901,7 @@ class CodeNode  {
   };
 }
 CodeNode.vref1 = function(name) {
-  const code = new SourceCode(name, 0, name.length);
+  const code = new SourceCode(name);
   const newNode = new CodeNode(code, 0, name.length);
   newNode.vref = name;
   newNode.value_type = 11;
@@ -2910,7 +2910,7 @@ CodeNode.vref1 = function(name) {
   return newNode;
 };
 CodeNode.vref2 = function(name, typeName) {
-  const code = new SourceCode(name, 0, name.length);
+  const code = new SourceCode(name);
   const newNode = new CodeNode(code, 0, name.length);
   newNode.vref = name;
   newNode.type_name = typeName;
@@ -2920,7 +2920,7 @@ CodeNode.vref2 = function(name, typeName) {
   return newNode;
 };
 CodeNode.newStr = function(name) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.string_value = name;
   newNode.value_type = 4;
@@ -2928,7 +2928,7 @@ CodeNode.newStr = function(name) {
   return newNode;
 };
 CodeNode.newBool = function(value) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.boolean_value = value;
   newNode.value_type = 5;
@@ -2936,7 +2936,7 @@ CodeNode.newBool = function(value) {
   return newNode;
 };
 CodeNode.newInt = function(value) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.int_value = value;
   newNode.value_type = 3;
@@ -2944,7 +2944,7 @@ CodeNode.newInt = function(value) {
   return newNode;
 };
 CodeNode.newDouble = function(value) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.double_value = value;
   newNode.value_type = 2;
@@ -2952,7 +2952,7 @@ CodeNode.newDouble = function(value) {
   return newNode;
 };
 CodeNode.op = function(opName) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.expression = true;
   const opNode = CodeNode.vref1(opName);
@@ -2960,7 +2960,7 @@ CodeNode.op = function(opName) {
   return newNode;
 };
 CodeNode.op2 = function(opName, param1) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.expression = true;
   const opNode = CodeNode.vref1(opName);
@@ -2969,7 +2969,7 @@ CodeNode.op2 = function(opName, param1) {
   return newNode;
 };
 CodeNode.op3 = function(opName, list) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.expression = true;
   const opNode = CodeNode.vref1(opName);
@@ -2981,7 +2981,7 @@ CodeNode.op3 = function(opName, list) {
   return newNode;
 };
 CodeNode.fromList = function(list) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.expression = true;
   for ( let i = 0; i < list.length; i++) {
@@ -2992,20 +2992,20 @@ CodeNode.fromList = function(list) {
   return newNode;
 };
 CodeNode.expressionNode = function() {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.expression = true;
   return newNode;
 };
 CodeNode.blockNode = function() {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.is_block_node = true;
   newNode.expression = true;
   return newNode;
 };
 CodeNode.blockFromList = function(list) {
-  const code = new SourceCode("", 0, 0);
+  const code = new SourceCode("");
   const newNode = new CodeNode(code, 0, 0);
   newNode.is_block_node = true;
   newNode.expression = true;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build:dist": "npm run compile && npm run build:dist:copy && npm run build:dist:module",
     "build:dist:copy": "cp ./bin/output.js ./dist/rgrc.js && cp ./bin/Lang.rgr ./dist/Lang.rgr && cp ./bin/stdops.rgr ./dist/stdops.rgr && rm -rf dist/lib && cp -r ./lib ./dist/lib",
-    "build:dist:module": "node bin/output.js -nodemodule -es6 -typescript ./compiler/ng_Compiler.rgr -d=./compiler/bin -o=api.ts && tsc --declaration --module commonjs --target es2015 --moduleResolution node --outDir ./dist ./compiler/bin/api.ts ; node scripts/patch-chain-desugar.js",
+    "build:dist:module": "node bin/output.js -nodemodule -es6 -typescript ./compiler/ng_Compiler.rgr -d=./compiler/bin -o=api.ts && tsc --declaration --module commonjs --target es2015 --moduleResolution node --outDir ./dist ./compiler/bin/api.ts && node scripts/patch-chain-desugar.js",
     "prepublishOnly": "npm run build:dist && npm run test:publish",
     "test-any-ts": "node bin/testcomp.js ./features/any/test_any.rgr -es6 -typescript",
     "test-any-csharp": "node bin/testcomp.js ./features/any/test_any.rgr -l=csharp",


### PR DESCRIPTION
SourceCode takes a single code_str, but thirteen factory methods in ng_CodeNode.rgr constructed it with three arguments:

    def code (new SourceCode( name 0 (strlen name)))
    def code (new SourceCode( "" 0 0))

copying the shape of the adjacent `new CodeNode(code 0 (strlen name))`, which genuinely takes three. JavaScript discards surplus arguments, so this never surfaced -- until the TypeScript API bundle was type checked, where it produced every one of the 13 errors build:dist:module was reporting:

    compiler/bin/api.ts(3191,53): error TS2554: Expected 1 arguments, but got 3.

Both SourceCode declarations in the tree (ng_CodeNode.rgr, which wins, and ng_RangerLispParser.rgr) take exactly one parameter, so the extra arguments were never read and removing them is a no-op at runtime.

tsc now exits 0 on the generated api.ts, so build:dist:module goes back to &&-chaining the desugar patch after tsc. That step was sequenced with `;` only to survive these errors; with them gone, a genuine type error blocks the build again rather than scrolling past in the publish log.

Verified: prepublishOnly runs clean end to end with no error TS output, 44 test files / 355 tests green, exit 0. Bootstrap reaches a fixpoint -- recompiling the compiler with itself reproduces bin/output.js byte for byte. The suites outside the publish gate are unchanged: ts-to-ranger-*, tsx-engine and physics-cannon are 95 passed with the one pre-existing ylos2 failure, and game-runner still fails the same 5 it fails on master.


Claude-Session: https://claude.ai/code/session_01NT8B9ehMrFV9i733HtkjNx