### PR TITLE
operators: JSON for the Python and the Rust target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **JSON for the Python and the Rust target** — `lib/JSON.rgr` declared no `python` and no `rust` template in any of its operator blocks, and `systemclass JSONDataObject` / `JSONArrayObject` / `JSONValueUnion` named no type for either target. A template block is part of the match, so the absence was not a fallback to some generic form: every program that touched a JSON object stopped in the type check with `Could not match argument types for json_object`, and `@serialize(true)` could not work on either target. The [FAQ answer on `toDictionary` / `fromDictionary`](https://terotests.github.io/Ranger/docs/faq/#how-do-i-write-an-object-to-json-and-read-it-back) showed that message in place of the Python and the Rust tab. Both targets now hold `print`, `getStr`, `getInt`, `getDouble`, `getBoolean`, `getObject`, `getArray`, `keys`, `isArray`, `asArray`, `getValue`, `array_length`, all six `set` variants, `push`, `json_object`, `json_array`, `from_string` and `to_string`, and `lib/stdlib.rgr` holds the union `case` for both:
+
+  - **Python** maps the three shapes onto `dict`, `list` and `object`, and reads and writes the text with the `json` module of the standard library. A getter is an inline lambda that checks the type of the value, so no polyfill is needed: `getInt` rejects a `bool`, because `bool` is a subclass of `int` in Python and `{"ok": true}` must not read back as an integer.
+  - **Rust** has no JSON type in the standard library, and the target writes code that `rustc` builds with no crate. The compiler adds the enum `RJson` as a polyfill, together with a reader and a writer for the text. A JSON object is a `std::collections::HashMap<String, RJson>` and a JSON array is a `Vec<RJson>`, both spelled in full so that the output needs no `use` line. The trait `RJsonValue` converts an argument of the union type `JSONArrayUnion` to the variant that fits it, which is what `push` and the `set` of a union value need.
+
+  `tests/fixtures/json_ops.rgr` builds an object, writes it as text, reads it back and reaches every value in it. `tests/compiler-json.test.ts` runs the generated program on JavaScript, on Python and on Rust and compares the three outputs, so a missing template can not pass as a compile-only success. `tests/compiler-serialize.test.ts` adds `python` and `rust` to the target list and runs the round trip of `serialize_roundtrip.rgr` — nested object, object array and object hash — on both
+
+### Fixed
+
+- **The `@serialize(true)` reader needed a lambda** — the generated `fromDictionary` read an object array and an object hash with `arr.forEach({ ... })`. The callback is the one construct that neither the Python nor the Rust writer emits: Python got a multi-statement `lambda` (`SyntaxError`) and Rust got the JavaScript arrow form (`expected one of ), ,, ., ? or an operator, found =>`). `ng_RangerSerializeClass.rgr` now writes an index loop over `array_length` / `getValue` for an array and over `keys` / `itemAt` for a hash. The loop uses the operators that every target already declares, so the reader no longer depends on the callback support of the target. A side effect on the JavaScript output: `fromDictionary` is no longer `async`, because the callback was what marked it so — `await` on the return value still works, and `dist/api.d.ts` states `T` in place of `Promise<T>`
+
+- **`try { } { }` wrote JavaScript for the Python and the Rust target** — neither had a template, so both fell through to the `*` form and the output held `try { ... } catch(e) { }` verbatim. Python now writes a `try:` / `except Exception:` statement, and each suite opens with `pass` because a generated catch block is often empty and a Python suite needs a statement. Rust has no exceptions, so the compiler writes the try block and states in a comment that it does not write the catch block
+
+- **The Rust file header sat after the first `use` line** — the writer put `#![allow(unused_parens)]` and the four other inner attributes into the class content, while an `(imp "...")` from an operator template writes its `use` line into the import slice, which is ahead of the content. An inner attribute has to precede every item of the file, so `rustc` rejected the output of every program that used a hash map with `an inner attribute is not permitted in this context`. The header now goes into the `before_imports` slice
+
+- **A Rust systemclass reached the output under its Ranger name** — `writeTypeDef` and `getObjectTypeString` in `ng_RangerRustClassWriter.rgr` did not read `systemNames`, so a `JSONDataObject` parameter compiled to `dict : JSONDataObject` and `rustc` saw an undeclared type. Both now name the type that the systemclass declares for `rust`
+
+- **`get` on a Rust hash map gave `Option<&T>`** — the operator is typed to give an optional `T`, and `HashMap::get` hands back a reference and takes one, so `scores.get("Alice".to_string())` did not compile at all. The template is now `get(&key).cloned()`
+
+- **A Rust hash field was constructed as `None`** — the constructor of a class initialized an array field with `Vec::new()` and an optional field with `None`, and a hash field fell into the second branch, so a `[string:T]` field made `rustc` report `expected HashMap<String, T>, found Option<_>`. A hash field now takes `HashMap::new()`
+
+- **A Python class field with no value read an undefined attribute** — `writeVarInitDef` wrote `self.one` with no assignment for a field that is neither an array nor a hash, and the constructor raised `AttributeError` the first time the class was used. The field now takes `None`, as a local variable already did
+
+- **A Python `(typeof N)` template wrote the Ranger type name** — the Python writer inherited the generic `writeTypeDef`, which writes `node.type_name`, so the union `case` produced `isinstance(item, JSONDataObject)` in place of `isinstance(item, dict)`. The Python writer now maps the built-in types and reads `systemNames`
+
+### Known gaps closed
+
+- **Python has no JSON support at all** (listed under 3.3.1) is closed by the entry above. The lambda gap of the `operator type:[T]` block stays open: `.map()`, `.filter()` and the other callback operators still emit a multi-statement Python lambda. The `@serialize(true)` reader no longer depends on that support
+
 ## [3.3.1] - 2026-08-01
 
 ### Fixed

--- a/bin/Lang.rgr
+++ b/bin/Lang.rgr
@@ -170,6 +170,44 @@ language {
             init _init
         }
         python {
+            ; The keywords of the language. A field named `as` wrote
+            ; `self.as = []`, which is a SyntaxError, so the program stopped
+            ; before the first statement of the main function.
+            and _and
+            as _as
+            assert _assert
+            async _async
+            await _await
+            break _break
+            class _class
+            continue _continue
+            def _def
+            del _del
+            elif _elif
+            else _else
+            except _except
+            finally _finally
+            for _for
+            from _from
+            global _global
+            if _if
+            import _import
+            in _in
+            is _is
+            lambda _lambda
+            nonlocal _nonlocal
+            not _not
+            or _or
+            pass _pass
+            raise _raise
+            return _return
+            try _try
+            while _while
+            with _with
+            yield _yield
+            None _None
+            True _True
+            False _False
             str _str
             int _int
             float _float
@@ -2229,6 +2267,14 @@ case class customException(smth:String)  extends Exception
                 swift3 ( "do {" nl I (block 1) i nl "} catch { " nl I (block 2) i nl "}" )
                 swift6 ( "do {" nl I (block 1) i nl "} catch { " nl I (block 2) i nl "}" )
                 cpp ( nl "try {" nl I (block 1) i nl "} catch( ... ) {" nl I (block 2) i nl "}" nl )
+                ; Python needs a statement in each suite, and a generated catch
+                ; block is often empty (the @serialize writer emits one), so both
+                ; suites open with `pass`.
+                python ( nl "try:" nl I "pass" nl (block 1) i nl "except Exception:" nl I "pass" nl (block 2) i nl )
+                ; Rust has no exceptions and the target writes code that rustc
+                ; builds without a crate, so there is nothing for the catch block
+                ; to catch: the try block is written and the catch block is not.
+                rust ( nl "/* try: Rust has no exceptions, so the catch block is not written */" nl (block 1) nl )
                 * ( nl "try {" nl I (block 1) i nl "} catch(e) {" nl I (block 2) i nl "}" nl )
             }
         }
@@ -3749,7 +3795,9 @@ r_optional_primitive<double> cpp_get_map_string_double_value( std::map<std::stri
                 ranger ( "(get " (e 1) " " (e 2) ")")                 
                 llvm ( "(get " (e 1) " " (e 2) ")")
                 java7 ( (e 1) ".get(" (e 2) ")" )
-                rust ( (e 1) ".get(" (e 2) ")" )
+                ; HashMap::get hands back Option<&T>, and the operator is typed
+                ; to give an optional T, so the borrow is cloned away.
+                rust ( (e 1) ".get(&" (e 2) ").cloned()" )
                 cpp ( "r_map_get_val(" (e 1) ", " (e 2) ")"
 (create_polyfill
 "

--- a/bin/output.js
+++ b/bin/output.js
@@ -66,41 +66,53 @@ class CmdParams  {
     return res;
   };
 }
-CmdParams.fromDictionary = async function(dict) {
+CmdParams.fromDictionary = function(dict) {
   const obj = new CmdParams();
   try {
     const values = (dict["flags"] instanceof Object ) ? dict ["flags"] : undefined ;
     if ( (typeof(values) !== "undefined" && values != null )  ) {
       const theObjflags = values;
       const obj_keys = Object.keys(theObjflags);
-      await operatorsOf.forEach_12(obj_keys, ((item, index) => { 
+      const key_len = obj_keys.length;
+      let key_i = 0;
+      while (key_i < key_len) {
+        const item = obj_keys[key_i];
         const v = typeof(theObjflags [item]) === "undefined" ? undefined :(theObjflags [item]) ;
         if ( (typeof(v) !== "undefined" && v != null )  ) {
           obj.flags[item] = v;
         }
-      }));
+        key_i = key_i + 1;
+      };
     }
     const values_1 = (dict["params"] instanceof Object ) ? dict ["params"] : undefined ;
     if ( (typeof(values_1) !== "undefined" && values_1 != null )  ) {
       const theObjparams = values_1;
       const obj_keys_1 = Object.keys(theObjparams);
-      await operatorsOf.forEach_12(obj_keys_1, ((item, index) => { 
-        const v_1 = (typeof (theObjparams [item]) != "string" ) ? undefined : theObjparams [item] 
+      const key_len_1 = obj_keys_1.length;
+      let key_i_1 = 0;
+      while (key_i_1 < key_len_1) {
+        const item_1 = obj_keys_1[key_i_1];
+        const v_1 = (typeof (theObjparams [item_1]) != "string" ) ? undefined : theObjparams [item_1] 
         ;
         if ( (typeof(v_1) !== "undefined" && v_1 != null )  ) {
-          obj.params[item] = v_1;
+          obj.params[item_1] = v_1;
         }
-      }));
+        key_i_1 = key_i_1 + 1;
+      };
     }
     const values_2 = (dict["values"] instanceof Array ) ? dict ["values"] : undefined ;
     if ( (typeof(values_2) !== "undefined" && values_2 != null )  ) {
       const arr = values_2;
-      operatorsOfJSONArrayObject_57.forEach_58(arr, ((item, index) => { 
-        if( typeof(item) === 'string' ) /* union case for string */ {
-          var oo = item;
+      const arr_len = arr.length;
+      let arr_i = 0;
+      while (arr_i < arr_len) {
+        const item_2 = arr[arr_i];
+        if( typeof(item_2) === 'string' ) /* union case for string */ {
+          var oo = item_2;
           obj.values.push(oo);
         };
-      }));
+        arr_i = arr_i + 1;
+      };
     }
   } catch(e) {
   }
@@ -172,7 +184,7 @@ class InputFSFolder  {
     return res;
   };
 }
-InputFSFolder.fromDictionary = async function(dict) {
+InputFSFolder.fromDictionary = function(dict) {
   const obj = new InputFSFolder();
   try {
     const v = (typeof (dict ["name"]) != "string" ) ? undefined : dict ["name"] 
@@ -196,24 +208,32 @@ InputFSFolder.fromDictionary = async function(dict) {
     const values = (dict["folders"] instanceof Array ) ? dict ["folders"] : undefined ;
     if ( (typeof(values) !== "undefined" && values != null )  ) {
       const arr = values;
-      await operatorsOf_57.forEach_58(arr, (async (item, index) => { 
+      const arr_len = arr.length;
+      let arr_i = 0;
+      while (arr_i < arr_len) {
+        const item = arr[arr_i];
         if( item instanceof Object ) /* union case */ {
           var oo = item;
-          const newObj = await InputFSFolder.fromDictionary(oo);
+          const newObj = InputFSFolder.fromDictionary(oo);
           obj.folders.push(newObj);
         };
-      }));
+        arr_i = arr_i + 1;
+      };
     }
     const values_1 = (dict["files"] instanceof Array ) ? dict ["files"] : undefined ;
     if ( (typeof(values_1) !== "undefined" && values_1 != null )  ) {
       const arr_1 = values_1;
-      await operatorsOf_57.forEach_58(arr_1, ((item, index) => { 
-        if( item instanceof Object ) /* union case */ {
-          var oo_1 = item;
+      const arr_len_1 = arr_1.length;
+      let arr_i_1 = 0;
+      while (arr_i_1 < arr_len_1) {
+        const item_1 = arr_1[arr_i_1];
+        if( item_1 instanceof Object ) /* union case */ {
+          var oo_1 = item_1;
           const newObj_1 = InputFSFile.fromDictionary(oo_1);
           obj.files.push(newObj_1);
         };
-      }));
+        arr_i_1 = arr_i_1 + 1;
+      };
     }
   } catch(e) {
   }
@@ -294,7 +314,7 @@ class InputEnv  {
     return res;
   };
 }
-InputEnv.fromDictionary = async function(dict) {
+InputEnv.fromDictionary = function(dict) {
   const obj = new InputEnv();
   try {
     const v = typeof(dict ["use_real"]) === "undefined" ? undefined :(dict ["use_real"]) ;
@@ -303,24 +323,28 @@ InputEnv.fromDictionary = async function(dict) {
     }
     const theValue = (dict["filesystem"] instanceof Object ) ? dict ["filesystem"] : undefined ;
     if ( (typeof(theValue) !== "undefined" && theValue != null )  ) {
-      const newObj = await InputFSFolder.fromDictionary((theValue));
+      const newObj = InputFSFolder.fromDictionary((theValue));
       obj.filesystem = newObj;
     }
     const values = (dict["envVars"] instanceof Object ) ? dict ["envVars"] : undefined ;
     if ( (typeof(values) !== "undefined" && values != null )  ) {
       const theObjenvVars = values;
       const obj_keys = Object.keys(theObjenvVars);
-      await operatorsOf.forEach_12(obj_keys, ((item, index) => { 
+      const key_len = obj_keys.length;
+      let key_i = 0;
+      while (key_i < key_len) {
+        const item = obj_keys[key_i];
         const v_1 = (typeof (theObjenvVars [item]) != "string" ) ? undefined : theObjenvVars [item] 
         ;
         if ( (typeof(v_1) !== "undefined" && v_1 != null )  ) {
           obj.envVars[item] = v_1;
         }
-      }));
+        key_i = key_i + 1;
+      };
     }
     const theValue_1 = (dict["commandLine"] instanceof Object ) ? dict ["commandLine"] : undefined ;
     if ( (typeof(theValue_1) !== "undefined" && theValue_1 != null )  ) {
-      const newObj_1 = await CmdParams.fromDictionary((theValue_1));
+      const newObj_1 = CmdParams.fromDictionary((theValue_1));
       obj.commandLine = newObj_1;
     }
   } catch(e) {
@@ -1532,7 +1556,7 @@ class CodeNodeLiteral  {
     return res;
   };
 }
-CodeNodeLiteral.fromDictionary = async function(dict) {
+CodeNodeLiteral.fromDictionary = function(dict) {
   const obj = new CodeNodeLiteral();
   try {
     const v = typeof(dict ["expression"]) === "undefined" ? undefined :(dict ["expression"]) ;
@@ -1566,12 +1590,16 @@ CodeNodeLiteral.fromDictionary = async function(dict) {
     const values = (dict["ns"] instanceof Array ) ? dict ["ns"] : undefined ;
     if ( (typeof(values) !== "undefined" && values != null )  ) {
       const arr = values;
-      await operatorsOf_57.forEach_58(arr, ((item, index) => { 
+      const arr_len = arr.length;
+      let arr_i = 0;
+      while (arr_i < arr_len) {
+        const item = arr[arr_i];
         if( typeof(item) === 'string' ) /* union case for string */ {
           var oo = item;
           obj.ns.push(oo);
         };
-      }));
+        arr_i = arr_i + 1;
+      };
     }
     const v_6 = typeof(dict ["has_vref_annotation"]) === "undefined" ? undefined :(dict ["has_vref_annotation"]) ;
     if ( (typeof(v_6) !== "undefined" && v_6 != null )  ) {
@@ -1579,7 +1607,7 @@ CodeNodeLiteral.fromDictionary = async function(dict) {
     }
     const theValue = (dict["vref_annotation"] instanceof Object ) ? dict ["vref_annotation"] : undefined ;
     if ( (typeof(theValue) !== "undefined" && theValue != null )  ) {
-      const newObj = await CodeNodeLiteral.fromDictionary((theValue));
+      const newObj = CodeNodeLiteral.fromDictionary((theValue));
       obj.vref_annotation = newObj;
     }
     const v_7 = typeof(dict ["has_type_annotation"]) === "undefined" ? undefined :(dict ["has_type_annotation"]) ;
@@ -1588,7 +1616,7 @@ CodeNodeLiteral.fromDictionary = async function(dict) {
     }
     const theValue_1 = (dict["type_annotation"] instanceof Object ) ? dict ["type_annotation"] : undefined ;
     if ( (typeof(theValue_1) !== "undefined" && theValue_1 != null )  ) {
-      const newObj_1 = await CodeNodeLiteral.fromDictionary((theValue_1));
+      const newObj_1 = CodeNodeLiteral.fromDictionary((theValue_1));
       obj.type_annotation = newObj_1;
     }
     const v_8 = isNaN( parseFloat(dict ["double_value"]) ) ? undefined : parseFloat(dict ["double_value"]) 
@@ -1612,63 +1640,83 @@ CodeNodeLiteral.fromDictionary = async function(dict) {
     }
     const theValue_2 = (dict["expression_value"] instanceof Object ) ? dict ["expression_value"] : undefined ;
     if ( (typeof(theValue_2) !== "undefined" && theValue_2 != null )  ) {
-      const newObj_2 = await CodeNodeLiteral.fromDictionary((theValue_2));
+      const newObj_2 = CodeNodeLiteral.fromDictionary((theValue_2));
       obj.expression_value = newObj_2;
     }
     const values_1 = (dict["props"] instanceof Object ) ? dict ["props"] : undefined ;
     if ( (typeof(values_1) !== "undefined" && values_1 != null )  ) {
       const theObjprops = values_1;
       const obj_keys = Object.keys(theObjprops);
-      await operatorsOf.forEach_12(obj_keys, (async (item, index) => { 
-        const theValue_3 = (theObjprops[item] instanceof Object ) ? theObjprops [item] : undefined ;
+      const key_len = obj_keys.length;
+      let key_i = 0;
+      while (key_i < key_len) {
+        const item_1 = obj_keys[key_i];
+        const theValue_3 = (theObjprops[item_1] instanceof Object ) ? theObjprops [item_1] : undefined ;
         if ( (typeof(theValue_3) !== "undefined" && theValue_3 != null )  ) {
-          const newObj_3 = await CodeNodeLiteral.fromDictionary((theValue_3));
-          obj.props[item] = newObj_3;
+          const newObj_3 = CodeNodeLiteral.fromDictionary((theValue_3));
+          obj.props[item_1] = newObj_3;
         }
-      }));
+        key_i = key_i + 1;
+      };
     }
     const values_2 = (dict["prop_keys"] instanceof Array ) ? dict ["prop_keys"] : undefined ;
     if ( (typeof(values_2) !== "undefined" && values_2 != null )  ) {
       const arr_1 = values_2;
-      await operatorsOf_57.forEach_58(arr_1, ((item, index) => { 
-        if( typeof(item) === 'string' ) /* union case for string */ {
-          var oo_1 = item;
+      const arr_len_1 = arr_1.length;
+      let arr_i_1 = 0;
+      while (arr_i_1 < arr_len_1) {
+        const item_2 = arr_1[arr_i_1];
+        if( typeof(item_2) === 'string' ) /* union case for string */ {
+          var oo_1 = item_2;
           obj.prop_keys.push(oo_1);
         };
-      }));
+        arr_i_1 = arr_i_1 + 1;
+      };
     }
     const values_3 = (dict["comments"] instanceof Array ) ? dict ["comments"] : undefined ;
     if ( (typeof(values_3) !== "undefined" && values_3 != null )  ) {
       const arr_2 = values_3;
-      await operatorsOf_57.forEach_58(arr_2, (async (item, index) => { 
-        if( item instanceof Object ) /* union case */ {
-          var oo_2 = item;
-          const newObj_4 = await CodeNodeLiteral.fromDictionary(oo_2);
+      const arr_len_2 = arr_2.length;
+      let arr_i_2 = 0;
+      while (arr_i_2 < arr_len_2) {
+        const item_3 = arr_2[arr_i_2];
+        if( item_3 instanceof Object ) /* union case */ {
+          var oo_2 = item_3;
+          const newObj_4 = CodeNodeLiteral.fromDictionary(oo_2);
           obj.comments.push(newObj_4);
         };
-      }));
+        arr_i_2 = arr_i_2 + 1;
+      };
     }
     const values_4 = (dict["children"] instanceof Array ) ? dict ["children"] : undefined ;
     if ( (typeof(values_4) !== "undefined" && values_4 != null )  ) {
       const arr_3 = values_4;
-      await operatorsOf_57.forEach_58(arr_3, (async (item, index) => { 
-        if( item instanceof Object ) /* union case */ {
-          var oo_3 = item;
-          const newObj_5 = await CodeNodeLiteral.fromDictionary(oo_3);
+      const arr_len_3 = arr_3.length;
+      let arr_i_3 = 0;
+      while (arr_i_3 < arr_len_3) {
+        const item_4 = arr_3[arr_i_3];
+        if( item_4 instanceof Object ) /* union case */ {
+          var oo_3 = item_4;
+          const newObj_5 = CodeNodeLiteral.fromDictionary(oo_3);
           obj.children.push(newObj_5);
         };
-      }));
+        arr_i_3 = arr_i_3 + 1;
+      };
     }
     const values_5 = (dict["attrs"] instanceof Array ) ? dict ["attrs"] : undefined ;
     if ( (typeof(values_5) !== "undefined" && values_5 != null )  ) {
       const arr_4 = values_5;
-      await operatorsOf_57.forEach_58(arr_4, (async (item, index) => { 
-        if( item instanceof Object ) /* union case */ {
-          var oo_4 = item;
-          const newObj_6 = await CodeNodeLiteral.fromDictionary(oo_4);
+      const arr_len_4 = arr_4.length;
+      let arr_i_4 = 0;
+      while (arr_i_4 < arr_len_4) {
+        const item_5 = arr_4[arr_i_4];
+        if( item_5 instanceof Object ) /* union case */ {
+          var oo_4 = item_5;
+          const newObj_6 = CodeNodeLiteral.fromDictionary(oo_4);
           obj.attrs.push(newObj_6);
         };
-      }));
+        arr_i_4 = arr_i_4 + 1;
+      };
     }
   } catch(e) {
   }
@@ -8138,7 +8186,7 @@ class RangerSerializeClass  {
     if ( nn.value_type == 6 ) {
       if ( this.canSerializeClass(nn.array_type, ctx) ) {
         wr.out("def values:JSONArrayObject (json_array)", true);
-        wr.out(((("for this." + pvar.compiledName) + " item:") + nn.array_type) + " i {", true);
+        wr.out(((("for this." + pvar.name) + " item:") + nn.array_type) + " i {", true);
         wr.indent(1);
         wr.out("def obj@(lives):JSONDataObject (item.toDictionary())", true);
         wr.out("push values obj", true);
@@ -8147,7 +8195,7 @@ class RangerSerializeClass  {
         wr.out(("set res  \"" + pvar.name) + "\" values ", true);
       } else {
         wr.out("def values:JSONArrayObject (json_array)", true);
-        wr.out(((("for this." + pvar.compiledName) + " item:") + nn.array_type) + " i {", true);
+        wr.out(((("for this." + pvar.name) + " item:") + nn.array_type) + " i {", true);
         wr.indent(1);
         wr.out("push values item", true);
         wr.indent(-1);
@@ -8159,10 +8207,10 @@ class RangerSerializeClass  {
     if ( nn.value_type == 7 ) {
       if ( this.canSerializeClass(nn.array_type, ctx) ) {
         wr.out("def values:JSONDataObject (json_object)", true);
-        wr.out(("def keyList (keys this." + pvar.compiledName) + ")", true);
+        wr.out(("def keyList (keys this." + pvar.name) + ")", true);
         wr.out("for keyList keyname:string index {", true);
         wr.indent(1);
-        wr.out(("def item (unwrap (get this." + pvar.compiledName) + " keyname))", true);
+        wr.out(("def item (unwrap (get this." + pvar.name) + " keyname))", true);
         if ( ctx.isDefinedClass(nn.array_type) ) {
           wr.out("def obj@(lives):JSONDataObject (item.toDictionary())", true);
           wr.out("set values keyname obj ", true);
@@ -8175,10 +8223,10 @@ class RangerSerializeClass  {
       } else {
         if ( ctx.isDefinedClass(nn.array_type) == false ) {
           wr.out("def values:JSONDataObject (json_object)", true);
-          wr.out(("def keyList (keys this." + pvar.compiledName) + ")", true);
+          wr.out(("def keyList (keys this." + pvar.name) + ")", true);
           wr.out("for keyList keyname:string index {", true);
           wr.indent(1);
-          wr.out(("def item (unwrap (get this." + pvar.compiledName) + " keyname))", true);
+          wr.out(("def item (unwrap (get this." + pvar.name) + " keyname))", true);
           wr.out("set values keyname item ", true);
           wr.indent(-1);
           wr.out("}", true);
@@ -8189,15 +8237,15 @@ class RangerSerializeClass  {
     }
     if ( nn.hasFlag("optional") ) {
       if ( ctx.isDefinedClass(nn.type_name) == false ) {
-        wr.out(((("set res  \"" + pvar.name) + "\" (unwrap this.") + pvar.compiledName) + ") ", true);
+        wr.out(((("set res  \"" + pvar.name) + "\" (unwrap this.") + pvar.name) + ") ", true);
       } else {
-        wr.out(((("set res  \"" + pvar.name) + "\" (call (unwrap this.") + pvar.compiledName) + ") toDictionary ()) ", true);
+        wr.out(((("set res  \"" + pvar.name) + "\" (call (unwrap this.") + pvar.name) + ") toDictionary ()) ", true);
       }
     } else {
       if ( ctx.isDefinedClass(nn.type_name) == false ) {
-        wr.out(((("set res  \"" + pvar.name) + "\" (this.") + pvar.compiledName) + ") ", true);
+        wr.out(((("set res  \"" + pvar.name) + "\" (this.") + pvar.name) + ") ", true);
       } else {
-        wr.out(((("set res  \"" + pvar.name) + "\" (this.") + pvar.compiledName) + ".toDictionary()) ", true);
+        wr.out(((("set res  \"" + pvar.name) + "\" (this.") + pvar.name) + ".toDictionary()) ", true);
       }
     }
   };
@@ -8208,16 +8256,20 @@ class RangerSerializeClass  {
         wr.out("if(!null? values) {", true);
         wr.indent(1);
         wr.out("def arr (unwrap values)", true);
-        wr.out("arr.forEach({", true);
+        wr.out("def arr_len (array_length arr)", true);
+        wr.out("def arr_i 0", true);
+        wr.out("while (arr_i < arr_len) {", true);
         wr.indent(1);
+        wr.out("def item (getValue arr arr_i)", true);
         wr.out("case item oo:JSONDataObject {", true);
         wr.indent(1);
         wr.out(("def newObj (" + nn.array_type) + ".fromDictionary(oo))", true);
         wr.out(("push obj." + pvar.name) + " newObj", true);
         wr.indent(-1);
         wr.out("}", true);
+        wr.out("arr_i = arr_i + 1", true);
         wr.indent(-1);
-        wr.out("})", true);
+        wr.out("}", true);
         wr.indent(-1);
         wr.out("}", true);
       } else {
@@ -8225,15 +8277,19 @@ class RangerSerializeClass  {
         wr.out("if(!null? values) {", true);
         wr.indent(1);
         wr.out("def arr (unwrap values)", true);
-        wr.out("arr.forEach({", true);
+        wr.out("def arr_len (array_length arr)", true);
+        wr.out("def arr_i 0", true);
+        wr.out("while (arr_i < arr_len) {", true);
         wr.indent(1);
+        wr.out("def item (getValue arr arr_i)", true);
         wr.out(("case item oo:" + nn.array_type) + " {", true);
         wr.indent(1);
         wr.out(("push obj." + pvar.name) + " oo", true);
         wr.indent(-1);
         wr.out("}", true);
+        wr.out("arr_i = arr_i + 1", true);
         wr.indent(-1);
-        wr.out("})", true);
+        wr.out("}", true);
         wr.indent(-1);
         wr.out("}", true);
       }
@@ -8246,8 +8302,11 @@ class RangerSerializeClass  {
         wr.indent(1);
         wr.out(("def theObj" + pvar.name) + " (unwrap values)", true);
         wr.out(("def obj_keys (keys theObj" + pvar.name) + ")", true);
-        wr.out("obj_keys.forEach({", true);
+        wr.out("def key_len (array_length obj_keys)", true);
+        wr.out("def key_i 0", true);
+        wr.out("while (key_i < key_len) {", true);
         wr.indent(1);
+        wr.out("def item (itemAt obj_keys key_i)", true);
         if ( ctx.isDefinedClass(nn.array_type) ) {
           wr.out(("def theValue (getObject theObj" + pvar.name) + " item ) ", true);
           wr.out("if(!null? theValue) {", true);
@@ -8258,8 +8317,9 @@ class RangerSerializeClass  {
           wr.out("}", true);
         } else {
         }
+        wr.out("key_i = key_i + 1", true);
         wr.indent(-1);
-        wr.out("})", true);
+        wr.out("}", true);
         wr.indent(-1);
         wr.out("}", true);
       } else {
@@ -8268,8 +8328,11 @@ class RangerSerializeClass  {
         wr.indent(1);
         wr.out(("def theObj" + pvar.name) + " (unwrap values)", true);
         wr.out(("def obj_keys (keys theObj" + pvar.name) + ")", true);
-        wr.out("obj_keys.forEach({", true);
+        wr.out("def key_len (array_length obj_keys)", true);
+        wr.out("def key_i 0", true);
+        wr.out("while (key_i < key_len) {", true);
         wr.indent(1);
+        wr.out("def item (itemAt obj_keys key_i)", true);
         if ( ctx.isDefinedClass(nn.array_type) ) {
         } else {
           switch (nn.array_type ) { 
@@ -8307,8 +8370,9 @@ class RangerSerializeClass  {
               break;
           };
         }
+        wr.out("key_i = key_i + 1", true);
         wr.indent(-1);
-        wr.out("})", true);
+        wr.out("}", true);
         wr.indent(-1);
         wr.out("}", true);
       }
@@ -8422,7 +8486,7 @@ class RangerSerializeClass  {
       const nn_2 = pvar_2.nameNode;
       if ( nn_2.hasFlag("optional") ) {
         wr.out("; optional variable", true);
-        wr.out(("if (!null? this." + pvar_2.compiledName) + ") {", true);
+        wr.out(("if (!null? this." + pvar_2.name) + ") {", true);
         wr.indent(1);
         this.createWRWriter2(pvar_2, nn_2, ctx, wr);
         wr.indent(-1);
@@ -20252,6 +20316,12 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         if ( tc.is_extended_by_children ) {
           return ("Rc<RefCell<dyn " + type_string) + "Trait>>";
         }
+        if ( tc.is_system ) {
+          const sysName = ( tc.systemNames.hasOwnProperty("rust") ? tc.systemNames["rust"] : undefined );
+          if ( (typeof(sysName) !== "undefined" && sysName != null )  ) {
+            return sysName;
+          }
+        }
       }
       return type_string;
     };
@@ -20399,7 +20469,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             if ( tc_1.is_extended_by_children ) {
               wr.out(("Rc<RefCell<dyn " + node.type_name) + "Trait>>", false);
             } else {
-              wr.out(this.getTypeString(node.type_name), false);
+              wr.out(this.getObjectTypeString(node.type_name, ctx), false);
             }
           } else {
             wr.out(this.getTypeString(node.type_name), false);
@@ -22122,16 +22192,17 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       ctx.setCurrentClass(cl);
       const wr = orig_wr;
       if ( this.fileHeaderWritten == false ) {
-        wr.out("#![allow(unused_parens)]", true);
-        wr.out("#![allow(unused_mut)]", true);
-        wr.out("#![allow(unused_variables)]", true);
-        wr.out("#![allow(non_snake_case)]", true);
-        wr.out("#![allow(dead_code)]", true);
-        wr.out("", true);
-        wr.out("use std::rc::Rc;", true);
-        wr.out("use std::rc::Weak;", true);
-        wr.out("use std::cell::RefCell;", true);
-        wr.out("", true);
+        const header = wr.getTag("before_imports");
+        header.out("#![allow(unused_parens)]", true);
+        header.out("#![allow(unused_mut)]", true);
+        header.out("#![allow(unused_variables)]", true);
+        header.out("#![allow(non_snake_case)]", true);
+        header.out("#![allow(dead_code)]", true);
+        header.out("", true);
+        header.out("use std::rc::Rc;", true);
+        header.out("use std::rc::Weak;", true);
+        header.out("use std::cell::RefCell;", true);
+        header.out("", true);
         this.fileHeaderWritten = true;
       }
       let hasTraitObjectField = false;
@@ -22207,8 +22278,13 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             if ( (pvar_2).isArray() ) {
               wr.out(this.adjustType(pvar_2.compiledName) + ": Vec::new(), ", true);
             } else {
-              if ( pvar_2.is_optional ) {
-                wr.out(this.adjustType(pvar_2.compiledName) + ": None, ", true);
+              if ( pvar_2.isHash() ) {
+                wr.out(this.adjustType(pvar_2.compiledName) + ": HashMap::new(), ", true);
+                wr.addImport("std::collections::HashMap");
+              } else {
+                if ( pvar_2.is_optional ) {
+                  wr.out(this.adjustType(pvar_2.compiledName) + ": None, ", true);
+                }
               }
             }
           }
@@ -27896,9 +27972,12 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         } else {
           if ( nn.value_type == 6 ) {
             wr.out(" = []", false);
-          }
-          if ( nn.value_type == 7 ) {
-            wr.out(" = {}", false);
+          } else {
+            if ( nn.value_type == 7 ) {
+              wr.out(" = {}", false);
+            } else {
+              wr.out(" = None", false);
+            }
           }
         }
         wr.newline();
@@ -28007,6 +28086,47 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         var item = body.children[i_1];
         await this.WalkNode(item, lambdaCtx, wr);
       };
+    };
+    getPythonTypeName (node, ctx) {
+      let v_type = node.value_type;
+      if ( ((v_type == 10) || (v_type == 11)) || (v_type == 0) ) {
+        v_type = node.typeNameAsType(ctx);
+      }
+      if ( node.eval_type != 0 ) {
+        v_type = node.eval_type;
+      }
+      switch (v_type ) { 
+        case 3 : 
+          return "int";
+        case 13 : 
+          return "int";
+        case 14 : 
+          return "int";
+        case 2 : 
+          return "float";
+        case 4 : 
+          return "str";
+        case 5 : 
+          return "bool";
+        case 6 : 
+          return "list";
+        case 7 : 
+          return "dict";
+      };
+      const tn = node.type_name;
+      if ( ctx.isDefinedClass(tn) ) {
+        const cc = ctx.findClass(tn);
+        if ( cc.is_system ) {
+          const sysName = ( cc.systemNames.hasOwnProperty("python") ? cc.systemNames["python"] : undefined );
+          if ( (typeof(sysName) !== "undefined" && sysName != null )  ) {
+            return sysName;
+          }
+        }
+      }
+      return tn;
+    };
+    async writeTypeDef (node, ctx, wr) {
+      wr.out(this.getPythonTypeName(node, ctx), false);
     };
     writeClassVarDef (node, ctx, wr) {
     };
@@ -43308,34 +43428,6 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
               operatorsOf_41.rc46func_43 = async function(node, ctx, wr) {
                 const parser = new RangerFlowParser();
                 return await parser.CreateFunctionObject(node, ctx, wr);
-              };
-              class operatorsOfJSONArrayObject_57  {
-                constructor() {
-                }
-              }
-              operatorsOfJSONArrayObject_57.forEach_58 = function(__self, cb) {
-                let cnt = __self.length;
-                let i_32 = 0;
-                while (cnt > 0) {
-                  const value_8 = __self[i_32];
-                  cb(value_8, i_32);
-                  cnt = cnt - 1;
-                  i_32 = i_32 + 1;
-                };
-              };
-              class operatorsOf_57  {
-                constructor() {
-                }
-              }
-              operatorsOf_57.forEach_58 = async function(__self, cb) {
-                let cnt_1 = __self.length;
-                let i_33 = 0;
-                while (cnt_1 > 0) {
-                  const value_9 = __self[i_33];
-                  await cb(value_9, i_33);
-                  cnt_1 = cnt_1 - 1;
-                  i_33 = i_33 + 1;
-                };
               };
 /* static JavaSript main routine at the end of the JS file */
 async function __js_main() {

--- a/compiler/JSON.rgr
+++ b/compiler/JSON.rgr
@@ -7,6 +7,16 @@
 ; https://msdn.microsoft.com/en-us/library/system.json.jsonobject(v=vs.95).aspx
 
 
+; Python and Rust hold the same three shapes as every other target: an object,
+; an array and a value that is one of the two plus the scalars.
+;
+; Python has the shapes in the language, so the mapping is dict / list / object
+; and the `json` module of the standard library reads and writes the text.
+;
+; Rust has no JSON type in the standard library and the target writes code that
+; `rustc` builds without a crate, so the value is the RJson enum that the
+; polyfills below declare. An object is a HashMap of it and an array is a Vec of
+; it, both spelled in full so that no `use` line is needed.
 systemclass JSONDataObject {
     es6 Object
     java7 JSONObject ( (imp "org.json.JSONObject") )
@@ -14,6 +24,8 @@ systemclass JSONDataObject {
     go "map[string]interface{}"
     swift3 '[String:Any]'
     swift6 '[String:Any]'
+    python dict
+    rust "std::collections::HashMap<String, RJson>"
 }
 
 systemclass JSONArrayObject {
@@ -23,6 +35,8 @@ systemclass JSONArrayObject {
     go "[]interface{}"
     swift3 '[Any]'
     swift6 '[Any]'
+    python list
+    rust "Vec<RJson>"
 }
 
 systemclass JSONKeyValue {
@@ -36,6 +50,8 @@ systemclass JSONValueUnion {
     go "interface{}"
     swift3 Any
     swift6 Any
+    python object
+    rust RJson
 }
 
 systemunion JSONValueUnion ( JSONDataObject JSONArrayObject string int double boolean )
@@ -75,7 +91,9 @@ operators {
                 "console.log(JSON.stringify(" (e 1) "));" nl
             )
             java7 @macro(true) ("print (to_string " (e 1) " )" (imp "org.json.JSONObject"))
-        }        
+            python ( "print(json.dumps(" (e 1) "))" (imp "json") )
+            rust @macro(true) ("print (to_string " (e 1) " )")
+        }
     }
 
     getStr _@(optional):string (e:JSONDataObject key:string) {
@@ -138,13 +156,25 @@ func r_get_opt_json_string( data map[string]interface{}, key string ) *GoNullabl
     res.has_value = false
     return res
 }
-")            
+")
 
+            )
+            python ( "(lambda v: v if isinstance(v, str) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_str(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_str(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<String> {
+    match o.get(k) { Some(RJson::Str(v)) => Some(v.clone()), _ => None }
+}
+")
             )
 
 
-        }                
-    } 
+        }
+    }
 
     getInt _@(optional):int (e:JSONDataObject key:string) {
          templates {
@@ -172,12 +202,24 @@ func r_get_opt_json_int( data map[string]interface{}, key string ) *GoNullable  
     res.has_value = false
     return res
 }
-")            
+")
 
             )
-            
-        }                
-    } 
+            python ( "(lambda v: v if isinstance(v, int) and not isinstance(v, bool) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_int(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_int(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<i64> {
+    match o.get(k) { Some(RJson::Int(v)) => Some(*v), Some(RJson::Double(v)) => Some(*v as i64), _ => None }
+}
+")
+            )
+
+        }
+    }
 
     getDouble _@(optional):double (e:JSONDataObject key:string) {
          templates {
@@ -205,12 +247,24 @@ func r_get_opt_json_double( data map[string]interface{}, key string ) *GoNullabl
     res.has_value = false
     return res
 }
-")            
+")
 
             )
-            
-        }                
-    } 
+            python ( "(lambda v: float(v) if isinstance(v, (int, float)) and not isinstance(v, bool) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_double(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_double(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<f64> {
+    match o.get(k) { Some(RJson::Double(v)) => Some(*v), Some(RJson::Int(v)) => Some(*v as f64), _ => None }
+}
+")
+            )
+
+        }
+    }
 
     getBoolean _@(optional):boolean (e:JSONDataObject key:string) {
          templates {
@@ -238,11 +292,23 @@ func r_get_opt_json_bool( data map[string]interface{}, key string ) *GoNullable 
     res.has_value = false
     return res
 }
-")            
+")
 
             )
-        }                
-    } 
+            python ( "(lambda v: v if isinstance(v, bool) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_bool(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_bool(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<bool> {
+    match o.get(k) { Some(RJson::Bool(v)) => Some(*v), _ => None }
+}
+")
+            )
+        }
+    }
 
     getObject _@(optional):JSONDataObject (e:JSONDataObject key:string) {
          templates {
@@ -286,11 +352,23 @@ func r_get_opt_json_obj( data map[string]interface{}, key string ) *GoNullable  
     res.has_value = false
     return res
 }
-")            
+")
 
             )
-        }                
-    } 
+            python ( "(lambda v: v if isinstance(v, dict) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_obj(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_obj(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<std::collections::HashMap<String, RJson>> {
+    match o.get(k) { Some(RJson::Obj(v)) => Some(v.clone()), _ => None }
+}
+")
+            )
+        }
+    }
 
 
     ; todo: proper array detection for optionals
@@ -320,11 +398,23 @@ func r_get_opt_array( data map[string]interface{}, key string ) *GoNullable  {
     res.has_value = false
     return res
 }
-')            
+')
 
             )
-        }                
-    } 
+            python ( "(lambda v: v if isinstance(v, list) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_arr(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_arr(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<Vec<RJson>> {
+    match o.get(k) { Some(RJson::Arr(v)) => Some(v.clone()), _ => None }
+}
+")
+            )
+        }
+    }
 
     keys _:[string] (e:JSONDataObject) {
         templates {
@@ -383,6 +473,13 @@ static ArrayList<String> __getJSONKeys(JSONObject obj)
                     "return strkeys" nl i "})()"
                 (imp "reflect"))
             php  ("array_keys(" (e 1) ")")
+            python ( "list(" (e 1) ".keys())" )
+            rust ( (e 1) ".keys().cloned().collect::<Vec<String>>()"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -400,7 +497,14 @@ func r_is_obj_array( data inteface{} ) bool {
     }
     return false
 }
-")            
+")
+            )
+            python ( "isinstance(" (e 1) ", list)" )
+            rust ( "matches!(&" (e 1) ", RJson::Arr(_))"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
             )
         }
     }
