### PR TITLE
Keep one SDL window for the whole v2 session; fix the launcher quit edge

### DIFF
--- a/gallery/game_engine/v2/games/cannon3d/game.info
+++ b/gallery/game_engine/v2/games/cannon3d/game.info
@@ -1,4 +1,4 @@
 name=Cannon 3D
-category=Games
+category=Tests
 index=3
 splitScreen=never

--- a/gallery/game_engine/v2/games/pinball/game.info
+++ b/gallery/game_engine/v2/games/pinball/game.info
@@ -1,4 +1,4 @@
 name=Pinball
-category=Games
+category=Tests
 index=4
 splitScreen=never

--- a/gallery/game_engine/v2/menu/RgLauncherUi.rgr
+++ b/gallery/game_engine/v2/menu/RgLauncherUi.rgr
@@ -181,7 +181,7 @@ class RgLauncherUi {
         this.footer.fontSize = 13.0
         def footLh:int (to_int (this.layer.ctx.lineHeight(this.footer.fontSize)))
         this.footerY = ((height - footLh) - 12)
-        this.footer.text = "A avaa, nuolet liikkuvat"
+        this.footer.text = "Nuolet liikkuvat, Space avaa, Q lopettaa"
         this.layoutCenteredLabel(this.footer cx this.footerY)
         this.layer.add(this.footer)
 
@@ -303,10 +303,10 @@ class RgLauncherUi {
         }
         if (this.page == 0) {
             this.sub.text = "valitse kategoria"
-            this.footer.text = "A avaa, nuolet liikkuvat"
+            this.footer.text = "Nuolet liikkuvat, Space avaa, Q lopettaa"
         } {
             this.sub.text = (itemAt this.categoryNames this.activeCat)
-            this.footer.text = "A pelaa, Q/B takaisin"
+            this.footer.text = "Space pelaa, Q takaisin"
         }
         ; Re-centre chrome labels whenever the copy changes (category name lengths
         ; differ; a fixed 200px box left the shorter Finnish strings off-centre).

--- a/gallery/game_engine/v2/menu/RgLauncherUi.rgr
+++ b/gallery/game_engine/v2/menu/RgLauncherUi.rgr
@@ -55,8 +55,14 @@ class RgLauncherUi {
     def categoryNames:[string]
     def catCards:[UIBox]
     def games:[RgLauncherGame]
+    def title:UILabel (new UILabel)
     def sub:UILabel (new UILabel)
     def footer:UILabel (new UILabel)
+    ; fixed vertical band for chrome so title/subtitle never overlap cards
+    def titleY:int 14
+    def subY:int 0
+    def footerY:int 0
+    def cardY:int 0
 
     ; override the scan root before init() (tests / alternate game trees)
     fn setGamesDir:void (dir:string) { this.gamesDir = dir }
@@ -66,6 +72,18 @@ class RgLauncherUi {
         def cx:int (idiv this.w 2)
         def totalW:int ((cardW * n) + (gap * (n - 1)))
         return (cx - (idiv totalW 2))
+    }
+
+    ; Place a label centred on x=cx at top y, sized to its measured text so
+    ; left-aligned UILabel drawing still reads as centred (v1 flex parity).
+    fn layoutCenteredLabel:void (lbl:UILabel cx:int y:int) {
+        def tw:int (to_int (this.layer.ctx.measureWidth(lbl.text lbl.fontSize)))
+        def lh:int (to_int (this.layer.ctx.lineHeight(lbl.fontSize)))
+        if (tw < 20) { tw = 20 }
+        if (lh < 12) { lh = 12 }
+        ; pad the box slightly so TTF glyphs aren't clipped at the edges
+        def pad:int 8
+        lbl.setBounds(((cx - (idiv tw 2)) - pad) y (tw + (pad * 2)) lh)
     }
 
     ; decode a game's game.info icon (relative to its folder) to an RGBA image
@@ -145,26 +163,43 @@ class RgLauncherUi {
 
         def cx:int (idiv width 2)
 
-        def title:UILabel (new UILabel)
-        title.text = "Ranger"
-        title.fontSize = 40.0
-        title.setBounds((cx - 90) (idiv height 12) 180 48)
-        this.layer.add(title)
+        ; Title + subtitle stacked with measured line heights (at 480×270 the old
+        ; h/12 + h/5 boxes overlapped: title glyphs ran past the subtitle baseline).
+        this.title.text = "Ranger"
+        this.title.fontSize = 34.0
+        this.layoutCenteredLabel(this.title cx this.titleY)
+        this.layer.add(this.title)
 
+        def titleLh:int (to_int (this.layer.ctx.lineHeight(this.title.fontSize)))
+        this.subY = ((this.titleY + titleLh) + 6)
         this.sub.text = "valitse kategoria"
-        this.sub.fontSize = 16.0
-        this.sub.setBounds((cx - 100) (idiv height 5) 200 20)
+        this.sub.fontSize = 15.0
+        this.layoutCenteredLabel(this.sub cx this.subY)
         this.layer.add(this.sub)
+
+        def subLh:int (to_int (this.layer.ctx.lineHeight(this.sub.fontSize)))
+        this.footer.fontSize = 13.0
+        def footLh:int (to_int (this.layer.ctx.lineHeight(this.footer.fontSize)))
+        this.footerY = ((height - footLh) - 12)
+        this.footer.text = "A avaa, nuolet liikkuvat"
+        this.layoutCenteredLabel(this.footer cx this.footerY)
+        this.layer.add(this.footer)
+
+        ; Cards sit below the subtitle band and above the footer.
+        this.cardY = ((this.subY + subLh) + 14)
+        def cardBottom:int (this.footerY - 10)
+        def cardMaxH:int (cardBottom - this.cardY)
+        def cardW:int (idiv width 4)
+        def cardH:int cardW
+        if (cardH > cardMaxH) { cardH = cardMaxH }
+        if (cardH < 64) { cardH = 64 }
 
         ; ---- DISCOVER the catalog from the filesystem (v1 model) -------------
         this.catalog.setGamesDir(this.gamesDir)
         this.catalog.scan()
         this.categoryNames = (this.catalog.categories())
 
-        def cardW:int (idiv width 4)
-        def cardH:int cardW
         def gap:int 24
-        def cardY:int (idiv height 3)
         def nCats:int (array_length this.categoryNames)
         def startX:int (this.rowStartX(nCats cardW gap))
         def ci:int 0
@@ -174,7 +209,7 @@ class RgLauncherUi {
             def ccard:UIBox (new UIBox)
             ccard.text = cname
             ccard.fontSize = 20.0
-            ccard.setBounds(cxi cardY cardW cardH)
+            ccard.setBounds(cxi this.cardY cardW cardH)
             this.layer.add(ccard)
             push this.catCards ccard
 
@@ -200,7 +235,7 @@ class RgLauncherUi {
                 ; one without falls back to a centered title on the plain card.
                 if (g.hasImg) { g.card.text = "" } { g.card.text = e.title }
                 def exj:int (eStartX + (ei * (eCardW + eGap)))
-                g.card.setBounds(exj cardY eCardW cardH)
+                g.card.setBounds(exj this.cardY eCardW cardH)
                 g.card.visible = false
                 this.layer.add(g.card)
                 push this.games g
@@ -211,11 +246,6 @@ class RgLauncherUi {
             if ((this.catFirstImageIndex(ci)) >= 0) { ccard.text = "" }
             ci = (ci + 1)
         }
-
-        this.footer.text = "A avaa, nuolet liikkuvat"
-        this.footer.fontSize = 13.0
-        this.footer.setBounds((cx - 110) (height - (idiv height 10)) 220 16)
-        this.layer.add(this.footer)
 
         this.selected = 0
         this.applyPage()
@@ -276,8 +306,14 @@ class RgLauncherUi {
             this.footer.text = "A avaa, nuolet liikkuvat"
         } {
             this.sub.text = (itemAt this.categoryNames this.activeCat)
-            this.footer.text = "A pelaa, B takaisin"
+            this.footer.text = "A pelaa, Q/B takaisin"
         }
+        ; Re-centre chrome labels whenever the copy changes (category name lengths
+        ; differ; a fixed 200px box left the shorter Finnish strings off-centre).
+        def cx:int (idiv this.w 2)
+        this.layoutCenteredLabel(this.title cx this.titleY)
+        this.layoutCenteredLabel(this.sub cx this.subY)
+        this.layoutCenteredLabel(this.footer cx this.footerY)
         this.highlight()
     }
 

--- a/gallery/game_engine/v2/menu/tests/launcher_ui_test.rgr
+++ b/gallery/game_engine/v2/menu/tests/launcher_ui_test.rgr
@@ -66,22 +66,35 @@ class LauncherUiTest {
         ui.init(480 270)
 
         ; ---- catalog DISCOVERED from the real v2 games folder ---------------
-        ; Only ylos2 (Pomppija) is a ported v2 game today, so the scan finds one
-        ; "Games" category with Pomppija in it. (Adding a game folder with a
-        ; game.info would extend this automatically — the test is intentionally
-        ; tied to the real filesystem, like v1's launcher.)
+        ; Games: Pomppija + Ylos3D (WASM). Tests: Cannon 3D + Pinball prototypes.
+        ; Categories appear in first-seen order (Games, then Tests).
         t.ok("at least one category discovered" ((ui.categoryCount()) >= 1))
+        t.ok("at least two categories (Games + Tests)" ((ui.categoryCount()) >= 2))
         t.ok("at least one game discovered" ((ui.gameCount()) >= 1))
         t.eqStr("first category is Games" (ui.selectedLabel()) "Games")
         t.eqStr("selected category name" (ui.selectedCategory()) "Games")
         ui.moveSelection(0 - 5)
         t.eqStr("left clamps to the first category" (ui.selectedLabel()) "Games")
+        ui.moveSelection(1)
+        t.eqStr("right moves to Tests" (ui.selectedLabel()) "Tests")
+        ui.moveSelection(0 - 1)
+        t.eqStr("back on Games" (ui.selectedLabel()) "Games")
 
         ; ---- it actually renders pixels + an accent card -------------------
         ui.render()
         t.ok("something was drawn into the canvas" ((LauncherUiTest.nonBackground(ui)) > 0))
         def catAccent:int (LauncherUiTest.countColor(ui 0 0 480 270 255 190 70))
         t.ok("the selected category card is accent-filled" (catAccent > 0))
+
+        ; title ("Ranger") and subtitle must not share the same vertical band —
+        ; previously both boxes overlapped at 480×270 (h/12 vs h/5).
+        t.ok("title sits above the subtitle" (ui.title.y < ui.sub.y))
+        t.ok("title and subtitle do not overlap vertically" ((ui.title.y + ui.title.h) <= ui.sub.y))
+        ; measured centering: label box straddles the canvas midline
+        def midX:int 240
+        t.ok("title box covers the horizontal center" ((ui.title.x < midX) && ((ui.title.x + ui.title.w) > midX)))
+        t.ok("subtitle box covers the horizontal center" ((ui.sub.x < midX) && ((ui.sub.x + ui.sub.w) > midX)))
+        t.ok("footer box covers the horizontal center" ((ui.footer.x < midX) && ((ui.footer.x + ui.footer.w) > midX)))
 
         ; ---- two-level navigation + real game handoff ----------------------
         def ui2:RgLauncherUi (new RgLauncherUi)
@@ -117,6 +130,16 @@ class LauncherUiTest {
         ui2.back()
         t.eqInt("back to the category page" (ui2.currentPage()) 0)
         t.eqStr("restored to the Games category" (ui2.selectedLabel()) "Games")
+
+        ; Tests category lists the prototype physics demos
+        ui2.moveSelection(1)
+        t.eqStr("Tests category is selectable" (ui2.selectedLabel()) "Tests")
+        def aT:int (ui2.activate())
+        t.eqInt("entering Tests does not launch" aT 0)
+        t.eqStr("first Tests entry is Cannon 3D" (ui2.selectedLabel()) "Cannon 3D")
+        ui2.moveSelection(1)
+        t.eqStr("second Tests entry is Pinball" (ui2.selectedLabel()) "Pinball")
+        ui2.back()
 
         ; page 1 renders the game cards (accent present somewhere)
         def _a2:int (ui2.activate())

--- a/gallery/game_engine/v2/menu/tests/launcher_ui_test.rgr
+++ b/gallery/game_engine/v2/menu/tests/launcher_ui_test.rgr
@@ -66,8 +66,10 @@ class LauncherUiTest {
         ui.init(480 270)
 
         ; ---- catalog DISCOVERED from the real v2 games folder ---------------
-        ; Games: Pomppija + Ylos3D (WASM). Tests: Cannon 3D + Pinball prototypes.
-        ; Categories appear in first-seen order (Games, then Tests).
+        ; Games: Pomppija, Ylos3D (WASM), Ylos3D. Tests: Cannon 3D + Pinball
+        ; prototypes. GameCatalog.categories() forces "Games" to the front when
+        ; present and leaves the rest in first-seen order, so the row is
+        ; Games, then Tests.
         t.ok("at least one category discovered" ((ui.categoryCount()) >= 1))
         t.ok("at least two categories (Games + Tests)" ((ui.categoryCount()) >= 2))
         t.ok("at least one game discovered" ((ui.gameCount()) >= 1))

--- a/gallery/game_engine/v2/runtime/sdl/README.md
+++ b/gallery/game_engine/v2/runtime/sdl/README.md
@@ -20,14 +20,28 @@ knowledge** and **no additions to `ranger:core`**.
 
 - `RgSdlGameHost.rgr` — the driver. Two entry loops share one window/present
   path: `runLauncher()` (present the rich launcher canvas via `gfx_present`,
-  navigate on key-press *edges*, hand off the chosen game to `run`) and `run`
-  (poll input → actions → `host.frame` → present → forward rumble, honour
-  the guest launch handoff). The window is always one pane (`480×270`, 16:9);
-  present follows the guest-declared pane count (1 pane → `gfx_present`, 2+ →
-  `gfx_present_split` which scales each full-res pane into a window half).
+  navigate on key-press *edges*, hand off the chosen game to `runIn`) and
+  `runIn` (poll input → actions → `host.frame` → present → forward rumble,
+  honour the guest launch handoff). The window is always one pane (`480×270`,
+  16:9); present follows the guest-declared pane count (1 pane → `gfx_present`,
+  2+ → `gfx_present_split` which scales each full-res pane into a window half).
   `clearRgb` is a neutral framebuffer clear, not a scene sky.
-  `launcherStep`/`mapMask`/`edge`/`toRgbaBuffer` are pure host-input/present
-  seams, unit-tested headlessly.
+  `launcherStep`/`mapMask`/`edge`/`foldQuitBits`/`toRgbaBuffer` are pure
+  host-input/present seams, unit-tested headlessly.
+
+  **One window per session** (v1 parity): `runLauncher()` opens the window once
+  and closes it once. Launching a game does *not* re-create it — `runIn` /
+  `runWasmIn` present into the window that is already open and retitle it, and
+  the launcher retitles it back on the way out. (`run` / `runWasm` are the
+  standalone wrappers that own a window, for driving one game with no launcher.)
+  The earlier `gfx_close` → game → `gfx_open` dance tore the SDL window down and
+  built a new one on every transition; on macOS that stacks a second window
+  frame over the first and throws away whatever position, size, or Space the
+  user had put the window in.
+
+  Because the window is shared, closing it from the title bar during a game is a
+  quit for the whole app, not a return to the launcher: `runIn` reports it
+  (return `2`) and `runLauncher` exits.
 - `RgSdlMain.rgr` — native entry; calls `runLauncher()` (engine chrome, not a
   game — games remain `.tsx`-only).
 - `../../menu/RgLauncherUi.rgr` — the launcher screen itself (title, subtitle,
@@ -62,10 +76,19 @@ v1 game runner, the v2 host needs **no wasm3 and no libcurl** — only the
 operators it actually calls are emitted (all `SDL2/SDL.h`); GL is pulled in only
 by `gfx_sdl.rgr`'s shared prelude.
 
-A window opens on the launcher: arrows move, Space/`A` selects (Games → pick a
-game → launch), `S` goes back, Q/Esc quits. WASD + Space drives P1 in-game,
-arrows drive P2; a game's `runtime.input.player(i).rumble(...)` calls reach the
-pad through `gfx_rumble_pad`.
+A window opens on the launcher: arrows or WASD move, Space/Enter/pad `A` selects
+(Games → pick a game → launch), `S` or Q/Esc/pad `B` goes back a page, and
+Q/Esc/pad `B` on the category page quits. The launcher merges keyboard P1
+(WASD), keyboard P2 (arrows), and gamepad 0 into one navigation mask
+(`launcherNavMask`, v1 parity) — arrow keys are a *distinct* SDL source from
+WASD, so reading source 0 alone would leave the launcher deaf to both the arrows
+and every pad. Back/quit is normalised onto one bit by `foldQuitBits` (Q/Esc `8`,
+pad `B` `64`, pad Select `1024`), so a single edge covers all three.
+
+In-game, WASD + Space drives P1 and arrows drive P2, unchanged; back/quit is
+read *separately* from the play mask (v1 keeps them apart so movement never
+doubles as "exit"). A game's `runtime.input.player(i).rumble(...)` calls reach
+the pad through `gfx_rumble_pad`.
 
 ## Audio
 
@@ -82,8 +105,11 @@ Stack under `v2/audio` (`game_soundscore` + `game_audio` + `game_vocal_fx`).
 Device open notes (macOS): default `SDL_AUDIODRIVER=coreaudio`; empty
 `SDL_GetNumAudioDevices` is not fatal (open system default via `NULL`);
 frequency/channel negotiation is allowed; host adopts `gfx_audio_sample_rate()`
-and retunes `GameVocalFx` to match. `gfx_close` clears `audioReady` so a
-launcher → game → launcher relaunch reopens the device.
+and retunes `GameVocalFx` to match. The device now outlives a launcher → game →
+launcher round trip (the window is no longer torn down between them), so
+`gfx_audio_open` is a no-op on the way back in; the launcher calls
+`gfx_audio_clear` + `resetAudioDevice()` when a game exits so the next game
+starts from a silent queue and a fresh synth cursor.
 
 > The final SDL2 **link** needs SDL2 headers, which are absent in CI — so the
 > headless suite compile-checks the host, validates the Ranger→C++ codegen, and

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
@@ -91,6 +91,11 @@ class RgSdlGameHost {
         def jump:boolean (((bit_and m 1) != 0) || ((bit_and m 4) != 0))
         this.host.bridge.input.setAction(player "jump" jump)
         this.host.bridge.input.setAction(player "action" ((bit_and m 4) != 0))
+        ; Q / Esc (bit 8) — host also exits the game loop on a rising edge; map
+        ; the logical actions so guests that poll "back"/"quit" see them too.
+        def quitHeld:boolean ((bit_and m 8) != 0)
+        this.host.bridge.input.setAction(player "back" quitHeld)
+        this.host.bridge.input.setAction(player "quit" quitHeld)
     }
 
     ; Forward newly-recorded haptic commands (bridge.input records what the guest
@@ -215,14 +220,24 @@ class RgSdlGameHost {
     }
 
     ; Advance the launcher menu one step from an input-mask edge transition:
-    ;   left(16)/right(32) edge -> moveSelection ; down(2) edge -> back ;
+    ;   left(16)/right(32) edge -> moveSelection ;
+    ;   down(2) or quit(8) edge on games page -> back ;
+    ;   quit(8) edge on categories -> return 2 (quit the launcher) ;
     ;   action(4) edge -> activate. Returns 1 when an ENTRY was activated (the
-    ;   caller reads ui.selectedDir()/selectedFile() and hands off), else 0.
-    ; This is the launcher's whole input contract — no gfx, no game, testable.
+    ;   caller reads ui.selectedDir()/selectedFile() and hands off), else 0
+    ;   (or 2 to quit). This is the launcher's whole input contract — no gfx,
+    ;   no game, testable.
     fn launcherStep:int (prev:int cur:int ui:RgLauncherUi) {
         if (this.edge(prev cur 16)) { ui.moveSelection(0 - 1) }
         if (this.edge(prev cur 32)) { ui.moveSelection(1) }
         if (this.edge(prev cur 2))  { ui.back() }
+        if (this.edge(prev cur 8)) {
+            if ((ui.currentPage()) == 1) {
+                ui.back()
+            } {
+                return 2
+            }
+        }
         if (this.edge(prev cur 4)) {
             def r:int (ui.activate())
             if (r == 1) { return 1 }
@@ -249,27 +264,31 @@ class RgSdlGameHost {
             def m:int (gfx_input_source_mask 0)
             def launch:int (this.launcherStep(prev m ui))
             prev = m
-            if (launch == 1) {
-                def d:string (ui.selectedDir())
-                def f:string (ui.selectedFile())
-                def eng:string (ui.selectedEngine())
-                gfx_close
-                this.resetAudioDevice()
-                ; wasm games run through the compiled loop, tsx through the
-                ; interpreted one — both drive the same bridge/presenter.
-                def _g:int 0
-                if (eng == "wasm") { _g = (this.runWasm(d f)) } { _g = (this.run(d f)) }
-                ; back from the game: reopen the launcher and resume on categories
-                gfx_clear_should_close
-                this.resetAudioDevice()
-                if ((gfx_open "Ranger" lw lh) == 0) { return 1 }
-                ui.back()
-                prev = 0
+            if (launch == 2) {
+                go = false
             } {
-                ui.render()
-                gfx_present (ui.raw()) lw lh
-                gfx_delay 16
-                if (gfx_should_close) { go = false }
+                if (launch == 1) {
+                    def d:string (ui.selectedDir())
+                    def f:string (ui.selectedFile())
+                    def eng:string (ui.selectedEngine())
+                    gfx_close
+                    this.resetAudioDevice()
+                    ; wasm games run through the compiled loop, tsx through the
+                    ; interpreted one — both drive the same bridge/presenter.
+                    def _g:int 0
+                    if (eng == "wasm") { _g = (this.runWasm(d f)) } { _g = (this.run(d f)) }
+                    ; back from the game: reopen the launcher and resume on categories
+                    gfx_clear_should_close
+                    this.resetAudioDevice()
+                    if ((gfx_open "Ranger" lw lh) == 0) { return 1 }
+                    ui.back()
+                    prev = 0
+                } {
+                    ui.render()
+                    gfx_present (ui.raw()) lw lh
+                    gfx_delay 16
+                    if (gfx_should_close) { go = false }
+                }
             }
         }
         gfx_close
@@ -310,8 +329,13 @@ class RgSdlGameHost {
         def fbL:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
         def fbR:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
         def go:boolean true
+        def prev:int 0
         while go {
             gfx_input_poll
+            def m:int (gfx_input_source_mask 0)
+            ; Q / Esc rising edge closes the game window (return to launcher)
+            if (this.edge(prev m 8)) { go = false }
+            prev = m
             this.wasmHost.frame(33.333)
             this.presentBridge(this.wasmHost.bridge fbL fbR)
             gfx_delay 16
@@ -339,9 +363,15 @@ class RgSdlGameHost {
         def fbL:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
         def fbR:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
         def go:boolean true
+        def prev:int 0
         while go {
             gfx_input_poll
-            this.mapMask(0 (gfx_input_source_mask 0))
+            def m0:int (gfx_input_source_mask 0)
+            ; Q / Esc rising edge closes the active game window and returns to
+            ; the launcher (v1 gameMenuBackHeld parity). Window-close still works.
+            if (this.edge(prev m0 8)) { go = false }
+            prev = m0
+            this.mapMask(0 m0)
             this.mapMask(1 (gfx_input_source_mask 1))
             this.host.frame(33.333)
             this.forwardRumble()

--- a/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
+++ b/gallery/game_engine/v2/runtime/sdl/RgSdlGameHost.rgr
@@ -219,6 +219,45 @@ class RgSdlGameHost {
         return (isSet && (wasSet == false))
     }
 
+    ; Menu navigation mask: keyboard P1 WASD (src 0) + arrow keys (src 1) +
+    ; gamepad 0 (src 2), OR'd. The arrow keys are a DISTINCT SDL source from
+    ; WASD, so they have to be merged explicitly — reading src 0 alone leaves the
+    ; launcher deaf to the arrow keys and to every gamepad, while the footer hint
+    ; advertises both. (v1 launcherNavMask, game_sdl_runner.rgr.)
+    fn launcherNavMask:int () {
+        def kb1:int (gfx_input_source_mask 0)
+        def kb2:int (gfx_input_source_mask 1)
+        def pad:int (gfx_input_source_mask 2)
+        return (bit_or (bit_or kb1 kb2) pad)
+    }
+
+    ; Fold the gamepad's B (64) and Select (1024) into the logical quit bit (8),
+    ; so back/quit is ONE edge regardless of which physical control produced it
+    ; (v1 gameMenuBackHeld reads exactly these three). PURE bit config — testable.
+    fn foldQuitBits:int (m:int) {
+        def out:int m
+        if ((bit_and m 64) != 0) { out = (bit_or out 8) }
+        if ((bit_and m 1024) != 0) { out = (bit_or out 8) }
+        return out
+    }
+
+    ; The launcher's whole physical read: navigation sources merged, back/quit
+    ; normalised onto bit 8.
+    fn launcherMask:int () {
+        def nav:int (this.launcherNavMask())
+        return (this.foldQuitBits(nav))
+    }
+
+    ; In-game back/quit, read SEPARATELY from the play mask (v1 keeps these apart
+    ; so that e.g. LEFT never doubles as "exit"): keyboard P1 Q/Esc, or gamepad 0
+    ; B / Select. Returned as a mask so the same edge() drives it.
+    fn gameQuitMask:int () {
+        def kb:int (bit_and (gfx_input_source_mask 0) 8)
+        def pad:int (bit_and (gfx_input_source_mask 2) 1088)
+        def both:int (bit_or kb pad)
+        return (this.foldQuitBits(both))
+    }
+
     ; Advance the launcher menu one step from an input-mask edge transition:
     ;   left(16)/right(32) edge -> moveSelection ;
     ;   down(2) or quit(8) edge on games page -> back ;
@@ -246,11 +285,20 @@ class RgSdlGameHost {
     }
 
     ; Open a window on the rich launcher screen (engine chrome), navigate it, and
-    ; hand off to the chosen game through the SAME generic run() the tests use.
+    ; hand off to the chosen game through the SAME generic runIn() the tests use.
     ; Single-surface present (gfx_present) of the launcher's SoftCanvas RGBA — the
     ; launcher is not split. Window is one pane (paneW×paneH, 16:9), matching the
     ; headless launcher tests and the in-game display aspect. Native-only loop
     ; (gfx_* stub to no-ops under es6).
+    ;
+    ; ONE WINDOW for the whole session (v1 parity, game_sdl_runner.run): the
+    ; window is opened once here and closed once on the way out; launching a game
+    ; only swaps what is presented into it and retitles it. The launcher used to
+    ; gfx_close before handing off and gfx_open again on the way back, which tore
+    ; down and re-created the SDL window (and SDL_Quit/SDL_Init with it) four
+    ; times per launch — on macOS that surfaces as a second window frame stacked
+    ; over the first, and any window position / size / space the user had chosen
+    ; is lost on every transition.
     fn runLauncher:int () {
         def lw:int this.paneW
         def lh:int this.paneH
@@ -261,7 +309,7 @@ class RgSdlGameHost {
         def go:boolean true
         while go {
             gfx_input_poll
-            def m:int (gfx_input_source_mask 0)
+            def m:int (this.launcherMask())
             def launch:int (this.launcherStep(prev m ui))
             prev = m
             if (launch == 2) {
@@ -271,18 +319,30 @@ class RgSdlGameHost {
                     def d:string (ui.selectedDir())
                     def f:string (ui.selectedFile())
                     def eng:string (ui.selectedEngine())
-                    gfx_close
                     this.resetAudioDevice()
                     ; wasm games run through the compiled loop, tsx through the
-                    ; interpreted one — both drive the same bridge/presenter.
-                    def _g:int 0
-                    if (eng == "wasm") { _g = (this.runWasm(d f)) } { _g = (this.run(d f)) }
-                    ; back from the game: reopen the launcher and resume on categories
-                    gfx_clear_should_close
-                    this.resetAudioDevice()
-                    if ((gfx_open "Ranger" lw lh) == 0) { return 1 }
-                    ui.back()
-                    prev = 0
+                    ; interpreted one — both drive the same bridge/presenter, and
+                    ; both present into the launcher's window.
+                    def g:int 0
+                    if (eng == "wasm") { g = (this.runWasmIn(d f)) } { g = (this.runIn(d f)) }
+                    ; The guest closed the shared window (title bar / Cmd-Q): that
+                    ; is a quit for the whole app, not a return to the launcher.
+                    if (g == 2) {
+                        go = false
+                    } {
+                        gfx_audio_clear
+                        this.resetAudioDevice()
+                        gfx_clear_should_close
+                        gfx_set_title "Ranger"
+                        ui.back()
+                        ; Reseed the edge state from the LIVE mask instead of 0:
+                        ; the key that ended the game (Q) is still physically down
+                        ; for another ~100 ms, and a 0 baseline reads that as a
+                        ; fresh press — which on the category page quits the whole
+                        ; launcher. (v1 syncInputEdges, game_sdl_runner.rgr.)
+                        gfx_input_poll
+                        prev = (this.launcherMask())
+                    }
                 } {
                     ui.render()
                     gfx_present (ui.raw()) lw lh
@@ -313,64 +373,92 @@ class RgSdlGameHost {
         gfx_present_split (fbL.toRgbaBuffer()) (fbR.toRgbaBuffer()) this.paneW this.paneH
     }
 
-    ; Open a window and run a COMPILED (wasm32) game to window close. The wasm
-    ; sibling of run(): the guest is a folder with a wasm module (engine=wasm),
-    ; loaded + framed through RgWasmGameHost, presented through the SAME presenter.
-    ; wasm_* are backed by wasm3 on the SDL/native build. Self-contained so the
-    ; interpreted run() path is untouched.
-    fn runWasm:int (dir:string moduleFile:string) {
+    ; Run a COMPILED (wasm32) game in the CALLER'S window. The wasm sibling of
+    ; runIn(): the guest is a folder with a wasm module (engine=wasm), loaded +
+    ; framed through RgWasmGameHost, presented through the SAME presenter. wasm_*
+    ; are backed by wasm3 on the SDL/native build. Self-contained so the
+    ; interpreted runIn() path is untouched. Same return codes as runIn():
+    ; 0 = load failed, 1 = player left the game, 2 = the window was closed.
+    fn runWasmIn:int (dir:string moduleFile:string) {
         if ((this.wasmHost.load(dir moduleFile)) == false) {
             return 0
         }
+        gfx_set_title ("Ranger v2 (wasm) — " + moduleFile)
+        def fbL:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
+        def fbR:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
+        def closed:boolean false
+        def go:boolean true
+        ; Seed from the live mask: the action key that launched this game may
+        ; still be held, and Q/B must not read as pressed before it is released.
+        gfx_input_poll
+        def prev:int (this.gameQuitMask())
+        while go {
+            gfx_input_poll
+            def q:int (this.gameQuitMask())
+            ; Q / Esc / pad B / pad Select rising edge leaves the game
+            if (this.edge(prev q 8)) { go = false }
+            prev = q
+            this.wasmHost.frame(33.333)
+            this.presentBridge(this.wasmHost.bridge fbL fbR)
+            gfx_delay 16
+            if (gfx_should_close) {
+                closed = true
+                go = false
+            }
+        }
+        if (closed) { return 2 }
+        return 1
+    }
+
+    ; Open a window and run a COMPILED (wasm32) game standalone (no launcher).
+    ; Owns the window; the launcher uses runWasmIn() instead so the session keeps
+    ; a single window.
+    fn runWasm:int (dir:string moduleFile:string) {
         def title:string ("Ranger v2 (wasm) — " + moduleFile)
         if ((gfx_open title this.paneW this.paneH) == 0) {
             return 0
         }
-        def fbL:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
-        def fbR:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
-        def go:boolean true
-        def prev:int 0
-        while go {
-            gfx_input_poll
-            def m:int (gfx_input_source_mask 0)
-            ; Q / Esc rising edge closes the game window (return to launcher)
-            if (this.edge(prev m 8)) { go = false }
-            prev = m
-            this.wasmHost.frame(33.333)
-            this.presentBridge(this.wasmHost.bridge fbL fbR)
-            gfx_delay 16
-            if (gfx_should_close) { go = false }
-        }
+        def r:int (this.runWasmIn(dir moduleFile))
         gfx_close
-        return 1
+        return r
     }
 
-    ; Open a window and run the game loop until the window closes. Generic: the
-    ; game is a folder of .tsx (dir/file). Honours the guest launch(path) request
-    ; generically (menu -> game) via the same RgGameHost handoff the tests use.
-    ; Display is always one pane size (paneW×paneH, 16:9). Split-screen games
-    ; still rasterise full-res panes; gfx_present_split GPU-scales each into a
-    ; window half (same as v1) — do not open a 2×-wide window.
-    fn run:int (dir:string file:string) {
+    ; Run the game loop in the CALLER'S window (no gfx_open / gfx_close here).
+    ; Generic: the game is a folder of .tsx (dir/file). Honours the guest
+    ; launch(path) request generically (menu -> game) via the same RgGameHost
+    ; handoff the tests use. Display is always one pane size (paneW×paneH, 16:9).
+    ; Split-screen games still rasterise full-res panes; gfx_present_split
+    ; GPU-scales each into a window half (same as v1) — do not open a 2×-wide
+    ; window.
+    ;
+    ; Returns 0 when the game failed to load, 1 when the player left it (Q / Esc /
+    ; pad B|Select) and the caller should resume, 2 when the WINDOW was closed —
+    ; the window is shared with the launcher, so that means "quit the app", not
+    ; "go back one screen".
+    fn runIn:int (dir:string file:string) {
         if ((this.host.load(dir file)) == false) {
             return 0
         }
-        def title:string ("Ranger v2 — " + file)
-        if ((gfx_open title this.paneW this.paneH) == 0) {
-            return 0
-        }
+        gfx_set_title ("Ranger v2 — " + file)
         this.initAudio()
         def fbL:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
         def fbR:RgFramebuffer (RgFramebuffer.create(this.paneW this.paneH))
+        def closed:boolean false
         def go:boolean true
-        def prev:int 0
+        ; Seed from the live mask: the action key that launched this game may
+        ; still be held, and Q/B must not read as pressed before it is released.
+        gfx_input_poll
+        def prev:int (this.gameQuitMask())
         while go {
             gfx_input_poll
             def m0:int (gfx_input_source_mask 0)
-            ; Q / Esc rising edge closes the active game window and returns to
-            ; the launcher (v1 gameMenuBackHeld parity). Window-close still works.
-            if (this.edge(prev m0 8)) { go = false }
-            prev = m0
+            ; Q / Esc / pad B / pad Select rising edge leaves the game and returns
+            ; to the launcher (v1 gameMenuBackHeld parity). Read separately from
+            ; the play mask so movement never doubles as "exit". Window-close
+            ; still works, and means quit.
+            def q:int (this.gameQuitMask())
+            if (this.edge(prev q 8)) { go = false }
+            prev = q
             this.mapMask(0 m0)
             this.mapMask(1 (gfx_input_source_mask 1))
             this.host.frame(33.333)
@@ -386,10 +474,26 @@ class RgSdlGameHost {
             }
             this.present(fbL fbR)
             gfx_delay 16
-            if (gfx_should_close) { go = false }
+            if (gfx_should_close) {
+                closed = true
+                go = false
+            }
         }
+        if (closed) { return 2 }
+        return 1
+    }
+
+    ; Open a window and run an interpreted (.tsx) game standalone (no launcher).
+    ; Owns the window; the launcher uses runIn() instead so the session keeps a
+    ; single window.
+    fn run:int (dir:string file:string) {
+        def title:string ("Ranger v2 — " + file)
+        if ((gfx_open title this.paneW this.paneH) == 0) {
+            return 0
+        }
+        def r:int (this.runIn(dir file))
         gfx_close
         this.resetAudioDevice()
-        return 1
+        return r
     }
 }

--- a/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
+++ b/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
@@ -62,7 +62,8 @@ class SdlHostTest {
         ; ---- launcher menu driven purely by input-mask edges ---------------
         def ui:RgLauncherUi (new RgLauncherUi)
         ui.init(480 270)
-        ; catalog: Games (Pomppija, Ylos3D WASM) + Tests (Cannon 3D, Pinball).
+        ; catalog: Games (Pomppija, Ylos3D WASM, Ylos3D) + Tests (Cannon 3D,
+        ; Pinball).
         ; Right edge moves to Tests; stay on Games for the handoff checks below.
         def s0:int (sdl.launcherStep(0 32 ui))
         t.eqInt("moving selection does not launch" s0 0)
@@ -107,6 +108,30 @@ class SdlHostTest {
         t.ok("quit bit maps to back action" (inp.isDown(0 "back")))
         sdl.mapMask(0 0)
         t.no("quit released" (inp.isDown(0 "quit")))
+
+        ; ---- back/quit is one logical edge, whatever produced it -------------
+        ; The launcher reads WASD + arrows + gamepad 0 merged, so the physical
+        ; back/quit controls (Q/Esc = 8, pad B = 64, pad Select = 1024) have to
+        ; collapse onto bit 8 before the edge is taken — otherwise "B takaisin"
+        ; is a hint with nothing behind it.
+        t.eqInt("Q already is the quit bit" (sdl.foldQuitBits(8)) 8)
+        t.eqInt("pad B folds into quit" (bit_and (sdl.foldQuitBits(64)) 8) 8)
+        t.eqInt("pad Select folds into quit" (bit_and (sdl.foldQuitBits(1024)) 8) 8)
+        t.eqInt("nothing pressed folds to nothing" (sdl.foldQuitBits(0)) 0)
+        t.eqInt("movement bits are untouched" (sdl.foldQuitBits(32)) 32)
+        ; a pad B press drives the launcher exactly like Q
+        def sB:int (sdl.launcherStep(0 (sdl.foldQuitBits(64)) ui))
+        t.eqInt("pad B on categories quits the launcher" sB 2)
+        def _reB:int (sdl.launcherStep(0 4 ui))
+        t.eqInt("re-entered games page for the pad test" (ui.currentPage()) 1)
+        def sBb:int (sdl.launcherStep(0 (sdl.foldQuitBits(1024)) ui))
+        t.eqInt("pad Select on games page is back" sBb 0)
+        t.eqInt("pad Select returned to categories" (ui.currentPage()) 0)
+        ; Holding the SAME control across the game -> launcher handoff must not
+        ; read as a fresh press: with the released-then-pressed edge already
+        ; consumed, a still-held mask produces no second edge.
+        def sHeld:int (sdl.launcherStep(8 8 ui))
+        t.eqInt("a held quit key is not a new edge" sHeld 0)
 
         ; ---- host music pump: a guest's music.play(score) is synthesised ----
         ; The bridge records the score (rgcore_music_play); the host owns the

--- a/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
+++ b/gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr
@@ -62,11 +62,13 @@ class SdlHostTest {
         ; ---- launcher menu driven purely by input-mask edges ---------------
         def ui:RgLauncherUi (new RgLauncherUi)
         ui.init(480 270)
-        ; the catalog is discovered from the real v2/games folder (one Games
-        ; category with Pomppija); moving on a single category clamps, no launch
+        ; catalog: Games (Pomppija, Ylos3D WASM) + Tests (Cannon 3D, Pinball).
+        ; Right edge moves to Tests; stay on Games for the handoff checks below.
         def s0:int (sdl.launcherStep(0 32 ui))
         t.eqInt("moving selection does not launch" s0 0)
-        t.eqStr("selection stays on the Games category" (ui.selectedLabel()) "Games")
+        t.eqStr("right moves to the Tests category" (ui.selectedLabel()) "Tests")
+        def sL:int (sdl.launcherStep(0 16 ui))
+        t.eqStr("left returns to Games" (ui.selectedLabel()) "Games")
         ; action edge (4) enters the Games category (page 1), no launch yet
         def s2:int (sdl.launcherStep(0 4 ui))
         t.eqInt("entering a category is not a launch" s2 0)
@@ -90,6 +92,21 @@ class SdlHostTest {
         def s4:int (sdl.launcherStep(0 2 ui))
         t.eqInt("back is not a launch" s4 0)
         t.eqInt("back to the category page" (ui.currentPage()) 0)
+        ; quit edge (8 / Q) on categories quits the launcher (return 2)
+        def sQ:int (sdl.launcherStep(0 8 ui))
+        t.eqInt("Q on categories quits the launcher" sQ 2)
+        ; re-enter Games; Q on the games page acts as back (not quit)
+        def _re:int (sdl.launcherStep(0 4 ui))
+        t.eqInt("re-entered games page" (ui.currentPage()) 1)
+        def sQb:int (sdl.launcherStep(0 8 ui))
+        t.eqInt("Q on games page is back, not quit" sQb 0)
+        t.eqInt("Q returned to categories" (ui.currentPage()) 0)
+        ; mapMask exposes quit/back so guests can poll them
+        sdl.mapMask(0 8)
+        t.ok("quit bit maps to quit action" (inp.isDown(0 "quit")))
+        t.ok("quit bit maps to back action" (inp.isDown(0 "back")))
+        sdl.mapMask(0 0)
+        t.no("quit released" (inp.isDown(0 "quit")))
 
         ; ---- host music pump: a guest's music.play(score) is synthesised ----
         ; The bridge records the score (rgcore_music_play); the host owns the


### PR DESCRIPTION
Builds on #450 (that commit is included here, attribution kept) and fixes what reviewing it turned up, plus the window behaviour that has differed from v1 since the v2 launcher landed.

## One window for the whole session

The v2 launcher tore its window down and built a new one on every transition: `runLauncher()` called `gfx_close` before handing off, `run()` called `gfx_open`, and both did it again on the way back — four SDL window lifecycles per launch, each with an `SDL_Quit`/`SDL_Init` pair. v1 never did this: `game_sdl_runner.run` opens once, closes once, and the menu and game loops share the window, swapping only the title via `gfx_set_title`. On macOS the v2 behaviour surfaces as a second window frame stacked over the first, and every transition throws away whatever position, size, or Space the user had put the window in.

`runIn()` / `runWasmIn()` now run a game in the caller's window; `run()` / `runWasm()` remain as the standalone wrappers that own one. Because the window is shared, closing it from the title bar during a game is a quit for the whole app rather than a return to the launcher, so the loops report it (return `2`) and `runLauncher` exits instead of reopening.

## Quit was re-triggered by its own key

Returning from a game reseeded the edge tracker with `prev = 0` while Q was still physically down, so the next poll read a fresh rising edge — and on the category page that edge quits the launcher. Pressing Q to leave a game therefore closed the whole app; a key press outlives the window teardown by a wide margin. Reseeding from the live mask is what v1's `syncInputEdges` does at exactly this point.

## Arrow keys, gamepads, and hints that were not backed by anything

The launcher read `gfx_input_source_mask(0)` alone. Arrow keys are a distinct SDL source and gamepads are sources 2..9, so neither did anything — while the footer advertised `nuolet liikkuvat` and a B button that was never mapped in `launcherStep`. v1 has an explicit comment warning about this exact mistake.

- `launcherNavMask()` merges keyboard P1 (WASD) + keyboard P2 (arrows) + gamepad 0, as v1's `launcherNavMask` does.
- `foldQuitBits()` collapses Q/Esc (`8`), pad B (`64`) and pad Select (`1024`) onto one logical quit bit, so a single edge covers all three — the same set v1's `gameMenuBackHeld` reads.
- `gameQuitMask()` keeps in-game back/quit separate from the play mask, so movement never doubles as "exit".
- Footer hints now name controls that exist.

## Also

Corrected two stale comments from #450: `Games` holds three entries (Pomppija, Ylos3D WASM, Ylos3D), and `GameCatalog.categories()` forces `Games` to the front rather than using first-seen order.

## Testing the v2 launcher locally

**Build and launch** (from the repo root — the launcher resolves its games folder and TTF font as paths relative to the working directory):

```bash
npm run engine:game-sdl:launcher:v2
```

That is `bash gallery/game_engine/scripts/build-sdl-v2.sh --run`: Ranger → C++, then wasm3 objects, then a native binary at `tmp/sdl-v2/ranger-v2`. Drop `--run` (or run the script directly with no argument) to build without launching, then start it yourself with `./tmp/sdl-v2/ranger-v2` from the repo root.

Needs a C++17 compiler, SDL2 dev libraries (`brew install sdl2` / `apt-get install libsdl2-dev`), libcurl, and OpenGL (system framework on macOS, `libGL` on Linux, `libgles2-mesa-dev` on a Pi).

**Controls:** arrows or WASD move, Space / Enter / pad `A` selects, `S` or Q/Esc/pad `B` goes back a page, Q/Esc/pad `B` on the category page quits.

**What to look for** — these are the things this PR changes and the headless suite cannot reach:

1. **One window frame.** Pick Games → a game → let it start. On macOS the game should take over the *same* window (the title changes to `Ranger v2 — …`), with no second frame appearing and no first window left underneath. Move or resize the window before launching: it should stay where you put it across the handoff and back.
2. **Q returns to the launcher and stops there.** In a running game, press and *hold* Q for a beat before releasing. It should land on the launcher's category page and stay there. Before this PR that closed the whole app, because the still-held key read as a fresh press.
3. **The window's close button quits.** Closing the window from the title bar (or Cmd-Q) during a game should exit the app, not bounce back to the launcher — the window is shared now, so there is nothing to go back to.
4. **Arrows and a gamepad actually navigate.** Both the arrow keys and a connected pad's d-pad should move the selection, `A` should open, `B` should go back. None of these did anything before.
5. **Two categories.** The top level should show Games and Tests, with Cannon 3D and Pinball under Tests.

**Headless suites** (no SDL needed, this is what CI can run):

```bash
bash gallery/game_engine/v2/tests/run.sh
```

Or just the two suites this PR touches:

```bash
bun bin/output.js -es6 gallery/game_engine/v2/tests/sdl/sdl_host_test.rgr -d=/tmp/v2 -o=t.js && bun /tmp/v2/t.js
bun bin/output.js -es6 gallery/game_engine/v2/menu/tests/launcher_ui_test.rgr -d=/tmp/v2 -o=l.js && bun /tmp/v2/l.js
```

(Swap `bun` for `node` if you do not have Bun; `run.sh` picks Bun automatically when it is on PATH and falls back to Node.)

## Test plan

- `tests/sdl/sdl_host_test` — 60 → 70 checks: each physical back/quit source folding onto bit 8, movement bits left alone, a pad B/Select press driving the launcher exactly like Q, and a held quit key producing no second edge.
- `menu/tests/launcher_ui_test` — unchanged assertions still green; layout measured at the real 480×270 (title 14–60, subtitle 66–86, cards 100–220, footer 241–258, no overlap).
- Full `bash gallery/game_engine/v2/tests/run.sh` — **106/106 suites + boundary gate green** (1 skipped: `mesh_editor/tests`, browser e2e).
- Ranger→C++ codegen verified: `runLauncher` emits exactly one `rgfx_open` and one `rgfx_close`, with neither in the game handoff between them.

Not verified here: the native SDL2 link (headers absent in this environment), so the manual pass above on macOS is still what confirms the doubled window frame is actually gone.