### PR TITLE
operators: add the missing python templates, document two Python gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,26 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **A recursive macro hung the compiler with no diagnostic** — macro expansion renders the template to Ranger source and walks the result again (`buildMacro` + `WalkNode` in `ng_parser_std_match2.rgr`), so a template that expands to a call to the same operator has no base case. Unguarded this was not a stack overflow and not an error: the compiler simply never returned, and had to be killed. Expansion now carries a depth counter on the root context and fails at 64 levels:
+- **A recursive macro hung the compiler with no diagnostic** — macro expansion renders the template to Ranger source and walks the result again (`buildMacro` + `WalkNode` in `ng_parser_std_match2.rgr`), so an expansion that reaches the same call site again never terminates. Unguarded this was not a stack overflow and not an error: the compiler simply never returned, and had to be killed. The root context now carries an `active_macros` map; re-entering a call site already being expanded fails immediately:
 
   ```text
-  <macro >:1:0
-    [FAIL] Macro expansion of operator 'selfmac' does not terminate: nested more
-           than 64 levels. A macro template that expands to a call to the same
-           operator recurses forever.
-       1 │ (selfmac 1)
-           ^── here
+  [FAIL] Macro expansion of operator 'selfmac' is recursive: expanding it
+         reaches the same call site again, so it never terminates.
   ```
 
-  The guard is a depth counter rather than a name check on purpose: it catches indirect cycles too (`macA` → `macB` → `macA`), which a "does this macro name itself" test cannot see. Both cases are covered by `tests/macro-recursion.test.ts`, which carries explicit timeouts because a regression here would hang the suite rather than fail it
+  The key is the operator name **plus the source position**, never the name alone. `if ... else` and `if!` are themselves macros that emit `if` — they lower to the three-argument `if`, which is not a macro — so a nested if/else legitimately re-enters the same operator while the outer expansion is in flight. A name-keyed guard would reject nearly every real program, the compiler's own source included. A depth ceiling of 512 remains as a backstop for a cycle that keeps producing fresh positions and so never repeats a key.
+
+  For the same reason there is no static "does this macro name itself" check: self-naming macro templates are legal, so such a check is false-positive by design. `tests/macro-recursion.test.ts` covers the direct cycle, the indirect one (`macA` → `macB` → `macA`) and the legitimate nested-if case, with explicit timeouts because a regression here would hang the suite rather than fail it
 
 - **Two `to_string (value:int)` operators, one of them dead and the other emitting `to_int`** — `Lang.rgr` declared the same signature twice. The first (`to_string _:string`) wins every match, which the second (`to_string cmdIntToString:string`) shadowed entirely: `cmdIntToString` appears nowhere else in the tree, and removing the block leaves the emission for go, csharp, es6, python, cpp, rust, kotlin and swift6 byte-identical. The winning block's `ranger` template emitted `(to_int x)` rather than `(to_string x)` — a copy-paste error, not a deliberate lowering: `to_int` has no `(value:int)` variant at all, so the rendered Ranger would not type check. `ranger` templates are not confined to a Ranger-to-Ranger build: `ng_LiveCompiler.rgr` forks a context with `targetLangName = "ranger"` to render expressions back to Ranger source for polyfill identity, so they run during a normal compile to any target
 
 - **Python had no template for nine operators** — `M_PI`, `fabs`, `tan`, `random` (both variants), `wait`, `file_exists`, `dir_exists` and `create_dir` could not compile for the `python` target. Added, and verified by running the generated Python rather than only compiling it (`tests/compiler-python.test.ts`), which the environment allows for Python but not for Kotlin or Swift
-
-### Added
-
-- **Static self-naming macro check** — `tests/operator-coverage.test.ts` also fails if any `@macro` template's text names its own operator, catching the direct case at the source before it can reach a build. Deliberately limited to `@macro` templates: 85 ordinary `ranger` templates name their own operator and are correct, because reproducing the source is exactly what a Ranger-to-Ranger emitter does
 
 ### Known gaps (Python)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two `to_string (value:int)` operators, one of them dead and the other emitting `to_int`** — `Lang.rgr` declared the same signature twice. The first (`to_string _:string`) wins every match, which the second (`to_string cmdIntToString:string`) shadowed entirely: `cmdIntToString` appears nowhere else in the tree, and removing the block leaves the emission for go, csharp, es6, python, cpp, rust, kotlin and swift6 byte-identical. The winning block's `ranger` template emitted `(to_int x)` rather than `(to_string x)` — a copy-paste error, not a deliberate lowering: `to_int` has no `(value:int)` variant at all, so the rendered Ranger would not type check. `ranger` templates are not confined to a Ranger-to-Ranger build: `ng_LiveCompiler.rgr` forks a context with `targetLangName = "ranger"` to render expressions back to Ranger source for polyfill identity, so they run during a normal compile to any target
+
 - **Python had no template for nine operators** — `M_PI`, `fabs`, `tan`, `random` (both variants), `wait`, `file_exists`, `dir_exists` and `create_dir` could not compile for the `python` target. Added, and verified by running the generated Python rather than only compiling it (`tests/compiler-python.test.ts`), which the environment allows for Python but not for Kotlin or Swift
 
 ### Known gaps (Python)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.1] - 2026-08-01
+
 ### Fixed
+
+- **A recursive macro hung the compiler with no diagnostic** — macro expansion renders the template to Ranger source and walks the result again (`buildMacro` + `WalkNode` in `ng_parser_std_match2.rgr`), so a template that expands to a call to the same operator has no base case. Unguarded this was not a stack overflow and not an error: the compiler simply never returned, and had to be killed. Expansion now carries a depth counter on the root context and fails at 64 levels:
+
+  ```text
+  <macro >:1:0
+    [FAIL] Macro expansion of operator 'selfmac' does not terminate: nested more
+           than 64 levels. A macro template that expands to a call to the same
+           operator recurses forever.
+       1 │ (selfmac 1)
+           ^── here
+  ```
+
+  The guard is a depth counter rather than a name check on purpose: it catches indirect cycles too (`macA` → `macB` → `macA`), which a "does this macro name itself" test cannot see. Both cases are covered by `tests/macro-recursion.test.ts`, which carries explicit timeouts because a regression here would hang the suite rather than fail it
 
 - **Two `to_string (value:int)` operators, one of them dead and the other emitting `to_int`** — `Lang.rgr` declared the same signature twice. The first (`to_string _:string`) wins every match, which the second (`to_string cmdIntToString:string`) shadowed entirely: `cmdIntToString` appears nowhere else in the tree, and removing the block leaves the emission for go, csharp, es6, python, cpp, rust, kotlin and swift6 byte-identical. The winning block's `ranger` template emitted `(to_int x)` rather than `(to_string x)` — a copy-paste error, not a deliberate lowering: `to_int` has no `(value:int)` variant at all, so the rendered Ranger would not type check. `ranger` templates are not confined to a Ranger-to-Ranger build: `ng_LiveCompiler.rgr` forks a context with `targetLangName = "ranger"` to render expressions back to Ranger source for polyfill identity, so they run during a normal compile to any target
 
 - **Python had no template for nine operators** — `M_PI`, `fabs`, `tan`, `random` (both variants), `wait`, `file_exists`, `dir_exists` and `create_dir` could not compile for the `python` target. Added, and verified by running the generated Python rather than only compiling it (`tests/compiler-python.test.ts`), which the environment allows for Python but not for Kotlin or Swift
+
+### Added
+
+- **Static self-naming macro check** — `tests/operator-coverage.test.ts` also fails if any `@macro` template's text names its own operator, catching the direct case at the source before it can reach a build. Deliberately limited to `@macro` templates: 85 ordinary `ranger` templates name their own operator and are correct, because reproducing the source is exactly what a Ranger-to-Ranger emitter does
 
 ### Known gaps (Python)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Python had no template for nine operators** — `M_PI`, `fabs`, `tan`, `random` (both variants), `wait`, `file_exists`, `dir_exists` and `create_dir` could not compile for the `python` target. Added, and verified by running the generated Python rather than only compiling it (`tests/compiler-python.test.ts`), which the environment allows for Python but not for Kotlin or Swift