@@ -408,7 +512,19 @@ func r_is_obj_array( data inteface{} ) bool {
     asArray _@(optional):JSONArrayObject (e:JSONValueUnion) {
         templates {
             es6 ( (e 1) " instanceof Array ? " (e 1 ) " : undefined")
-        }        
+            python ( "(lambda v: v if isinstance(v, list) else None)(" (e 1) ")" )
+            rust ( "r_json_as_arr(&" (e 1) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_as_arr(v: &RJson) -> Option<Vec<RJson>> {
+    match v { RJson::Arr(a) => Some(a.clone()), _ => None }
+}
+")
+            )
+        }
     }
 
     getValue _:JSONValueUnion (e:JSONArrayObject index:int) {
@@ -438,19 +554,39 @@ static Object __getJSONValue(JSONArray o, Integer item)
             kotlin ( (e 1) ".get(" (e 2) ")")
             go ( (e 1) "[" (e 2) "]")
             php ( (e 1) "[" (e 2) "]")
+            python ( (e 1) "[" (e 2) "]")
+            rust ( "r_json_at(&" (e 1) ", " (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_at(a: &Vec<RJson>, i: i64) -> RJson {
+    if i < 0 || (i as usize) >= a.len() { return RJson::Null; }
+    a[i as usize].clone()
+}
+")
+            )
         }
     }
 
     array_length _:int (e:JSONArrayObject) {
         templates {
             ranger ("(array_length " (e 1) ")")
-            es6 ( (e 1) ".length") 
+            es6 ( (e 1) ".length")
             java7 ( (e 1) ".length()" )
             kotlin ( (e 1) ".length()" )
             swift3 ( (e 1) ".count")
             swift6 ( (e 1) ".count")
             go( "int64(len(" (e 1) "))" )
             php ( "count(" (e 1) ")" )
+            python ( "len(" (e 1) ")" )
+            rust ( "((" (e 1) ").len() as i64)"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -464,6 +600,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Int((" (e 3) ") as i64));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -477,6 +620,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Str((" (e 3) ").to_string()));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -490,6 +640,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Int(" (e 3) "));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -503,6 +660,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Double(" (e 3) "));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -516,6 +680,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Bool(" (e 3) "));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -529,6 +700,61 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            ; The value is one of the six members of the union, so the RJsonValue
+            ; trait picks the variant that fits the type the argument has.
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), (" (e 3) ").r_json_value());"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+trait RJsonValue { fn r_json_value(&self) -> RJson; }
+impl RJsonValue for i64 { fn r_json_value(&self) -> RJson { RJson::Int(*self) } }
+impl RJsonValue for i32 { fn r_json_value(&self) -> RJson { RJson::Int(*self as i64) } }
+impl RJsonValue for f64 { fn r_json_value(&self) -> RJson { RJson::Double(*self) } }
+impl RJsonValue for bool { fn r_json_value(&self) -> RJson { RJson::Bool(*self) } }
+impl RJsonValue for String { fn r_json_value(&self) -> RJson { RJson::Str(self.clone()) } }
+impl RJsonValue for str { fn r_json_value(&self) -> RJson { RJson::Str(self.to_string()) } }
+impl RJsonValue for Vec<RJson> { fn r_json_value(&self) -> RJson { RJson::Arr(self.clone()) } }
+impl RJsonValue for std::collections::HashMap<String, RJson> { fn r_json_value(&self) -> RJson { RJson::Obj(self.clone()) } }
+impl RJsonValue for RJson { fn r_json_value(&self) -> RJson { self.clone() } }
+")
+            )
+        }
+    }
+
+    ; Rust narrows a union by matching the enum variant, and the variant is not
+    ; the type name that `(typeof 2)` writes, so the generic `case` in stdlib.rgr
+    ; can not serve it. These two entries name the JSON shapes directly. A target
+    ; that has no template here does not match them and reaches the generic one.
+    case _@(newcontext):void ( arg@(union):JSONValueUnion item@(define):JSONDataObject code:block ) {
+        templates {
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Obj(" (e 2) ") = &" (e 1) " {" nl I
+                        "let mut " (e 2) " : std::collections::HashMap<String, RJson> = " (e 2) ".clone();" nl
+                        (block 3)
+                        nl i "}"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
+        }
+    }
+
+    case _@(newcontext):void ( arg@(union):JSONValueUnion item@(define):JSONArrayObject code:block ) {
+        templates {
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Arr(" (e 2) ") = &" (e 1) " {" nl I
+                        "let mut " (e 2) " : Vec<RJson> = " (e 2) ".clone();" nl
+                        (block 3)
+                        nl i "}"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -566,9 +792,108 @@ function r_json_to_array($str) {
 }
 "
 
-)            
+)
             )
-        }        
+            python ( "json.loads(" (e 1) ")" (imp "json") )
+            rust ( "r_json_parse_obj(&" (e 1) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_skip_ws(s: &[u8], i: &mut usize) {
+    while *i < s.len() && (s[*i] == 32 || s[*i] == 9 || s[*i] == 10 || s[*i] == 13) { *i += 1; }
+}
+fn r_json_read_string(s: &[u8], i: &mut usize) -> String {
+    let mut out: Vec<u8> = Vec::new();
+    *i += 1;
+    while *i < s.len() && s[*i] != 34 {
+        if s[*i] == 92 && (*i + 1) < s.len() {
+            *i += 1;
+            let e = s[*i];
+            if e == 110 { out.push(10); }
+            else if e == 116 { out.push(9); }
+            else if e == 114 { out.push(13); }
+            else if e == 98 { out.push(8); }
+            else if e == 102 { out.push(12); }
+            else if e == 117 {
+                let mut code: u32 = 0;
+                let mut k = 0;
+                while k < 4 && (*i + 1) < s.len() {
+                    *i += 1;
+                    code = code * 16 + (s[*i] as char).to_digit(16).unwrap_or(0);
+                    k += 1;
+                }
+                let mut buf = [0u8; 4];
+                let ch = char::from_u32(code).unwrap_or(63 as char);
+                out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+            }
+            else { out.push(e); }
+        } else {
+            out.push(s[*i]);
+        }
+        *i += 1;
+    }
+    *i += 1;
+    String::from_utf8_lossy(&out).to_string()
+}
+fn r_json_read_value(s: &[u8], i: &mut usize) -> RJson {
+    r_json_skip_ws(s, i);
+    if *i >= s.len() { return RJson::Null; }
+    let c = s[*i];
+    if c == 123 {
+        let mut o: std::collections::HashMap<String, RJson> = std::collections::HashMap::new();
+        *i += 1;
+        loop {
+            r_json_skip_ws(s, i);
+            if *i >= s.len() || s[*i] == 125 { *i += 1; break; }
+            if s[*i] == 44 { *i += 1; continue; }
+            if s[*i] != 34 { *i += 1; continue; }
+            let key = r_json_read_string(s, i);
+            r_json_skip_ws(s, i);
+            if *i < s.len() && s[*i] == 58 { *i += 1; }
+            let value = r_json_read_value(s, i);
+            o.insert(key, value);
+        }
+        return RJson::Obj(o);
+    }
+    if c == 91 {
+        let mut a: Vec<RJson> = Vec::new();
+        *i += 1;
+        loop {
+            r_json_skip_ws(s, i);
+            if *i >= s.len() || s[*i] == 93 { *i += 1; break; }
+            if s[*i] == 44 { *i += 1; continue; }
+            let value = r_json_read_value(s, i);
+            a.push(value);
+        }
+        return RJson::Arr(a);
+    }
+    if c == 34 { return RJson::Str(r_json_read_string(s, i)); }
+    if c == 116 { *i += 4; return RJson::Bool(true); }
+    if c == 102 { *i += 5; return RJson::Bool(false); }
+    if c == 110 { *i += 4; return RJson::Null; }
+    let start = *i;
+    let mut is_double = false;
+    while *i < s.len() {
+        let d = s[*i];
+        if d == 46 || d == 101 || d == 69 { is_double = true; }
+        if d == 44 || d == 125 || d == 93 || d == 32 || d == 10 || d == 13 || d == 9 { break; }
+        *i += 1;
+    }
+    let text = String::from_utf8_lossy(&s[start..*i]).to_string();
+    if is_double { RJson::Double(text.parse::<f64>().unwrap_or(0.0)) } else { RJson::Int(text.parse::<i64>().unwrap_or(0)) }
+}
+fn r_json_parse_obj(text: &str) -> std::collections::HashMap<String, RJson> {
+    let mut i: usize = 0;
+    match r_json_read_value(text.as_bytes(), &mut i) {
+        RJson::Obj(o) => o,
+        _ => std::collections::HashMap::new(),
+    }
+}
+")
+            )
+        }
     }
 
     to_string _:string (e:JSONDataObject) {
@@ -599,10 +924,70 @@ func __toJSONData ( data interface{} ) string {
 	b, _ := json.Marshal(data)
 	return string(b)
 }
-")            
+")
             )
             php ( "json_encode(" (e 1) ")")
