### PR TITLE
Temporarily disable slow engine-contract CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,9 +205,14 @@ jobs:
   # vitest jobs do not exercise these paths at all. Ungated for the same reason
   # as runtime-conformance: the code is under gallery/ but a change on either
   # side of that boundary can break it.
+  #
+  # TEMPORARILY DISABLED: this job dominates wall-clock CI (~5 min vs ~1 min
+  # for the other jobs). Re-enable by removing `if: false` and restoring the
+  # test-gate check below. Still runnable locally via `npm run engine:v2:test`.
   engine-contract:
     name: engine-contract
     needs: changes
+    if: false
     runs-on: ubuntu-latest
 
     steps:
@@ -240,17 +245,19 @@ jobs:
             echo "Runtime conformance tests failed or were cancelled"
             exit 1
           fi
-          if [ "${{ needs.engine-contract.result }}" != "success" ]; then
-            echo "Engine contract suite failed or was cancelled"
-            exit 1
-          fi
+          # engine-contract is temporarily disabled (if: false → skipped).
+          # When re-enabling, require success again:
+          # if [ "${{ needs.engine-contract.result }}" != "success" ]; then
+          #   echo "Engine contract suite failed or was cancelled"
+          #   exit 1
+          # fi
 
           if [ "${{ needs.changes.outputs.gallery_only }}" = "true" ]; then
             if [ "${{ needs.gallery-smoke.result }}" != "success" ]; then
               echo "Gallery smoke test failed or was cancelled"
               exit 1
             fi
-            echo "Gallery-only change: smoke, runtime conformance and engine contract passed (full checks skipped)"
+            echo "Gallery-only change: smoke and runtime conformance passed (full checks skipped; engine-contract temporarily disabled)"
             exit 0
           fi
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The `engine-contract` job (`npm run engine:v2:test`) has been dominating CI wall-clock time — about **5 minutes** vs ~1 minute for the other jobs — so it is skipped for now.

### Changes
- Set `if: false` on the `engine-contract` job in `.github/workflows/ci.yml`
- Stop requiring it in `test-gate` (commented restore instructions included)

Still runnable locally via `npm run engine:v2:test`. Re-enable by removing `if: false` and restoring the gated success check.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcc3f-ef07-72ef-91b3-ccd998dc4710?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcc3f-ef07-72ef-91b3-ccd998dc4710&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