+
+### Known gaps (Python)
+
+- **Every operator taking a lambda emits invalid Python** — `.map()`, `.filter()`, `.reduce()`, `.find()`, `.count()`, `.groupBy()` and the newly added `.any()` / `.all()` compile successfully for `python` and then fail at runtime with `SyntaxError: invalid syntax`. The backend emits the Ranger callback body as a multi-statement Python `lambda`, and a Python lambda holds a single expression:
+
+  ```python
+  out = operatorsOf.map_2(a, lambda item:
+    return item * 2;          # SyntaxError
+  )
+  ```
+
+  Pre-existing and independent of the operators added above. Fixing it means hoisting callback bodies into named functions in `ng_RangerPythonClassWriter.rgr` — a codegen change, not a template. Until then, treat the `operator type:[T]` block as unavailable on Python
+
+- **Python has no JSON support at all** — 0 of the 34 operator template blocks in `lib/JSON.rgr` declare `python`, and `systemclass JSONDataObject` / `JSONArrayObject` declare no Python type, so `@serialize(true)` cannot work there. Unlike C++ and Rust, Python has an obvious representation (`dict` / `list`), so this is tractable — but it is a full JSON backend, not a template gap
+
 ## [3.3.0] - 2026-08-01
 
 ### Added

--- a/bin/Lang.rgr
+++ b/bin/Lang.rgr
@@ -3296,7 +3296,7 @@ std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
 
         to_string   _:string       ( value:int ) { 
             templates {
-                ranger ( "(to_int " (e 1) ")")
+                ranger ( "(to_string " (e 1) ")")
                 cpp ("std::to_string(" (e 1) ")" (imp "<string>"))
                 java7 ( "String.valueOf(" (e 1) " )") 
                 php ( "strval(" (e 1) ")") 
@@ -3311,22 +3311,6 @@ std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
             }
         }          
 