-        }        
+            python ( "json.dumps(" (e 1) ")" (imp "json") )
+            rust ( "r_json_to_string(&RJson::Obj(" (e 1) ".clone()))"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_escape(s: &str, out: &mut String) {
+    out.push(34 as u8 as char);
+    for c in s.chars() {
+        let n = c as u32;
+        if n == 34 || n == 92 { out.push(92 as u8 as char); out.push(c); }
+        else if n == 10 { out.push(92 as u8 as char); out.push('n'); }
+        else if n == 13 { out.push(92 as u8 as char); out.push('r'); }
+        else if n == 9 { out.push(92 as u8 as char); out.push('t'); }
+        else if n < 0x20 {
+            out.push(92 as u8 as char);
+            out.push('u');
+            out.push_str(&format!(\"{:04x}\", n));
+        }
+        else { out.push(c); }
+    }
+    out.push(34 as u8 as char);
+}
+fn r_json_write(v: &RJson, out: &mut String) {
+    match v {
+        RJson::Null => out.push_str(\"null\"),
+        RJson::Bool(b) => out.push_str(if *b { \"true\" } else { \"false\" }),
+        RJson::Int(i) => out.push_str(&i.to_string()),
+        RJson::Double(d) => { if d.is_finite() { out.push_str(&format!(\"{}\", d)) } else { out.push_str(\"null\") } }
+        RJson::Str(s) => r_json_escape(s, out),
+        RJson::Arr(a) => {
+            out.push('[');
+            for (i, it) in a.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                r_json_write(it, out);
+            }
+            out.push(']');
+        }
+        RJson::Obj(o) => {
+            let mut keys: Vec<&String> = o.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                r_json_escape(k, out);
+                out.push(':');
+                r_json_write(&o[*k], out);
+            }
+            out.push('}');
+        }
+    }
+}
+fn r_json_to_string(v: &RJson) -> String {
+    let mut out = String::new();
+    r_json_write(v, &mut out);
+    out
+}
+")
+            )
+        }
     }
 
     to_string _:string (e:JSONArrayObject) {
@@ -621,10 +1006,70 @@ func __toJSONData ( data interface{} ) string {
 	b, _ := json.Marshal(data)
 	return string(b)
 }
-")            
+")
             )
             php ( "json_encode(" (e 1) ")")
-        }        
+            python ( "json.dumps(" (e 1) ")" (imp "json") )
+            rust ( "r_json_to_string(&RJson::Arr(" (e 1) ".clone()))"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_escape(s: &str, out: &mut String) {
+    out.push(34 as u8 as char);
+    for c in s.chars() {
+        let n = c as u32;
+        if n == 34 || n == 92 { out.push(92 as u8 as char); out.push(c); }
+        else if n == 10 { out.push(92 as u8 as char); out.push('n'); }
+        else if n == 13 { out.push(92 as u8 as char); out.push('r'); }
+        else if n == 9 { out.push(92 as u8 as char); out.push('t'); }
+        else if n < 0x20 {
+            out.push(92 as u8 as char);
+            out.push('u');
+            out.push_str(&format!(\"{:04x}\", n));
+        }
+        else { out.push(c); }
+    }
+    out.push(34 as u8 as char);
+}
+fn r_json_write(v: &RJson, out: &mut String) {
+    match v {
+        RJson::Null => out.push_str(\"null\"),
+        RJson::Bool(b) => out.push_str(if *b { \"true\" } else { \"false\" }),
+        RJson::Int(i) => out.push_str(&i.to_string()),
+        RJson::Double(d) => { if d.is_finite() { out.push_str(&format!(\"{}\", d)) } else { out.push_str(\"null\") } }
+        RJson::Str(s) => r_json_escape(s, out),
+        RJson::Arr(a) => {
+            out.push('[');
+            for (i, it) in a.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                r_json_write(it, out);
+            }
+            out.push(']');
+        }
+        RJson::Obj(o) => {
+            let mut keys: Vec<&String> = o.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                r_json_escape(k, out);
+                out.push(':');
+                r_json_write(&o[*k], out);
+            }
+            out.push('}');
+        }
+    }
+}
+fn r_json_to_string(v: &RJson) -> String {
+    let mut out = String::new();
+    r_json_write(v, &mut out);
+    out
+}
+")
+            )
+        }
     }
 
     push _@(moves@( 2 1 ) ):void ( e@(mutates):JSONArrayObject el:JSONArrayUnion) {
@@ -637,7 +1082,26 @@ func __toJSONData ( data interface{} ) string {
             swift6 ( (e 1) ".append(" (e 2) ");")
             go( (e 1) " = append(" (e 1) "," (e 2) ")")
             php ( "array_push(" (e 1) ", " (e 2) ");")
-        }           
+            python ( (e 1) ".append(" (e 2) ")")
+            rust ( (e 1) ".push((" (e 2) ").r_json_value());"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+trait RJsonValue { fn r_json_value(&self) -> RJson; }
+impl RJsonValue for i64 { fn r_json_value(&self) -> RJson { RJson::Int(*self) } }
+impl RJsonValue for i32 { fn r_json_value(&self) -> RJson { RJson::Int(*self as i64) } }
+impl RJsonValue for f64 { fn r_json_value(&self) -> RJson { RJson::Double(*self) } }
+impl RJsonValue for bool { fn r_json_value(&self) -> RJson { RJson::Bool(*self) } }
+impl RJsonValue for String { fn r_json_value(&self) -> RJson { RJson::Str(self.clone()) } }
+impl RJsonValue for str { fn r_json_value(&self) -> RJson { RJson::Str(self.to_string()) } }
+impl RJsonValue for Vec<RJson> { fn r_json_value(&self) -> RJson { RJson::Arr(self.clone()) } }
+impl RJsonValue for std::collections::HashMap<String, RJson> { fn r_json_value(&self) -> RJson { RJson::Obj(self.clone()) } }
+impl RJsonValue for RJson { fn r_json_value(&self) -> RJson { self.clone() } }
+")
+            )
+        }
     }
     json_array json@(expands):JSONArrayObject () {
         templates {
@@ -649,7 +1113,14 @@ func __toJSONData ( data interface{} ) string {
             kotlin ("JSONArray()")
             go ( "make([]interface{},0)" )
             php ( "array()" )
-        }        
+            python ( "[]" )
+            rust ( "Vec::<RJson>::new()"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
+        }
     }
     json_object json:JSONDataObject () {
         templates {
@@ -661,7 +1132,14 @@ func __toJSONData ( data interface{} ) string {
             kotlin ("JSONObject()")
             go ( "make(map[string]interface{})" )
             php ( "array()")
-        }        
+            python ( "{}" )
+            rust ( "std::collections::HashMap::<String, RJson>::new()"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
+        }
     }
     json_array json@(expands):JSONArrayObject ( e@(block):JSONArrayUnion ) {
         templates {
@@ -672,7 +1150,8 @@ func __toJSONData ( data interface{} ) string {
             java7 ("new JSONArray" (imp "org.json.JSONArray") (plugin 'maven' (  (dep 'org.json' 'json' '20171018'  ) ) ))
             go ( "make([]interface{},0)" )
             php ( "array()" )
-        }        
+            python ("[" ( repeat_from 1 (  (block 1) ) ) "]")
+        }
     }
     json_obj json@(expands):JSONDataObject ( e@(block):JSONObjectUnion ) {
         templates {

--- a/compiler/Lang.rgr
+++ b/compiler/Lang.rgr
@@ -170,6 +170,44 @@ language {
             init _init
         }
         python {
+            ; The keywords of the language. A field named `as` wrote
+            ; `self.as = []`, which is a SyntaxError, so the program stopped
+            ; before the first statement of the main function.
+            and _and
+            as _as
+            assert _assert
+            async _async
+            await _await
+            break _break
+            class _class
+            continue _continue
+            def _def
+            del _del
+            elif _elif
+            else _else
+            except _except
+            finally _finally
+            for _for
+            from _from
+            global _global
+            if _if
+            import _import
+            in _in
+            is _is
+            lambda _lambda
+            nonlocal _nonlocal
+            not _not
+            or _or
+            pass _pass
+            raise _raise
+            return _return
+            try _try
+            while _while
+            with _with
+            yield _yield
+            None _None
+            True _True
+            False _False
             str _str
             int _int
             float _float
@@ -2229,6 +2267,14 @@ case class customException(smth:String)  extends Exception
                 swift3 ( "do {" nl I (block 1) i nl "} catch { " nl I (block 2) i nl "}" )
                 swift6 ( "do {" nl I (block 1) i nl "} catch { " nl I (block 2) i nl "}" )
                 cpp ( nl "try {" nl I (block 1) i nl "} catch( ... ) {" nl I (block 2) i nl "}" nl )
+                ; Python needs a statement in each suite, and a generated catch
+                ; block is often empty (the @serialize writer emits one), so both
+                ; suites open with `pass`.
+                python ( nl "try:" nl I "pass" nl (block 1) i nl "except Exception:" nl I "pass" nl (block 2) i nl )
+                ; Rust has no exceptions and the target writes code that rustc
+                ; builds without a crate, so there is nothing for the catch block
+                ; to catch: the try block is written and the catch block is not.
+                rust ( nl "/* try: Rust has no exceptions, so the catch block is not written */" nl (block 1) nl )
                 * ( nl "try {" nl I (block 1) i nl "} catch(e) {" nl I (block 2) i nl "}" nl )
             }
         }
@@ -3749,7 +3795,9 @@ r_optional_primitive<double> cpp_get_map_string_double_value( std::map<std::stri
                 ranger ( "(get " (e 1) " " (e 2) ")")                 
                 llvm ( "(get " (e 1) " " (e 2) ")")
                 java7 ( (e 1) ".get(" (e 2) ")" )
-                rust ( (e 1) ".get(" (e 2) ")" )
+                ; HashMap::get hands back Option<&T>, and the operator is typed
+                ; to give an optional T, so the borrow is cloned away.
+                rust ( (e 1) ".get(&" (e 2) ").cloned()" )
                 cpp ( "r_map_get_val(" (e 1) ", " (e 2) ")"
 (create_polyfill
 "

--- a/compiler/ng_RangerPythonClassWriter.rgr
+++ b/compiler/ng_RangerPythonClassWriter.rgr
@@ -185,11 +185,17 @@ class RangerPythonClassWriter {
         this.WalkNode(value ctx wr)
         ctx.unsetInExpr()
       } {
+        ; A field with no value still needs one. Without the None branch the
+        ; line read `self.one`, which raises AttributeError the first time the
+        ; class is constructed. writeVarDef below does the same for locals.
         if (nn.value_type == RangerNodeType.Array) {
           wr.out(" = []" false)
-        }
-        if (nn.value_type == RangerNodeType.Hash) {
-          wr.out(" = {}" false)
+        } {
+          if (nn.value_type == RangerNodeType.Hash) {
+            wr.out(" = {}" false)
+          } {
+            wr.out(" = None" false)
+          }
         }
       }
       wr.newline()
@@ -305,6 +311,62 @@ class RangerPythonClassWriter {
       this.WalkNode(item lambdaCtx wr)
     }
   } 
+
+  ; The Python target writes no type annotations, so a type name only reaches
+  ; the output through a `(typeof N)` template — `isinstance` in the union
+  ; `case` is the one that matters. The name there has to be the Python type,
+  ; not the Ranger one: `isinstance(item, dict)`, never
+  ; `isinstance(item, JSONDataObject)`.
+  fn getPythonTypeName:string (node:CodeNode ctx:RangerAppWriterContext) {
+    def v_type:RangerNodeType node.value_type
+    if (((v_type == RangerNodeType.Object) || (v_type == RangerNodeType.VRef)) || (v_type == RangerNodeType.NoType)) {
+      v_type = (node.typeNameAsType(ctx))
+    }
+    if (node.eval_type != RangerNodeType.NoType) {
+      v_type = node.eval_type
+    }
+    switch v_type {
+      case RangerNodeType.Integer {
+        return "int"
+      }
+      case RangerNodeType.Enum {
+        return "int"
+      }
+      case RangerNodeType.Char {
+        return "int"
+      }
+      case RangerNodeType.Double {
+        return "float"
+      }
+      case RangerNodeType.String {
+        return "str"
+      }
+      case RangerNodeType.Boolean {
+        return "bool"
+      }
+      case RangerNodeType.Array {
+        return "list"
+      }
+      case RangerNodeType.Hash {
+        return "dict"
+      }
+    }
+    def tn:string node.type_name
+    if (ctx.isDefinedClass(tn)) {
+      def cc:RangerAppClassDesc (ctx.findClass(tn))
+      if cc.is_system {
+        def sysName@(optional):string (get cc.systemNames "python")
+        if (!null? sysName) {
+          return (unwrap sysName)
+        }
+      }
+    }
+    return tn
+  }
+
+  fn writeTypeDef:void (node:CodeNode ctx:RangerAppWriterContext wr:CodeWriter) {
+    wr.out((this.getPythonTypeName(node ctx)) false)
+  }
 
   fn writeClassVarDef:void (node:CodeNode ctx:RangerAppWriterContext wr:CodeWriter) {
     ; Python doesn't need class variable declarations at class level

--- a/compiler/ng_RangerRustClassWriter.rgr
+++ b/compiler/ng_RangerRustClassWriter.rgr
@@ -116,6 +116,15 @@ class RangerRustClassWriter {
       if tc.is_extended_by_children {
         return ("Rc<RefCell<dyn " + type_string + "Trait>>")
       }
+      ; A systemclass names one type per target. Without this the Ranger name
+      ; reached the output and rustc saw an undeclared type: JSONDataObject
+      ; instead of the HashMap that JSON.rgr declares for Rust.
+      if tc.is_system {
+        def sysName@(optional):string (get tc.systemNames "rust")
+        if (!null? sysName) {
+          return (unwrap sysName)
+        }
+      }
     }
     return type_string
   }
@@ -288,7 +297,7 @@ class RangerRustClassWriter {
           if tc.is_extended_by_children {
             wr.out(("Rc<RefCell<dyn " + node.type_name + "Trait>>") false)
           } {
-            wr.out((this.getTypeString(node.type_name)) false)
+            wr.out((this.getObjectTypeString(node.type_name ctx)) false)
           }
         } {
           wr.out((this.getTypeString(node.type_name)) false)
@@ -2363,18 +2372,23 @@ class RangerRustClassWriter {
     
     def wr:CodeWriter orig_wr
     
-    ; Write file header with allow directives for common warnings
+    ; Write file header with allow directives for common warnings.
+    ; The lines go into the "before_imports" slice: an inner attribute (#![..])
+    ; has to precede every item in the file, and an (imp "...") from an operator
+    ; template writes a `use` line ahead of the class content. Written here they
+    ; ended up after that line and rustc rejected the file.
     if (fileHeaderWritten == false) {
-      wr.out("#![allow(unused_parens)]" true)
-      wr.out("#![allow(unused_mut)]" true)
-      wr.out("#![allow(unused_variables)]" true)
-      wr.out("#![allow(non_snake_case)]" true)
-      wr.out("#![allow(dead_code)]" true)
-      wr.out("" true)
-      wr.out("use std::rc::Rc;" true)
-      wr.out("use std::rc::Weak;" true)
-      wr.out("use std::cell::RefCell;" true)
-      wr.out("" true)
+      def header:CodeWriter (wr.getTag("before_imports"))
+      header.out("#![allow(unused_parens)]" true)
+      header.out("#![allow(unused_mut)]" true)
+      header.out("#![allow(unused_variables)]" true)
+      header.out("#![allow(non_snake_case)]" true)
+      header.out("#![allow(dead_code)]" true)
+      header.out("" true)
+      header.out("use std::rc::Rc;" true)
+      header.out("use std::rc::Weak;" true)
+      header.out("use std::cell::RefCell;" true)
+      header.out("" true)
       fileHeaderWritten = true
     }
     
@@ -2452,9 +2466,17 @@ class RangerRustClassWriter {
           if (pvar.isArray()) {
             wr.out(((this.adjustType(pvar.compiledName)) + ": Vec::new(), ") true)
           } {
-            ; Initialize optional fields with None
-            if pvar.is_optional {
-              wr.out(((this.adjustType(pvar.compiledName)) + ": None, ") true)
+            ; A hash field is a HashMap, never an Option: without this branch
+            ; the constructor wrote `None` into a HashMap field and rustc
+            ; rejected the struct literal.
+            if (pvar.isHash()) {
+              wr.out(((this.adjustType(pvar.compiledName)) + ": HashMap::new(), ") true)
+              wr.addImport("std::collections::HashMap")
+            } {
+              ; Initialize optional fields with None
+              if pvar.is_optional {
+                wr.out(((this.adjustType(pvar.compiledName)) + ": None, ") true)
+              }
             }
           }
         }

--- a/compiler/ng_RangerSerializeClass.rgr
+++ b/compiler/ng_RangerSerializeClass.rgr
@@ -226,7 +226,7 @@ class RangerSerializeClass {
             ; TODO: serializing primitives...
             if(this.canSerializeClass(nn.array_type ctx)) {
                 wr.out("def values:JSONArrayObject (json_array)" , true)
-                wr.out("for this." + pvar.compiledName +" item:"+nn.array_type + " i {" , true)
+                wr.out("for this." + pvar.name +" item:"+nn.array_type + " i {" , true)
                     wr.indent(1)
                     wr.out("def obj@(lives):JSONDataObject (item.toDictionary())" true)
                     wr.out("push values obj" true)
@@ -235,7 +235,7 @@ class RangerSerializeClass {
                 wr.out("set res  \"" + pvar.name + "\" values " , true)
             } {
                 wr.out("def values:JSONArrayObject (json_array)" , true)
-                wr.out("for this." + pvar.compiledName +" item:"+nn.array_type + " i {" , true)
+                wr.out("for this." + pvar.name +" item:"+nn.array_type + " i {" , true)
                     wr.indent(1)
                     wr.out("push values item" true)
                     wr.indent(-1)
@@ -247,10 +247,10 @@ class RangerSerializeClass {
         if(nn.value_type == RangerNodeType.Hash) {
             if(this.canSerializeClass(nn.array_type ctx)) {
                 wr.out("def values:JSONDataObject (json_object)" , true)
-                wr.out("def keyList (keys this." + pvar.compiledName + ")" , true)
+                wr.out("def keyList (keys this." + pvar.name + ")" , true)
                 wr.out("for keyList keyname:string index {" , true)
                     wr.indent(1)
-                    wr.out("def item (unwrap (get this." + pvar.compiledName + " keyname))" , true)
+                    wr.out("def item (unwrap (get this." + pvar.name + " keyname))" , true)
 
                     if( ctx.isDefinedClass(nn.array_type) ) {
                       wr.out("def obj@(lives):JSONDataObject (item.toDictionary())" true)
@@ -264,11 +264,11 @@ class RangerSerializeClass {
             } {
                 if( (ctx.isDefinedClass(nn.array_type) ) == false ) {
                     wr.out("def values:JSONDataObject (json_object)" , true)
-                    wr.out("def keyList (keys this." + pvar.compiledName + ")" , true)
+                    wr.out("def keyList (keys this." + pvar.name + ")" , true)
                     wr.out("for keyList keyname:string index {" , true)
-        ;            wr.out("for this." + pvar.compiledName + " keyname {" , true)
+        ;            wr.out("for this." + pvar.name + " keyname {" , true)
                         wr.indent(1)
-                        wr.out("def item (unwrap (get this." + pvar.compiledName + " keyname))" , true)
+                        wr.out("def item (unwrap (get this." + pvar.name + " keyname))" , true)
                         wr.out("set values keyname item " true)                      
                         wr.indent(-1)
                     wr.out("}" true)          
@@ -279,15 +279,15 @@ class RangerSerializeClass {
         }
         if(nn.hasFlag("optional")) {
             if( (ctx.isDefinedClass(nn.type_name) ) == false ) {
-                wr.out("set res  \"" + pvar.name + "\" (unwrap this." + pvar.compiledName +") " , true )
+                wr.out("set res  \"" + pvar.name + "\" (unwrap this." + pvar.name +") " , true )
             } {
-                wr.out("set res  \"" + pvar.name + "\" (call (unwrap this." + pvar.compiledName +") toDictionary ()) " , true )
+                wr.out("set res  \"" + pvar.name + "\" (call (unwrap this." + pvar.name +") toDictionary ()) " , true )
             }
         } {
             if( (ctx.isDefinedClass(nn.type_name) ) == false ) {
-                wr.out("set res  \"" + pvar.name + "\" (this." + pvar.compiledName +") " , true )
+                wr.out("set res  \"" + pvar.name + "\" (this." + pvar.name +") " , true )
             } {
-                wr.out("set res  \"" + pvar.name + "\" (this." + pvar.compiledName +".toDictionary()) " , true )
+                wr.out("set res  \"" + pvar.name + "\" (this." + pvar.name +".toDictionary()) " , true )
             }
         }
     }
@@ -302,16 +302,20 @@ class RangerSerializeClass {
                 wr.out("if(!null? values) {" true)
                 wr.indent(1)
                 wr.out("def arr (unwrap values)" true)
-                wr.out("arr.forEach({" , true)
+                wr.out("def arr_len (array_length arr)" true)
+                wr.out("def arr_i 0" true)
+                wr.out("while (arr_i < arr_len) {" true)
                     wr.indent(1)
+                    wr.out("def item (getValue arr arr_i)" true)
                     wr.out("case item oo:JSONDataObject {" true)
                     wr.indent(1)
                         wr.out("def newObj (" + nn.array_type + ".fromDictionary(oo))" , true)
                         wr.out("push obj." + pvar.name + " newObj" , true)
                     wr.indent(-1)
                     wr.out("}" true)
+                    wr.out("arr_i = arr_i + 1" true)
                     wr.indent(-1)
-                wr.out("})" true)          
+                wr.out("}" true)
                 wr.indent(-1)
                 wr.out("}" true)
             } {
@@ -319,16 +323,19 @@ class RangerSerializeClass {
                 wr.out("if(!null? values) {" true)
                 wr.indent(1)
                 wr.out("def arr (unwrap values)" true)
-                wr.out("arr.forEach({" , true)
+                wr.out("def arr_len (array_length arr)" true)
+                wr.out("def arr_i 0" true)
+                wr.out("while (arr_i < arr_len) {" true)
                     wr.indent(1)
+                    wr.out("def item (getValue arr arr_i)" true)
                     wr.out("case item oo:" + nn.array_type + " {" , true)
                     wr.indent(1)
-;                        wr.out("def newObj (" + nn.array_type + ".fromDictionary(oo))" , true)
                         wr.out("push obj." + pvar.name + " oo" , true)
                     wr.indent(-1)
                     wr.out("}" true)
+                    wr.out("arr_i = arr_i + 1" true)
                     wr.indent(-1)
-                wr.out("})" true)          
+                wr.out("}" true)
                 wr.indent(-1)
                 wr.out("}" true)                
             }        
@@ -341,11 +348,12 @@ class RangerSerializeClass {
                 wr.indent(1)                
                 wr.out("def theObj" + pvar.name + " (unwrap values)" , true)    
                 wr.out("def obj_keys (keys theObj" + pvar.name + ")" , true)
-                wr.out("obj_keys.forEach({" , true)
+                wr.out("def key_len (array_length obj_keys)" true)
+                wr.out("def key_i 0" true)
+                wr.out("while (key_i < key_len) {" true)
                     wr.indent(1)
+                    wr.out("def item (itemAt obj_keys key_i)" true)
                     if( ctx.isDefinedClass(nn.array_type) ) {
-                      ;wr.out("try {" true)
-                      ;wr.indent(1)
                       wr.out("def theValue (getObject theObj" + pvar.name + " item ) " , true)
                       wr.out("if(!null? theValue) {" true)
                       wr.indent(1)
@@ -353,13 +361,11 @@ class RangerSerializeClass {
                       wr.out("set obj." + pvar.name + " item newObj " , true)
                       wr.indent(-1)
                       wr.out("}" true)
-                      ;wr.indent(-1)
-                      ;wr.out("} {" true)                      
-                      ;wr.out("}" true)
                     } {
                     }
+                    wr.out("key_i = key_i + 1" true)
                     wr.indent(-1)
-                wr.out("})" true)          
+                wr.out("}" true)
                 wr.indent(-1)
                 wr.out("}" true)
             } {
@@ -369,8 +375,11 @@ class RangerSerializeClass {
                 wr.indent(1)                
                 wr.out("def theObj" + pvar.name + " (unwrap values)" , true)    
                 wr.out("def obj_keys (keys theObj" + pvar.name + ")" , true)
-                wr.out("obj_keys.forEach({" , true)
+                wr.out("def key_len (array_length obj_keys)" true)
+                wr.out("def key_i 0" true)
+                wr.out("while (key_i < key_len) {" true)
                     wr.indent(1)
+                    wr.out("def item (itemAt obj_keys key_i)" true)
                     if( ctx.isDefinedClass(nn.array_type) ) {
 
                     } {
@@ -410,8 +419,9 @@ class RangerSerializeClass {
                           }
                         }
                     }
+                    wr.out("key_i = key_i + 1" true)
                     wr.indent(-1)
-                wr.out("})" true)          
+                wr.out("}" true)
                 wr.indent(-1)
                 wr.out("}" true)
                 
@@ -540,7 +550,7 @@ class RangerSerializeClass {
             def nn:CodeNode (unwrap pvar.nameNode)
             if(nn.hasFlag("optional")) {
                 wr.out("; optional variable" true)
-                wr.out("if (!null? this." + pvar.compiledName + ") {",  true)
+                wr.out("if (!null? this." + pvar.name + ") {",  true)
                     wr.indent(1)
                     this.createWRWriter2( pvar nn ctx wr)            
                     wr.indent(-1)

--- a/compiler/stdlib.rgr
+++ b/compiler/stdlib.rgr
@@ -26,6 +26,18 @@ operators {
                         (block 3)
                         nl i "}"
             )
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", bool):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            )
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Bool(" (e 2) ") = &" (e 1) " {" nl I
+                        "let " (e 2) " : bool = *" (e 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            )
         }
     }
     case             _@(newcontext):void           ( arg@(union):T item2@(define):int code:block )  {
@@ -45,6 +57,18 @@ operators {
             kotlin (
                 (forkctx _ ) (def 2) "if( " (e 1) " is Int ) /* union case for int */ {" nl I
                         "val " (e 2) " : Int = " (e 1) " as Int;" nl
+                        (block 3)
+                        nl i "}"
+            )
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", int) and not isinstance(" (e 1) ", bool):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            )
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Int(" (e 2) ") = &" (e 1) " {" nl I
+                        "let " (e 2) " : i64 = *" (e 2) ";" nl
                         (block 3)
                         nl i "}"
             )
@@ -70,6 +94,18 @@ operators {
                         (block 3)
                         nl i "}"
             )
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", float):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            )
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Double(" (e 2) ") = &" (e 1) " {" nl I
+                        "let " (e 2) " : f64 = *" (e 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            )
         }
     }
 
@@ -90,6 +126,18 @@ operators {
             kotlin (
                 (forkctx _ ) (def 2) "if( " (e 1) " is String ) /* union case for string */ {" nl I
                         "val " (e 2) " : String = " (e 1) " as String;" nl
+                        (block 3)
+                        nl i "}"
+            )
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", str):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            )
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Str(" (e 2) ") = &" (e 1) " {" nl I
+                        "let " (e 2) " : String = " (e 2) ".clone();" nl
                         (block 3)
                         nl i "}"
             )
@@ -157,6 +205,12 @@ operators {
                         "val " (e 2) " : " (typeof 2) " = " (e 1) " as " (typeof 2) ";" nl
                         (block 3)
                         nl i "}"
+            ) 
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", " (typeof 2) "):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
             ) 
             cpp (
                 (forkctx _ ) (def 2) "if( mpark::holds_alternative<" (typeof 2) ">(" (e 1) ") ) {" nl I

--- a/dist/Lang.rgr
+++ b/dist/Lang.rgr
@@ -170,6 +170,44 @@ language {
             init _init
         }
         python {
+            ; The keywords of the language. A field named `as` wrote
+            ; `self.as = []`, which is a SyntaxError, so the program stopped
+            ; before the first statement of the main function.
+            and _and
+            as _as
+            assert _assert
+            async _async
+            await _await
+            break _break
+            class _class
+            continue _continue
+            def _def
+            del _del
+            elif _elif
+            else _else
+            except _except
+            finally _finally
+            for _for
+            from _from
+            global _global
+            if _if
+            import _import
+            in _in
+            is _is
+            lambda _lambda
+            nonlocal _nonlocal
+            not _not
+            or _or
+            pass _pass
+            raise _raise
+            return _return
+            try _try
+            while _while
+            with _with
+            yield _yield
+            None _None
+            True _True
+            False _False
             str _str
             int _int
             float _float
@@ -2229,6 +2267,14 @@ case class customException(smth:String)  extends Exception
                 swift3 ( "do {" nl I (block 1) i nl "} catch { " nl I (block 2) i nl "}" )
                 swift6 ( "do {" nl I (block 1) i nl "} catch { " nl I (block 2) i nl "}" )
                 cpp ( nl "try {" nl I (block 1) i nl "} catch( ... ) {" nl I (block 2) i nl "}" nl )
+                ; Python needs a statement in each suite, and a generated catch
+                ; block is often empty (the @serialize writer emits one), so both
+                ; suites open with `pass`.
+                python ( nl "try:" nl I "pass" nl (block 1) i nl "except Exception:" nl I "pass" nl (block 2) i nl )
+                ; Rust has no exceptions and the target writes code that rustc
+                ; builds without a crate, so there is nothing for the catch block
+                ; to catch: the try block is written and the catch block is not.
+                rust ( nl "/* try: Rust has no exceptions, so the catch block is not written */" nl (block 1) nl )
                 * ( nl "try {" nl I (block 1) i nl "} catch(e) {" nl I (block 2) i nl "}" nl )
             }
         }
@@ -3749,7 +3795,9 @@ r_optional_primitive<double> cpp_get_map_string_double_value( std::map<std::stri
                 ranger ( "(get " (e 1) " " (e 2) ")")                 
                 llvm ( "(get " (e 1) " " (e 2) ")")
                 java7 ( (e 1) ".get(" (e 2) ")" )
-                rust ( (e 1) ".get(" (e 2) ")" )
+                ; HashMap::get hands back Option<&T>, and the operator is typed
+                ; to give an optional T, so the borrow is cloned away.
+                rust ( (e 1) ".get(&" (e 2) ").cloned()" )
                 cpp ( "r_map_get_val(" (e 1) ", " (e 2) ")"
 (create_polyfill
 "

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -12,7 +12,7 @@ export declare class CmdParams {
     getParam(name: string): string | undefined;
     collect(): void;
     toDictionary(): Record<string, any>;
-    static fromDictionary(dict: Record<string, any>): Promise<CmdParams>;
+    static fromDictionary(dict: Record<string, any>): CmdParams;
 }
 export declare class test_cmdparams {
     constructor();
@@ -28,7 +28,7 @@ export declare class InputFSFolder {
     constructor();
     forTree(cb: (item: InputFSFolder) => void): void;
     toDictionary(): Record<string, any>;
-    static fromDictionary(dict: Record<string, any>): Promise<InputFSFolder>;
+    static fromDictionary(dict: Record<string, any>): InputFSFolder;
 }
 export declare class InputFSFile {
     name: string;
@@ -49,7 +49,7 @@ export declare class InputEnv {
     constructor();
     setEnv(name: string, value: string): void;
     toDictionary(): Record<string, any>;
-    static fromDictionary(dict: Record<string, any>): Promise<InputEnv>;
+    static fromDictionary(dict: Record<string, any>): InputEnv;
 }
 export declare class test_input_filesystem {
     constructor();
@@ -416,7 +416,7 @@ export declare class CodeNodeLiteral {
     attrs: Array<CodeNodeLiteral>;
     constructor();
     toDictionary(): Record<string, any>;
-    static fromDictionary(dict: Record<string, any>): Promise<CodeNodeLiteral>;
+    static fromDictionary(dict: Record<string, any>): CodeNodeLiteral;
 }
 export declare class CodeNode {
     code?: SourceCode;
@@ -1847,6 +1847,8 @@ export declare class RangerPythonClassWriter extends RangerGenericClassWriter {
     CreatePropertyGet(node: CodeNode, ctx: RangerAppWriterContext, wr: CodeWriter): Promise<void>;
     CreateLambdaCall(node: CodeNode, ctx: RangerAppWriterContext, wr: CodeWriter): Promise<void>;
     CreateLambda(node: CodeNode, ctx: RangerAppWriterContext, wr: CodeWriter): Promise<void>;
+    getPythonTypeName(node: CodeNode, ctx: RangerAppWriterContext): string;
+    writeTypeDef(node: CodeNode, ctx: RangerAppWriterContext, wr: CodeWriter): Promise<void>;
     writeClassVarDef(node: CodeNode, ctx: RangerAppWriterContext, wr: CodeWriter): void;
     writeArgsDef(fnDesc: RangerAppFunctionDesc, ctx: RangerAppWriterContext, wr: CodeWriter): void;
     writeArrayLiteral(node: CodeNode, ctx: RangerAppWriterContext, wr: CodeWriter): Promise<void>;

--- a/dist/api.js
+++ b/dist/api.js
@@ -90,47 +90,60 @@ class CmdParams {
     }
     ;
     static fromDictionary(dict) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const obj = new CmdParams();
-            try {
-                const values = (dict["flags"] instanceof Object) ? dict["flags"] : undefined;
-                if ((typeof (values) !== "undefined" && values != null)) {
-                    const theObjflags = values;
-                    const obj_keys = Object.keys(theObjflags);
-                    yield operatorsOf.forEach_12(obj_keys, ((item, index) => {
-                        const v = typeof (theObjflags[item]) === "undefined" ? undefined : (theObjflags[item]);
-                        if ((typeof (v) !== "undefined" && v != null)) {
-                            obj.flags[item] = v;
-                        }
-                    }));
+        const obj = new CmdParams();
+        try {
+            const values = (dict["flags"] instanceof Object) ? dict["flags"] : undefined;
+            if ((typeof (values) !== "undefined" && values != null)) {
+                const theObjflags = values;
+                const obj_keys = Object.keys(theObjflags);
+                const key_len = obj_keys.length;
+                let key_i = 0;
+                while (key_i < key_len) {
+                    const item = obj_keys[key_i];
+                    const v = typeof (theObjflags[item]) === "undefined" ? undefined : (theObjflags[item]);
+                    if ((typeof (v) !== "undefined" && v != null)) {
+                        obj.flags[item] = v;
+                    }
+                    key_i = key_i + 1;
                 }
-                const values_1 = (dict["params"] instanceof Object) ? dict["params"] : undefined;
-                if ((typeof (values_1) !== "undefined" && values_1 != null)) {
-                    const theObjparams = values_1;
-                    const obj_keys_1 = Object.keys(theObjparams);
-                    yield operatorsOf.forEach_12(obj_keys_1, ((item, index) => {
-                        const v_1 = (typeof (theObjparams[item]) != "string") ? undefined : theObjparams[item];
-                        if ((typeof (v_1) !== "undefined" && v_1 != null)) {
-                            obj.params[item] = v_1;
-                        }
-                    }));
-                }
-                const values_2 = (dict["values"] instanceof Array) ? dict["values"] : undefined;
-                if ((typeof (values_2) !== "undefined" && values_2 != null)) {
-                    const arr = values_2;
-                    operatorsOfJSONArrayObject_57.forEach_58(arr, ((item, index) => {
-                        if (typeof (item) === 'string') /* union case for string */ {
-                            var oo = item;
-                            obj.values.push(oo);
-                        }
-                        ;
-                    }));
-                }
+                ;
             }
-            catch (e) {
+            const values_1 = (dict["params"] instanceof Object) ? dict["params"] : undefined;
+            if ((typeof (values_1) !== "undefined" && values_1 != null)) {
+                const theObjparams = values_1;
+                const obj_keys_1 = Object.keys(theObjparams);
+                const key_len_1 = obj_keys_1.length;
+                let key_i_1 = 0;
+                while (key_i_1 < key_len_1) {
+                    const item_1 = obj_keys_1[key_i_1];
+                    const v_1 = (typeof (theObjparams[item_1]) != "string") ? undefined : theObjparams[item_1];
+                    if ((typeof (v_1) !== "undefined" && v_1 != null)) {
+                        obj.params[item_1] = v_1;
+                    }
+                    key_i_1 = key_i_1 + 1;
+                }
+                ;
             }
-            return obj;
-        });
+            const values_2 = (dict["values"] instanceof Array) ? dict["values"] : undefined;
+            if ((typeof (values_2) !== "undefined" && values_2 != null)) {
+                const arr = values_2;
+                const arr_len = arr.length;
+                let arr_i = 0;
+                while (arr_i < arr_len) {
+                    const item_2 = arr[arr_i];
+                    if (typeof (item_2) === 'string') /* union case for string */ {
+                        var oo = item_2;
+                        obj.values.push(oo);
+                    }
+                    ;
+                    arr_i = arr_i + 1;
+                }
+                ;
+            }
+        }
+        catch (e) {
+        }
+        return obj;
     }
     ;
 }
@@ -211,54 +224,62 @@ class InputFSFolder {
     }
     ;
     static fromDictionary(dict) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const obj = new InputFSFolder();
-            try {
-                const v = (typeof (dict["name"]) != "string") ? undefined : dict["name"];
-                if ((typeof (v) !== "undefined" && v != null)) {
-                    obj.name = v;
-                }
-                const v_1 = (typeof (dict["data"]) != "string") ? undefined : dict["data"];
-                if ((typeof (v_1) !== "undefined" && v_1 != null)) {
-                    obj.data = v_1;
-                }
-                const v_2 = typeof (dict["is_folder"]) === "undefined" ? undefined : (dict["is_folder"]);
-                if ((typeof (v_2) !== "undefined" && v_2 != null)) {
-                    obj.is_folder = v_2;
-                }
-                const v_3 = typeof (dict["base64bin"]) === "undefined" ? undefined : (dict["base64bin"]);
-                if ((typeof (v_3) !== "undefined" && v_3 != null)) {
-                    obj.base64bin = v_3;
-                }
-                const values = (dict["folders"] instanceof Array) ? dict["folders"] : undefined;
-                if ((typeof (values) !== "undefined" && values != null)) {
-                    const arr = values;
-                    yield operatorsOf_57.forEach_58(arr, ((item, index) => __awaiter(this, void 0, void 0, function* () {
-                        if (item instanceof Object) /* union case */ {
-                            var oo = item;
-                            const newObj = yield InputFSFolder.fromDictionary(oo);
-                            obj.folders.push(newObj);
-                        }
-                        ;
-                    })));
-                }
-                const values_1 = (dict["files"] instanceof Array) ? dict["files"] : undefined;
-                if ((typeof (values_1) !== "undefined" && values_1 != null)) {
-                    const arr_1 = values_1;
-                    yield operatorsOf_57.forEach_58(arr_1, ((item, index) => {
-                        if (item instanceof Object) /* union case */ {
-                            var oo_1 = item;
-                            const newObj_1 = InputFSFile.fromDictionary(oo_1);
-                            obj.files.push(newObj_1);
-                        }
-                        ;
-                    }));
-                }
+        const obj = new InputFSFolder();
+        try {
+            const v = (typeof (dict["name"]) != "string") ? undefined : dict["name"];
+            if ((typeof (v) !== "undefined" && v != null)) {
+                obj.name = v;
             }
-            catch (e) {
+            const v_1 = (typeof (dict["data"]) != "string") ? undefined : dict["data"];
+            if ((typeof (v_1) !== "undefined" && v_1 != null)) {
+                obj.data = v_1;
             }
-            return obj;
-        });
+            const v_2 = typeof (dict["is_folder"]) === "undefined" ? undefined : (dict["is_folder"]);
+            if ((typeof (v_2) !== "undefined" && v_2 != null)) {
+                obj.is_folder = v_2;
+            }
+            const v_3 = typeof (dict["base64bin"]) === "undefined" ? undefined : (dict["base64bin"]);
+            if ((typeof (v_3) !== "undefined" && v_3 != null)) {
+                obj.base64bin = v_3;
+            }
+            const values = (dict["folders"] instanceof Array) ? dict["folders"] : undefined;
+            if ((typeof (values) !== "undefined" && values != null)) {
+                const arr = values;
+                const arr_len = arr.length;
+                let arr_i = 0;
+                while (arr_i < arr_len) {
+                    const item = arr[arr_i];
+                    if (item instanceof Object) /* union case */ {
+                        var oo = item;
+                        const newObj = InputFSFolder.fromDictionary(oo);
+                        obj.folders.push(newObj);
+                    }
+                    ;
+                    arr_i = arr_i + 1;
+                }
+                ;
+            }
+            const values_1 = (dict["files"] instanceof Array) ? dict["files"] : undefined;
+            if ((typeof (values_1) !== "undefined" && values_1 != null)) {
+                const arr_1 = values_1;
+                const arr_len_1 = arr_1.length;
+                let arr_i_1 = 0;
+                while (arr_i_1 < arr_len_1) {
+                    const item_1 = arr_1[arr_i_1];
+                    if (item_1 instanceof Object) /* union case */ {
+                        var oo_1 = item_1;
+                        const newObj_1 = InputFSFile.fromDictionary(oo_1);
+                        obj.files.push(newObj_1);
+                    }
+                    ;
+                    arr_i_1 = arr_i_1 + 1;
+                }
+                ;
+            }
+        }
+        catch (e) {
+        }
+        return obj;
     }
     ;
 }
@@ -345,39 +366,42 @@ class InputEnv {
     }
     ;
     static fromDictionary(dict) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const obj = new InputEnv();
-            try {
-                const v = typeof (dict["use_real"]) === "undefined" ? undefined : (dict["use_real"]);
-                if ((typeof (v) !== "undefined" && v != null)) {
-                    obj.use_real = v;
-                }
-                const theValue = (dict["filesystem"] instanceof Object) ? dict["filesystem"] : undefined;
-                if ((typeof (theValue) !== "undefined" && theValue != null)) {
-                    const newObj = yield InputFSFolder.fromDictionary((theValue));
-                    obj.filesystem = newObj;
-                }
-                const values = (dict["envVars"] instanceof Object) ? dict["envVars"] : undefined;
-                if ((typeof (values) !== "undefined" && values != null)) {
-                    const theObjenvVars = values;
-                    const obj_keys = Object.keys(theObjenvVars);
-                    yield operatorsOf.forEach_12(obj_keys, ((item, index) => {
-                        const v_1 = (typeof (theObjenvVars[item]) != "string") ? undefined : theObjenvVars[item];
-                        if ((typeof (v_1) !== "undefined" && v_1 != null)) {
-                            obj.envVars[item] = v_1;
-                        }
-                    }));
-                }
-                const theValue_1 = (dict["commandLine"] instanceof Object) ? dict["commandLine"] : undefined;
-                if ((typeof (theValue_1) !== "undefined" && theValue_1 != null)) {
-                    const newObj_1 = yield CmdParams.fromDictionary((theValue_1));
-                    obj.commandLine = newObj_1;
-                }
+        const obj = new InputEnv();
+        try {
+            const v = typeof (dict["use_real"]) === "undefined" ? undefined : (dict["use_real"]);
+            if ((typeof (v) !== "undefined" && v != null)) {
+                obj.use_real = v;
             }
-            catch (e) {
+            const theValue = (dict["filesystem"] instanceof Object) ? dict["filesystem"] : undefined;
+            if ((typeof (theValue) !== "undefined" && theValue != null)) {
+                const newObj = InputFSFolder.fromDictionary((theValue));
+                obj.filesystem = newObj;
             }
-            return obj;
-        });
+            const values = (dict["envVars"] instanceof Object) ? dict["envVars"] : undefined;
+            if ((typeof (values) !== "undefined" && values != null)) {
+                const theObjenvVars = values;
+                const obj_keys = Object.keys(theObjenvVars);
+                const key_len = obj_keys.length;
+                let key_i = 0;
+                while (key_i < key_len) {
+                    const item = obj_keys[key_i];
+                    const v_1 = (typeof (theObjenvVars[item]) != "string") ? undefined : theObjenvVars[item];
+                    if ((typeof (v_1) !== "undefined" && v_1 != null)) {
+                        obj.envVars[item] = v_1;
+                    }
+                    key_i = key_i + 1;
+                }
+                ;
+            }
+            const theValue_1 = (dict["commandLine"] instanceof Object) ? dict["commandLine"] : undefined;
+            if ((typeof (theValue_1) !== "undefined" && theValue_1 != null)) {
+                const newObj_1 = CmdParams.fromDictionary((theValue_1));
+                obj.commandLine = newObj_1;
+            }
+        }
+        catch (e) {
+        }
+        return obj;
     }
     ;
 }
@@ -1719,147 +1743,175 @@ class CodeNodeLiteral {
     }
     ;
     static fromDictionary(dict) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const obj = new CodeNodeLiteral();
-            try {
-                const v = typeof (dict["expression"]) === "undefined" ? undefined : (dict["expression"]);
-                if ((typeof (v) !== "undefined" && v != null)) {
-                    obj.expression = v;
-                }
-                const v_1 = (typeof (dict["vref"]) != "string") ? undefined : dict["vref"];
-                if ((typeof (v_1) !== "undefined" && v_1 != null)) {
-                    obj.vref = v_1;
-                }
-                const v_2 = typeof (dict["is_block_node"]) === "undefined" ? undefined : (dict["is_block_node"]);
-                if ((typeof (v_2) !== "undefined" && v_2 != null)) {
-                    obj.is_block_node = v_2;
-                }
-                const v_3 = (typeof (dict["type_name"]) != "string") ? undefined : dict["type_name"];
-                if ((typeof (v_3) !== "undefined" && v_3 != null)) {
-                    obj.type_name = v_3;
-                }
-                const v_4 = (typeof (dict["key_type"]) != "string") ? undefined : dict["key_type"];
-                if ((typeof (v_4) !== "undefined" && v_4 != null)) {
-                    obj.key_type = v_4;
-                }
-                const v_5 = (typeof (dict["array_type"]) != "string") ? undefined : dict["array_type"];
-                if ((typeof (v_5) !== "undefined" && v_5 != null)) {
-                    obj.array_type = v_5;
-                }
-                const values = (dict["ns"] instanceof Array) ? dict["ns"] : undefined;
-                if ((typeof (values) !== "undefined" && values != null)) {
-                    const arr = values;
-                    yield operatorsOf_57.forEach_58(arr, ((item, index) => {
-                        if (typeof (item) === 'string') /* union case for string */ {
-                            var oo = item;
-                            obj.ns.push(oo);
-                        }
-                        ;
-                    }));
-                }
-                const v_6 = typeof (dict["has_vref_annotation"]) === "undefined" ? undefined : (dict["has_vref_annotation"]);
-                if ((typeof (v_6) !== "undefined" && v_6 != null)) {
-                    obj.has_vref_annotation = v_6;
-                }
-                const theValue = (dict["vref_annotation"] instanceof Object) ? dict["vref_annotation"] : undefined;
-                if ((typeof (theValue) !== "undefined" && theValue != null)) {
-                    const newObj = yield CodeNodeLiteral.fromDictionary((theValue));
-                    obj.vref_annotation = newObj;
-                }
-                const v_7 = typeof (dict["has_type_annotation"]) === "undefined" ? undefined : (dict["has_type_annotation"]);
-                if ((typeof (v_7) !== "undefined" && v_7 != null)) {
-                    obj.has_type_annotation = v_7;
-                }
-                const theValue_1 = (dict["type_annotation"] instanceof Object) ? dict["type_annotation"] : undefined;
-                if ((typeof (theValue_1) !== "undefined" && theValue_1 != null)) {
-                    const newObj_1 = yield CodeNodeLiteral.fromDictionary((theValue_1));
-                    obj.type_annotation = newObj_1;
-                }
-                const v_8 = isNaN(parseFloat(dict["double_value"])) ? undefined : parseFloat(dict["double_value"]);
-                if ((typeof (v_8) !== "undefined" && v_8 != null)) {
-                    obj.double_value = v_8;
-                }
-                const v_9 = (typeof (dict["string_value"]) != "string") ? undefined : dict["string_value"];
-                if ((typeof (v_9) !== "undefined" && v_9 != null)) {
-                    obj.string_value = v_9;
-                }
-                const v_10 = isNaN(parseInt(dict["int_value"])) ? undefined : parseInt(dict["int_value"]);
-                if ((typeof (v_10) !== "undefined" && v_10 != null)) {
-                    obj.int_value = v_10;
-                }
-                const v_11 = typeof (dict["boolean_value"]) === "undefined" ? undefined : (dict["boolean_value"]);
-                if ((typeof (v_11) !== "undefined" && v_11 != null)) {
-                    obj.boolean_value = v_11;
-                }
-                const theValue_2 = (dict["expression_value"] instanceof Object) ? dict["expression_value"] : undefined;
-                if ((typeof (theValue_2) !== "undefined" && theValue_2 != null)) {
-                    const newObj_2 = yield CodeNodeLiteral.fromDictionary((theValue_2));
-                    obj.expression_value = newObj_2;
-                }
-                const values_1 = (dict["props"] instanceof Object) ? dict["props"] : undefined;
-                if ((typeof (values_1) !== "undefined" && values_1 != null)) {
-                    const theObjprops = values_1;
-                    const obj_keys = Object.keys(theObjprops);
-                    yield operatorsOf.forEach_12(obj_keys, ((item, index) => __awaiter(this, void 0, void 0, function* () {
-                        const theValue_3 = (theObjprops[item] instanceof Object) ? theObjprops[item] : undefined;
-                        if ((typeof (theValue_3) !== "undefined" && theValue_3 != null)) {
-                            const newObj_3 = yield CodeNodeLiteral.fromDictionary((theValue_3));
-                            obj.props[item] = newObj_3;
-                        }
-                    })));
-                }
-                const values_2 = (dict["prop_keys"] instanceof Array) ? dict["prop_keys"] : undefined;
-                if ((typeof (values_2) !== "undefined" && values_2 != null)) {
-                    const arr_1 = values_2;
-                    yield operatorsOf_57.forEach_58(arr_1, ((item, index) => {
-                        if (typeof (item) === 'string') /* union case for string */ {
-                            var oo_1 = item;
-                            obj.prop_keys.push(oo_1);
-                        }
-                        ;
-                    }));
-                }
-                const values_3 = (dict["comments"] instanceof Array) ? dict["comments"] : undefined;
-                if ((typeof (values_3) !== "undefined" && values_3 != null)) {
-                    const arr_2 = values_3;
-                    yield operatorsOf_57.forEach_58(arr_2, ((item, index) => __awaiter(this, void 0, void 0, function* () {
-                        if (item instanceof Object) /* union case */ {
-                            var oo_2 = item;
-                            const newObj_4 = yield CodeNodeLiteral.fromDictionary(oo_2);
-                            obj.comments.push(newObj_4);
-                        }
-                        ;
-                    })));
-                }
-                const values_4 = (dict["children"] instanceof Array) ? dict["children"] : undefined;
-                if ((typeof (values_4) !== "undefined" && values_4 != null)) {
-                    const arr_3 = values_4;
-                    yield operatorsOf_57.forEach_58(arr_3, ((item, index) => __awaiter(this, void 0, void 0, function* () {
-                        if (item instanceof Object) /* union case */ {
-                            var oo_3 = item;
-                            const newObj_5 = yield CodeNodeLiteral.fromDictionary(oo_3);
-                            obj.children.push(newObj_5);
-                        }
-                        ;
-                    })));
-                }
-                const values_5 = (dict["attrs"] instanceof Array) ? dict["attrs"] : undefined;
-                if ((typeof (values_5) !== "undefined" && values_5 != null)) {
-                    const arr_4 = values_5;
-                    yield operatorsOf_57.forEach_58(arr_4, ((item, index) => __awaiter(this, void 0, void 0, function* () {
-                        if (item instanceof Object) /* union case */ {
-                            var oo_4 = item;
-                            const newObj_6 = yield CodeNodeLiteral.fromDictionary(oo_4);
-                            obj.attrs.push(newObj_6);
-                        }
-                        ;
-                    })));
-                }
+        const obj = new CodeNodeLiteral();
+        try {
+            const v = typeof (dict["expression"]) === "undefined" ? undefined : (dict["expression"]);
+            if ((typeof (v) !== "undefined" && v != null)) {
+                obj.expression = v;
             }
-            catch (e) {
+            const v_1 = (typeof (dict["vref"]) != "string") ? undefined : dict["vref"];
+            if ((typeof (v_1) !== "undefined" && v_1 != null)) {
+                obj.vref = v_1;
             }
-            return obj;
-        });
+            const v_2 = typeof (dict["is_block_node"]) === "undefined" ? undefined : (dict["is_block_node"]);
+            if ((typeof (v_2) !== "undefined" && v_2 != null)) {
+                obj.is_block_node = v_2;
+            }
+            const v_3 = (typeof (dict["type_name"]) != "string") ? undefined : dict["type_name"];
+            if ((typeof (v_3) !== "undefined" && v_3 != null)) {
+                obj.type_name = v_3;
+            }
+            const v_4 = (typeof (dict["key_type"]) != "string") ? undefined : dict["key_type"];
+            if ((typeof (v_4) !== "undefined" && v_4 != null)) {
+                obj.key_type = v_4;
+            }
+            const v_5 = (typeof (dict["array_type"]) != "string") ? undefined : dict["array_type"];
+            if ((typeof (v_5) !== "undefined" && v_5 != null)) {
+                obj.array_type = v_5;
+            }
+            const values = (dict["ns"] instanceof Array) ? dict["ns"] : undefined;
+            if ((typeof (values) !== "undefined" && values != null)) {
+                const arr = values;
+                const arr_len = arr.length;
+                let arr_i = 0;
+                while (arr_i < arr_len) {
+                    const item = arr[arr_i];
+                    if (typeof (item) === 'string') /* union case for string */ {
+                        var oo = item;
+                        obj.ns.push(oo);
+                    }
+                    ;
+                    arr_i = arr_i + 1;
+                }
+                ;
+            }
+            const v_6 = typeof (dict["has_vref_annotation"]) === "undefined" ? undefined : (dict["has_vref_annotation"]);
+            if ((typeof (v_6) !== "undefined" && v_6 != null)) {
+                obj.has_vref_annotation = v_6;
+            }
+            const theValue = (dict["vref_annotation"] instanceof Object) ? dict["vref_annotation"] : undefined;
+            if ((typeof (theValue) !== "undefined" && theValue != null)) {
+                const newObj = CodeNodeLiteral.fromDictionary((theValue));
+                obj.vref_annotation = newObj;
+            }
+            const v_7 = typeof (dict["has_type_annotation"]) === "undefined" ? undefined : (dict["has_type_annotation"]);
+            if ((typeof (v_7) !== "undefined" && v_7 != null)) {
+                obj.has_type_annotation = v_7;
+            }
+            const theValue_1 = (dict["type_annotation"] instanceof Object) ? dict["type_annotation"] : undefined;
+            if ((typeof (theValue_1) !== "undefined" && theValue_1 != null)) {
+                const newObj_1 = CodeNodeLiteral.fromDictionary((theValue_1));
+                obj.type_annotation = newObj_1;
+            }
+            const v_8 = isNaN(parseFloat(dict["double_value"])) ? undefined : parseFloat(dict["double_value"]);
+            if ((typeof (v_8) !== "undefined" && v_8 != null)) {
+                obj.double_value = v_8;
+            }
+            const v_9 = (typeof (dict["string_value"]) != "string") ? undefined : dict["string_value"];
+            if ((typeof (v_9) !== "undefined" && v_9 != null)) {
+                obj.string_value = v_9;
+            }
+            const v_10 = isNaN(parseInt(dict["int_value"])) ? undefined : parseInt(dict["int_value"]);
+            if ((typeof (v_10) !== "undefined" && v_10 != null)) {
+                obj.int_value = v_10;
+            }
+            const v_11 = typeof (dict["boolean_value"]) === "undefined" ? undefined : (dict["boolean_value"]);
+            if ((typeof (v_11) !== "undefined" && v_11 != null)) {
+                obj.boolean_value = v_11;
+            }
+            const theValue_2 = (dict["expression_value"] instanceof Object) ? dict["expression_value"] : undefined;
+            if ((typeof (theValue_2) !== "undefined" && theValue_2 != null)) {
+                const newObj_2 = CodeNodeLiteral.fromDictionary((theValue_2));
+                obj.expression_value = newObj_2;
+            }
+            const values_1 = (dict["props"] instanceof Object) ? dict["props"] : undefined;
+            if ((typeof (values_1) !== "undefined" && values_1 != null)) {
+                const theObjprops = values_1;
+                const obj_keys = Object.keys(theObjprops);
+                const key_len = obj_keys.length;
+                let key_i = 0;
+                while (key_i < key_len) {
+                    const item_1 = obj_keys[key_i];
+                    const theValue_3 = (theObjprops[item_1] instanceof Object) ? theObjprops[item_1] : undefined;
+                    if ((typeof (theValue_3) !== "undefined" && theValue_3 != null)) {
+                        const newObj_3 = CodeNodeLiteral.fromDictionary((theValue_3));
+                        obj.props[item_1] = newObj_3;
+                    }
+                    key_i = key_i + 1;
+                }
+                ;
+            }
+            const values_2 = (dict["prop_keys"] instanceof Array) ? dict["prop_keys"] : undefined;
+            if ((typeof (values_2) !== "undefined" && values_2 != null)) {
+                const arr_1 = values_2;
+                const arr_len_1 = arr_1.length;
+                let arr_i_1 = 0;
+                while (arr_i_1 < arr_len_1) {
+                    const item_2 = arr_1[arr_i_1];
+                    if (typeof (item_2) === 'string') /* union case for string */ {
+                        var oo_1 = item_2;
+                        obj.prop_keys.push(oo_1);
+                    }
+                    ;
+                    arr_i_1 = arr_i_1 + 1;
+                }
+                ;
+            }
+            const values_3 = (dict["comments"] instanceof Array) ? dict["comments"] : undefined;
+            if ((typeof (values_3) !== "undefined" && values_3 != null)) {
+                const arr_2 = values_3;
+                const arr_len_2 = arr_2.length;
+                let arr_i_2 = 0;
+                while (arr_i_2 < arr_len_2) {
+                    const item_3 = arr_2[arr_i_2];
+                    if (item_3 instanceof Object) /* union case */ {
+                        var oo_2 = item_3;
+                        const newObj_4 = CodeNodeLiteral.fromDictionary(oo_2);
+                        obj.comments.push(newObj_4);
+                    }
+                    ;
+                    arr_i_2 = arr_i_2 + 1;
+                }
+                ;
+            }
+            const values_4 = (dict["children"] instanceof Array) ? dict["children"] : undefined;
+            if ((typeof (values_4) !== "undefined" && values_4 != null)) {
+                const arr_3 = values_4;
+                const arr_len_3 = arr_3.length;
+                let arr_i_3 = 0;
+                while (arr_i_3 < arr_len_3) {
+                    const item_4 = arr_3[arr_i_3];
+                    if (item_4 instanceof Object) /* union case */ {
+                        var oo_3 = item_4;
+                        const newObj_5 = CodeNodeLiteral.fromDictionary(oo_3);
+                        obj.children.push(newObj_5);
+                    }
+                    ;
+                    arr_i_3 = arr_i_3 + 1;
+                }
+                ;
+            }
+            const values_5 = (dict["attrs"] instanceof Array) ? dict["attrs"] : undefined;
+            if ((typeof (values_5) !== "undefined" && values_5 != null)) {
+                const arr_4 = values_5;
+                const arr_len_4 = arr_4.length;
+                let arr_i_4 = 0;
+                while (arr_i_4 < arr_len_4) {
+                    const item_5 = arr_4[arr_i_4];
+                    if (item_5 instanceof Object) /* union case */ {
+                        var oo_4 = item_5;
+                        const newObj_6 = CodeNodeLiteral.fromDictionary(oo_4);
+                        obj.attrs.push(newObj_6);
+                    }
+                    ;
+                    arr_i_4 = arr_i_4 + 1;
+                }
+                ;
+            }
+        }
+        catch (e) {
+        }
+        return obj;
     }
     ;
 }
@@ -9000,7 +9052,7 @@ class RangerSerializeClass {
         if (nn.value_type == 6) {
             if (this.canSerializeClass(nn.array_type, ctx)) {
                 wr.out("def values:JSONArrayObject (json_array)", true);
-                wr.out(((("for this." + pvar.compiledName) + " item:") + nn.array_type) + " i {", true);
+                wr.out(((("for this." + pvar.name) + " item:") + nn.array_type) + " i {", true);
                 wr.indent(1);
                 wr.out("def obj@(lives):JSONDataObject (item.toDictionary())", true);
                 wr.out("push values obj", true);
@@ -9010,7 +9062,7 @@ class RangerSerializeClass {
             }
             else {
                 wr.out("def values:JSONArrayObject (json_array)", true);
-                wr.out(((("for this." + pvar.compiledName) + " item:") + nn.array_type) + " i {", true);
+                wr.out(((("for this." + pvar.name) + " item:") + nn.array_type) + " i {", true);
                 wr.indent(1);
                 wr.out("push values item", true);
                 wr.indent(-1);
@@ -9022,10 +9074,10 @@ class RangerSerializeClass {
         if (nn.value_type == 7) {
             if (this.canSerializeClass(nn.array_type, ctx)) {
                 wr.out("def values:JSONDataObject (json_object)", true);
-                wr.out(("def keyList (keys this." + pvar.compiledName) + ")", true);
+                wr.out(("def keyList (keys this." + pvar.name) + ")", true);
                 wr.out("for keyList keyname:string index {", true);
                 wr.indent(1);
-                wr.out(("def item (unwrap (get this." + pvar.compiledName) + " keyname))", true);
+                wr.out(("def item (unwrap (get this." + pvar.name) + " keyname))", true);
                 if (ctx.isDefinedClass(nn.array_type)) {
                     wr.out("def obj@(lives):JSONDataObject (item.toDictionary())", true);
                     wr.out("set values keyname obj ", true);
@@ -9040,10 +9092,10 @@ class RangerSerializeClass {
             else {
                 if (ctx.isDefinedClass(nn.array_type) == false) {
                     wr.out("def values:JSONDataObject (json_object)", true);
-                    wr.out(("def keyList (keys this." + pvar.compiledName) + ")", true);
+                    wr.out(("def keyList (keys this." + pvar.name) + ")", true);
                     wr.out("for keyList keyname:string index {", true);
                     wr.indent(1);
-                    wr.out(("def item (unwrap (get this." + pvar.compiledName) + " keyname))", true);
+                    wr.out(("def item (unwrap (get this." + pvar.name) + " keyname))", true);
                     wr.out("set values keyname item ", true);
                     wr.indent(-1);
                     wr.out("}", true);
@@ -9054,18 +9106,18 @@ class RangerSerializeClass {
         }
         if (nn.hasFlag("optional")) {
             if (ctx.isDefinedClass(nn.type_name) == false) {
-                wr.out(((("set res  \"" + pvar.name) + "\" (unwrap this.") + pvar.compiledName) + ") ", true);
+                wr.out(((("set res  \"" + pvar.name) + "\" (unwrap this.") + pvar.name) + ") ", true);
             }
             else {
-                wr.out(((("set res  \"" + pvar.name) + "\" (call (unwrap this.") + pvar.compiledName) + ") toDictionary ()) ", true);
+                wr.out(((("set res  \"" + pvar.name) + "\" (call (unwrap this.") + pvar.name) + ") toDictionary ()) ", true);
             }
         }
         else {
             if (ctx.isDefinedClass(nn.type_name) == false) {
-                wr.out(((("set res  \"" + pvar.name) + "\" (this.") + pvar.compiledName) + ") ", true);
+                wr.out(((("set res  \"" + pvar.name) + "\" (this.") + pvar.name) + ") ", true);
             }
             else {
-                wr.out(((("set res  \"" + pvar.name) + "\" (this.") + pvar.compiledName) + ".toDictionary()) ", true);
+                wr.out(((("set res  \"" + pvar.name) + "\" (this.") + pvar.name) + ".toDictionary()) ", true);
             }
         }
     }
@@ -9077,16 +9129,20 @@ class RangerSerializeClass {
                 wr.out("if(!null? values) {", true);
                 wr.indent(1);
                 wr.out("def arr (unwrap values)", true);
-                wr.out("arr.forEach({", true);
+                wr.out("def arr_len (array_length arr)", true);
+                wr.out("def arr_i 0", true);
+                wr.out("while (arr_i < arr_len) {", true);
                 wr.indent(1);
+                wr.out("def item (getValue arr arr_i)", true);
                 wr.out("case item oo:JSONDataObject {", true);
                 wr.indent(1);
                 wr.out(("def newObj (" + nn.array_type) + ".fromDictionary(oo))", true);
                 wr.out(("push obj." + pvar.name) + " newObj", true);
                 wr.indent(-1);
                 wr.out("}", true);
+                wr.out("arr_i = arr_i + 1", true);
                 wr.indent(-1);
-                wr.out("})", true);
+                wr.out("}", true);
                 wr.indent(-1);
                 wr.out("}", true);
             }
@@ -9095,15 +9151,19 @@ class RangerSerializeClass {
                 wr.out("if(!null? values) {", true);
                 wr.indent(1);
                 wr.out("def arr (unwrap values)", true);
-                wr.out("arr.forEach({", true);
+                wr.out("def arr_len (array_length arr)", true);
+                wr.out("def arr_i 0", true);
+                wr.out("while (arr_i < arr_len) {", true);
                 wr.indent(1);
+                wr.out("def item (getValue arr arr_i)", true);
                 wr.out(("case item oo:" + nn.array_type) + " {", true);
                 wr.indent(1);
                 wr.out(("push obj." + pvar.name) + " oo", true);
                 wr.indent(-1);
                 wr.out("}", true);
+                wr.out("arr_i = arr_i + 1", true);
                 wr.indent(-1);
-                wr.out("})", true);
+                wr.out("}", true);
                 wr.indent(-1);
                 wr.out("}", true);
             }
@@ -9116,8 +9176,11 @@ class RangerSerializeClass {
                 wr.indent(1);
                 wr.out(("def theObj" + pvar.name) + " (unwrap values)", true);
                 wr.out(("def obj_keys (keys theObj" + pvar.name) + ")", true);
-                wr.out("obj_keys.forEach({", true);
+                wr.out("def key_len (array_length obj_keys)", true);
+                wr.out("def key_i 0", true);
+                wr.out("while (key_i < key_len) {", true);
                 wr.indent(1);
+                wr.out("def item (itemAt obj_keys key_i)", true);
                 if (ctx.isDefinedClass(nn.array_type)) {
                     wr.out(("def theValue (getObject theObj" + pvar.name) + " item ) ", true);
                     wr.out("if(!null? theValue) {", true);
@@ -9129,8 +9192,9 @@ class RangerSerializeClass {
                 }
                 else {
                 }
+                wr.out("key_i = key_i + 1", true);
                 wr.indent(-1);
-                wr.out("})", true);
+                wr.out("}", true);
                 wr.indent(-1);
                 wr.out("}", true);
             }
@@ -9140,8 +9204,11 @@ class RangerSerializeClass {
                 wr.indent(1);
                 wr.out(("def theObj" + pvar.name) + " (unwrap values)", true);
                 wr.out(("def obj_keys (keys theObj" + pvar.name) + ")", true);
-                wr.out("obj_keys.forEach({", true);
+                wr.out("def key_len (array_length obj_keys)", true);
+                wr.out("def key_i 0", true);
+                wr.out("while (key_i < key_len) {", true);
                 wr.indent(1);
+                wr.out("def item (itemAt obj_keys key_i)", true);
                 if (ctx.isDefinedClass(nn.array_type)) {
                 }
                 else {
@@ -9181,8 +9248,9 @@ class RangerSerializeClass {
                     }
                     ;
                 }
+                wr.out("key_i = key_i + 1", true);
                 wr.indent(-1);
-                wr.out("})", true);
+                wr.out("}", true);
                 wr.indent(-1);
                 wr.out("}", true);
             }
@@ -9302,7 +9370,7 @@ class RangerSerializeClass {
             const nn_2 = pvar_2.nameNode;
             if (nn_2.hasFlag("optional")) {
                 wr.out("; optional variable", true);
-                wr.out(("if (!null? this." + pvar_2.compiledName) + ") {", true);
+                wr.out(("if (!null? this." + pvar_2.name) + ") {", true);
                 wr.indent(1);
                 this.createWRWriter2(pvar_2, nn_2, ctx, wr);
                 wr.indent(-1);
@@ -22220,6 +22288,12 @@ class RangerRustClassWriter extends RangerGenericClassWriter {
             if (tc.is_extended_by_children) {
                 return ("Rc<RefCell<dyn " + type_string) + "Trait>>";
             }
+            if (tc.is_system) {
+                const sysName = (tc.systemNames.hasOwnProperty("rust") ? tc.systemNames["rust"] : undefined);
+                if ((typeof (sysName) !== "undefined" && sysName != null)) {
+                    return sysName;
+                }
+            }
         }
         return type_string;
     }
@@ -22377,7 +22451,7 @@ class RangerRustClassWriter extends RangerGenericClassWriter {
                             wr.out(("Rc<RefCell<dyn " + node.type_name) + "Trait>>", false);
                         }
                         else {
-                            wr.out(this.getTypeString(node.type_name), false);
+                            wr.out(this.getObjectTypeString(node.type_name, ctx), false);
                         }
                     }
                     else {
@@ -24235,16 +24309,17 @@ class RangerRustClassWriter extends RangerGenericClassWriter {
             ctx.setCurrentClass(cl);
             const wr = orig_wr;
             if (this.fileHeaderWritten == false) {
-                wr.out("#![allow(unused_parens)]", true);
-                wr.out("#![allow(unused_mut)]", true);
-                wr.out("#![allow(unused_variables)]", true);
-                wr.out("#![allow(non_snake_case)]", true);
-                wr.out("#![allow(dead_code)]", true);
-                wr.out("", true);
-                wr.out("use std::rc::Rc;", true);
-                wr.out("use std::rc::Weak;", true);
-                wr.out("use std::cell::RefCell;", true);
-                wr.out("", true);
+                const header = wr.getTag("before_imports");
+                header.out("#![allow(unused_parens)]", true);
+                header.out("#![allow(unused_mut)]", true);
+                header.out("#![allow(unused_variables)]", true);
+                header.out("#![allow(non_snake_case)]", true);
+                header.out("#![allow(dead_code)]", true);
+                header.out("", true);
+                header.out("use std::rc::Rc;", true);
+                header.out("use std::rc::Weak;", true);
+                header.out("use std::cell::RefCell;", true);
+                header.out("", true);
                 this.fileHeaderWritten = true;
             }
             let hasTraitObjectField = false;
@@ -24326,8 +24401,14 @@ class RangerRustClassWriter extends RangerGenericClassWriter {
                             wr.out(this.adjustType(pvar_2.compiledName) + ": Vec::new(), ", true);
                         }
                         else {
-                            if (pvar_2.is_optional) {
-                                wr.out(this.adjustType(pvar_2.compiledName) + ": None, ", true);
+                            if (pvar_2.isHash()) {
+                                wr.out(this.adjustType(pvar_2.compiledName) + ": HashMap::new(), ", true);
+                                wr.addImport("std::collections::HashMap");
+                            }
+                            else {
+                                if (pvar_2.is_optional) {
+                                    wr.out(this.adjustType(pvar_2.compiledName) + ": None, ", true);
+                                }
                             }
                         }
                     }
@@ -30550,8 +30631,13 @@ class RangerPythonClassWriter extends RangerGenericClassWriter {
                     if (nn.value_type == 6) {
                         wr.out(" = []", false);
                     }
-                    if (nn.value_type == 7) {
-                        wr.out(" = {}", false);
+                    else {
+                        if (nn.value_type == 7) {
+                            wr.out(" = {}", false);
+                        }
+                        else {
+                            wr.out(" = None", false);
+                        }
                     }
                 }
                 wr.newline();
@@ -30683,6 +30769,52 @@ class RangerPythonClassWriter extends RangerGenericClassWriter {
                 yield this.WalkNode(item, lambdaCtx, wr);
             }
             ;
+        });
+    }
+    ;
+    getPythonTypeName(node, ctx) {
+        let v_type = node.value_type;
+        if (((v_type == 10) || (v_type == 11)) || (v_type == 0)) {
+            v_type = node.typeNameAsType(ctx);
+        }
+        if (node.eval_type != 0) {
+            v_type = node.eval_type;
+        }
+        switch (v_type) {
+            case 3:
+                return "int";
+            case 13:
+                return "int";
+            case 14:
+                return "int";
+            case 2:
+                return "float";
+            case 4:
+                return "str";
+            case 5:
+                return "bool";
+            case 6:
+                return "list";
+            case 7:
+                return "dict";
+        }
+        ;
+        const tn = node.type_name;
+        if (ctx.isDefinedClass(tn)) {
+            const cc = ctx.findClass(tn);
+            if (cc.is_system) {
+                const sysName = (cc.systemNames.hasOwnProperty("python") ? cc.systemNames["python"] : undefined);
+                if ((typeof (sysName) !== "undefined" && sysName != null)) {
+                    return sysName;
+                }
+            }
+        }
+        return tn;
+    }
+    ;
+    writeTypeDef(node, ctx, wr) {
+        return __awaiter(this, void 0, void 0, function* () {
+            wr.out(this.getPythonTypeName(node, ctx), false);
         });
     }
     ;
@@ -47352,40 +47484,6 @@ class operatorsOf_41 {
         return __awaiter(this, void 0, void 0, function* () {
             const parser = new RangerFlowParser();
             return yield parser.CreateFunctionObject(node, ctx, wr);
-        });
-    }
-    ;
-}
-class operatorsOfJSONArrayObject_57 {
-    constructor() {
-    }
-    static forEach_58(__self, cb) {
-        let cnt = __self.length;
-        let i_32 = 0;
-        while (cnt > 0) {
-            const value_8 = __self[i_32];
-            cb(value_8, i_32);
-            cnt = cnt - 1;
-            i_32 = i_32 + 1;
-        }
-        ;
-    }
-    ;
-}
-class operatorsOf_57 {
-    constructor() {
-    }
-    static forEach_58(__self, cb) {
-        return __awaiter(this, void 0, void 0, function* () {
-            let cnt_1 = __self.length;
-            let i_33 = 0;
-            while (cnt_1 > 0) {
-                const value_9 = __self[i_33];
-                yield cb(value_9, i_33);
-                cnt_1 = cnt_1 - 1;
-                i_33 = i_33 + 1;
-            }
-            ;
         });
     }
     ;

--- a/dist/lib/JSON.rgr
+++ b/dist/lib/JSON.rgr
@@ -7,6 +7,16 @@
 ; https://msdn.microsoft.com/en-us/library/system.json.jsonobject(v=vs.95).aspx
 
 
+; Python and Rust hold the same three shapes as every other target: an object,
+; an array and a value that is one of the two plus the scalars.
+;
+; Python has the shapes in the language, so the mapping is dict / list / object
+; and the `json` module of the standard library reads and writes the text.
+;
+; Rust has no JSON type in the standard library and the target writes code that
+; `rustc` builds without a crate, so the value is the RJson enum that the
+; polyfills below declare. An object is a HashMap of it and an array is a Vec of
+; it, both spelled in full so that no `use` line is needed.
 systemclass JSONDataObject {
     es6 Object
     java7 JSONObject ( (imp "org.json.JSONObject") )
@@ -14,6 +24,8 @@ systemclass JSONDataObject {
     go "map[string]interface{}"
     swift3 '[String:Any]'
     swift6 '[String:Any]'
+    python dict
+    rust "std::collections::HashMap<String, RJson>"
 }
 
 systemclass JSONArrayObject {
@@ -23,6 +35,8 @@ systemclass JSONArrayObject {
     go "[]interface{}"
     swift3 '[Any]'
     swift6 '[Any]'
+    python list
+    rust "Vec<RJson>"
 }
 
 systemclass JSONKeyValue {
@@ -36,6 +50,8 @@ systemclass JSONValueUnion {
     go "interface{}"
     swift3 Any
     swift6 Any
+    python object
+    rust RJson
 }
 
 systemunion JSONValueUnion ( JSONDataObject JSONArrayObject string int double boolean )
@@ -75,7 +91,9 @@ operators {
                 "console.log(JSON.stringify(" (e 1) "));" nl
             )
             java7 @macro(true) ("print (to_string " (e 1) " )" (imp "org.json.JSONObject"))
-        }        
+            python ( "print(json.dumps(" (e 1) "))" (imp "json") )
+            rust @macro(true) ("print (to_string " (e 1) " )")
+        }
     }
 
     getStr _@(optional):string (e:JSONDataObject key:string) {
@@ -138,13 +156,25 @@ func r_get_opt_json_string( data map[string]interface{}, key string ) *GoNullabl
     res.has_value = false
     return res
 }
-")            
+")
 
+            )
+            python ( "(lambda v: v if isinstance(v, str) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_str(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_str(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<String> {
+    match o.get(k) { Some(RJson::Str(v)) => Some(v.clone()), _ => None }
+}
+")
             )
 
 
-        }                
-    } 
+        }
+    }
 
     getInt _@(optional):int (e:JSONDataObject key:string) {
          templates {
@@ -172,12 +202,24 @@ func r_get_opt_json_int( data map[string]interface{}, key string ) *GoNullable  
     res.has_value = false
     return res
 }
-")            
+")
 
             )
-            
-        }                
-    } 
+            python ( "(lambda v: v if isinstance(v, int) and not isinstance(v, bool) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_int(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_int(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<i64> {
+    match o.get(k) { Some(RJson::Int(v)) => Some(*v), Some(RJson::Double(v)) => Some(*v as i64), _ => None }
+}
+")
+            )
+
+        }
+    }
 
     getDouble _@(optional):double (e:JSONDataObject key:string) {
          templates {
@@ -205,12 +247,24 @@ func r_get_opt_json_double( data map[string]interface{}, key string ) *GoNullabl
     res.has_value = false
     return res
 }
-")            
+")
 
             )
-            
-        }                
-    } 
+            python ( "(lambda v: float(v) if isinstance(v, (int, float)) and not isinstance(v, bool) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_double(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_double(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<f64> {
+    match o.get(k) { Some(RJson::Double(v)) => Some(*v), Some(RJson::Int(v)) => Some(*v as f64), _ => None }
+}
+")
+            )
+
+        }
+    }
 
     getBoolean _@(optional):boolean (e:JSONDataObject key:string) {
          templates {
@@ -238,11 +292,23 @@ func r_get_opt_json_bool( data map[string]interface{}, key string ) *GoNullable 
     res.has_value = false
     return res
 }
-")            
+")
 
             )
-        }                
-    } 
+            python ( "(lambda v: v if isinstance(v, bool) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_bool(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_bool(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<bool> {
+    match o.get(k) { Some(RJson::Bool(v)) => Some(*v), _ => None }
+}
+")
+            )
+        }
+    }
 
     getObject _@(optional):JSONDataObject (e:JSONDataObject key:string) {
          templates {
@@ -286,11 +352,23 @@ func r_get_opt_json_obj( data map[string]interface{}, key string ) *GoNullable  
     res.has_value = false
     return res
 }
-")            
+")
 
             )
-        }                
-    } 
+            python ( "(lambda v: v if isinstance(v, dict) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_obj(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_obj(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<std::collections::HashMap<String, RJson>> {
+    match o.get(k) { Some(RJson::Obj(v)) => Some(v.clone()), _ => None }
+}
+")
+            )
+        }
+    }
 
 
     ; todo: proper array detection for optionals
@@ -320,11 +398,23 @@ func r_get_opt_array( data map[string]interface{}, key string ) *GoNullable  {
     res.has_value = false
     return res
 }
-')            
+')
 
             )
-        }                
-    } 
+            python ( "(lambda v: v if isinstance(v, list) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_arr(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_arr(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<Vec<RJson>> {
+    match o.get(k) { Some(RJson::Arr(v)) => Some(v.clone()), _ => None }
+}
+")
+            )
+        }
+    }
 
     keys _:[string] (e:JSONDataObject) {
         templates {
@@ -383,6 +473,13 @@ static ArrayList<String> __getJSONKeys(JSONObject obj)
                     "return strkeys" nl i "})()"
                 (imp "reflect"))
             php  ("array_keys(" (e 1) ")")
+            python ( "list(" (e 1) ".keys())" )
+            rust ( (e 1) ".keys().cloned().collect::<Vec<String>>()"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -400,7 +497,14 @@ func r_is_obj_array( data inteface{} ) bool {
     }
     return false
 }
-")            
+")
+            )
+            python ( "isinstance(" (e 1) ", list)" )
+            rust ( "matches!(&" (e 1) ", RJson::Arr(_))"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
             )
         }
     }
@@ -408,7 +512,19 @@ func r_is_obj_array( data inteface{} ) bool {
     asArray _@(optional):JSONArrayObject (e:JSONValueUnion) {
         templates {
             es6 ( (e 1) " instanceof Array ? " (e 1 ) " : undefined")
-        }        
+            python ( "(lambda v: v if isinstance(v, list) else None)(" (e 1) ")" )
+            rust ( "r_json_as_arr(&" (e 1) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_as_arr(v: &RJson) -> Option<Vec<RJson>> {
+    match v { RJson::Arr(a) => Some(a.clone()), _ => None }
+}
+")
+            )
+        }
     }
 
     getValue _:JSONValueUnion (e:JSONArrayObject index:int) {
@@ -438,19 +554,39 @@ static Object __getJSONValue(JSONArray o, Integer item)
             kotlin ( (e 1) ".get(" (e 2) ")")
             go ( (e 1) "[" (e 2) "]")
             php ( (e 1) "[" (e 2) "]")
+            python ( (e 1) "[" (e 2) "]")
+            rust ( "r_json_at(&" (e 1) ", " (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_at(a: &Vec<RJson>, i: i64) -> RJson {
+    if i < 0 || (i as usize) >= a.len() { return RJson::Null; }
+    a[i as usize].clone()
+}
+")
+            )
         }
     }
 
     array_length _:int (e:JSONArrayObject) {
         templates {
             ranger ("(array_length " (e 1) ")")
-            es6 ( (e 1) ".length") 
+            es6 ( (e 1) ".length")
             java7 ( (e 1) ".length()" )
             kotlin ( (e 1) ".length()" )
             swift3 ( (e 1) ".count")
             swift6 ( (e 1) ".count")
             go( "int64(len(" (e 1) "))" )
             php ( "count(" (e 1) ")" )
+            python ( "len(" (e 1) ")" )
+            rust ( "((" (e 1) ").len() as i64)"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -464,6 +600,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Int((" (e 3) ") as i64));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -477,6 +620,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Str((" (e 3) ").to_string()));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -490,6 +640,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Int(" (e 3) "));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -503,6 +660,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Double(" (e 3) "));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -516,6 +680,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Bool(" (e 3) "));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -529,6 +700,61 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            ; The value is one of the six members of the union, so the RJsonValue
+            ; trait picks the variant that fits the type the argument has.
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), (" (e 3) ").r_json_value());"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+trait RJsonValue { fn r_json_value(&self) -> RJson; }
+impl RJsonValue for i64 { fn r_json_value(&self) -> RJson { RJson::Int(*self) } }
+impl RJsonValue for i32 { fn r_json_value(&self) -> RJson { RJson::Int(*self as i64) } }
+impl RJsonValue for f64 { fn r_json_value(&self) -> RJson { RJson::Double(*self) } }
+impl RJsonValue for bool { fn r_json_value(&self) -> RJson { RJson::Bool(*self) } }
+impl RJsonValue for String { fn r_json_value(&self) -> RJson { RJson::Str(self.clone()) } }
+impl RJsonValue for str { fn r_json_value(&self) -> RJson { RJson::Str(self.to_string()) } }
+impl RJsonValue for Vec<RJson> { fn r_json_value(&self) -> RJson { RJson::Arr(self.clone()) } }
+impl RJsonValue for std::collections::HashMap<String, RJson> { fn r_json_value(&self) -> RJson { RJson::Obj(self.clone()) } }
+impl RJsonValue for RJson { fn r_json_value(&self) -> RJson { self.clone() } }
+")
+            )
+        }
+    }
+
+    ; Rust narrows a union by matching the enum variant, and the variant is not
+    ; the type name that `(typeof 2)` writes, so the generic `case` in stdlib.rgr
+    ; can not serve it. These two entries name the JSON shapes directly. A target
+    ; that has no template here does not match them and reaches the generic one.
+    case _@(newcontext):void ( arg@(union):JSONValueUnion item@(define):JSONDataObject code:block ) {
+        templates {
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Obj(" (e 2) ") = &" (e 1) " {" nl I
+                        "let mut " (e 2) " : std::collections::HashMap<String, RJson> = " (e 2) ".clone();" nl
+                        (block 3)
+                        nl i "}"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
+        }
+    }
+
+    case _@(newcontext):void ( arg@(union):JSONValueUnion item@(define):JSONArrayObject code:block ) {
+        templates {
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Arr(" (e 2) ") = &" (e 1) " {" nl I
+                        "let mut " (e 2) " : Vec<RJson> = " (e 2) ".clone();" nl
+                        (block 3)
+                        nl i "}"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -566,9 +792,108 @@ function r_json_to_array($str) {
 }
 "
 
-)            
+)
             )
-        }        
+            python ( "json.loads(" (e 1) ")" (imp "json") )
+            rust ( "r_json_parse_obj(&" (e 1) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_skip_ws(s: &[u8], i: &mut usize) {
+    while *i < s.len() && (s[*i] == 32 || s[*i] == 9 || s[*i] == 10 || s[*i] == 13) { *i += 1; }
+}
+fn r_json_read_string(s: &[u8], i: &mut usize) -> String {
+    let mut out: Vec<u8> = Vec::new();
+    *i += 1;
+    while *i < s.len() && s[*i] != 34 {
+        if s[*i] == 92 && (*i + 1) < s.len() {
+            *i += 1;
+            let e = s[*i];
+            if e == 110 { out.push(10); }
+            else if e == 116 { out.push(9); }
+            else if e == 114 { out.push(13); }
+            else if e == 98 { out.push(8); }
+            else if e == 102 { out.push(12); }
+            else if e == 117 {
+                let mut code: u32 = 0;
+                let mut k = 0;
+                while k < 4 && (*i + 1) < s.len() {
+                    *i += 1;
+                    code = code * 16 + (s[*i] as char).to_digit(16).unwrap_or(0);
+                    k += 1;
+                }
+                let mut buf = [0u8; 4];
+                let ch = char::from_u32(code).unwrap_or(63 as char);
+                out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+            }
+            else { out.push(e); }
+        } else {
+            out.push(s[*i]);
+        }
+        *i += 1;
+    }
+    *i += 1;
+    String::from_utf8_lossy(&out).to_string()
+}
+fn r_json_read_value(s: &[u8], i: &mut usize) -> RJson {
+    r_json_skip_ws(s, i);
+    if *i >= s.len() { return RJson::Null; }
+    let c = s[*i];
+    if c == 123 {
+        let mut o: std::collections::HashMap<String, RJson> = std::collections::HashMap::new();
+        *i += 1;
+        loop {
+            r_json_skip_ws(s, i);
+            if *i >= s.len() || s[*i] == 125 { *i += 1; break; }
+            if s[*i] == 44 { *i += 1; continue; }
+            if s[*i] != 34 { *i += 1; continue; }
+            let key = r_json_read_string(s, i);
+            r_json_skip_ws(s, i);
+            if *i < s.len() && s[*i] == 58 { *i += 1; }
+            let value = r_json_read_value(s, i);
+            o.insert(key, value);
+        }
+        return RJson::Obj(o);
+    }
+    if c == 91 {
+        let mut a: Vec<RJson> = Vec::new();
+        *i += 1;
+        loop {
+            r_json_skip_ws(s, i);
+            if *i >= s.len() || s[*i] == 93 { *i += 1; break; }
+            if s[*i] == 44 { *i += 1; continue; }
+            let value = r_json_read_value(s, i);
+            a.push(value);
+        }
+        return RJson::Arr(a);
+    }
+    if c == 34 { return RJson::Str(r_json_read_string(s, i)); }
+    if c == 116 { *i += 4; return RJson::Bool(true); }
+    if c == 102 { *i += 5; return RJson::Bool(false); }
+    if c == 110 { *i += 4; return RJson::Null; }
+    let start = *i;
+    let mut is_double = false;
+    while *i < s.len() {
+        let d = s[*i];
+        if d == 46 || d == 101 || d == 69 { is_double = true; }
+        if d == 44 || d == 125 || d == 93 || d == 32 || d == 10 || d == 13 || d == 9 { break; }
+        *i += 1;
+    }
+    let text = String::from_utf8_lossy(&s[start..*i]).to_string();
+    if is_double { RJson::Double(text.parse::<f64>().unwrap_or(0.0)) } else { RJson::Int(text.parse::<i64>().unwrap_or(0)) }
+}
+fn r_json_parse_obj(text: &str) -> std::collections::HashMap<String, RJson> {
+    let mut i: usize = 0;
+    match r_json_read_value(text.as_bytes(), &mut i) {
+        RJson::Obj(o) => o,
+        _ => std::collections::HashMap::new(),
+    }
+}
+")
+            )
+        }
     }
 
     to_string _:string (e:JSONDataObject) {
@@ -599,10 +924,70 @@ func __toJSONData ( data interface{} ) string {
 	b, _ := json.Marshal(data)
 	return string(b)
 }
-")            
+")
             )
             php ( "json_encode(" (e 1) ")")
-        }        
+            python ( "json.dumps(" (e 1) ")" (imp "json") )
+            rust ( "r_json_to_string(&RJson::Obj(" (e 1) ".clone()))"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_escape(s: &str, out: &mut String) {
+    out.push(34 as u8 as char);
+    for c in s.chars() {
+        let n = c as u32;
+        if n == 34 || n == 92 { out.push(92 as u8 as char); out.push(c); }
+        else if n == 10 { out.push(92 as u8 as char); out.push('n'); }
+        else if n == 13 { out.push(92 as u8 as char); out.push('r'); }
+        else if n == 9 { out.push(92 as u8 as char); out.push('t'); }
+        else if n < 0x20 {
+            out.push(92 as u8 as char);
+            out.push('u');
+            out.push_str(&format!(\"{:04x}\", n));
+        }
+        else { out.push(c); }
+    }
+    out.push(34 as u8 as char);
+}
+fn r_json_write(v: &RJson, out: &mut String) {
+    match v {
+        RJson::Null => out.push_str(\"null\"),
+        RJson::Bool(b) => out.push_str(if *b { \"true\" } else { \"false\" }),
+        RJson::Int(i) => out.push_str(&i.to_string()),
+        RJson::Double(d) => { if d.is_finite() { out.push_str(&format!(\"{}\", d)) } else { out.push_str(\"null\") } }
+        RJson::Str(s) => r_json_escape(s, out),
+        RJson::Arr(a) => {
+            out.push('[');
+            for (i, it) in a.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                r_json_write(it, out);
+            }
+            out.push(']');
+        }
+        RJson::Obj(o) => {
+            let mut keys: Vec<&String> = o.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                r_json_escape(k, out);
+                out.push(':');
+                r_json_write(&o[*k], out);
+            }
+            out.push('}');
+        }
+    }
+}
+fn r_json_to_string(v: &RJson) -> String {
+    let mut out = String::new();
+    r_json_write(v, &mut out);
+    out
+}
+")
+            )
+        }
     }
 
     to_string _:string (e:JSONArrayObject) {
@@ -621,10 +1006,70 @@ func __toJSONData ( data interface{} ) string {
 	b, _ := json.Marshal(data)
 	return string(b)
 }
-")            
+")
             )
             php ( "json_encode(" (e 1) ")")
-        }        
+            python ( "json.dumps(" (e 1) ")" (imp "json") )
+            rust ( "r_json_to_string(&RJson::Arr(" (e 1) ".clone()))"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_escape(s: &str, out: &mut String) {
+    out.push(34 as u8 as char);
+    for c in s.chars() {
+        let n = c as u32;
+        if n == 34 || n == 92 { out.push(92 as u8 as char); out.push(c); }
+        else if n == 10 { out.push(92 as u8 as char); out.push('n'); }
+        else if n == 13 { out.push(92 as u8 as char); out.push('r'); }
+        else if n == 9 { out.push(92 as u8 as char); out.push('t'); }
+        else if n < 0x20 {
+            out.push(92 as u8 as char);
+            out.push('u');
+            out.push_str(&format!(\"{:04x}\", n));
+        }
+        else { out.push(c); }
+    }
+    out.push(34 as u8 as char);
+}
+fn r_json_write(v: &RJson, out: &mut String) {
+    match v {
+        RJson::Null => out.push_str(\"null\"),
+        RJson::Bool(b) => out.push_str(if *b { \"true\" } else { \"false\" }),
+        RJson::Int(i) => out.push_str(&i.to_string()),
+        RJson::Double(d) => { if d.is_finite() { out.push_str(&format!(\"{}\", d)) } else { out.push_str(\"null\") } }
+        RJson::Str(s) => r_json_escape(s, out),
+        RJson::Arr(a) => {
+            out.push('[');
+            for (i, it) in a.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                r_json_write(it, out);
+            }
+            out.push(']');
+        }
+        RJson::Obj(o) => {
+            let mut keys: Vec<&String> = o.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                r_json_escape(k, out);
+                out.push(':');
+                r_json_write(&o[*k], out);
+            }
+            out.push('}');
+        }
+    }
+}
+fn r_json_to_string(v: &RJson) -> String {
+    let mut out = String::new();
+    r_json_write(v, &mut out);
+    out
+}
+")
+            )
+        }
     }
 
     push _@(moves@( 2 1 ) ):void ( e@(mutates):JSONArrayObject el:JSONArrayUnion) {
@@ -637,7 +1082,26 @@ func __toJSONData ( data interface{} ) string {
             swift6 ( (e 1) ".append(" (e 2) ");")
             go( (e 1) " = append(" (e 1) "," (e 2) ")")
             php ( "array_push(" (e 1) ", " (e 2) ");")
-        }           
+            python ( (e 1) ".append(" (e 2) ")")
+            rust ( (e 1) ".push((" (e 2) ").r_json_value());"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+trait RJsonValue { fn r_json_value(&self) -> RJson; }
+impl RJsonValue for i64 { fn r_json_value(&self) -> RJson { RJson::Int(*self) } }
+impl RJsonValue for i32 { fn r_json_value(&self) -> RJson { RJson::Int(*self as i64) } }
+impl RJsonValue for f64 { fn r_json_value(&self) -> RJson { RJson::Double(*self) } }
+impl RJsonValue for bool { fn r_json_value(&self) -> RJson { RJson::Bool(*self) } }
+impl RJsonValue for String { fn r_json_value(&self) -> RJson { RJson::Str(self.clone()) } }
+impl RJsonValue for str { fn r_json_value(&self) -> RJson { RJson::Str(self.to_string()) } }
+impl RJsonValue for Vec<RJson> { fn r_json_value(&self) -> RJson { RJson::Arr(self.clone()) } }
+impl RJsonValue for std::collections::HashMap<String, RJson> { fn r_json_value(&self) -> RJson { RJson::Obj(self.clone()) } }
+impl RJsonValue for RJson { fn r_json_value(&self) -> RJson { self.clone() } }
+")
+            )
+        }
     }
     json_array json@(expands):JSONArrayObject () {
         templates {
@@ -649,7 +1113,14 @@ func __toJSONData ( data interface{} ) string {
             kotlin ("JSONArray()")
             go ( "make([]interface{},0)" )
             php ( "array()" )
-        }        
+            python ( "[]" )
+            rust ( "Vec::<RJson>::new()"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
+        }
     }
     json_object json:JSONDataObject () {
         templates {
@@ -661,7 +1132,14 @@ func __toJSONData ( data interface{} ) string {
             kotlin ("JSONObject()")
             go ( "make(map[string]interface{})" )
             php ( "array()")
-        }        
+            python ( "{}" )
+            rust ( "std::collections::HashMap::<String, RJson>::new()"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
+        }
     }
     json_array json@(expands):JSONArrayObject ( e@(block):JSONArrayUnion ) {
         templates {
@@ -672,7 +1150,8 @@ func __toJSONData ( data interface{} ) string {
             java7 ("new JSONArray" (imp "org.json.JSONArray") (plugin 'maven' (  (dep 'org.json' 'json' '20171018'  ) ) ))
             go ( "make([]interface{},0)" )
             php ( "array()" )
-        }        
+            python ("[" ( repeat_from 1 (  (block 1) ) ) "]")
+        }
     }
     json_obj json@(expands):JSONDataObject ( e@(block):JSONObjectUnion ) {
         templates {

--- a/dist/lib/stdlib.rgr
+++ b/dist/lib/stdlib.rgr
@@ -26,6 +26,18 @@ operators {
                         (block 3)
                         nl i "}"
             )
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", bool):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            )
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Bool(" (e 2) ") = &" (e 1) " {" nl I
+                        "let " (e 2) " : bool = *" (e 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            )
         }
     }
     case             _@(newcontext):void           ( arg@(union):T item2@(define):int code:block )  {
@@ -45,6 +57,18 @@ operators {
             kotlin (
                 (forkctx _ ) (def 2) "if( " (e 1) " is Int ) /* union case for int */ {" nl I
                         "val " (e 2) " : Int = " (e 1) " as Int;" nl
+                        (block 3)
+                        nl i "}"
+            )
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", int) and not isinstance(" (e 1) ", bool):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            )
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Int(" (e 2) ") = &" (e 1) " {" nl I
+                        "let " (e 2) " : i64 = *" (e 2) ";" nl
                         (block 3)
                         nl i "}"
             )
@@ -70,6 +94,18 @@ operators {
                         (block 3)
                         nl i "}"
             )
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", float):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            )
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Double(" (e 2) ") = &" (e 1) " {" nl I
+                        "let " (e 2) " : f64 = *" (e 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            )
         }
     }
 
@@ -90,6 +126,18 @@ operators {
             kotlin (
                 (forkctx _ ) (def 2) "if( " (e 1) " is String ) /* union case for string */ {" nl I
                         "val " (e 2) " : String = " (e 1) " as String;" nl
+                        (block 3)
+                        nl i "}"
+            )
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", str):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            )
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Str(" (e 2) ") = &" (e 1) " {" nl I
+                        "let " (e 2) " : String = " (e 2) ".clone();" nl
                         (block 3)
                         nl i "}"
             )
@@ -157,6 +205,12 @@ operators {
                         "val " (e 2) " : " (typeof 2) " = " (e 1) " as " (typeof 2) ";" nl
                         (block 3)
                         nl i "}"
+            ) 
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", " (typeof 2) "):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
             ) 
             cpp (
                 (forkctx _ ) (def 2) "if( mpark::holds_alternative<" (typeof 2) ">(" (e 1) ") ) {" nl I

--- a/dist/rgrc.js
+++ b/dist/rgrc.js
@@ -66,41 +66,53 @@ class CmdParams  {
     return res;
   };
 }
-CmdParams.fromDictionary = async function(dict) {
+CmdParams.fromDictionary = function(dict) {
   const obj = new CmdParams();
   try {
     const values = (dict["flags"] instanceof Object ) ? dict ["flags"] : undefined ;
     if ( (typeof(values) !== "undefined" && values != null )  ) {
       const theObjflags = values;
       const obj_keys = Object.keys(theObjflags);
-      await operatorsOf.forEach_12(obj_keys, ((item, index) => { 
+      const key_len = obj_keys.length;
+      let key_i = 0;
+      while (key_i < key_len) {
+        const item = obj_keys[key_i];
         const v = typeof(theObjflags [item]) === "undefined" ? undefined :(theObjflags [item]) ;
         if ( (typeof(v) !== "undefined" && v != null )  ) {
           obj.flags[item] = v;
         }
-      }));
+        key_i = key_i + 1;
+      };
     }
     const values_1 = (dict["params"] instanceof Object ) ? dict ["params"] : undefined ;
     if ( (typeof(values_1) !== "undefined" && values_1 != null )  ) {
       const theObjparams = values_1;
       const obj_keys_1 = Object.keys(theObjparams);
-      await operatorsOf.forEach_12(obj_keys_1, ((item, index) => { 
-        const v_1 = (typeof (theObjparams [item]) != "string" ) ? undefined : theObjparams [item] 
+      const key_len_1 = obj_keys_1.length;
+      let key_i_1 = 0;
+      while (key_i_1 < key_len_1) {
+        const item_1 = obj_keys_1[key_i_1];
+        const v_1 = (typeof (theObjparams [item_1]) != "string" ) ? undefined : theObjparams [item_1] 
         ;
         if ( (typeof(v_1) !== "undefined" && v_1 != null )  ) {
-          obj.params[item] = v_1;
+          obj.params[item_1] = v_1;
         }
-      }));
+        key_i_1 = key_i_1 + 1;
+      };
     }
     const values_2 = (dict["values"] instanceof Array ) ? dict ["values"] : undefined ;
     if ( (typeof(values_2) !== "undefined" && values_2 != null )  ) {
       const arr = values_2;
-      operatorsOfJSONArrayObject_57.forEach_58(arr, ((item, index) => { 
-        if( typeof(item) === 'string' ) /* union case for string */ {
-          var oo = item;
+      const arr_len = arr.length;
+      let arr_i = 0;
+      while (arr_i < arr_len) {
+        const item_2 = arr[arr_i];
+        if( typeof(item_2) === 'string' ) /* union case for string */ {
+          var oo = item_2;
           obj.values.push(oo);
         };
-      }));
+        arr_i = arr_i + 1;
+      };
     }
   } catch(e) {
   }
@@ -172,7 +184,7 @@ class InputFSFolder  {
     return res;
   };
 }
-InputFSFolder.fromDictionary = async function(dict) {
+InputFSFolder.fromDictionary = function(dict) {
   const obj = new InputFSFolder();
   try {
     const v = (typeof (dict ["name"]) != "string" ) ? undefined : dict ["name"] 
@@ -196,24 +208,32 @@ InputFSFolder.fromDictionary = async function(dict) {
     const values = (dict["folders"] instanceof Array ) ? dict ["folders"] : undefined ;
     if ( (typeof(values) !== "undefined" && values != null )  ) {
       const arr = values;
-      await operatorsOf_57.forEach_58(arr, (async (item, index) => { 
+      const arr_len = arr.length;
+      let arr_i = 0;
+      while (arr_i < arr_len) {
+        const item = arr[arr_i];
         if( item instanceof Object ) /* union case */ {
           var oo = item;
-          const newObj = await InputFSFolder.fromDictionary(oo);
+          const newObj = InputFSFolder.fromDictionary(oo);
           obj.folders.push(newObj);
         };
-      }));
+        arr_i = arr_i + 1;
+      };
     }
     const values_1 = (dict["files"] instanceof Array ) ? dict ["files"] : undefined ;
     if ( (typeof(values_1) !== "undefined" && values_1 != null )  ) {
       const arr_1 = values_1;
-      await operatorsOf_57.forEach_58(arr_1, ((item, index) => { 
-        if( item instanceof Object ) /* union case */ {
-          var oo_1 = item;
+      const arr_len_1 = arr_1.length;
+      let arr_i_1 = 0;
+      while (arr_i_1 < arr_len_1) {
+        const item_1 = arr_1[arr_i_1];
+        if( item_1 instanceof Object ) /* union case */ {
+          var oo_1 = item_1;
           const newObj_1 = InputFSFile.fromDictionary(oo_1);
           obj.files.push(newObj_1);
         };
-      }));
+        arr_i_1 = arr_i_1 + 1;
+      };
     }
   } catch(e) {
   }
@@ -294,7 +314,7 @@ class InputEnv  {
     return res;
   };
 }
-InputEnv.fromDictionary = async function(dict) {
+InputEnv.fromDictionary = function(dict) {
   const obj = new InputEnv();
   try {
     const v = typeof(dict ["use_real"]) === "undefined" ? undefined :(dict ["use_real"]) ;
@@ -303,24 +323,28 @@ InputEnv.fromDictionary = async function(dict) {
     }
     const theValue = (dict["filesystem"] instanceof Object ) ? dict ["filesystem"] : undefined ;
     if ( (typeof(theValue) !== "undefined" && theValue != null )  ) {
-      const newObj = await InputFSFolder.fromDictionary((theValue));
+      const newObj = InputFSFolder.fromDictionary((theValue));
       obj.filesystem = newObj;
     }
     const values = (dict["envVars"] instanceof Object ) ? dict ["envVars"] : undefined ;
     if ( (typeof(values) !== "undefined" && values != null )  ) {
       const theObjenvVars = values;
       const obj_keys = Object.keys(theObjenvVars);
-      await operatorsOf.forEach_12(obj_keys, ((item, index) => { 
+      const key_len = obj_keys.length;
+      let key_i = 0;
+      while (key_i < key_len) {
+        const item = obj_keys[key_i];
         const v_1 = (typeof (theObjenvVars [item]) != "string" ) ? undefined : theObjenvVars [item] 
         ;
         if ( (typeof(v_1) !== "undefined" && v_1 != null )  ) {
           obj.envVars[item] = v_1;
         }
-      }));
+        key_i = key_i + 1;
+      };
     }
     const theValue_1 = (dict["commandLine"] instanceof Object ) ? dict ["commandLine"] : undefined ;
     if ( (typeof(theValue_1) !== "undefined" && theValue_1 != null )  ) {
-      const newObj_1 = await CmdParams.fromDictionary((theValue_1));
+      const newObj_1 = CmdParams.fromDictionary((theValue_1));
       obj.commandLine = newObj_1;
     }
   } catch(e) {
@@ -1532,7 +1556,7 @@ class CodeNodeLiteral  {
     return res;
   };
 }
-CodeNodeLiteral.fromDictionary = async function(dict) {
+CodeNodeLiteral.fromDictionary = function(dict) {
   const obj = new CodeNodeLiteral();
   try {
     const v = typeof(dict ["expression"]) === "undefined" ? undefined :(dict ["expression"]) ;
@@ -1566,12 +1590,16 @@ CodeNodeLiteral.fromDictionary = async function(dict) {
     const values = (dict["ns"] instanceof Array ) ? dict ["ns"] : undefined ;
     if ( (typeof(values) !== "undefined" && values != null )  ) {
       const arr = values;
-      await operatorsOf_57.forEach_58(arr, ((item, index) => { 
+      const arr_len = arr.length;
+      let arr_i = 0;
+      while (arr_i < arr_len) {
+        const item = arr[arr_i];
         if( typeof(item) === 'string' ) /* union case for string */ {
           var oo = item;
           obj.ns.push(oo);
         };
-      }));
+        arr_i = arr_i + 1;
+      };
     }
     const v_6 = typeof(dict ["has_vref_annotation"]) === "undefined" ? undefined :(dict ["has_vref_annotation"]) ;
     if ( (typeof(v_6) !== "undefined" && v_6 != null )  ) {
@@ -1579,7 +1607,7 @@ CodeNodeLiteral.fromDictionary = async function(dict) {
     }
     const theValue = (dict["vref_annotation"] instanceof Object ) ? dict ["vref_annotation"] : undefined ;
     if ( (typeof(theValue) !== "undefined" && theValue != null )  ) {
-      const newObj = await CodeNodeLiteral.fromDictionary((theValue));
+      const newObj = CodeNodeLiteral.fromDictionary((theValue));
       obj.vref_annotation = newObj;
     }
     const v_7 = typeof(dict ["has_type_annotation"]) === "undefined" ? undefined :(dict ["has_type_annotation"]) ;
@@ -1588,7 +1616,7 @@ CodeNodeLiteral.fromDictionary = async function(dict) {
     }
     const theValue_1 = (dict["type_annotation"] instanceof Object ) ? dict ["type_annotation"] : undefined ;
     if ( (typeof(theValue_1) !== "undefined" && theValue_1 != null )  ) {
-      const newObj_1 = await CodeNodeLiteral.fromDictionary((theValue_1));
+      const newObj_1 = CodeNodeLiteral.fromDictionary((theValue_1));
       obj.type_annotation = newObj_1;
     }
     const v_8 = isNaN( parseFloat(dict ["double_value"]) ) ? undefined : parseFloat(dict ["double_value"]) 
@@ -1612,63 +1640,83 @@ CodeNodeLiteral.fromDictionary = async function(dict) {
     }
     const theValue_2 = (dict["expression_value"] instanceof Object ) ? dict ["expression_value"] : undefined ;
     if ( (typeof(theValue_2) !== "undefined" && theValue_2 != null )  ) {
-      const newObj_2 = await CodeNodeLiteral.fromDictionary((theValue_2));
+      const newObj_2 = CodeNodeLiteral.fromDictionary((theValue_2));
       obj.expression_value = newObj_2;
     }
     const values_1 = (dict["props"] instanceof Object ) ? dict ["props"] : undefined ;
     if ( (typeof(values_1) !== "undefined" && values_1 != null )  ) {
       const theObjprops = values_1;
       const obj_keys = Object.keys(theObjprops);
-      await operatorsOf.forEach_12(obj_keys, (async (item, index) => { 
-        const theValue_3 = (theObjprops[item] instanceof Object ) ? theObjprops [item] : undefined ;
+      const key_len = obj_keys.length;
+      let key_i = 0;
+      while (key_i < key_len) {
+        const item_1 = obj_keys[key_i];
+        const theValue_3 = (theObjprops[item_1] instanceof Object ) ? theObjprops [item_1] : undefined ;
         if ( (typeof(theValue_3) !== "undefined" && theValue_3 != null )  ) {
-          const newObj_3 = await CodeNodeLiteral.fromDictionary((theValue_3));
-          obj.props[item] = newObj_3;
+          const newObj_3 = CodeNodeLiteral.fromDictionary((theValue_3));
+          obj.props[item_1] = newObj_3;
         }
-      }));
+        key_i = key_i + 1;
+      };
     }
     const values_2 = (dict["prop_keys"] instanceof Array ) ? dict ["prop_keys"] : undefined ;
     if ( (typeof(values_2) !== "undefined" && values_2 != null )  ) {
       const arr_1 = values_2;
-      await operatorsOf_57.forEach_58(arr_1, ((item, index) => { 
-        if( typeof(item) === 'string' ) /* union case for string */ {
-          var oo_1 = item;
+      const arr_len_1 = arr_1.length;
+      let arr_i_1 = 0;
+      while (arr_i_1 < arr_len_1) {
+        const item_2 = arr_1[arr_i_1];
+        if( typeof(item_2) === 'string' ) /* union case for string */ {
+          var oo_1 = item_2;
           obj.prop_keys.push(oo_1);
         };
-      }));
+        arr_i_1 = arr_i_1 + 1;
+      };
     }
     const values_3 = (dict["comments"] instanceof Array ) ? dict ["comments"] : undefined ;
     if ( (typeof(values_3) !== "undefined" && values_3 != null )  ) {
       const arr_2 = values_3;
-      await operatorsOf_57.forEach_58(arr_2, (async (item, index) => { 
-        if( item instanceof Object ) /* union case */ {
-          var oo_2 = item;
-          const newObj_4 = await CodeNodeLiteral.fromDictionary(oo_2);
+      const arr_len_2 = arr_2.length;
+      let arr_i_2 = 0;
+      while (arr_i_2 < arr_len_2) {
+        const item_3 = arr_2[arr_i_2];
+        if( item_3 instanceof Object ) /* union case */ {
+          var oo_2 = item_3;
+          const newObj_4 = CodeNodeLiteral.fromDictionary(oo_2);
           obj.comments.push(newObj_4);
         };
-      }));
+        arr_i_2 = arr_i_2 + 1;
+      };
     }
     const values_4 = (dict["children"] instanceof Array ) ? dict ["children"] : undefined ;
     if ( (typeof(values_4) !== "undefined" && values_4 != null )  ) {
       const arr_3 = values_4;
-      await operatorsOf_57.forEach_58(arr_3, (async (item, index) => { 
-        if( item instanceof Object ) /* union case */ {
-          var oo_3 = item;
-          const newObj_5 = await CodeNodeLiteral.fromDictionary(oo_3);
+      const arr_len_3 = arr_3.length;
+      let arr_i_3 = 0;
+      while (arr_i_3 < arr_len_3) {
+        const item_4 = arr_3[arr_i_3];
+        if( item_4 instanceof Object ) /* union case */ {
+          var oo_3 = item_4;
+          const newObj_5 = CodeNodeLiteral.fromDictionary(oo_3);
           obj.children.push(newObj_5);
         };
-      }));
+        arr_i_3 = arr_i_3 + 1;
+      };
     }
     const values_5 = (dict["attrs"] instanceof Array ) ? dict ["attrs"] : undefined ;
     if ( (typeof(values_5) !== "undefined" && values_5 != null )  ) {
       const arr_4 = values_5;
-      await operatorsOf_57.forEach_58(arr_4, (async (item, index) => { 
-        if( item instanceof Object ) /* union case */ {
-          var oo_4 = item;
-          const newObj_6 = await CodeNodeLiteral.fromDictionary(oo_4);
+      const arr_len_4 = arr_4.length;
+      let arr_i_4 = 0;
+      while (arr_i_4 < arr_len_4) {
+        const item_5 = arr_4[arr_i_4];
+        if( item_5 instanceof Object ) /* union case */ {
+          var oo_4 = item_5;
+          const newObj_6 = CodeNodeLiteral.fromDictionary(oo_4);
           obj.attrs.push(newObj_6);
         };
-      }));
+        arr_i_4 = arr_i_4 + 1;
+      };
     }
   } catch(e) {
   }
@@ -8138,7 +8186,7 @@ class RangerSerializeClass  {
     if ( nn.value_type == 6 ) {
       if ( this.canSerializeClass(nn.array_type, ctx) ) {
         wr.out("def values:JSONArrayObject (json_array)", true);
-        wr.out(((("for this." + pvar.compiledName) + " item:") + nn.array_type) + " i {", true);
+        wr.out(((("for this." + pvar.name) + " item:") + nn.array_type) + " i {", true);
         wr.indent(1);
         wr.out("def obj@(lives):JSONDataObject (item.toDictionary())", true);
         wr.out("push values obj", true);
@@ -8147,7 +8195,7 @@ class RangerSerializeClass  {
         wr.out(("set res  \"" + pvar.name) + "\" values ", true);
       } else {
         wr.out("def values:JSONArrayObject (json_array)", true);
-        wr.out(((("for this." + pvar.compiledName) + " item:") + nn.array_type) + " i {", true);
+        wr.out(((("for this." + pvar.name) + " item:") + nn.array_type) + " i {", true);
         wr.indent(1);
         wr.out("push values item", true);
         wr.indent(-1);
@@ -8159,10 +8207,10 @@ class RangerSerializeClass  {
     if ( nn.value_type == 7 ) {
       if ( this.canSerializeClass(nn.array_type, ctx) ) {
         wr.out("def values:JSONDataObject (json_object)", true);
-        wr.out(("def keyList (keys this." + pvar.compiledName) + ")", true);
+        wr.out(("def keyList (keys this." + pvar.name) + ")", true);
         wr.out("for keyList keyname:string index {", true);
         wr.indent(1);
-        wr.out(("def item (unwrap (get this." + pvar.compiledName) + " keyname))", true);
+        wr.out(("def item (unwrap (get this." + pvar.name) + " keyname))", true);
         if ( ctx.isDefinedClass(nn.array_type) ) {
           wr.out("def obj@(lives):JSONDataObject (item.toDictionary())", true);
           wr.out("set values keyname obj ", true);
@@ -8175,10 +8223,10 @@ class RangerSerializeClass  {
       } else {
         if ( ctx.isDefinedClass(nn.array_type) == false ) {
           wr.out("def values:JSONDataObject (json_object)", true);
-          wr.out(("def keyList (keys this." + pvar.compiledName) + ")", true);
+          wr.out(("def keyList (keys this." + pvar.name) + ")", true);
           wr.out("for keyList keyname:string index {", true);
           wr.indent(1);
-          wr.out(("def item (unwrap (get this." + pvar.compiledName) + " keyname))", true);
+          wr.out(("def item (unwrap (get this." + pvar.name) + " keyname))", true);
           wr.out("set values keyname item ", true);
           wr.indent(-1);
           wr.out("}", true);
@@ -8189,15 +8237,15 @@ class RangerSerializeClass  {
     }
     if ( nn.hasFlag("optional") ) {
       if ( ctx.isDefinedClass(nn.type_name) == false ) {
-        wr.out(((("set res  \"" + pvar.name) + "\" (unwrap this.") + pvar.compiledName) + ") ", true);
+        wr.out(((("set res  \"" + pvar.name) + "\" (unwrap this.") + pvar.name) + ") ", true);
       } else {
-        wr.out(((("set res  \"" + pvar.name) + "\" (call (unwrap this.") + pvar.compiledName) + ") toDictionary ()) ", true);
+        wr.out(((("set res  \"" + pvar.name) + "\" (call (unwrap this.") + pvar.name) + ") toDictionary ()) ", true);
       }
     } else {
       if ( ctx.isDefinedClass(nn.type_name) == false ) {
-        wr.out(((("set res  \"" + pvar.name) + "\" (this.") + pvar.compiledName) + ") ", true);
+        wr.out(((("set res  \"" + pvar.name) + "\" (this.") + pvar.name) + ") ", true);
       } else {
-        wr.out(((("set res  \"" + pvar.name) + "\" (this.") + pvar.compiledName) + ".toDictionary()) ", true);
+        wr.out(((("set res  \"" + pvar.name) + "\" (this.") + pvar.name) + ".toDictionary()) ", true);
       }
     }
   };
@@ -8208,16 +8256,20 @@ class RangerSerializeClass  {
         wr.out("if(!null? values) {", true);
         wr.indent(1);
         wr.out("def arr (unwrap values)", true);
-        wr.out("arr.forEach({", true);
+        wr.out("def arr_len (array_length arr)", true);
+        wr.out("def arr_i 0", true);
+        wr.out("while (arr_i < arr_len) {", true);
         wr.indent(1);
+        wr.out("def item (getValue arr arr_i)", true);
         wr.out("case item oo:JSONDataObject {", true);
         wr.indent(1);
         wr.out(("def newObj (" + nn.array_type) + ".fromDictionary(oo))", true);
         wr.out(("push obj." + pvar.name) + " newObj", true);
         wr.indent(-1);
         wr.out("}", true);
+        wr.out("arr_i = arr_i + 1", true);
         wr.indent(-1);
-        wr.out("})", true);
+        wr.out("}", true);
         wr.indent(-1);
         wr.out("}", true);
       } else {
@@ -8225,15 +8277,19 @@ class RangerSerializeClass  {
         wr.out("if(!null? values) {", true);
         wr.indent(1);
         wr.out("def arr (unwrap values)", true);
-        wr.out("arr.forEach({", true);
+        wr.out("def arr_len (array_length arr)", true);
+        wr.out("def arr_i 0", true);
+        wr.out("while (arr_i < arr_len) {", true);
         wr.indent(1);
+        wr.out("def item (getValue arr arr_i)", true);
         wr.out(("case item oo:" + nn.array_type) + " {", true);
         wr.indent(1);
         wr.out(("push obj." + pvar.name) + " oo", true);
         wr.indent(-1);
         wr.out("}", true);
+        wr.out("arr_i = arr_i + 1", true);
         wr.indent(-1);
-        wr.out("})", true);
+        wr.out("}", true);
         wr.indent(-1);
         wr.out("}", true);
       }
@@ -8246,8 +8302,11 @@ class RangerSerializeClass  {
         wr.indent(1);
         wr.out(("def theObj" + pvar.name) + " (unwrap values)", true);
         wr.out(("def obj_keys (keys theObj" + pvar.name) + ")", true);
-        wr.out("obj_keys.forEach({", true);
+        wr.out("def key_len (array_length obj_keys)", true);
+        wr.out("def key_i 0", true);
+        wr.out("while (key_i < key_len) {", true);
         wr.indent(1);
+        wr.out("def item (itemAt obj_keys key_i)", true);
         if ( ctx.isDefinedClass(nn.array_type) ) {
           wr.out(("def theValue (getObject theObj" + pvar.name) + " item ) ", true);
           wr.out("if(!null? theValue) {", true);
@@ -8258,8 +8317,9 @@ class RangerSerializeClass  {
           wr.out("}", true);
         } else {
         }
+        wr.out("key_i = key_i + 1", true);
         wr.indent(-1);
-        wr.out("})", true);
+        wr.out("}", true);
         wr.indent(-1);
         wr.out("}", true);
       } else {
@@ -8268,8 +8328,11 @@ class RangerSerializeClass  {
         wr.indent(1);
         wr.out(("def theObj" + pvar.name) + " (unwrap values)", true);
         wr.out(("def obj_keys (keys theObj" + pvar.name) + ")", true);
-        wr.out("obj_keys.forEach({", true);
+        wr.out("def key_len (array_length obj_keys)", true);
+        wr.out("def key_i 0", true);
+        wr.out("while (key_i < key_len) {", true);
         wr.indent(1);
+        wr.out("def item (itemAt obj_keys key_i)", true);
         if ( ctx.isDefinedClass(nn.array_type) ) {
         } else {
           switch (nn.array_type ) { 
@@ -8307,8 +8370,9 @@ class RangerSerializeClass  {
               break;
           };
         }
+        wr.out("key_i = key_i + 1", true);
         wr.indent(-1);
-        wr.out("})", true);
+        wr.out("}", true);
         wr.indent(-1);
         wr.out("}", true);
       }
@@ -8422,7 +8486,7 @@ class RangerSerializeClass  {
       const nn_2 = pvar_2.nameNode;
       if ( nn_2.hasFlag("optional") ) {
         wr.out("; optional variable", true);
-        wr.out(("if (!null? this." + pvar_2.compiledName) + ") {", true);
+        wr.out(("if (!null? this." + pvar_2.name) + ") {", true);
         wr.indent(1);
         this.createWRWriter2(pvar_2, nn_2, ctx, wr);
         wr.indent(-1);
@@ -20252,6 +20316,12 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         if ( tc.is_extended_by_children ) {
           return ("Rc<RefCell<dyn " + type_string) + "Trait>>";
         }
+        if ( tc.is_system ) {
+          const sysName = ( tc.systemNames.hasOwnProperty("rust") ? tc.systemNames["rust"] : undefined );
+          if ( (typeof(sysName) !== "undefined" && sysName != null )  ) {
+            return sysName;
+          }
+        }
       }
       return type_string;
     };
@@ -20399,7 +20469,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             if ( tc_1.is_extended_by_children ) {
               wr.out(("Rc<RefCell<dyn " + node.type_name) + "Trait>>", false);
             } else {
-              wr.out(this.getTypeString(node.type_name), false);
+              wr.out(this.getObjectTypeString(node.type_name, ctx), false);
             }
           } else {
             wr.out(this.getTypeString(node.type_name), false);
@@ -22122,16 +22192,17 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       ctx.setCurrentClass(cl);
       const wr = orig_wr;
       if ( this.fileHeaderWritten == false ) {
-        wr.out("#![allow(unused_parens)]", true);
-        wr.out("#![allow(unused_mut)]", true);
-        wr.out("#![allow(unused_variables)]", true);
-        wr.out("#![allow(non_snake_case)]", true);
-        wr.out("#![allow(dead_code)]", true);
-        wr.out("", true);
-        wr.out("use std::rc::Rc;", true);
-        wr.out("use std::rc::Weak;", true);
-        wr.out("use std::cell::RefCell;", true);
-        wr.out("", true);
+        const header = wr.getTag("before_imports");
+        header.out("#![allow(unused_parens)]", true);
+        header.out("#![allow(unused_mut)]", true);
+        header.out("#![allow(unused_variables)]", true);
+        header.out("#![allow(non_snake_case)]", true);
+        header.out("#![allow(dead_code)]", true);
+        header.out("", true);
+        header.out("use std::rc::Rc;", true);
+        header.out("use std::rc::Weak;", true);
+        header.out("use std::cell::RefCell;", true);
+        header.out("", true);
         this.fileHeaderWritten = true;
       }
       let hasTraitObjectField = false;
@@ -22207,8 +22278,13 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
             if ( (pvar_2).isArray() ) {
               wr.out(this.adjustType(pvar_2.compiledName) + ": Vec::new(), ", true);
             } else {
-              if ( pvar_2.is_optional ) {
-                wr.out(this.adjustType(pvar_2.compiledName) + ": None, ", true);
+              if ( pvar_2.isHash() ) {
+                wr.out(this.adjustType(pvar_2.compiledName) + ": HashMap::new(), ", true);
+                wr.addImport("std::collections::HashMap");
+              } else {
+                if ( pvar_2.is_optional ) {
+                  wr.out(this.adjustType(pvar_2.compiledName) + ": None, ", true);
+                }
               }
             }
           }
@@ -27896,9 +27972,12 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         } else {
           if ( nn.value_type == 6 ) {
             wr.out(" = []", false);
-          }
-          if ( nn.value_type == 7 ) {
-            wr.out(" = {}", false);
+          } else {
+            if ( nn.value_type == 7 ) {
+              wr.out(" = {}", false);
+            } else {
+              wr.out(" = None", false);
+            }
           }
         }
         wr.newline();
@@ -28007,6 +28086,47 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         var item = body.children[i_1];
         await this.WalkNode(item, lambdaCtx, wr);
       };
+    };
+    getPythonTypeName (node, ctx) {
+      let v_type = node.value_type;
+      if ( ((v_type == 10) || (v_type == 11)) || (v_type == 0) ) {
+        v_type = node.typeNameAsType(ctx);
+      }
+      if ( node.eval_type != 0 ) {
+        v_type = node.eval_type;
+      }
+      switch (v_type ) { 
+        case 3 : 
+          return "int";
+        case 13 : 
+          return "int";
+        case 14 : 
+          return "int";
+        case 2 : 
+          return "float";
+        case 4 : 
+          return "str";
+        case 5 : 
+          return "bool";
+        case 6 : 
+          return "list";
+        case 7 : 
+          return "dict";
+      };
+      const tn = node.type_name;
+      if ( ctx.isDefinedClass(tn) ) {
+        const cc = ctx.findClass(tn);
+        if ( cc.is_system ) {
+          const sysName = ( cc.systemNames.hasOwnProperty("python") ? cc.systemNames["python"] : undefined );
+          if ( (typeof(sysName) !== "undefined" && sysName != null )  ) {
+            return sysName;
+          }
+        }
+      }
+      return tn;
+    };
+    async writeTypeDef (node, ctx, wr) {
+      wr.out(this.getPythonTypeName(node, ctx), false);
     };
     writeClassVarDef (node, ctx, wr) {
     };
@@ -43308,34 +43428,6 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
               operatorsOf_41.rc46func_43 = async function(node, ctx, wr) {
                 const parser = new RangerFlowParser();
                 return await parser.CreateFunctionObject(node, ctx, wr);
-              };
-              class operatorsOfJSONArrayObject_57  {
-                constructor() {
-                }
-              }
-              operatorsOfJSONArrayObject_57.forEach_58 = function(__self, cb) {
-                let cnt = __self.length;
-                let i_32 = 0;
-                while (cnt > 0) {
-                  const value_8 = __self[i_32];
-                  cb(value_8, i_32);
-                  cnt = cnt - 1;
-                  i_32 = i_32 + 1;
-                };
-              };
-              class operatorsOf_57  {
-                constructor() {
-                }
-              }
-              operatorsOf_57.forEach_58 = async function(__self, cb) {
-                let cnt_1 = __self.length;
-                let i_33 = 0;
-                while (cnt_1 > 0) {
-                  const value_9 = __self[i_33];
-                  await cb(value_9, i_33);
-                  cnt_1 = cnt_1 - 1;
-                  i_33 = i_33 + 1;
-                };
               };
 /* static JavaSript main routine at the end of the JS file */
 async function __js_main() {

--- a/docs/site/src/content/docs/targets/overview.md
+++ b/docs/site/src/content/docs/targets/overview.md
@@ -58,3 +58,11 @@ complete file is behind the link under the code.
   compiler writes the correct operation for each target.
 - **Reference counting.** The Rust and the C++ output use reference counting.
   The annotations `weak`, `strong`, `lives` and `temp` control it.
+- **The catch block in Rust.** Rust has no exceptions. The compiler writes the
+  try block of `try { } { }` and it does not write the catch block. A program
+  for the Rust target must report a fault with a return value.
+- **JSON in Rust.** The Rust output uses no crate, so the compiler adds the
+  enum `RJson` and the functions that read and write the text. A JSON object is
+  a `HashMap<String, RJson>` and a JSON array is a `Vec<RJson>`.
+- **JSON in Python.** A JSON object is a `dict`, a JSON array is a `list`, and
+  the module `json` of the standard library reads and writes the text.

--- a/lib/JSON.rgr
+++ b/lib/JSON.rgr
@@ -7,6 +7,16 @@
 ; https://msdn.microsoft.com/en-us/library/system.json.jsonobject(v=vs.95).aspx
 
 
+; Python and Rust hold the same three shapes as every other target: an object,
+; an array and a value that is one of the two plus the scalars.
+;
+; Python has the shapes in the language, so the mapping is dict / list / object
+; and the `json` module of the standard library reads and writes the text.
+;
+; Rust has no JSON type in the standard library and the target writes code that
+; `rustc` builds without a crate, so the value is the RJson enum that the
+; polyfills below declare. An object is a HashMap of it and an array is a Vec of
+; it, both spelled in full so that no `use` line is needed.
 systemclass JSONDataObject {
     es6 Object
     java7 JSONObject ( (imp "org.json.JSONObject") )
@@ -14,6 +24,8 @@ systemclass JSONDataObject {
     go "map[string]interface{}"
     swift3 '[String:Any]'
     swift6 '[String:Any]'
+    python dict
+    rust "std::collections::HashMap<String, RJson>"
 }
 
 systemclass JSONArrayObject {
@@ -23,6 +35,8 @@ systemclass JSONArrayObject {
     go "[]interface{}"
     swift3 '[Any]'
     swift6 '[Any]'
+    python list
+    rust "Vec<RJson>"
 }
 
 systemclass JSONKeyValue {
@@ -36,6 +50,8 @@ systemclass JSONValueUnion {
     go "interface{}"
     swift3 Any
     swift6 Any
+    python object
+    rust RJson
 }
 
 systemunion JSONValueUnion ( JSONDataObject JSONArrayObject string int double boolean )
@@ -75,7 +91,9 @@ operators {
                 "console.log(JSON.stringify(" (e 1) "));" nl
             )
             java7 @macro(true) ("print (to_string " (e 1) " )" (imp "org.json.JSONObject"))
-        }        
+            python ( "print(json.dumps(" (e 1) "))" (imp "json") )
+            rust @macro(true) ("print (to_string " (e 1) " )")
+        }
     }
 
     getStr _@(optional):string (e:JSONDataObject key:string) {
@@ -138,13 +156,25 @@ func r_get_opt_json_string( data map[string]interface{}, key string ) *GoNullabl
     res.has_value = false
     return res
 }
-")            
+")
 
+            )
+            python ( "(lambda v: v if isinstance(v, str) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_str(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_str(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<String> {
+    match o.get(k) { Some(RJson::Str(v)) => Some(v.clone()), _ => None }
+}
+")
             )
 
 
-        }                
-    } 
+        }
+    }
 
     getInt _@(optional):int (e:JSONDataObject key:string) {
          templates {
@@ -172,12 +202,24 @@ func r_get_opt_json_int( data map[string]interface{}, key string ) *GoNullable  
     res.has_value = false
     return res
 }
-")            
+")
 
             )
-            
-        }                
-    } 
+            python ( "(lambda v: v if isinstance(v, int) and not isinstance(v, bool) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_int(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_int(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<i64> {
+    match o.get(k) { Some(RJson::Int(v)) => Some(*v), Some(RJson::Double(v)) => Some(*v as i64), _ => None }
+}
+")
+            )
+
+        }
+    }
 
     getDouble _@(optional):double (e:JSONDataObject key:string) {
          templates {
@@ -205,12 +247,24 @@ func r_get_opt_json_double( data map[string]interface{}, key string ) *GoNullabl
     res.has_value = false
     return res
 }
-")            
+")
 
             )
-            
-        }                
-    } 
+            python ( "(lambda v: float(v) if isinstance(v, (int, float)) and not isinstance(v, bool) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_double(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_double(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<f64> {
+    match o.get(k) { Some(RJson::Double(v)) => Some(*v), Some(RJson::Int(v)) => Some(*v as f64), _ => None }
+}
+")
+            )
+
+        }
+    }
 
     getBoolean _@(optional):boolean (e:JSONDataObject key:string) {
          templates {
@@ -238,11 +292,23 @@ func r_get_opt_json_bool( data map[string]interface{}, key string ) *GoNullable 
     res.has_value = false
     return res
 }
-")            
+")
 
             )
-        }                
-    } 
+            python ( "(lambda v: v if isinstance(v, bool) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_bool(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_bool(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<bool> {
+    match o.get(k) { Some(RJson::Bool(v)) => Some(*v), _ => None }
+}
+")
+            )
+        }
+    }
 
     getObject _@(optional):JSONDataObject (e:JSONDataObject key:string) {
          templates {
@@ -286,11 +352,23 @@ func r_get_opt_json_obj( data map[string]interface{}, key string ) *GoNullable  
     res.has_value = false
     return res
 }
-")            
+")
 
             )
-        }                
-    } 
+            python ( "(lambda v: v if isinstance(v, dict) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_obj(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_obj(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<std::collections::HashMap<String, RJson>> {
+    match o.get(k) { Some(RJson::Obj(v)) => Some(v.clone()), _ => None }
+}
+")
+            )
+        }
+    }
 
 
     ; todo: proper array detection for optionals
@@ -320,11 +398,23 @@ func r_get_opt_array( data map[string]interface{}, key string ) *GoNullable  {
     res.has_value = false
     return res
 }
-')            
+')
 
             )
-        }                
-    } 
+            python ( "(lambda v: v if isinstance(v, list) else None)(" (e 1) ".get(" (e 2) "))" )
+            rust ( "r_json_get_arr(&" (e 1) ", &" (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_get_arr(o: &std::collections::HashMap<String, RJson>, k: &str) -> Option<Vec<RJson>> {
+    match o.get(k) { Some(RJson::Arr(v)) => Some(v.clone()), _ => None }
+}
+")
+            )
+        }
+    }
 
     keys _:[string] (e:JSONDataObject) {
         templates {
@@ -383,6 +473,13 @@ static ArrayList<String> __getJSONKeys(JSONObject obj)
                     "return strkeys" nl i "})()"
                 (imp "reflect"))
             php  ("array_keys(" (e 1) ")")
+            python ( "list(" (e 1) ".keys())" )
+            rust ( (e 1) ".keys().cloned().collect::<Vec<String>>()"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -400,7 +497,14 @@ func r_is_obj_array( data inteface{} ) bool {
     }
     return false
 }
-")            
+")
+            )
+            python ( "isinstance(" (e 1) ", list)" )
+            rust ( "matches!(&" (e 1) ", RJson::Arr(_))"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
             )
         }
     }
@@ -408,7 +512,19 @@ func r_is_obj_array( data inteface{} ) bool {
     asArray _@(optional):JSONArrayObject (e:JSONValueUnion) {
         templates {
             es6 ( (e 1) " instanceof Array ? " (e 1 ) " : undefined")
-        }        
+            python ( "(lambda v: v if isinstance(v, list) else None)(" (e 1) ")" )
+            rust ( "r_json_as_arr(&" (e 1) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_as_arr(v: &RJson) -> Option<Vec<RJson>> {
+    match v { RJson::Arr(a) => Some(a.clone()), _ => None }
+}
+")
+            )
+        }
     }
 
     getValue _:JSONValueUnion (e:JSONArrayObject index:int) {
@@ -438,19 +554,39 @@ static Object __getJSONValue(JSONArray o, Integer item)
             kotlin ( (e 1) ".get(" (e 2) ")")
             go ( (e 1) "[" (e 2) "]")
             php ( (e 1) "[" (e 2) "]")
+            python ( (e 1) "[" (e 2) "]")
+            rust ( "r_json_at(&" (e 1) ", " (e 2) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_at(a: &Vec<RJson>, i: i64) -> RJson {
+    if i < 0 || (i as usize) >= a.len() { return RJson::Null; }
+    a[i as usize].clone()
+}
+")
+            )
         }
     }
 
     array_length _:int (e:JSONArrayObject) {
         templates {
             ranger ("(array_length " (e 1) ")")
-            es6 ( (e 1) ".length") 
+            es6 ( (e 1) ".length")
             java7 ( (e 1) ".length()" )
             kotlin ( (e 1) ".length()" )
             swift3 ( (e 1) ".count")
             swift6 ( (e 1) ".count")
             go( "int64(len(" (e 1) "))" )
             php ( "count(" (e 1) ")" )
+            python ( "len(" (e 1) ")" )
+            rust ( "((" (e 1) ").len() as i64)"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -464,6 +600,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Int((" (e 3) ") as i64));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -477,6 +620,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Str((" (e 3) ").to_string()));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -490,6 +640,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Int(" (e 3) "));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -503,6 +660,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Double(" (e 3) "));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -516,6 +680,13 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), RJson::Bool(" (e 3) "));"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -529,6 +700,61 @@ static Object __getJSONValue(JSONArray o, Integer item)
             swift3 ( (e 1) "[" (e 2) "] = " (e 3) )
             swift6 ( (e 1) "[" (e 2) "] = " (e 3) )
             php ( (e 1) "[" (e 2) "] = " (e 3) ";" )
+            python ( (e 1) "[" (e 2) "] = " (e 3) )
+            ; The value is one of the six members of the union, so the RJsonValue
+            ; trait picks the variant that fits the type the argument has.
+            rust ( (e 1) ".insert((" (e 2) ").to_string(), (" (e 3) ").r_json_value());"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+trait RJsonValue { fn r_json_value(&self) -> RJson; }
+impl RJsonValue for i64 { fn r_json_value(&self) -> RJson { RJson::Int(*self) } }
+impl RJsonValue for i32 { fn r_json_value(&self) -> RJson { RJson::Int(*self as i64) } }
+impl RJsonValue for f64 { fn r_json_value(&self) -> RJson { RJson::Double(*self) } }
+impl RJsonValue for bool { fn r_json_value(&self) -> RJson { RJson::Bool(*self) } }
+impl RJsonValue for String { fn r_json_value(&self) -> RJson { RJson::Str(self.clone()) } }
+impl RJsonValue for str { fn r_json_value(&self) -> RJson { RJson::Str(self.to_string()) } }
+impl RJsonValue for Vec<RJson> { fn r_json_value(&self) -> RJson { RJson::Arr(self.clone()) } }
+impl RJsonValue for std::collections::HashMap<String, RJson> { fn r_json_value(&self) -> RJson { RJson::Obj(self.clone()) } }
+impl RJsonValue for RJson { fn r_json_value(&self) -> RJson { self.clone() } }
+")
+            )
+        }
+    }
+
+    ; Rust narrows a union by matching the enum variant, and the variant is not
+    ; the type name that `(typeof 2)` writes, so the generic `case` in stdlib.rgr
+    ; can not serve it. These two entries name the JSON shapes directly. A target
+    ; that has no template here does not match them and reaches the generic one.
+    case _@(newcontext):void ( arg@(union):JSONValueUnion item@(define):JSONDataObject code:block ) {
+        templates {
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Obj(" (e 2) ") = &" (e 1) " {" nl I
+                        "let mut " (e 2) " : std::collections::HashMap<String, RJson> = " (e 2) ".clone();" nl
+                        (block 3)
+                        nl i "}"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
+        }
+    }
+
+    case _@(newcontext):void ( arg@(union):JSONValueUnion item@(define):JSONArrayObject code:block ) {
+        templates {
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Arr(" (e 2) ") = &" (e 1) " {" nl I
+                        "let mut " (e 2) " : Vec<RJson> = " (e 2) ".clone();" nl
+                        (block 3)
+                        nl i "}"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
         }
     }
 
@@ -566,9 +792,108 @@ function r_json_to_array($str) {
 }
 "
 
-)            
+)
             )