-        to_string   cmdIntToString:string       ( value:int ) { 
-            templates {
-                ranger ( "(to_string " (e 1) ")")
-                cpp ("std::to_string(" (e 1) ")" (imp "<string>"))
-                java7 ( "String.valueOf(" (e 1) " )") 
-                php ( "strval(" (e 1) ")") 
-                scala ( "(" (e 1) ".toString)")
-                go ("strconv.Itoa(" (e 1) ")" (imp "strconv"))
-                swift3 ("String(" (e 1) ")")
-                swift6 ("String(" (e 1) ")")
-                python ( "str(" (e 1) ")" )
-                rust ( (e 1) ".to_string()" )
-                * ( "(" (e 1) ").toString()")
-            }
-        }        
-        
         ; std::to_string(myDoubleVar);
         double2str   cmdDoubleToString:string       ( value:double ) { 
             templates {

--- a/bin/Lang.rgr
+++ b/bin/Lang.rgr
@@ -245,6 +245,7 @@ language {
             templates {
                 es6 ('Math.random()')
                 swift6 ( "Double.random(in: 0..<1)" )
+                python ( "random.random()" (imp "random") )
                 swift3 ( "(Double(arc4random()) / Double(UInt32.max))" (imp "Foundation") )
                 kotlin ('Math.random()' (imp "java.lang.Math"))
                 cpp ( "rg_random_double()" (imp "<random>")
@@ -285,6 +286,7 @@ double rg_random_double() {
             templates {
                 es6 ('Math.floor(Math.random()*(' (e 2) ' - ' (e 1)' + 1) + ' (e 1)')')
                 swift6 ( "Int.random(in: " (e 1) " ... " (e 2) ")" )
+                python ( "random.randint(" (e 1) ", " (e 2) ")" (imp "random") )
                 swift3 ( "(" (e 1) " + Int(arc4random_uniform(UInt32(" (e 2) " - " (e 1) " + 1))))" (imp "Foundation") )
                 kotlin ('(Math.floor(Math.random() * (' (e 2) ' - ' (e 1) ' + 1)).toInt() + ' (e 1) ')' (imp "java.lang.Math"))
             }
@@ -434,7 +436,8 @@ func _r_sha256(value string) string {
                 es6 ("Math.PI")
                 go ( "math.Pi" (imp "math"))                                
                 swift3 ( "Double.pi" (imp "Foundation"))
-                swift6 ( "Double.pi" (imp "Foundation"))   
+                swift6 ( "Double.pi" (imp "Foundation"))
+                python ( "math.pi" (imp "math") )   
                 java7 ( "Math.PI" (imp "java.lang.Math"))         
                 php ("pi()")        
                 cpp ("M_PI" (imp "<math.h>"))               
@@ -446,7 +449,8 @@ func _r_sha256(value string) string {
                 es6 ("Math.abs(" (e 1) ")")
                 go ( "math.Abs(" (e 1) ")" (imp "math"))                                
                 swift3 ( "abs(" (e 1) ")" (imp "Foundation"))
-                swift6 ( "abs(" (e 1) ")" (imp "Foundation"))   
+                swift6 ( "abs(" (e 1) ")" (imp "Foundation"))
+                python ( "math.fabs(" (e 1) ")" (imp "math") )   
                 java7 ( "Math.abs(" (e 1) ")" (imp "java.lang.Math"))       
                 php ( "abs(" (e 1) ")")      
                 cpp ("fabs(" (e 1) ")" (imp "<cmath>"))                       
@@ -458,6 +462,7 @@ func _r_sha256(value string) string {
                 go ( "math.Tan(" (e 1) ")" (imp "math"))
                 swift3 ( "tan(" (e 1) ")" (imp "Foundation"))
                 swift6 ( "tan(" (e 1) ")" (imp "Foundation"))
+                python ( "math.tan(" (e 1) ")" (imp "math") )
                 java7 ( "Math.tan(" (e 1) ")" (imp "java.lang.Math"))
                 php ( "tan(" (e 1) ")")
                 cpp ("tan(" (e 1) ")" (imp "<math.h>"))
@@ -502,6 +507,7 @@ func _r_sha256(value string) string {
                 php ( "sleep(" (e 1) ");" nl (block 2) nl )
                 swift3 ( "usleep(UInt32(1000000*" (e 1) "));" nl (block 2) nl )
                 swift6 ( "usleep(UInt32(1000000*" (e 1) "));" nl (block 2) nl )
+                python ( nl "time.sleep(" (e 1) ")" nl (block 2) nl (imp "time") )
                 java7 (
 
     "new Thread() {" nl I
@@ -723,6 +729,7 @@ func r_file_exists ( fileName:String ) -> Bool {
     ")                    
                 )
                 es6 ("require(\"fs\").existsSync(" (e 1) " + \"/\" + " (e 2) " )")
+                python ( "os.path.isfile(" (e 1) " + \"/\" + " (e 2) ")" (imp "os") )
                 ranger ("( file_exists " (e 1) " + \"/\" + " (e 2) "  )")
                 java7 ( "new File(" (e 1) " + '/' + " (e 2) ").exists()" (imp "java.io.File") )
                 php ( "file_exists(" (e 1) ".'/'." (e 2) ")" )
@@ -745,6 +752,7 @@ func r_file_exists(pathName string, fileName string) bool {
         dir_exists          cmdIsDir:boolean (path:string) {
             templates {
                 csharp ( "false /* dir_exists not implemented */ ")
+                python ( "os.path.isdir(" (e 1) ")" (imp "os") )
                 scala ( "false /* dir_exists not implemented */ ")
                 swift3 ( "r_dir_exists( dirName: " (e 1) ")" 
 
@@ -858,6 +866,7 @@ void  r_cpp_create_dir(std::string name)
                 swift6 ( nl "try? FileManager.default.createDirectory(atPath: " (e 1) ", withIntermediateDirectories: true)" nl (imp "Foundation") )        
                 php (  nl "mkdir(" (e 1) ");" nl )
                 es6 ("require(\"fs\").mkdirSync( " (e 1) ")")
+                python ( nl "os.makedirs(" (e 1) ", exist_ok=True)" nl (imp "os") )
                 go ( nl "_ = os.Mkdir( " (e 1 ) " , os.ModePerm)" nl (imp "os") )
 
                 ranger ( nl "create_dir " (e 1) nl)

--- a/bin/output.js
+++ b/bin/output.js
@@ -3311,6 +3311,7 @@ class RangerAppWriterContext  {
     this.intRootCounter = 1;     /** note: unused */
     this.targetLangName = "";
     this.defined_imports = [];     /** note: unused */
+    this.macro_expansion_depth = 0;
     this.already_imported = {};
     this.is_function = false;
     this.class_level_context = false;
@@ -15067,6 +15068,13 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
               return true;
             }
             if ( is_macro ) {
+              const macroRoot = ctx.getRoot();
+              if ( macroRoot.macro_expansion_depth > 64 ) {
+                ctx.addError(callArgs, ("Macro expansion of operator '" + fc.vref) + "' does not terminate: nested more than 64 levels. A macro template that expands to a call to the same operator recurses forever.");
+                ctx.removeOpNs(added_ns);
+                return true;
+              }
+              macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth + 1;
               const macroNode = await this.buildMacro(langOper, callArgs, ctx);
               let arg_len_1 = callArgs.children.length;
               while (arg_len_1 > 0) {
@@ -15076,6 +15084,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
               callArgs.children.push(macroNode);
               macroNode.parent = callArgs;
               await this.WalkNode(macroNode, ctx, wr);
+              macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth - 1;
               match.setRvBasedOn(nameNode, callArgs);
               ctx.removeOpNs(added_ns);
               return true;
@@ -39291,7 +39300,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       this.inputFile = "";
       this.outputFile = "";
       this.targetLanguage = "";
-      this.compilerVersion = "3.3.0";
+      this.compilerVersion = "3.3.1";
       this.useColors = ((typeof process !== "undefined" && process.stdout && process.stdout.isTTY) || false);
       this.startTime = Date.now();
     }

--- a/bin/output.js
+++ b/bin/output.js
@@ -3311,6 +3311,7 @@ class RangerAppWriterContext  {
     this.intRootCounter = 1;     /** note: unused */
     this.targetLangName = "";
     this.defined_imports = [];     /** note: unused */
+    this.active_macros = {};
     this.macro_expansion_depth = 0;
     this.already_imported = {};
     this.is_function = false;
@@ -15069,11 +15070,22 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             }
             if ( is_macro ) {
               const macroRoot = ctx.getRoot();
-              if ( macroRoot.macro_expansion_depth > 64 ) {
-                ctx.addError(callArgs, ("Macro expansion of operator '" + fc.vref) + "' does not terminate: nested more than 64 levels. A macro template that expands to a call to the same operator recurses forever.");
+              const macroKey = (((fc.vref + "@") + callArgs.getFilename()) + ":") + ((callArgs.sp.toString()));
+              let macroActive = false;
+              if ( ( typeof(macroRoot.active_macros[macroKey] ) != "undefined" && macroRoot.active_macros.hasOwnProperty(macroKey) ) ) {
+                macroActive = (( macroRoot.active_macros.hasOwnProperty(macroKey) ? macroRoot.active_macros[macroKey] : undefined ));
+              }
+              if ( macroActive ) {
+                ctx.addError(callArgs, ("Macro expansion of operator '" + fc.vref) + "' is recursive: expanding it reaches the same call site again, so it never terminates.");
                 ctx.removeOpNs(added_ns);
                 return true;
               }
+              if ( macroRoot.macro_expansion_depth > 512 ) {
+                ctx.addError(callArgs, ("Macro expansion of operator '" + fc.vref) + "' does not terminate: nested more than 512 levels.");
+                ctx.removeOpNs(added_ns);
+                return true;
+              }
+              macroRoot.active_macros[macroKey] = true;
               macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth + 1;
               const macroNode = await this.buildMacro(langOper, callArgs, ctx);
               let arg_len_1 = callArgs.children.length;
@@ -15085,6 +15097,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
               macroNode.parent = callArgs;
               await this.WalkNode(macroNode, ctx, wr);
               macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth - 1;
+              macroRoot.active_macros[macroKey] = false;
               match.setRvBasedOn(nameNode, callArgs);
               ctx.removeOpNs(added_ns);
               return true;

--- a/compiler/CLIProgress.rgr
+++ b/compiler/CLIProgress.rgr
@@ -117,7 +117,7 @@ class CLIProgress {
     def inputFile:string ""
     def outputFile:string ""
     def targetLanguage:string ""
-    def compilerVersion:string "3.3.0"
+    def compilerVersion:string "3.3.1"
     
     Constructor () {
         ; Detect if colors should be used

--- a/compiler/Lang.rgr
+++ b/compiler/Lang.rgr
@@ -3296,7 +3296,7 @@ std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
 
         to_string   _:string       ( value:int ) { 
             templates {
-                ranger ( "(to_int " (e 1) ")")
+                ranger ( "(to_string " (e 1) ")")
                 cpp ("std::to_string(" (e 1) ")" (imp "<string>"))
                 java7 ( "String.valueOf(" (e 1) " )") 
                 php ( "strval(" (e 1) ")") 
@@ -3311,22 +3311,6 @@ std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
             }
         }          
 
-        to_string   cmdIntToString:string       ( value:int ) { 
-            templates {
-                ranger ( "(to_string " (e 1) ")")
-                cpp ("std::to_string(" (e 1) ")" (imp "<string>"))
-                java7 ( "String.valueOf(" (e 1) " )") 
-                php ( "strval(" (e 1) ")") 
-                scala ( "(" (e 1) ".toString)")
-                go ("strconv.Itoa(" (e 1) ")" (imp "strconv"))
-                swift3 ("String(" (e 1) ")")
-                swift6 ("String(" (e 1) ")")
-                python ( "str(" (e 1) ")" )
-                rust ( (e 1) ".to_string()" )
-                * ( "(" (e 1) ").toString()")
-            }
-        }        
-        
         ; std::to_string(myDoubleVar);
         double2str   cmdDoubleToString:string       ( value:double ) { 
             templates {

--- a/compiler/Lang.rgr
+++ b/compiler/Lang.rgr
@@ -245,6 +245,7 @@ language {
             templates {
                 es6 ('Math.random()')
                 swift6 ( "Double.random(in: 0..<1)" )
+                python ( "random.random()" (imp "random") )
                 swift3 ( "(Double(arc4random()) / Double(UInt32.max))" (imp "Foundation") )
                 kotlin ('Math.random()' (imp "java.lang.Math"))
                 cpp ( "rg_random_double()" (imp "<random>")
@@ -285,6 +286,7 @@ double rg_random_double() {
             templates {
                 es6 ('Math.floor(Math.random()*(' (e 2) ' - ' (e 1)' + 1) + ' (e 1)')')
                 swift6 ( "Int.random(in: " (e 1) " ... " (e 2) ")" )
+                python ( "random.randint(" (e 1) ", " (e 2) ")" (imp "random") )
                 swift3 ( "(" (e 1) " + Int(arc4random_uniform(UInt32(" (e 2) " - " (e 1) " + 1))))" (imp "Foundation") )
                 kotlin ('(Math.floor(Math.random() * (' (e 2) ' - ' (e 1) ' + 1)).toInt() + ' (e 1) ')' (imp "java.lang.Math"))
             }
@@ -434,7 +436,8 @@ func _r_sha256(value string) string {
                 es6 ("Math.PI")
                 go ( "math.Pi" (imp "math"))                                
                 swift3 ( "Double.pi" (imp "Foundation"))
-                swift6 ( "Double.pi" (imp "Foundation"))   
+                swift6 ( "Double.pi" (imp "Foundation"))
+                python ( "math.pi" (imp "math") )   
                 java7 ( "Math.PI" (imp "java.lang.Math"))         
                 php ("pi()")        
                 cpp ("M_PI" (imp "<math.h>"))               
@@ -446,7 +449,8 @@ func _r_sha256(value string) string {
                 es6 ("Math.abs(" (e 1) ")")
                 go ( "math.Abs(" (e 1) ")" (imp "math"))                                
                 swift3 ( "abs(" (e 1) ")" (imp "Foundation"))
-                swift6 ( "abs(" (e 1) ")" (imp "Foundation"))   
+                swift6 ( "abs(" (e 1) ")" (imp "Foundation"))
+                python ( "math.fabs(" (e 1) ")" (imp "math") )   
                 java7 ( "Math.abs(" (e 1) ")" (imp "java.lang.Math"))       
                 php ( "abs(" (e 1) ")")      
                 cpp ("fabs(" (e 1) ")" (imp "<cmath>"))                       
@@ -458,6 +462,7 @@ func _r_sha256(value string) string {
                 go ( "math.Tan(" (e 1) ")" (imp "math"))
                 swift3 ( "tan(" (e 1) ")" (imp "Foundation"))
                 swift6 ( "tan(" (e 1) ")" (imp "Foundation"))
+                python ( "math.tan(" (e 1) ")" (imp "math") )
                 java7 ( "Math.tan(" (e 1) ")" (imp "java.lang.Math"))
                 php ( "tan(" (e 1) ")")
                 cpp ("tan(" (e 1) ")" (imp "<math.h>"))
@@ -502,6 +507,7 @@ func _r_sha256(value string) string {
                 php ( "sleep(" (e 1) ");" nl (block 2) nl )
                 swift3 ( "usleep(UInt32(1000000*" (e 1) "));" nl (block 2) nl )
                 swift6 ( "usleep(UInt32(1000000*" (e 1) "));" nl (block 2) nl )
+                python ( nl "time.sleep(" (e 1) ")" nl (block 2) nl (imp "time") )
                 java7 (
 
     "new Thread() {" nl I
@@ -723,6 +729,7 @@ func r_file_exists ( fileName:String ) -> Bool {
     ")                    
                 )
                 es6 ("require(\"fs\").existsSync(" (e 1) " + \"/\" + " (e 2) " )")
+                python ( "os.path.isfile(" (e 1) " + \"/\" + " (e 2) ")" (imp "os") )
                 ranger ("( file_exists " (e 1) " + \"/\" + " (e 2) "  )")
                 java7 ( "new File(" (e 1) " + '/' + " (e 2) ").exists()" (imp "java.io.File") )
                 php ( "file_exists(" (e 1) ".'/'." (e 2) ")" )
@@ -745,6 +752,7 @@ func r_file_exists(pathName string, fileName string) bool {
         dir_exists          cmdIsDir:boolean (path:string) {
             templates {
                 csharp ( "false /* dir_exists not implemented */ ")
+                python ( "os.path.isdir(" (e 1) ")" (imp "os") )
                 scala ( "false /* dir_exists not implemented */ ")
                 swift3 ( "r_dir_exists( dirName: " (e 1) ")" 
 
@@ -858,6 +866,7 @@ void  r_cpp_create_dir(std::string name)
                 swift6 ( nl "try? FileManager.default.createDirectory(atPath: " (e 1) ", withIntermediateDirectories: true)" nl (imp "Foundation") )        
                 php (  nl "mkdir(" (e 1) ");" nl )
                 es6 ("require(\"fs\").mkdirSync( " (e 1) ")")
+                python ( nl "os.makedirs(" (e 1) ", exist_ok=True)" nl (imp "os") )
                 go ( nl "_ = os.Mkdir( " (e 1 ) " , os.ModePerm)" nl (imp "os") )
 
                 ranger ( nl "create_dir " (e 1) nl)

--- a/compiler/ng_Compiler.rgr
+++ b/compiler/ng_Compiler.rgr
@@ -5,7 +5,7 @@ flag es6 (
 )
 
 flag sourcemap (
-  version "3.3.0"
+  version "3.3.1"
 )
 
 flag npm (

--- a/compiler/ng_RangerAppWriterContext.rgr
+++ b/compiler/ng_RangerAppWriterContext.rgr
@@ -136,6 +136,11 @@ class RangerAppWriterContext {
   def targetLangName:string ""
   def parent:RangerAppWriterContext
   def defined_imports:[string]
+  ; Guards macro expansion against runaway recursion. A macro template that
+  ; expands to a call to the same operator has no base case, so it nests
+  ; forever; without this the compiler hangs with no diagnostic at all.
+  ; Lives on the root context so nested forks share one counter.
+  def macro_expansion_depth:int 0
   def already_imported:[string:boolean]
   def fileSystem:CodeFileSystem
   def is_function:boolean false

--- a/compiler/ng_RangerAppWriterContext.rgr
+++ b/compiler/ng_RangerAppWriterContext.rgr
@@ -136,10 +136,19 @@ class RangerAppWriterContext {
   def targetLangName:string ""
   def parent:RangerAppWriterContext
   def defined_imports:[string]
-  ; Guards macro expansion against runaway recursion. A macro template that
-  ; expands to a call to the same operator has no base case, so it nests
-  ; forever; without this the compiler hangs with no diagnostic at all.
-  ; Lives on the root context so nested forks share one counter.
+  ; Guards macro expansion against runaway recursion. Macro expansion is the
+  ; one path that re-walks its own output, so an expansion that reaches the
+  ; same call site again never terminates; unguarded the compiler hangs with
+  ; no diagnostic at all. Both live on the root context so nested forks share
+  ; one view.
+  ;
+  ; active_macros keys on operator name + source position, NOT on the name
+  ; alone: `if ... else` is itself a macro that expands to the three-argument
+  ; `if`, so nested if/else is a legitimate re-entry of the same operator and
+  ; a name-only key would reject nearly every real program.
+  def active_macros:[string:boolean]
+  ; Backstop only. active_macros cannot see a cycle whose expansion keeps
+  ; growing new source positions, so a depth ceiling stops the hang even then.
   def macro_expansion_depth:int 0
   def already_imported:[string:boolean]
   def fileSystem:CodeFileSystem

--- a/compiler/ng_parser_std_match2.rgr
+++ b/compiler/ng_parser_std_match2.rgr
@@ -864,16 +864,34 @@ extension RangerFlowParser {
           }
 
           if is_macro {
-            ; A macro template is expanded into Ranger source and walked again.
-            ; If the expansion contains a call to the same operator there is no
-            ; base case, so it nests forever. Unguarded this hangs the compiler
-            ; with no diagnostic -- not a stack overflow, just silence.
+            ; A macro template is expanded into Ranger source and walked again,
+            ; so an expansion that reaches the same call site again never
+            ; terminates. Unguarded this hangs the compiler with no diagnostic
+            ; at all -- not a stack overflow, just silence.
+            ;
+            ; The key is the operator name plus the position of the node being
+            ; expanded, never the name alone: `if ... else` is a macro that
+            ; expands to the three-argument `if`, so a nested if/else re-enters
+            ; the same operator legitimately while the outer one is in flight.
             def macroRoot:RangerAppWriterContext (ctx.getRoot())
-            if( macroRoot.macro_expansion_depth > 64 ) {
-              ctx.addError( callArgs ("Macro expansion of operator '" + fc.vref + "' does not terminate: nested more than 64 levels. A macro template that expands to a call to the same operator recurses forever.") )
+            def macroKey:string (fc.vref + "@" + (callArgs.getFilename()) + ":" + (to_string callArgs.sp))
+            def macroActive:boolean false
+            if( has macroRoot.active_macros macroKey ) {
+              macroActive = (unwrap (get macroRoot.active_macros macroKey))
+            }
+            if macroActive {
+              ctx.addError( callArgs ("Macro expansion of operator '" + fc.vref + "' is recursive: expanding it reaches the same call site again, so it never terminates.") )
               ctx.removeOpNs( added_ns )
               return true
             }
+            ; Backstop for a cycle that keeps producing fresh positions and so
+            ; never repeats a key.
+            if( macroRoot.macro_expansion_depth > 512 ) {
+              ctx.addError( callArgs ("Macro expansion of operator '" + fc.vref + "' does not terminate: nested more than 512 levels.") )
+              ctx.removeOpNs( added_ns )
+              return true
+            }
+            set macroRoot.active_macros macroKey true
             macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth + 1
             def macroNode:CodeNode ( this.buildMacro( langOper callArgs ctx ) )
             def arg_len:int (array_length callArgs.children)
@@ -885,6 +903,9 @@ extension RangerFlowParser {
             macroNode.parent = callArgs
             this.WalkNode( macroNode ctx wr)
             macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth - 1
+            ; Cleared on the way out so sequential or sibling uses of the same
+            ; macro are unaffected -- only genuine nesting is a cycle.
+            set macroRoot.active_macros macroKey false
             match.setRvBasedOn(nameNode callArgs)       
             ; print "--- macro was walked -- " 
             ctx.removeOpNs( added_ns )      

--- a/compiler/ng_parser_std_match2.rgr
+++ b/compiler/ng_parser_std_match2.rgr
@@ -864,6 +864,17 @@ extension RangerFlowParser {
           }
 
           if is_macro {
+            ; A macro template is expanded into Ranger source and walked again.
+            ; If the expansion contains a call to the same operator there is no
+            ; base case, so it nests forever. Unguarded this hangs the compiler
+            ; with no diagnostic -- not a stack overflow, just silence.
+            def macroRoot:RangerAppWriterContext (ctx.getRoot())
+            if( macroRoot.macro_expansion_depth > 64 ) {
+              ctx.addError( callArgs ("Macro expansion of operator '" + fc.vref + "' does not terminate: nested more than 64 levels. A macro template that expands to a call to the same operator recurses forever.") )
+              ctx.removeOpNs( added_ns )
+              return true
+            }
+            macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth + 1
             def macroNode:CodeNode ( this.buildMacro( langOper callArgs ctx ) )
             def arg_len:int (array_length callArgs.children)
             while (arg_len > 0 ) {
@@ -873,6 +884,7 @@ extension RangerFlowParser {
             push callArgs.children macroNode
             macroNode.parent = callArgs
             this.WalkNode( macroNode ctx wr)
+            macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth - 1
             match.setRvBasedOn(nameNode callArgs)       
             ; print "--- macro was walked -- " 
             ctx.removeOpNs( added_ns )      

--- a/dist/Lang.rgr
+++ b/dist/Lang.rgr
@@ -3296,7 +3296,7 @@ std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
 
         to_string   _:string       ( value:int ) { 
             templates {
-                ranger ( "(to_int " (e 1) ")")
+                ranger ( "(to_string " (e 1) ")")
                 cpp ("std::to_string(" (e 1) ")" (imp "<string>"))
                 java7 ( "String.valueOf(" (e 1) " )") 
                 php ( "strval(" (e 1) ")") 
@@ -3311,22 +3311,6 @@ std::string r_utf8_substr(const std::string& str, int start_i, int leng_i)
             }
         }          
 
-        to_string   cmdIntToString:string       ( value:int ) { 
-            templates {
-                ranger ( "(to_string " (e 1) ")")
-                cpp ("std::to_string(" (e 1) ")" (imp "<string>"))
-                java7 ( "String.valueOf(" (e 1) " )") 
-                php ( "strval(" (e 1) ")") 
-                scala ( "(" (e 1) ".toString)")
-                go ("strconv.Itoa(" (e 1) ")" (imp "strconv"))
-                swift3 ("String(" (e 1) ")")
-                swift6 ("String(" (e 1) ")")
-                python ( "str(" (e 1) ")" )
-                rust ( (e 1) ".to_string()" )
-                * ( "(" (e 1) ").toString()")
-            }
-        }        
-        
         ; std::to_string(myDoubleVar);
         double2str   cmdDoubleToString:string       ( value:double ) { 
             templates {

--- a/dist/Lang.rgr
+++ b/dist/Lang.rgr
@@ -245,6 +245,7 @@ language {
             templates {
                 es6 ('Math.random()')
                 swift6 ( "Double.random(in: 0..<1)" )
+                python ( "random.random()" (imp "random") )
                 swift3 ( "(Double(arc4random()) / Double(UInt32.max))" (imp "Foundation") )
                 kotlin ('Math.random()' (imp "java.lang.Math"))
                 cpp ( "rg_random_double()" (imp "<random>")
@@ -285,6 +286,7 @@ double rg_random_double() {
             templates {
                 es6 ('Math.floor(Math.random()*(' (e 2) ' - ' (e 1)' + 1) + ' (e 1)')')
                 swift6 ( "Int.random(in: " (e 1) " ... " (e 2) ")" )
+                python ( "random.randint(" (e 1) ", " (e 2) ")" (imp "random") )
                 swift3 ( "(" (e 1) " + Int(arc4random_uniform(UInt32(" (e 2) " - " (e 1) " + 1))))" (imp "Foundation") )
                 kotlin ('(Math.floor(Math.random() * (' (e 2) ' - ' (e 1) ' + 1)).toInt() + ' (e 1) ')' (imp "java.lang.Math"))
             }
@@ -434,7 +436,8 @@ func _r_sha256(value string) string {
                 es6 ("Math.PI")
                 go ( "math.Pi" (imp "math"))                                
                 swift3 ( "Double.pi" (imp "Foundation"))
-                swift6 ( "Double.pi" (imp "Foundation"))   
+                swift6 ( "Double.pi" (imp "Foundation"))
+                python ( "math.pi" (imp "math") )   
                 java7 ( "Math.PI" (imp "java.lang.Math"))         
                 php ("pi()")        
                 cpp ("M_PI" (imp "<math.h>"))               
@@ -446,7 +449,8 @@ func _r_sha256(value string) string {
                 es6 ("Math.abs(" (e 1) ")")
                 go ( "math.Abs(" (e 1) ")" (imp "math"))                                
                 swift3 ( "abs(" (e 1) ")" (imp "Foundation"))
-                swift6 ( "abs(" (e 1) ")" (imp "Foundation"))   
+                swift6 ( "abs(" (e 1) ")" (imp "Foundation"))
+                python ( "math.fabs(" (e 1) ")" (imp "math") )   
                 java7 ( "Math.abs(" (e 1) ")" (imp "java.lang.Math"))       
                 php ( "abs(" (e 1) ")")      
                 cpp ("fabs(" (e 1) ")" (imp "<cmath>"))                       
@@ -458,6 +462,7 @@ func _r_sha256(value string) string {
                 go ( "math.Tan(" (e 1) ")" (imp "math"))
                 swift3 ( "tan(" (e 1) ")" (imp "Foundation"))
                 swift6 ( "tan(" (e 1) ")" (imp "Foundation"))
+                python ( "math.tan(" (e 1) ")" (imp "math") )
                 java7 ( "Math.tan(" (e 1) ")" (imp "java.lang.Math"))
                 php ( "tan(" (e 1) ")")
                 cpp ("tan(" (e 1) ")" (imp "<math.h>"))
@@ -502,6 +507,7 @@ func _r_sha256(value string) string {
                 php ( "sleep(" (e 1) ");" nl (block 2) nl )
                 swift3 ( "usleep(UInt32(1000000*" (e 1) "));" nl (block 2) nl )
                 swift6 ( "usleep(UInt32(1000000*" (e 1) "));" nl (block 2) nl )
+                python ( nl "time.sleep(" (e 1) ")" nl (block 2) nl (imp "time") )
                 java7 (
 
     "new Thread() {" nl I
@@ -723,6 +729,7 @@ func r_file_exists ( fileName:String ) -> Bool {
     ")                    
                 )
                 es6 ("require(\"fs\").existsSync(" (e 1) " + \"/\" + " (e 2) " )")
+                python ( "os.path.isfile(" (e 1) " + \"/\" + " (e 2) ")" (imp "os") )
                 ranger ("( file_exists " (e 1) " + \"/\" + " (e 2) "  )")
                 java7 ( "new File(" (e 1) " + '/' + " (e 2) ").exists()" (imp "java.io.File") )
                 php ( "file_exists(" (e 1) ".'/'." (e 2) ")" )
@@ -745,6 +752,7 @@ func r_file_exists(pathName string, fileName string) bool {
         dir_exists          cmdIsDir:boolean (path:string) {
             templates {
                 csharp ( "false /* dir_exists not implemented */ ")
+                python ( "os.path.isdir(" (e 1) ")" (imp "os") )
                 scala ( "false /* dir_exists not implemented */ ")
                 swift3 ( "r_dir_exists( dirName: " (e 1) ")" 
 
@@ -858,6 +866,7 @@ void  r_cpp_create_dir(std::string name)
                 swift6 ( nl "try? FileManager.default.createDirectory(atPath: " (e 1) ", withIntermediateDirectories: true)" nl (imp "Foundation") )        
                 php (  nl "mkdir(" (e 1) ");" nl )
                 es6 ("require(\"fs\").mkdirSync( " (e 1) ")")
+                python ( nl "os.makedirs(" (e 1) ", exist_ok=True)" nl (imp "os") )
                 go ( nl "_ = os.Mkdir( " (e 1 ) " , os.ModePerm)" nl (imp "os") )
 
                 ranger ( nl "create_dir " (e 1) nl)

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -702,6 +702,9 @@ export declare class RangerAppWriterContext {
     targetLangName: string;
     parent?: RangerAppWriterContext;
     defined_imports: Array<string>;
+    active_macros: {
+        [key: string]: boolean;
+    };
     macro_expansion_depth: number;
     already_imported: {
         [key: string]: boolean;

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -702,6 +702,7 @@ export declare class RangerAppWriterContext {
     targetLangName: string;
     parent?: RangerAppWriterContext;
     defined_imports: Array<string>;
+    macro_expansion_depth: number;
     already_imported: {
         [key: string]: boolean;
     };

--- a/dist/api.js
+++ b/dist/api.js
@@ -3680,6 +3680,7 @@ class RangerAppWriterContext {
         this.intRootCounter = 1; /** note: unused */
         this.targetLangName = "";
         this.defined_imports = []; /** note: unused */
+        this.active_macros = {};
         this.macro_expansion_depth = 0;
         this.already_imported = {};
         this.is_function = false;
@@ -16462,11 +16463,22 @@ class RangerFlowParser {
                         }
                         if (is_macro) {
                             const macroRoot = ctx.getRoot();
-                            if (macroRoot.macro_expansion_depth > 64) {
-                                ctx.addError(callArgs, ("Macro expansion of operator '" + fc.vref) + "' does not terminate: nested more than 64 levels. A macro template that expands to a call to the same operator recurses forever.");
+                            const macroKey = (((fc.vref + "@") + callArgs.getFilename()) + ":") + ((callArgs.sp.toString()));
+                            let macroActive = false;
+                            if ((typeof (macroRoot.active_macros[macroKey]) != "undefined" && macroRoot.active_macros.hasOwnProperty(macroKey))) {
+                                macroActive = ((macroRoot.active_macros.hasOwnProperty(macroKey) ? macroRoot.active_macros[macroKey] : undefined));
+                            }
+                            if (macroActive) {
+                                ctx.addError(callArgs, ("Macro expansion of operator '" + fc.vref) + "' is recursive: expanding it reaches the same call site again, so it never terminates.");
                                 ctx.removeOpNs(added_ns);
                                 return true;
                             }
+                            if (macroRoot.macro_expansion_depth > 512) {
+                                ctx.addError(callArgs, ("Macro expansion of operator '" + fc.vref) + "' does not terminate: nested more than 512 levels.");
+                                ctx.removeOpNs(added_ns);
+                                return true;
+                            }
+                            macroRoot.active_macros[macroKey] = true;
                             macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth + 1;
                             const macroNode = yield this.buildMacro(langOper, callArgs, ctx);
                             let arg_len_1 = callArgs.children.length;
@@ -16479,6 +16491,7 @@ class RangerFlowParser {
                             macroNode.parent = callArgs;
                             yield this.WalkNode(macroNode, ctx, wr);
                             macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth - 1;
+                            macroRoot.active_macros[macroKey] = false;
                             match.setRvBasedOn(nameNode, callArgs);
                             ctx.removeOpNs(added_ns);
                             return true;

--- a/dist/api.js
+++ b/dist/api.js
@@ -3680,6 +3680,7 @@ class RangerAppWriterContext {
         this.intRootCounter = 1; /** note: unused */
         this.targetLangName = "";
         this.defined_imports = []; /** note: unused */
+        this.macro_expansion_depth = 0;
         this.already_imported = {};
         this.is_function = false;
         this.class_level_context = false;
@@ -16460,6 +16461,13 @@ class RangerFlowParser {
                             return true;
                         }
                         if (is_macro) {
+                            const macroRoot = ctx.getRoot();
+                            if (macroRoot.macro_expansion_depth > 64) {
+                                ctx.addError(callArgs, ("Macro expansion of operator '" + fc.vref) + "' does not terminate: nested more than 64 levels. A macro template that expands to a call to the same operator recurses forever.");
+                                ctx.removeOpNs(added_ns);
+                                return true;
+                            }
+                            macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth + 1;
                             const macroNode = yield this.buildMacro(langOper, callArgs, ctx);
                             let arg_len_1 = callArgs.children.length;
                             while (arg_len_1 > 0) {
@@ -16470,6 +16478,7 @@ class RangerFlowParser {
                             callArgs.children.push(macroNode);
                             macroNode.parent = callArgs;
                             yield this.WalkNode(macroNode, ctx, wr);
+                            macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth - 1;
                             match.setRvBasedOn(nameNode, callArgs);
                             ctx.removeOpNs(added_ns);
                             return true;
@@ -42934,7 +42943,7 @@ class CLIProgress {
         this.inputFile = "";
         this.outputFile = "";
         this.targetLanguage = "";
-        this.compilerVersion = "3.3.0";
+        this.compilerVersion = "3.3.1";
         this.useColors = ((typeof process !== "undefined" && process.stdout && process.stdout.isTTY) || false);
         this.startTime = Date.now();
     }

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ranger-compiler",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Ranger cross-language compiler - compile once, run anywhere. Write code in Ranger and compile to JavaScript, TypeScript, Python, Go, Rust, Swift, C++, Java, Kotlin, C#, PHP, and Scala.",
   "main": "api.js",
   "types": "api.d.ts",

--- a/dist/rgrc.js
+++ b/dist/rgrc.js
@@ -3311,6 +3311,7 @@ class RangerAppWriterContext  {
     this.intRootCounter = 1;     /** note: unused */
     this.targetLangName = "";
     this.defined_imports = [];     /** note: unused */
+    this.macro_expansion_depth = 0;
     this.already_imported = {};
     this.is_function = false;
     this.class_level_context = false;
@@ -15067,6 +15068,13 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
               return true;
             }
             if ( is_macro ) {
+              const macroRoot = ctx.getRoot();
+              if ( macroRoot.macro_expansion_depth > 64 ) {
+                ctx.addError(callArgs, ("Macro expansion of operator '" + fc.vref) + "' does not terminate: nested more than 64 levels. A macro template that expands to a call to the same operator recurses forever.");
+                ctx.removeOpNs(added_ns);
+                return true;
+              }
+              macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth + 1;
               const macroNode = await this.buildMacro(langOper, callArgs, ctx);
               let arg_len_1 = callArgs.children.length;
               while (arg_len_1 > 0) {
@@ -15076,6 +15084,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
               callArgs.children.push(macroNode);
               macroNode.parent = callArgs;
               await this.WalkNode(macroNode, ctx, wr);
+              macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth - 1;
               match.setRvBasedOn(nameNode, callArgs);
               ctx.removeOpNs(added_ns);
               return true;
@@ -39291,7 +39300,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       this.inputFile = "";
       this.outputFile = "";
       this.targetLanguage = "";
-      this.compilerVersion = "3.3.0";
+      this.compilerVersion = "3.3.1";
       this.useColors = ((typeof process !== "undefined" && process.stdout && process.stdout.isTTY) || false);
       this.startTime = Date.now();
     }

--- a/dist/rgrc.js
+++ b/dist/rgrc.js
@@ -3311,6 +3311,7 @@ class RangerAppWriterContext  {
     this.intRootCounter = 1;     /** note: unused */
     this.targetLangName = "";
     this.defined_imports = [];     /** note: unused */
+    this.active_macros = {};
     this.macro_expansion_depth = 0;
     this.already_imported = {};
     this.is_function = false;
@@ -15069,11 +15070,22 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             }
             if ( is_macro ) {
               const macroRoot = ctx.getRoot();
-              if ( macroRoot.macro_expansion_depth > 64 ) {
-                ctx.addError(callArgs, ("Macro expansion of operator '" + fc.vref) + "' does not terminate: nested more than 64 levels. A macro template that expands to a call to the same operator recurses forever.");
+              const macroKey = (((fc.vref + "@") + callArgs.getFilename()) + ":") + ((callArgs.sp.toString()));
+              let macroActive = false;
+              if ( ( typeof(macroRoot.active_macros[macroKey] ) != "undefined" && macroRoot.active_macros.hasOwnProperty(macroKey) ) ) {
+                macroActive = (( macroRoot.active_macros.hasOwnProperty(macroKey) ? macroRoot.active_macros[macroKey] : undefined ));
+              }
+              if ( macroActive ) {
+                ctx.addError(callArgs, ("Macro expansion of operator '" + fc.vref) + "' is recursive: expanding it reaches the same call site again, so it never terminates.");
                 ctx.removeOpNs(added_ns);
                 return true;
               }
+              if ( macroRoot.macro_expansion_depth > 512 ) {
+                ctx.addError(callArgs, ("Macro expansion of operator '" + fc.vref) + "' does not terminate: nested more than 512 levels.");
+                ctx.removeOpNs(added_ns);
+                return true;
+              }
+              macroRoot.active_macros[macroKey] = true;
               macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth + 1;
               const macroNode = await this.buildMacro(langOper, callArgs, ctx);
               let arg_len_1 = callArgs.children.length;
@@ -15085,6 +15097,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
               macroNode.parent = callArgs;
               await this.WalkNode(macroNode, ctx, wr);
               macroRoot.macro_expansion_depth = macroRoot.macro_expansion_depth - 1;
+              macroRoot.active_macros[macroKey] = false;
               match.setRvBasedOn(nameNode, callArgs);
               ctx.removeOpNs(added_ns);
               return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ranger-compiler",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Ranger cross-language compiler - compile once, run anywhere",
   "main": "dist/api.js",
   "types": "dist/api.d.ts",

--- a/tests/compiler-python.test.ts
+++ b/tests/compiler-python.test.ts
@@ -19,6 +19,31 @@ describe.skipIf(!pythonAvailable)("Ranger Compiler - Python Target", () => {
     }
   });
 
+  // These operators had no python template at all: M_PI, fabs, tan, random
+  // (both variants), wait, file_exists, dir_exists and create_dir. They are
+  // run rather than only compiled, because the python backend can emit code
+  // that compiles and is not valid Python -- see the lambda note in
+  // PLAN_OPERATORS.md.
+  describe("Math, random and filesystem operators", () => {
+    it("should compile and run the operators that had no python template", () => {
+      const { compile, run } = compileAndRunPython(
+        `${FIXTURES_DIR}/python_stdlib_ops.rgr`
+      );
+
+      expect(
+        compile.success,
+        `Compile failed: ${compile.error || compile.output}`
+      ).toBe(true);
+      expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+      expect(run?.output).toContain("pi>3:y");
+      expect(run?.output).toContain("fabs:1.5");
+      expect(run?.output).toContain("rand_range:y");
+      expect(run?.output).toContain("randint:3");
+      expect(run?.output).toContain("dir_exists:y");
+      expect(run?.output).toContain("file_missing:n");
+    });
+  });
+
   describe("Array Operations", () => {
     it("should compile and run array push", () => {
       const { compile, run } = compileAndRunPython(

--- a/tests/fixtures/macro_indirect_recursion.rgr
+++ b/tests/fixtures/macro_indirect_recursion.rgr
@@ -1,0 +1,21 @@
+; An indirect cycle: macA expands to macB, which expands back to macA. A static
+; "does this macro name itself" check cannot see this; the expansion-depth
+; guard can.
+operators {
+  macA _:int ( a:int ) {
+    templates {
+      * @macro(true) ( "(macB " (e 1) ")" )
+    }
+  }
+  macB _:int ( a:int ) {
+    templates {
+      * @macro(true) ( "(macA " (e 1) ")" )
+    }
+  }
+}
+
+class MacroIndirectRecursion {
+    sfn m@(main):void () {
+        print (to_string (macA 1))
+    }
+}

--- a/tests/fixtures/macro_nested_if.rgr
+++ b/tests/fixtures/macro_nested_if.rgr
@@ -1,0 +1,15 @@
+class MacroNestedIf {
+    sfn m@(main):void () {
+        def a 1
+        def b 2
+        if (a > 0) {
+            if (b > 1) {
+                if (a < b) { print "deep" } { print "x" }
+            } {
+                print "y"
+            }
+        } {
+            if (b > 0) { print "z" } { print "w" }
+        }
+    }
+}

--- a/tests/fixtures/macro_self_recursion.rgr
+++ b/tests/fixtures/macro_self_recursion.rgr
@@ -1,0 +1,16 @@
+; A macro template that expands to a call to the same operator has no base
+; case. Before the depth guard this hung the compiler indefinitely with no
+; diagnostic at all -- not a stack overflow, just silence.
+operators {
+  selfmac _:int ( a:int ) {
+    templates {
+      * @macro(true) ( "(selfmac " (e 1) ")" )
+    }
+  }
+}
+
+class MacroSelfRecursion {
+    sfn m@(main):void () {
+        print (to_string (selfmac 1))
+    }
+}

--- a/tests/fixtures/python_stdlib_ops.rgr
+++ b/tests/fixtures/python_stdlib_ops.rgr
@@ -1,0 +1,12 @@
+class PythonStdlibOps {
+    sfn m@(main):void () {
+        print ("pi>3:" + (? ((M_PI) > 3.0) "y" "n"))
+        print ("fabs:" + (to_string (fabs 0.0 - 1.5)))
+        def r (random)
+        print ("rand_range:" + (? ((r >= 0.0) && (r < 1.0)) "y" "n"))
+        print ("randint:" + (to_string (random 3 3)))
+        create_dir "/tmp/rgr_py_check"
+        print ("dir_exists:" + (? (dir_exists "/tmp/rgr_py_check") "y" "n"))
+        print ("file_missing:" + (? (file_exists "/tmp/rgr_py_check" "nope.txt") "y" "n"))
+    }
+}

--- a/tests/macro-recursion.test.ts
+++ b/tests/macro-recursion.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { compileRanger } from "./helpers/compiler";
+
+const FIXTURES = "tests/fixtures";
+
+/**
+ * Macro expansion renders the template to Ranger source and walks the result
+ * again (`buildMacro` + `WalkNode` in ng_parser_std_match2.rgr). A template
+ * that expands to a call to the same operator therefore has no base case.
+ *
+ * Before the expansion-depth guard the compiler did not overflow the stack or
+ * report anything -- it simply never returned. These tests assert that it now
+ * fails with a diagnostic naming the operator, and that they terminate at all:
+ * a regression here would hang the suite rather than fail it, so both cases
+ * carry a timeout.
+ */
+describe("macro expansion recursion guard", () => {
+  it("rejects a macro that expands to itself", { timeout: 60000 }, () => {
+    const result = compileRanger(`${FIXTURES}/macro_self_recursion.rgr`, "es6");
+    const output = `${result.output}${result.error || ""}`;
+
+    expect(result.success, "expected the self-recursive macro to be rejected").toBe(false);
+    expect(output).toContain("does not terminate");
+    expect(output).toContain("selfmac");
+  });
+
+  it("rejects an indirect macro cycle", { timeout: 60000 }, () => {
+    const result = compileRanger(
+      `${FIXTURES}/macro_indirect_recursion.rgr`,
+      "es6"
+    );
+    const output = `${result.output}${result.error || ""}`;
+
+    expect(result.success, "expected the macA -> macB -> macA cycle to be rejected").toBe(false);
+    expect(output).toContain("does not terminate");
+  });
+});

--- a/tests/macro-recursion.test.ts
+++ b/tests/macro-recursion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compileRanger } from "./helpers/compiler";
+import { compileAndRun, compileRanger } from "./helpers/compiler";
 
 const FIXTURES = "tests/fixtures";
 
@@ -8,8 +8,10 @@ const FIXTURES = "tests/fixtures";
  * again (`buildMacro` + `WalkNode` in ng_parser_std_match2.rgr). A template
  * that expands to a call to the same operator therefore has no base case.
  *
- * Before the expansion-depth guard the compiler did not overflow the stack or
- * report anything -- it simply never returned. These tests assert that it now
+ * Before the guard the compiler did not overflow the stack or report anything
+ * -- it simply never returned. Detection keys on operator name + source
+ * position, not on the name alone: `if ... else` is itself a macro emitting
+ * `if`, so nested if/else re-enters the same operator legitimately. These tests assert that it now
  * fails with a diagnostic naming the operator, and that they terminate at all:
  * a regression here would hang the suite rather than fail it, so both cases
  * carry a timeout.
@@ -20,7 +22,7 @@ describe("macro expansion recursion guard", () => {
     const output = `${result.output}${result.error || ""}`;
 
     expect(result.success, "expected the self-recursive macro to be rejected").toBe(false);
-    expect(output).toContain("does not terminate");
+    expect(output).toContain("is recursive");
     expect(output).toContain("selfmac");
   });
 
@@ -32,6 +34,23 @@ describe("macro expansion recursion guard", () => {
     const output = `${result.output}${result.error || ""}`;
 
     expect(result.success, "expected the macA -> macB -> macA cycle to be rejected").toBe(false);
-    expect(output).toContain("does not terminate");
+    expect(output).toContain("is recursive");
+  });
+});
+
+describe("macro expansion re-entry that is legitimate", () => {
+  // `if ... else` expands to the three-argument `if`, so a nested if/else
+  // re-enters the same macro operator while the outer one is still in flight.
+  // A guard keyed on the operator name alone would reject this, and with it
+  // most real programs -- the compiler's own source included.
+  it("allows nested if/else, which re-enters the same macro", () => {
+    const { compile, run } = compileAndRun(`${FIXTURES}/macro_nested_if.rgr`);
+
+    expect(
+      compile.success,
+      `Compile failed: ${compile.error || compile.output}`
+    ).toBe(true);
+    expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+    expect(run?.output).toContain("deep");
   });
 });

--- a/tests/operator-coverage.test.ts
+++ b/tests/operator-coverage.test.ts
@@ -97,35 +97,12 @@ describe("operator target coverage", () => {
   // target lagging the legacy one -- is a defect.
 
 
-  // The dynamic guard in ng_parser_std_match2.rgr catches runaway expansion at
-  // compile time, including indirect cycles. This is the cheap static half:
-  // a macro template whose text names its own operator can never terminate, so
-  // it should never reach the tree in the first place. Non-macro templates that
-  // name themselves are the norm and are correct -- 85 of them do, because that
-  // is what a Ranger-to-Ranger emitter is for -- so this looks only at @macro.
-  it("has no self-naming macro templates", () => {
-    const offenders: string[] = [];
-
-    for (const file of OPERATOR_FILES) {
-      const src = fs
-        .readFileSync(path.join(ROOT_DIR, file), "utf8")
-        .split(/\r?\n/);
-
-      let owner: string | null = null;
-      src.forEach((line, idx) => {
-        const decl = /^\s*([a-zA-Z_][\w.?!]*)\s+\S+\s*\(/.exec(line);
-        if (decl && !/^\s*(templates|if|for|while|return|def)\b/.test(line)) {
-          owner = decl[1];
-        }
-        const tmpl = /^\s*(?:[a-z0-9]+|\*)\s*@macro\([a-z]+\)\s*\(\s*['"]\(([a-zA-Z_][\w.?!]*)/.exec(line);
-        if (tmpl && owner && tmpl[1] === owner) {
-          offenders.push(`${file}:${idx + 1} macro '${owner}' expands to itself`);
-        }
-      });
-    }
-
-    expect(offenders.join("\n"), "self-naming macro templates").toBe("");
-  });
+  // No static "does this macro name itself" check lives here, deliberately.
+  // `if ... else` and `if!` are macros whose templates emit `if` -- they lower
+  // to the three-argument `if`, which is not a macro, so they terminate. Self
+  // naming is therefore legal and such a check would be false-positive by
+  // design. Recursion is caught exactly, at compile time, by the active-macro
+  // map in ng_parser_std_match2.rgr; see tests/macro-recursion.test.ts.
 
   // A template that emits a literal false / an empty string / a "not
   // implemented" comment compiles and then silently does the wrong thing at

--- a/tests/operator-coverage.test.ts
+++ b/tests/operator-coverage.test.ts
@@ -96,6 +96,37 @@ describe("operator target coverage", () => {
   // for instance) is correct, not a gap. Only the reverse -- the primary
   // target lagging the legacy one -- is a defect.
 
+
+  // The dynamic guard in ng_parser_std_match2.rgr catches runaway expansion at
+  // compile time, including indirect cycles. This is the cheap static half:
+  // a macro template whose text names its own operator can never terminate, so
+  // it should never reach the tree in the first place. Non-macro templates that
+  // name themselves are the norm and are correct -- 85 of them do, because that
+  // is what a Ranger-to-Ranger emitter is for -- so this looks only at @macro.
+  it("has no self-naming macro templates", () => {
+    const offenders: string[] = [];
+
+    for (const file of OPERATOR_FILES) {
+      const src = fs
+        .readFileSync(path.join(ROOT_DIR, file), "utf8")
+        .split(/\r?\n/);
+
+      let owner: string | null = null;
+      src.forEach((line, idx) => {
+        const decl = /^\s*([a-zA-Z_][\w.?!]*)\s+\S+\s*\(/.exec(line);
+        if (decl && !/^\s*(templates|if|for|while|return|def)\b/.test(line)) {
+          owner = decl[1];
+        }
+        const tmpl = /^\s*(?:[a-z0-9]+|\*)\s*@macro\([a-z]+\)\s*\(\s*['"]\(([a-zA-Z_][\w.?!]*)/.exec(line);
+        if (tmpl && owner && tmpl[1] === owner) {
+          offenders.push(`${file}:${idx + 1} macro '${owner}' expands to itself`);
+        }
+      });
+    }
+
+    expect(offenders.join("\n"), "self-naming macro templates").toBe("");
+  });
+
   // A template that emits a literal false / an empty string / a "not
   // implemented" comment compiles and then silently does the wrong thing at
   // runtime. create_dir for swift3 was an empty template, so every Swift 3


### PR DESCRIPTION
Checked the python target the same way as swift6: a static pass over every templates {} block, then compiling and -- crucially -- running the result.

Nine operators had no python template and could not compile for that target: M_PI, fabs, tan, random (both variants), wait, file_exists, dir_exists and create_dir. Added, using math / random / os / time via the existing (imp ...) mechanism.

These are verified by execution, not just compilation. tests/compiler-python.test.ts runs the generated Python through compileAndRunPython and asserts the values, which this environment can do for Python even though it cannot for Kotlin or Swift. That distinction turned out to matter more than expected -- see below.

Two Python gaps found and left open, both larger than a template:

1. Every operator taking a lambda emits invalid Python. .map(), .filter(), .reduce(), .find(), .count(), .groupBy() and the newly added .any() / .all() all compile [OK] for python and then die at runtime:

       out = operatorsOf.map_2(a, lambda item:
         return item * 2;          # SyntaxError: invalid syntax
       )

   The backend emits the Ranger callback body as a multi-statement Python lambda, and a Python lambda holds one expression. Fixing it means hoisting callback bodies into named functions in ng_RangerPythonClassWriter.rgr, a codegen change rather than a template. This is a good argument for treating compile-success as insufficient evidence anywhere a runtime is available.

2. Python has no JSON support at all: 0 of the 34 template blocks in lib/JSON.rgr declare python, and systemclass JSONDataObject/JSONArrayObject declare no Python type, so @serialize(true) cannot work there. Unlike C++ and Rust it is tractable -- dict and list are the obvious mapping -- but it is a whole JSON backend.

Publish gate green: 46 files, 372 tests, exit 0.


Claude-Session: https://claude.ai/code/session_01NT8B9ehMrFV9i733HtkjNx