-        }        
+            python ( "json.loads(" (e 1) ")" (imp "json") )
+            rust ( "r_json_parse_obj(&" (e 1) ")"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_skip_ws(s: &[u8], i: &mut usize) {
+    while *i < s.len() && (s[*i] == 32 || s[*i] == 9 || s[*i] == 10 || s[*i] == 13) { *i += 1; }
+}
+fn r_json_read_string(s: &[u8], i: &mut usize) -> String {
+    let mut out: Vec<u8> = Vec::new();
+    *i += 1;
+    while *i < s.len() && s[*i] != 34 {
+        if s[*i] == 92 && (*i + 1) < s.len() {
+            *i += 1;
+            let e = s[*i];
+            if e == 110 { out.push(10); }
+            else if e == 116 { out.push(9); }
+            else if e == 114 { out.push(13); }
+            else if e == 98 { out.push(8); }
+            else if e == 102 { out.push(12); }
+            else if e == 117 {
+                let mut code: u32 = 0;
+                let mut k = 0;
+                while k < 4 && (*i + 1) < s.len() {
+                    *i += 1;
+                    code = code * 16 + (s[*i] as char).to_digit(16).unwrap_or(0);
+                    k += 1;
+                }
+                let mut buf = [0u8; 4];
+                let ch = char::from_u32(code).unwrap_or(63 as char);
+                out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+            }
+            else { out.push(e); }
+        } else {
+            out.push(s[*i]);
+        }
+        *i += 1;
+    }
+    *i += 1;
+    String::from_utf8_lossy(&out).to_string()
+}
+fn r_json_read_value(s: &[u8], i: &mut usize) -> RJson {
+    r_json_skip_ws(s, i);
+    if *i >= s.len() { return RJson::Null; }
+    let c = s[*i];
+    if c == 123 {
+        let mut o: std::collections::HashMap<String, RJson> = std::collections::HashMap::new();
+        *i += 1;
+        loop {
+            r_json_skip_ws(s, i);
+            if *i >= s.len() || s[*i] == 125 { *i += 1; break; }
+            if s[*i] == 44 { *i += 1; continue; }
+            if s[*i] != 34 { *i += 1; continue; }
+            let key = r_json_read_string(s, i);
+            r_json_skip_ws(s, i);
+            if *i < s.len() && s[*i] == 58 { *i += 1; }
+            let value = r_json_read_value(s, i);
+            o.insert(key, value);
+        }
+        return RJson::Obj(o);
+    }
+    if c == 91 {
+        let mut a: Vec<RJson> = Vec::new();
+        *i += 1;
+        loop {
+            r_json_skip_ws(s, i);
+            if *i >= s.len() || s[*i] == 93 { *i += 1; break; }
+            if s[*i] == 44 { *i += 1; continue; }
+            let value = r_json_read_value(s, i);
+            a.push(value);
+        }
+        return RJson::Arr(a);
+    }
+    if c == 34 { return RJson::Str(r_json_read_string(s, i)); }
+    if c == 116 { *i += 4; return RJson::Bool(true); }
+    if c == 102 { *i += 5; return RJson::Bool(false); }
+    if c == 110 { *i += 4; return RJson::Null; }
+    let start = *i;
+    let mut is_double = false;
+    while *i < s.len() {
+        let d = s[*i];
+        if d == 46 || d == 101 || d == 69 { is_double = true; }
+        if d == 44 || d == 125 || d == 93 || d == 32 || d == 10 || d == 13 || d == 9 { break; }
+        *i += 1;
+    }
+    let text = String::from_utf8_lossy(&s[start..*i]).to_string();
+    if is_double { RJson::Double(text.parse::<f64>().unwrap_or(0.0)) } else { RJson::Int(text.parse::<i64>().unwrap_or(0)) }
+}
+fn r_json_parse_obj(text: &str) -> std::collections::HashMap<String, RJson> {
+    let mut i: usize = 0;
+    match r_json_read_value(text.as_bytes(), &mut i) {
+        RJson::Obj(o) => o,
+        _ => std::collections::HashMap::new(),
+    }
+}
+")
+            )
+        }
     }
 
     to_string _:string (e:JSONDataObject) {
@@ -599,10 +924,70 @@ func __toJSONData ( data interface{} ) string {
 	b, _ := json.Marshal(data)
 	return string(b)
 }
-")            
+")
             )
             php ( "json_encode(" (e 1) ")")
-        }        
+            python ( "json.dumps(" (e 1) ")" (imp "json") )
+            rust ( "r_json_to_string(&RJson::Obj(" (e 1) ".clone()))"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_escape(s: &str, out: &mut String) {
+    out.push(34 as u8 as char);
+    for c in s.chars() {
+        let n = c as u32;
+        if n == 34 || n == 92 { out.push(92 as u8 as char); out.push(c); }
+        else if n == 10 { out.push(92 as u8 as char); out.push('n'); }
+        else if n == 13 { out.push(92 as u8 as char); out.push('r'); }
+        else if n == 9 { out.push(92 as u8 as char); out.push('t'); }
+        else if n < 0x20 {
+            out.push(92 as u8 as char);
+            out.push('u');
+            out.push_str(&format!(\"{:04x}\", n));
+        }
+        else { out.push(c); }
+    }
+    out.push(34 as u8 as char);
+}
+fn r_json_write(v: &RJson, out: &mut String) {
+    match v {
+        RJson::Null => out.push_str(\"null\"),
+        RJson::Bool(b) => out.push_str(if *b { \"true\" } else { \"false\" }),
+        RJson::Int(i) => out.push_str(&i.to_string()),
+        RJson::Double(d) => { if d.is_finite() { out.push_str(&format!(\"{}\", d)) } else { out.push_str(\"null\") } }
+        RJson::Str(s) => r_json_escape(s, out),
+        RJson::Arr(a) => {
+            out.push('[');
+            for (i, it) in a.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                r_json_write(it, out);
+            }
+            out.push(']');
+        }
+        RJson::Obj(o) => {
+            let mut keys: Vec<&String> = o.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                r_json_escape(k, out);
+                out.push(':');
+                r_json_write(&o[*k], out);
+            }
+            out.push('}');
+        }
+    }
+}
+fn r_json_to_string(v: &RJson) -> String {
+    let mut out = String::new();
+    r_json_write(v, &mut out);
+    out
+}
+")
+            )
+        }
     }
 
     to_string _:string (e:JSONArrayObject) {
@@ -621,10 +1006,70 @@ func __toJSONData ( data interface{} ) string {
 	b, _ := json.Marshal(data)
 	return string(b)
 }
-")            
+")
             )
             php ( "json_encode(" (e 1) ")")
-        }        
+            python ( "json.dumps(" (e 1) ")" (imp "json") )
+            rust ( "r_json_to_string(&RJson::Arr(" (e 1) ".clone()))"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+fn r_json_escape(s: &str, out: &mut String) {
+    out.push(34 as u8 as char);
+    for c in s.chars() {
+        let n = c as u32;
+        if n == 34 || n == 92 { out.push(92 as u8 as char); out.push(c); }
+        else if n == 10 { out.push(92 as u8 as char); out.push('n'); }
+        else if n == 13 { out.push(92 as u8 as char); out.push('r'); }
+        else if n == 9 { out.push(92 as u8 as char); out.push('t'); }
+        else if n < 0x20 {
+            out.push(92 as u8 as char);
+            out.push('u');
+            out.push_str(&format!(\"{:04x}\", n));
+        }
+        else { out.push(c); }
+    }
+    out.push(34 as u8 as char);
+}
+fn r_json_write(v: &RJson, out: &mut String) {
+    match v {
+        RJson::Null => out.push_str(\"null\"),
+        RJson::Bool(b) => out.push_str(if *b { \"true\" } else { \"false\" }),
+        RJson::Int(i) => out.push_str(&i.to_string()),
+        RJson::Double(d) => { if d.is_finite() { out.push_str(&format!(\"{}\", d)) } else { out.push_str(\"null\") } }
+        RJson::Str(s) => r_json_escape(s, out),
+        RJson::Arr(a) => {
+            out.push('[');
+            for (i, it) in a.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                r_json_write(it, out);
+            }
+            out.push(']');
+        }
+        RJson::Obj(o) => {
+            let mut keys: Vec<&String> = o.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                r_json_escape(k, out);
+                out.push(':');
+                r_json_write(&o[*k], out);
+            }
+            out.push('}');
+        }
+    }
+}
+fn r_json_to_string(v: &RJson) -> String {
+    let mut out = String::new();
+    r_json_write(v, &mut out);
+    out
+}
+")
+            )
+        }
     }
 
     push _@(moves@( 2 1 ) ):void ( e@(mutates):JSONArrayObject el:JSONArrayUnion) {
@@ -637,7 +1082,26 @@ func __toJSONData ( data interface{} ) string {
             swift6 ( (e 1) ".append(" (e 2) ");")
             go( (e 1) " = append(" (e 1) "," (e 2) ")")
             php ( "array_push(" (e 1) ", " (e 2) ");")
-        }           
+            python ( (e 1) ".append(" (e 2) ")")
+            rust ( (e 1) ".push((" (e 2) ").r_json_value());"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+(create_polyfill "
+trait RJsonValue { fn r_json_value(&self) -> RJson; }
+impl RJsonValue for i64 { fn r_json_value(&self) -> RJson { RJson::Int(*self) } }
+impl RJsonValue for i32 { fn r_json_value(&self) -> RJson { RJson::Int(*self as i64) } }
+impl RJsonValue for f64 { fn r_json_value(&self) -> RJson { RJson::Double(*self) } }
+impl RJsonValue for bool { fn r_json_value(&self) -> RJson { RJson::Bool(*self) } }
+impl RJsonValue for String { fn r_json_value(&self) -> RJson { RJson::Str(self.clone()) } }
+impl RJsonValue for str { fn r_json_value(&self) -> RJson { RJson::Str(self.to_string()) } }
+impl RJsonValue for Vec<RJson> { fn r_json_value(&self) -> RJson { RJson::Arr(self.clone()) } }
+impl RJsonValue for std::collections::HashMap<String, RJson> { fn r_json_value(&self) -> RJson { RJson::Obj(self.clone()) } }
+impl RJsonValue for RJson { fn r_json_value(&self) -> RJson { self.clone() } }
+")
+            )
+        }
     }
     json_array json@(expands):JSONArrayObject () {
         templates {
@@ -649,7 +1113,14 @@ func __toJSONData ( data interface{} ) string {
             kotlin ("JSONArray()")
             go ( "make([]interface{},0)" )
             php ( "array()" )
-        }        
+            python ( "[]" )
+            rust ( "Vec::<RJson>::new()"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
+        }
     }
     json_object json:JSONDataObject () {
         templates {
@@ -661,7 +1132,14 @@ func __toJSONData ( data interface{} ) string {
             kotlin ("JSONObject()")
             go ( "make(map[string]interface{})" )
             php ( "array()")
-        }        
+            python ( "{}" )
+            rust ( "std::collections::HashMap::<String, RJson>::new()"
+(create_polyfill "
+#[derive(Clone, Debug, PartialEq)]
+enum RJson { Null, Bool(bool), Int(i64), Double(f64), Str(String), Arr(Vec<RJson>), Obj(std::collections::HashMap<String, RJson>) }
+")
+            )
+        }
     }
     json_array json@(expands):JSONArrayObject ( e@(block):JSONArrayUnion ) {
         templates {
@@ -672,7 +1150,8 @@ func __toJSONData ( data interface{} ) string {
             java7 ("new JSONArray" (imp "org.json.JSONArray") (plugin 'maven' (  (dep 'org.json' 'json' '20171018'  ) ) ))
             go ( "make([]interface{},0)" )
             php ( "array()" )
-        }        
+            python ("[" ( repeat_from 1 (  (block 1) ) ) "]")
+        }
     }
     json_obj json@(expands):JSONDataObject ( e@(block):JSONObjectUnion ) {
         templates {

--- a/lib/stdlib.rgr
+++ b/lib/stdlib.rgr
@@ -26,6 +26,18 @@ operators {
                         (block 3)
                         nl i "}"
             )
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", bool):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            )
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Bool(" (e 2) ") = &" (e 1) " {" nl I
+                        "let " (e 2) " : bool = *" (e 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            )
         }
     }
     case             _@(newcontext):void           ( arg@(union):T item2@(define):int code:block )  {
@@ -45,6 +57,18 @@ operators {
             kotlin (
                 (forkctx _ ) (def 2) "if( " (e 1) " is Int ) /* union case for int */ {" nl I
                         "val " (e 2) " : Int = " (e 1) " as Int;" nl
+                        (block 3)
+                        nl i "}"
+            )
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", int) and not isinstance(" (e 1) ", bool):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            )
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Int(" (e 2) ") = &" (e 1) " {" nl I
+                        "let " (e 2) " : i64 = *" (e 2) ";" nl
                         (block 3)
                         nl i "}"
             )
@@ -70,6 +94,18 @@ operators {
                         (block 3)
                         nl i "}"
             )
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", float):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            )
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Double(" (e 2) ") = &" (e 1) " {" nl I
+                        "let " (e 2) " : f64 = *" (e 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            )
         }
     }
 
@@ -90,6 +126,18 @@ operators {
             kotlin (
                 (forkctx _ ) (def 2) "if( " (e 1) " is String ) /* union case for string */ {" nl I
                         "val " (e 2) " : String = " (e 1) " as String;" nl
+                        (block 3)
+                        nl i "}"
+            )
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", str):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            )
+            rust (
+                (forkctx _ ) (def 2) "if let RJson::Str(" (e 2) ") = &" (e 1) " {" nl I
+                        "let " (e 2) " : String = " (e 2) ".clone();" nl
                         (block 3)
                         nl i "}"
             )
@@ -157,6 +205,12 @@ operators {
                         "val " (e 2) " : " (typeof 2) " = " (e 1) " as " (typeof 2) ";" nl
                         (block 3)
                         nl i "}"
+            ) 
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", " (typeof 2) "):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
             ) 
             cpp (
                 (forkctx _ ) (def 2) "if( mpark::holds_alternative<" (typeof 2) ">(" (e 1) ") ) {" nl I

--- a/tests/compiler-json.test.ts
+++ b/tests/compiler-json.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  compileAndRun,
+  compileAndRunPython,
+  compileAndRunRust,
+  getGeneratedRustCode,
+  isPythonAvailable,
+  isRustAvailable,
+} from "./helpers/compiler";
+
+const FIXTURE = "tests/fixtures/json_ops.rgr";
+
+// The JSON operators (JSON.rgr) are per-target templates, so an operator with
+// no template for one target fails on that target only. Python and Rust had no
+// templates at all: every program that touched a JSONDataObject stopped with
+// "Could not match argument types for json_object". These tests read the values
+// back on each target so a missing template can not pass unnoticed.
+const EXPECTED = [
+  "name=ranger",
+  "count=3",
+  "ratio=0.5",
+  "ok=yes",
+  "items=3",
+  "first=first",
+  "kind=child",
+  "keys=5",
+  "missing=none",
+  "json-ops-ok",
+];
+
+describe("JSON operators", () => {
+  it("round trips an object through text on JavaScript", () => {
+    const { compile, run } = compileAndRun(FIXTURE);
+
+    expect(
+      compile.success,
+      `Compile failed: ${compile.error || compile.output}`
+    ).toBe(true);
+    expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+    for (const line of EXPECTED) {
+      expect(run?.output).toContain(line);
+    }
+  });
+
+  it.skipIf(!isPythonAvailable())(
+    "round trips an object through text on Python",
+    () => {
+      const { compile, run } = compileAndRunPython(FIXTURE);
+
+      expect(
+        compile.success,
+        `Compile failed: ${compile.error || compile.output}`
+      ).toBe(true);
+      expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+      for (const line of EXPECTED) {
+        expect(run?.output).toContain(line);
+      }
+    }
+  );
+
+  it.skipIf(!isRustAvailable())(
+    "round trips an object through text on Rust",
+    () => {
+      const { compile, run } = compileAndRunRust(FIXTURE);
+
+      expect(
+        compile.success,
+        `Compile failed: ${compile.error || compile.output}`
+      ).toBe(true);
+      expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+      for (const line of EXPECTED) {
+        expect(run?.output).toContain(line);
+      }
+    }
+  );
+
+  // The Rust file header holds inner attributes (#![allow(...)]), which have to
+  // precede every item. An (imp "...") from an operator template writes its
+  // `use` line into the import slice, which sits ahead of the class content, so
+  // a header written with the content ended up second and rustc rejected the
+  // file with "an inner attribute is not permitted in this context".
+  it("writes the Rust inner attributes ahead of every use line", () => {
+    const result = getGeneratedRustCode("tests/fixtures/hash_map.rgr");
+    expect(result.success, `Compile failed: ${result.error}`).toBe(true);
+
+    const firstUse = result.code.indexOf("use ");
+    const lastAttribute = result.code.lastIndexOf("#![");
+
+    expect(firstUse).toBeGreaterThan(-1);
+    expect(lastAttribute).toBeGreaterThan(-1);
+    expect(lastAttribute).toBeLessThan(firstUse);
+  });
+});

--- a/tests/compiler-serialize.test.ts
+++ b/tests/compiler-serialize.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { compileAndRun, compileRanger } from "./helpers/compiler";
+import {
+  compileAndRun,
+  compileAndRunPython,
+  compileAndRunRust,
+  compileRanger,
+  isPythonAvailable,
+  isRustAvailable,
+} from "./helpers/compiler";
 
 const FIXTURES = "tests/fixtures/serialize";
 
@@ -73,7 +80,7 @@ describe("@serialize(true) across target backends", () => {
   // kotlin is left out because a hash field in a @serialize class does not
   // compile there yet: the `keys` operator for JSONDataObject has no kotlin
   // template. Same defect class as the Swift 6 gaps below, still open.
-  const targets = ["es6", "swift3", "swift6", "go"];
+  const targets = ["es6", "swift3", "swift6", "go", "python", "rust"];
 
   for (const target of targets) {
     it(`compiles a serialized class with object arrays for ${target}`, () => {
@@ -97,6 +104,61 @@ describe("@serialize(true) across target backends", () => {
       ).toBe(true);
     }
   });
+});
+
+// A serializer that compiles is not a serializer that works: the generated
+// toDictionary / fromDictionary have to give the same values back. The
+// JavaScript round trip above is the reference, and these two run the same
+// program on the targets that had no JSON templates at all.
+describe("@serialize(true) round trip on Python and Rust", () => {
+  const programs = [
+    {
+      fixture: "serialize_roundtrip",
+      expected: [
+        "title=parent",
+        "tags=a",
+        "one=solo",
+        "kid=first:7",
+        "hash=hashed",
+        "serialize-roundtrip-ok",
+      ],
+    },
+    { fixture: "serialize_cyclic", expected: ["serialize-cyclic-ok"] },
+    {
+      fixture: "serialize_manual",
+      expected: ["kid=manual", "serialize-manual-ok"],
+    },
+  ];
+
+  for (const { fixture, expected } of programs) {
+    it.skipIf(!isPythonAvailable())(`runs ${fixture} on Python`, () => {
+      const { compile, run } = compileAndRunPython(
+        `${FIXTURES}/${fixture}.rgr`
+      );
+
+      expect(
+        compile.success,
+        `Compile failed: ${compile.error || compile.output}`
+      ).toBe(true);
+      expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+      for (const line of expected) {
+        expect(run?.output).toContain(line);
+      }
+    });
+
+    it.skipIf(!isRustAvailable())(`runs ${fixture} on Rust`, () => {
+      const { compile, run } = compileAndRunRust(`${FIXTURES}/${fixture}.rgr`);
+
+      expect(
+        compile.success,
+        `Compile failed: ${compile.error || compile.output}`
+      ).toBe(true);
+      expect(run?.success, `Run failed: ${run?.error}`).toBe(true);
+      for (const line of expected) {
+        expect(run?.output).toContain(line);
+      }
+    });
+  }
 });
 
 describe("@serialize(true) diagnostics for non serializable types", () => {

--- a/tests/fixtures/json_ops.rgr
+++ b/tests/fixtures/json_ops.rgr
@@ -1,0 +1,77 @@
+; The JSON library operators on their own: build an object, write it as text,
+; read the text back and reach every value in it.
+Import "stdlib.rgr"
+
+class JsonOps {
+    sfn m@(main):void () {
+        def obj:JSONDataObject (json_object)
+        set obj "name" "ranger"
+        set obj "count" 3
+        set obj "ratio" 0.5
+        set obj "ok" true
+
+        def items:JSONArrayObject (json_array)
+        push items "first"
+        push items 2
+
+        def child:JSONDataObject (json_object)
+        set child "kind" "child"
+        push items child
+
+        set obj "items" items
+
+        def text:string (to_string obj)
+        def back:JSONDataObject (json_object)
+        try {
+            back = (from_string text)
+        } {
+            print "parse failed"
+        }
+
+        def name (getStr back "name")
+        if (!null? name) {
+            print ("name=" + (unwrap name))
+        }
+        def count (getInt back "count")
+        if (!null? count) {
+            print ("count=" + (unwrap count))
+        }
+        def ratio (getDouble back "ratio")
+        if (!null? ratio) {
+            print ("ratio=" + (unwrap ratio))
+        }
+        def ok (getBoolean back "ok")
+        if (!null? ok) {
+            if (unwrap ok) {
+                print "ok=yes"
+            }
+        }
+
+        def arr (getArray back "items")
+        if (!null? arr) {
+            def a (unwrap arr)
+            print ("items=" + (array_length a))
+            def v0 (getValue a 0)
+            case v0 s:string {
+                print ("first=" + s)
+            }
+            def v2 (getValue a 2)
+            case v2 o:JSONDataObject {
+                def kind (getStr o "kind")
+                if (!null? kind) {
+                    print ("kind=" + (unwrap kind))
+                }
+            }
+        }
+
+        def theKeys (keys back)
+        print ("keys=" + (array_length theKeys))
+
+        def missing (getStr back "nope")
+        if (null? missing) {
+            print "missing=none"
+        }
+
+        print "json-ops-ok"
+    }
+}


### PR DESCRIPTION
lib/JSON.rgr declared no python and no rust template in any of its
operator blocks, and the three systemclasses named no type for either
target. A template block is part of the match, so every program that
touched a JSON object stopped in the type check with "Could not match
argument types for json_object", and @serialize(true) could not work.
The FAQ answer on toDictionary / fromDictionary showed that message in
place of the Python and the Rust tab.

Python maps the shapes onto dict / list / object and reads and writes
the text with the json module. A getter is an inline lambda that checks
the type, so no polyfill is needed; getInt rejects a bool, because bool
is a subclass of int in Python.

Rust has no JSON type in the standard library and the target writes code
that rustc builds with no crate, so the compiler adds the enum RJson as
a polyfill together with a reader and a writer for the text. An object
is a HashMap<String, RJson> and an array is a Vec<RJson>, both spelled
in full so that the output needs no use line. The trait RJsonValue
converts a union argument to the variant that fits it.

The generated @serialize reader read an object array and an object hash
with arr.forEach({ ... }), the one construct neither writer emits. It
now uses an index loop over array_length / getValue and over keys /
itemAt, so it depends only on operators that every target declares. A
side effect on the JavaScript output: fromDictionary is no longer async,
because the callback was what marked it so.

Also fixed on the way, each of them reached by the JSON work:

- try { } { } wrote JavaScript for both targets. Python now writes
  try: / except Exception:, each suite opened with pass because a
  generated catch block is often empty. Rust has no exceptions, so the
  compiler writes the try block and states that it drops the catch.
- The Rust file header sat after the first use line, so rustc rejected
  every program that used a hash map. It goes into before_imports now.
- A Rust systemclass reached the output under its Ranger name.
- get on a Rust hash map gave Option<&T> for an optional T.
- A Rust hash field was constructed as None.
- A Python class field with no value read an undefined attribute.
- A Python (typeof N) template wrote the Ranger type name.
- The Python reserved words held the built-ins but no keyword, so a
  field named `as` wrote self.as and the module did not parse.
- The generated JSON serializer wrote the target-renamed field name into
  Ranger source, which the second compilation could not resolve.

tests/fixtures/json_ops.rgr builds an object, writes it as text, reads
it back and reaches every value in it. tests/compiler-json.test.ts runs
it on JavaScript, Python and Rust and compares the three outputs.
compiler-serialize.test.ts adds python and rust to the target list and
runs the round trip of three fixtures on both.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SG7eDSGamLK3m1iiAfgPAf