### PR TITLE
Ship v2 interpreter live demos on GitHub Pages /games/v2/

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,8 @@
 #   /games/   -> the Ranger game engine compiled to JavaScript, running games
 #                in the browser via a virtual filesystem (Pong today; the WASM
 #                car game + a GPU 3D demo are the next entries).
+#   /games/v2/ -> v2 interpreter live demos (staged ComponentEngine +
+#                RgRegistryBridge / RgGameHost — ylos2 2D + live 3D guests).
 #   /docs/    -> the language documentation. The operator reference is generated
 #                from compiler/Lang.rgr and lib/*.rgr by docs/tools, and the
 #                examples on it are compiled by the compiler built in this job,
@@ -22,6 +24,7 @@ on:
     paths:
       - "playground/**"
       - "gallery/game_engine/web/**"
+      - "gallery/game_engine/v2/**"
       - "gallery/game_engine/tests/pong_runner_demo.rgr"
       - "gallery/game_engine/scripting/**"
       - "compiler/**"
@@ -77,6 +80,10 @@ jobs:
       # ---- Three.js cube on the GPU (.tsx interpreter -> Ranger Three -> WebGL)
       - name: Build tsx3d WebGL demo
         run: node gallery/game_engine/web/build-tsx3d.mjs --out "$GITHUB_WORKSPACE/_site/games/tsx3d"
+
+      # ---- v2 interpreter live demos (ComponentEngine migrate/src + registry)
+      - name: Build v2 interpreter Pages demos
+        run: node gallery/game_engine/v2/web/build-pages.mjs --out "$GITHUB_WORKSPACE/_site/games/v2"
 
       # ---- Documentation site at /docs/ ----------------------------------
       - name: Install documentation dependencies

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -81,7 +81,11 @@ jobs:
       - name: Build tsx3d WebGL demo
         run: node gallery/game_engine/web/build-tsx3d.mjs --out "$GITHUB_WORKSPACE/_site/games/tsx3d"
 
-      # ---- v2 interpreter live demos (ComponentEngine migrate/src + registry)
+      # ---- v2 interpreter live demos + Monaco editor (ComponentEngine migrate/src)
+      - name: Install v2 games-site dependencies (Monaco + esbuild)
+        working-directory: gallery/game_engine/v2/web
+        run: npm ci
+
       - name: Build v2 interpreter Pages demos
         run: node gallery/game_engine/v2/web/build-pages.mjs --out "$GITHUB_WORKSPACE/_site/games/v2"
 

--- a/gallery/game_engine/v2/web/README.md
+++ b/gallery/game_engine/v2/web/README.md
@@ -4,12 +4,14 @@
 
 VFS + canvas host + build scripts for running the engine in the browser / Pages.
 
-**GitHub Pages:** `build-pages.mjs` ships the v2 interpreter live demos to
-`/games/v2/` (see `deploy-pages.yml`). Locally:
+**GitHub Pages:** `build-pages.mjs` ships the v2 interpreter live demos **with a
+Monaco live editor** to `/games/v2/` (see `deploy-pages.yml`). Each game folder
+also gets its own editor page. Locally:
 
 ```
-npm run engine:v2:pages:build   # -> dist/pages (hub + live2d + live3d guests)
-npm run engine:v2:pages:smoke   # build + headless Chromium non-blank canvas gate
+cd gallery/game_engine/v2/web && npm ci   # Monaco + esbuild
+npm run engine:v2:pages:build            # -> dist/pages (hub + per-game editors)
+npm run engine:v2:pages:smoke            # headless Chromium non-blank canvas gate
 ```
 
 **Plan phase:** after v2 headless gates; point builds at v2 modules gradually.

--- a/gallery/game_engine/v2/web/README.md
+++ b/gallery/game_engine/v2/web/README.md
@@ -4,6 +4,14 @@
 
 VFS + canvas host + build scripts for running the engine in the browser / Pages.
 
+**GitHub Pages:** `build-pages.mjs` ships the v2 interpreter live demos to
+`/games/v2/` (see `deploy-pages.yml`). Locally:
+
+```
+npm run engine:v2:pages:build   # -> dist/pages (hub + live2d + live3d guests)
+npm run engine:v2:pages:smoke   # build + headless Chromium non-blank canvas gate
+```
+
 **Plan phase:** after v2 headless gates; point builds at v2 modules gradually.
 
 ## GPU demos (real WebGL, headless-verifiable)

--- a/gallery/game_engine/v2/web/build-live2d.mjs
+++ b/gallery/game_engine/v2/web/build-live2d.mjs
@@ -50,6 +50,9 @@ const FACADES = [
   "gallery/game_engine/v2/modules/ranger_core/ranger_core.tsx",
   "gallery/game_engine/v2/modules/ranger_2d/ranger_2d.tsx",
   "gallery/game_engine/v2/modules/ranger_three/ranger_three.tsx",
+  // RgGameHost.load registers ranger:cannon alongside the other façades even
+  // when the guest never imports it — omit and the browser VFS throws ENOENT.
+  "gallery/game_engine/v2/modules/ranger_cannon/ranger_cannon.tsx",
 ];
 
 // The real ylos2 game: index.tsx + the atlases it loads via pkg:// + the real
@@ -59,15 +62,25 @@ const FACADES = [
 // atlas's `image assets/p1_walk.png` → <GAME_DIR>/assets/p1_walk.png resolve.
 const GAME_DIR = "gallery/game_engine/v2/games/ylos2";
 const GAME_FILE = "index.tsx";
-const GAME_ASSETS = [
-  "gallery/game_engine/v2/games/ylos2/index.tsx",
-  "gallery/game_engine/v2/games/ylos2/p1.atlas",
-  "gallery/game_engine/v2/games/ylos2/p2.atlas",
-  "gallery/game_engine/v2/games/ylos2/enemy.atlas",
-  "gallery/game_engine/v2/games/ylos2/assets/p1_walk.png",
-  "gallery/game_engine/v2/games/ylos2/assets/p2_walk.png",
-  "gallery/game_engine/v2/games/ylos2/assets/enemy_walk.png",
-];
+// Package every file under the game dir (atlases + PNG sheets + index.tsx).
+// Skipping tests/ keeps the zip small; anything the guest loads via pkg:// must
+// be present or the browser VFS throws ENOENT at load time.
+function listGameAssets(relDir) {
+  const abs = path.join(ROOT, relDir);
+  const out = [];
+  const walk = (dir, rel) => {
+    for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (ent.name === "tests" || ent.name === "." || ent.name === "..") continue;
+      const absPath = path.join(dir, ent.name);
+      const relPath = rel + "/" + ent.name;
+      if (ent.isDirectory()) walk(absPath, relPath);
+      else out.push(relPath.split(path.sep).join("/"));
+    }
+  };
+  walk(abs, relDir);
+  return out.sort();
+}
+const GAME_ASSETS = listGameAssets(GAME_DIR);
 
 const log = (...a) => console.log("[live2d-build]", ...a);
 const sh = (cmd, args, opts) => execFileSync(cmd, args, { stdio: "inherit", cwd: ROOT, ...opts });

--- a/gallery/game_engine/v2/web/build-pages.mjs
+++ b/gallery/game_engine/v2/web/build-pages.mjs
@@ -1,20 +1,23 @@
 // ============================================================================
-// build-pages.mjs — assemble the v2 interpreter demos for GitHub Pages /games/v2/
+// build-pages.mjs — assemble the v2 interpreter demos + Monaco live editor
 // ============================================================================
 //
 //   node gallery/game_engine/v2/web/build-pages.mjs [--out <dir>]
 //
-// Builds the LIVE-path browser demos that run the staged v2 ComponentEngine
-// (interp/migrate/src) through RgGameHost / RgRegistryBridge, then writes a
-// small hub index.html so /games/v2/ is browsable. Used by deploy-pages.yml.
+// Builds LIVE-path browser demos (staged v2 ComponentEngine), a Monaco editor
+// hub at the out root, and a per-demo editor page for each game. Used by
+// deploy-pages.yml → /games/v2/.
 // ============================================================================
 
 import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import url from "node:url";
 
 const HERE = path.dirname(url.fileURLToPath(import.meta.url));
+const SRC = path.join(HERE, "src");
 const ROOT = (() => {
   let d = HERE;
   for (let i = 0; i < 8; i++) {
@@ -36,57 +39,84 @@ const DEMOS = [
     id: "live2d",
     title: "Ylos2 — live ranger:2d",
     blurb: "Real v2 climber game: ComponentEngine → RgRegistryBridge → software 2D present.",
-    build: () =>
-      sh("node", [
-        "gallery/game_engine/v2/web/build-live2d.mjs",
-        "--out",
-        path.join(OUT, "live2d"),
-      ]),
+    kind: "live2d",
+    bundle: "live2d.bundle.js",
+    width: 480,
+    height: 270,
+    clearRgb: 0x4f96cf,
+    editPath: "gallery/game_engine/v2/games/ylos2/index.tsx",
+    controls: "Arrow keys / A-D move · Space / W jump",
+    build: (outDir) =>
+      sh("node", ["gallery/game_engine/v2/web/build-live2d.mjs", "--out", outDir]),
   },
   {
     id: "live3d",
     title: "Cube — live ranger:three",
     blurb: "Canonical cube on the live registry path (no reconciler).",
-    build: () =>
+    kind: "live3d",
+    bundle: "live3d.bundle.js",
+    width: 480,
+    height: 480,
+    editPath: "gallery/game_engine/v2/web/guests/three/cube_live.tsx",
+    controls: "Auto-spinning cube (edit tick() to change motion)",
+    build: (outDir) =>
       sh("node", [
         "gallery/game_engine/v2/web/build-live3d.mjs",
         "--guest",
         "cube_live.tsx",
         "--out",
-        path.join(OUT, "live3d"),
+        outDir,
       ]),
   },
   {
     id: "teapot",
     title: "Teapot — live ranger:three",
     blurb: "Utah teapot guest on the same live 3D host.",
-    build: () =>
+    kind: "live3d",
+    bundle: "live3d.bundle.js",
+    width: 480,
+    height: 480,
+    editPath: "gallery/game_engine/v2/web/guests/three/teapot_live.tsx",
+    controls: "Edit teapot_live.tsx — reload rebuilds the scene",
+    build: (outDir) =>
       sh("node", [
         "gallery/game_engine/v2/web/build-live3d.mjs",
         "--guest",
         "teapot_live.tsx",
         "--out",
-        path.join(OUT, "teapot"),
+        outDir,
       ]),
   },
   {
     id: "courtyard",
     title: "Courtyard — live ranger:three",
     blurb: "Procedural courtyard (planes + boxes) on the live path.",
-    build: () =>
+    kind: "live3d",
+    bundle: "live3d.bundle.js",
+    width: 480,
+    height: 480,
+    editPath: "gallery/game_engine/v2/web/guests/three/courtyard_live.tsx",
+    controls: "Edit courtyard_live.tsx — reload rebuilds the scene",
+    build: (outDir) =>
       sh("node", [
         "gallery/game_engine/v2/web/build-live3d.mjs",
         "--guest",
         "courtyard_live.tsx",
         "--out",
-        path.join(OUT, "courtyard"),
+        outDir,
       ]),
   },
   {
     id: "model",
     title: "glTF model — live ranger:three",
     blurb: "Loads diamond.glb through the live GLTFModel path.",
-    build: () =>
+    kind: "live3d",
+    bundle: "live3d.bundle.js",
+    width: 480,
+    height: 480,
+    editPath: "gallery/game_engine/v2/web/guests/three/model_live.tsx",
+    controls: "Edit model_live.tsx — reload rebuilds the scene",
+    build: (outDir) =>
       sh("node", [
         "gallery/game_engine/v2/web/build-live3d.mjs",
         "--guest",
@@ -94,113 +124,288 @@ const DEMOS = [
         "--asset",
         "games/ylos3d/models/diamond.glb",
         "--out",
-        path.join(OUT, "model"),
+        outDir,
       ]),
   },
 ];
 
+function demoManifest(d) {
+  return {
+    id: d.id,
+    title: d.title,
+    blurb: d.blurb,
+    kind: d.kind,
+    bundle: d.bundle,
+    width: d.width,
+    height: d.height,
+    clearRgb: d.clearRgb || 0,
+    editPath: d.editPath,
+    controls: d.controls || "",
+    href: "./" + d.id + "/",
+  };
+}
+
+async function buildEditor(outDir) {
+  let esbuild;
+  try {
+    esbuild = await import("esbuild");
+  } catch {
+    log("esbuild not installed — skipping Monaco (npm ci in gallery/game_engine/v2/web)");
+    return false;
+  }
+  const req = createRequire(import.meta.url);
+  let editorWorker, tsWorker;
+  try {
+    editorWorker = req.resolve("monaco-editor/esm/vs/editor/editor.worker.js");
+    tsWorker = req.resolve("monaco-editor/esm/vs/language/typescript/ts.worker.js");
+  } catch {
+    log("monaco-editor not installed — skipping editor");
+    return false;
+  }
+  const common = {
+    bundle: true,
+    format: "iife",
+    loader: { ".ttf": "dataurl" },
+    legalComments: "none",
+    logLevel: "silent",
+  };
+  await esbuild.build({
+    ...common,
+    entryPoints: [path.join(SRC, "editor.entry.mjs")],
+    outfile: path.join(outDir, "editor.bundle.js"),
+  });
+  await esbuild.build({
+    ...common,
+    entryPoints: { "editor.worker": editorWorker, "ts.worker": tsWorker },
+    outdir: outDir,
+  });
+  const kb = (fs.statSync(path.join(outDir, "editor.bundle.js")).size / 1024).toFixed(0);
+  log("bundled Monaco editor (" + kb + " KB + workers)");
+  return true;
+}
+
+function copySharedRuntime(outDir) {
+  for (const f of [
+    "vfs.js",
+    "engine-host.js",
+    "live2d-viewer.js",
+    "live3d-viewer.js",
+    "live-editor.js",
+  ]) {
+    fs.copyFileSync(path.join(SRC, f), path.join(outDir, f));
+  }
+}
+
+function cacheBustHtml(htmlPath, names, rootDir) {
+  const h = crypto.createHash("sha1");
+  for (const n of names) {
+    const p = path.join(rootDir, n);
+    if (fs.existsSync(p)) h.update(fs.readFileSync(p));
+  }
+  const ver = h.digest("hex").slice(0, 10);
+  let html = fs.readFileSync(htmlPath, "utf8");
+  for (const n of names) {
+    html = html.replaceAll("./" + n, "./" + n + "?v=" + ver);
+    html = html.replaceAll("../" + n, "../" + n + "?v=" + ver);
+  }
+  fs.writeFileSync(htmlPath, html);
+  return ver;
+}
+
+function writePerDemoEditor(demoDir, demo, editorOk) {
+  // Self-contained demos.json so the locked page (and browser_smoke) work when
+  // the static server root is the demo folder itself.
+  fs.writeFileSync(
+    path.join(demoDir, "demos.json"),
+    JSON.stringify([demoManifest(demo)], null, 2)
+  );
+  // Each game folder gets a Monaco editor locked to that demo; shared Monaco /
+  // viewers load from the parent /games/v2/ directory.
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${demo.title} — v2 live editor</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='14' font-size='14'>⚡</text></svg>"
+    />
+    <link rel="stylesheet" href="../editor.bundle.css" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0c1020; --panel: #151a2e; --ink: #e6e9f3; --muted: #97a0bd;
+        --accent: #6ea8ff; --good: #58d38c;
+      }
+      * { box-sizing: border-box; }
+      html, body { height: 100%; }
+      body {
+        margin: 0;
+        font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+        background: radial-gradient(1200px 600px at 50% -10%, #1b2140, var(--bg));
+        color: var(--ink);
+        display: flex; flex-direction: column; min-height: 100vh;
+      }
+      header { padding: 18px 22px 6px; }
+      h1 { margin: 0; font-size: 20px; letter-spacing: -0.02em; }
+      .sub { color: var(--muted); margin: 2px 0 0; font-size: 13px; }
+      .sub code, .sub a { color: var(--accent); }
+      .toolbar {
+        display: flex; gap: 12px; align-items: center; flex-wrap: wrap;
+        padding: 10px 22px;
+      }
+      select, button {
+        font: inherit; color: var(--ink); background: #1e2540;
+        border: 1px solid #313a5c; border-radius: 8px; padding: 7px 11px; cursor: pointer;
+      }
+      button:hover, select:hover { border-color: var(--accent); }
+      label.chk { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); cursor: pointer; }
+      .status { margin-left: auto; color: var(--muted); font-size: 13px; min-width: 0; }
+      .status .ok { color: var(--good); }
+      main {
+        --editor-pct: 55%;
+        flex: 1; display: flex; gap: 0; padding: 4px 22px 22px;
+        align-items: stretch; min-height: 0;
+      }
+      .card {
+        background: var(--panel); border: 1px solid #262d47; border-radius: 12px;
+        overflow: hidden; box-shadow: 0 20px 60px -30px #000a;
+        display: flex; flex-direction: column; min-height: 0;
+      }
+      .card .cap {
+        padding: 8px 12px; color: var(--muted); font-size: 12px;
+        border-bottom: 1px solid #262d47; flex: 0 0 auto;
+      }
+      .editor-pane { flex: 0 0 var(--editor-pct); min-width: 240px; max-width: calc(100% - 210px); }
+      .view-pane { flex: 1 1 auto; min-width: 200px; }
+      .splitter {
+        flex: 0 0 10px; margin: 0 2px; cursor: col-resize; touch-action: none;
+        position: relative; align-self: stretch; border-radius: 6px;
+      }
+      .splitter::before {
+        content: ""; position: absolute; top: 12px; bottom: 12px; left: 3px; right: 3px;
+        border-radius: 3px; background: #262d47;
+      }
+      .splitter:hover::before, body.splitting .splitter::before { background: var(--accent); }
+      body.splitting { cursor: col-resize; user-select: none; }
+      #editor { flex: 1; min-height: 280px; width: 100%; height: 100%; }
+      .stage { padding: 14px; flex: 1; min-width: 0; }
+      canvas {
+        display: block; image-rendering: pixelated;
+        width: 100%; max-width: 100%; height: auto; aspect-ratio: 16 / 9;
+        border-radius: 8px; background: #0a0e1a;
+      }
+      canvas.square { aspect-ratio: 1 / 1; image-rendering: auto; }
+      .controls { color: var(--muted); font-size: 12.5px; margin-top: 10px; }
+      .hint { color: var(--muted); font-size: 12px; padding: 0 22px 18px; }
+      .hint a, .hint code { color: var(--accent); }
+      main.no-editor .editor-pane, main.no-editor .splitter { display: none; }
+      main.no-editor .view-pane { flex: 1 1 auto; max-width: none; }
+      @media (max-width: 900px) {
+        main { flex-direction: column; gap: 14px; }
+        .editor-pane { flex: none; width: 100%; max-width: none; }
+        .splitter { display: none; }
+        #editor { height: 45vh; flex: none; }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>${demo.title}</h1>
+      <p class="sub">
+        v2 interpreter live editor —
+        <a href="../">all v2 games</a> ·
+        <a href="../../">v1 games</a>
+      </p>
+    </header>
+    <div class="toolbar">
+      <label>Game <select id="game"></select></label>
+      <label class="chk"><input type="checkbox" id="autoreload" checked /> Auto-reload on edit</label>
+      <button id="reload">Reload now</button>
+      <button id="restart">Restart</button>
+      <button id="pause">Pause</button>
+      <span class="status" id="status">loading…</span>
+    </div>
+    <main id="split">
+      <section class="card editor-pane">
+        <div class="cap" id="filecap">script</div>
+        <div id="editor"></div>
+      </section>
+      <div class="splitter" id="splitter" role="separator" aria-orientation="vertical"
+        aria-label="Resize editor and game view" aria-valuemin="20" aria-valuemax="80"
+        aria-valuenow="55" tabindex="0"></div>
+      <section class="card view-pane">
+        <div class="cap">canvas — v2 interpreter</div>
+        <div class="stage">
+          <canvas id="screen" width="${demo.width}" height="${demo.height}" tabindex="0"></canvas>
+          <div class="controls" id="controls"></div>
+        </div>
+      </section>
+    </main>
+    <p class="hint">
+      Edit the guest <code>.tsx</code>; auto-reload rebuilds a fresh host.
+      ${editorOk ? "" : "Monaco bundle missing — rebuild with <code>npm ci</code> in <code>v2/web</code>."}
+    </p>
+    <script>window.RangerEditorBase = "../";</script>
+    <script>window.RANGER_V2_ASSET_BASE = "./";</script>
+    <script>window.RANGER_V2_DEMOS_JSON = "./demos.json";</script>
+    <script>window.RANGER_V2_LOCKED_DEMO = ${JSON.stringify(demo.id)};</script>
+    <script src="../vfs.js"></script>
+    <script src="../engine-host.js"></script>
+    <script src="../live2d-viewer.js"></script>
+    <script src="../live3d-viewer.js"></script>
+    <script src="../editor.bundle.js"></script>
+    <script src="../live-editor.js"></script>
+  </body>
+</html>
+`;
+  fs.writeFileSync(path.join(demoDir, "index.html"), html);
+}
+
+// --- main -------------------------------------------------------------------
 fs.rmSync(OUT, { recursive: true, force: true });
 fs.mkdirSync(OUT, { recursive: true });
 
 for (const demo of DEMOS) {
   log("building", demo.id);
-  demo.build();
+  const demoOut = path.join(OUT, demo.id);
+  demo.build(demoOut);
+  // Drop the view-only index from build-live*; replace with editor page below.
 }
 
-const cards = DEMOS.map(
-  (d) => `      <a class="card" href="./${d.id}/">
-        <h2>${d.title}</h2>
-        <p>${d.blurb}</p>
-        <span class="go">Open →</span>
-      </a>`
-).join("\n");
+copySharedRuntime(OUT);
+const editorOk = await buildEditor(OUT);
+fs.copyFileSync(path.join(HERE, "editor.html"), path.join(OUT, "index.html"));
 
-const hub = `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Ranger v2 interpreter — live demos</title>
-    <link
-      rel="icon"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='14' font-size='14'>⚡</text></svg>"
-    />
-    <style>
-      :root {
-        color-scheme: dark;
-        --bg: #0c1020;
-        --panel: #151a2e;
-        --ink: #e6e9f3;
-        --muted: #97a0bd;
-        --accent: #6ea8ff;
-      }
-      * { box-sizing: border-box; }
-      body {
-        margin: 0;
-        min-height: 100vh;
-        color: var(--ink);
-        font: 15px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-        background: radial-gradient(1200px 600px at 50% -10%, #1b2140, var(--bg));
-        padding: 36px 20px 64px;
-      }
-      .wrap { max-width: 920px; margin: 0 auto; }
-      h1 { margin: 0 0 6px; font-size: 26px; letter-spacing: -0.02em; }
-      .sub { color: var(--muted); margin: 0 0 28px; max-width: 720px; }
-      .sub code { color: var(--accent); }
-      .grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-        gap: 14px;
-      }
-      a.card {
-        display: block;
-        text-decoration: none;
-        color: inherit;
-        background: var(--panel);
-        border: 1px solid #262d47;
-        border-radius: 14px;
-        padding: 18px 18px 16px;
-        box-shadow: 0 20px 60px -30px #000a;
-        transition: border-color 0.12s ease, transform 0.12s ease;
-      }
-      a.card:hover { border-color: var(--accent); transform: translateY(-1px); }
-      a.card h2 { margin: 0 0 8px; font-size: 16px; }
-      a.card p { margin: 0 0 14px; color: var(--muted); font-size: 13.5px; min-height: 3.2em; }
-      a.card .go { color: var(--accent); font-size: 13px; }
-      footer { margin-top: 28px; color: var(--muted); font-size: 13px; }
-      footer a { color: var(--accent); }
-    </style>
-  </head>
-  <body>
-    <div class="wrap">
-      <h1>Ranger v2 interpreter</h1>
-      <p class="sub">
-        These demos run the staged v2 <code>ComponentEngine</code>
-        (<code>gallery/game_engine/v2/interp/migrate/src</code>) in the browser —
-        live registry transport, no classic reconciler. The main
-        <a href="../">/games/</a> editor still ships the v1 GameRunner path.
-      </p>
-      <div class="grid">
-${cards}
-      </div>
-      <footer>
-        Built from <code>gallery/game_engine/v2/web/build-pages.mjs</code>.
-        Back to <a href="../">all games</a> · <a href="../../">playground</a> ·
-        <a href="../../docs/">docs</a>.
-      </footer>
-    </div>
-  </body>
-</html>
-`;
+const manifest = DEMOS.map(demoManifest);
+fs.writeFileSync(path.join(OUT, "demos.json"), JSON.stringify(manifest, null, 2));
 
-fs.writeFileSync(path.join(OUT, "index.html"), hub);
+for (const demo of DEMOS) {
+  writePerDemoEditor(path.join(OUT, demo.id), demo, editorOk);
+  // Keep a view-only fallback next to the editor for smoke tests that only
+  // need the canvas (browser_smoke loads #screen without Monaco).
+  // The editor index is the default; smoke uses the same page (canvas still present).
+}
+
+const sharedNames = [
+  "vfs.js",
+  "engine-host.js",
+  "live2d-viewer.js",
+  "live3d-viewer.js",
+  "live-editor.js",
+  "editor.bundle.js",
+  "editor.bundle.css",
+  "demos.json",
+];
+const ver = cacheBustHtml(path.join(OUT, "index.html"), sharedNames, OUT);
+for (const demo of DEMOS) {
+  cacheBustHtml(path.join(OUT, demo.id, "index.html"), sharedNames, OUT);
+}
 fs.writeFileSync(
-  path.join(OUT, "demos.json"),
-  JSON.stringify(
-    DEMOS.map((d) => ({ id: d.id, title: d.title, blurb: d.blurb, href: `./${d.id}/` })),
-    null,
-    2
-  )
+  path.join(OUT, "build-info.json"),
+  JSON.stringify({ editor: editorOk, demos: manifest.map((d) => d.id), version: ver }, null, 2)
 );
-log("wrote hub →", OUT);
-log("demos:", DEMOS.map((d) => d.id).join(", "));
+
+log("wrote hub + per-demo editors →", OUT);
+log("demos:", DEMOS.map((d) => d.id).join(", "), editorOk ? "(with Monaco)" : "(no Monaco)");

--- a/gallery/game_engine/v2/web/build-pages.mjs
+++ b/gallery/game_engine/v2/web/build-pages.mjs
@@ -1,0 +1,206 @@
+// ============================================================================
+// build-pages.mjs — assemble the v2 interpreter demos for GitHub Pages /games/v2/
+// ============================================================================
+//
+//   node gallery/game_engine/v2/web/build-pages.mjs [--out <dir>]
+//
+// Builds the LIVE-path browser demos that run the staged v2 ComponentEngine
+// (interp/migrate/src) through RgGameHost / RgRegistryBridge, then writes a
+// small hub index.html so /games/v2/ is browsable. Used by deploy-pages.yml.
+// ============================================================================
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+
+const HERE = path.dirname(url.fileURLToPath(import.meta.url));
+const ROOT = (() => {
+  let d = HERE;
+  for (let i = 0; i < 8; i++) {
+    if (fs.existsSync(path.join(d, "bin", "output.js"))) return d;
+    d = path.dirname(d);
+  }
+  return path.resolve(HERE, "..", "..", "..", "..");
+})();
+
+const argv = process.argv.slice(2);
+const outArg = argv.indexOf("--out");
+const OUT = path.resolve(outArg >= 0 ? argv[outArg + 1] : path.join(HERE, "dist", "pages"));
+
+const log = (...a) => console.log("[v2-pages]", ...a);
+const sh = (cmd, args) => execFileSync(cmd, args, { stdio: "inherit", cwd: ROOT });
+
+const DEMOS = [
+  {
+    id: "live2d",
+    title: "Ylos2 — live ranger:2d",
+    blurb: "Real v2 climber game: ComponentEngine → RgRegistryBridge → software 2D present.",
+    build: () =>
+      sh("node", [
+        "gallery/game_engine/v2/web/build-live2d.mjs",
+        "--out",
+        path.join(OUT, "live2d"),
+      ]),
+  },
+  {
+    id: "live3d",
+    title: "Cube — live ranger:three",
+    blurb: "Canonical cube on the live registry path (no reconciler).",
+    build: () =>
+      sh("node", [
+        "gallery/game_engine/v2/web/build-live3d.mjs",
+        "--guest",
+        "cube_live.tsx",
+        "--out",
+        path.join(OUT, "live3d"),
+      ]),
+  },
+  {
+    id: "teapot",
+    title: "Teapot — live ranger:three",
+    blurb: "Utah teapot guest on the same live 3D host.",
+    build: () =>
+      sh("node", [
+        "gallery/game_engine/v2/web/build-live3d.mjs",
+        "--guest",
+        "teapot_live.tsx",
+        "--out",
+        path.join(OUT, "teapot"),
+      ]),
+  },
+  {
+    id: "courtyard",
+    title: "Courtyard — live ranger:three",
+    blurb: "Procedural courtyard (planes + boxes) on the live path.",
+    build: () =>
+      sh("node", [
+        "gallery/game_engine/v2/web/build-live3d.mjs",
+        "--guest",
+        "courtyard_live.tsx",
+        "--out",
+        path.join(OUT, "courtyard"),
+      ]),
+  },
+  {
+    id: "model",
+    title: "glTF model — live ranger:three",
+    blurb: "Loads diamond.glb through the live GLTFModel path.",
+    build: () =>
+      sh("node", [
+        "gallery/game_engine/v2/web/build-live3d.mjs",
+        "--guest",
+        "model_live.tsx",
+        "--asset",
+        "games/ylos3d/models/diamond.glb",
+        "--out",
+        path.join(OUT, "model"),
+      ]),
+  },
+];
+
+fs.rmSync(OUT, { recursive: true, force: true });
+fs.mkdirSync(OUT, { recursive: true });
+
+for (const demo of DEMOS) {
+  log("building", demo.id);
+  demo.build();
+}
+
+const cards = DEMOS.map(
+  (d) => `      <a class="card" href="./${d.id}/">
+        <h2>${d.title}</h2>
+        <p>${d.blurb}</p>
+        <span class="go">Open →</span>
+      </a>`
+).join("\n");
+
+const hub = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ranger v2 interpreter — live demos</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='14' font-size='14'>⚡</text></svg>"
+    />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0c1020;
+        --panel: #151a2e;
+        --ink: #e6e9f3;
+        --muted: #97a0bd;
+        --accent: #6ea8ff;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        color: var(--ink);
+        font: 15px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+        background: radial-gradient(1200px 600px at 50% -10%, #1b2140, var(--bg));
+        padding: 36px 20px 64px;
+      }
+      .wrap { max-width: 920px; margin: 0 auto; }
+      h1 { margin: 0 0 6px; font-size: 26px; letter-spacing: -0.02em; }
+      .sub { color: var(--muted); margin: 0 0 28px; max-width: 720px; }
+      .sub code { color: var(--accent); }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: 14px;
+      }
+      a.card {
+        display: block;
+        text-decoration: none;
+        color: inherit;
+        background: var(--panel);
+        border: 1px solid #262d47;
+        border-radius: 14px;
+        padding: 18px 18px 16px;
+        box-shadow: 0 20px 60px -30px #000a;
+        transition: border-color 0.12s ease, transform 0.12s ease;
+      }
+      a.card:hover { border-color: var(--accent); transform: translateY(-1px); }
+      a.card h2 { margin: 0 0 8px; font-size: 16px; }
+      a.card p { margin: 0 0 14px; color: var(--muted); font-size: 13.5px; min-height: 3.2em; }
+      a.card .go { color: var(--accent); font-size: 13px; }
+      footer { margin-top: 28px; color: var(--muted); font-size: 13px; }
+      footer a { color: var(--accent); }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Ranger v2 interpreter</h1>
+      <p class="sub">
+        These demos run the staged v2 <code>ComponentEngine</code>
+        (<code>gallery/game_engine/v2/interp/migrate/src</code>) in the browser —
+        live registry transport, no classic reconciler. The main
+        <a href="../">/games/</a> editor still ships the v1 GameRunner path.
+      </p>
+      <div class="grid">
+${cards}
+      </div>
+      <footer>
+        Built from <code>gallery/game_engine/v2/web/build-pages.mjs</code>.
+        Back to <a href="../">all games</a> · <a href="../../">playground</a> ·
+        <a href="../../docs/">docs</a>.
+      </footer>
+    </div>
+  </body>
+</html>
+`;
+
+fs.writeFileSync(path.join(OUT, "index.html"), hub);
+fs.writeFileSync(
+  path.join(OUT, "demos.json"),
+  JSON.stringify(
+    DEMOS.map((d) => ({ id: d.id, title: d.title, blurb: d.blurb, href: `./${d.id}/` })),
+    null,
+    2
+  )
+);
+log("wrote hub →", OUT);
+log("demos:", DEMOS.map((d) => d.id).join(", "));

--- a/gallery/game_engine/v2/web/editor.html
+++ b/gallery/game_engine/v2/web/editor.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ranger v2 — live editor</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='14' font-size='14'>⚡</text></svg>"
+    />
+    <link rel="stylesheet" href="./editor.bundle.css" />
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0c1020;
+        --panel: #151a2e;
+        --ink: #e6e9f3;
+        --muted: #97a0bd;
+        --accent: #6ea8ff;
+        --good: #58d38c;
+      }
+      * { box-sizing: border-box; }
+      html, body { height: 100%; }
+      body {
+        margin: 0;
+        font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+        background: radial-gradient(1200px 600px at 50% -10%, #1b2140, var(--bg));
+        color: var(--ink);
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+      header { padding: 18px 22px 6px; }
+      h1 { margin: 0; font-size: 20px; letter-spacing: -0.02em; }
+      .sub { color: var(--muted); margin: 2px 0 0; font-size: 13px; }
+      .sub code, .sub a { color: var(--accent); }
+      .toolbar {
+        display: flex; gap: 12px; align-items: center; flex-wrap: wrap;
+        padding: 10px 22px;
+      }
+      select, button {
+        font: inherit; color: var(--ink); background: #1e2540;
+        border: 1px solid #313a5c; border-radius: 8px; padding: 7px 11px; cursor: pointer;
+      }
+      button:hover, select:hover { border-color: var(--accent); }
+      label.chk { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); cursor: pointer; }
+      .status { margin-left: auto; color: var(--muted); font-size: 13px; min-width: 0; }
+      .status .ok { color: var(--good); }
+      main {
+        --editor-pct: 55%;
+        flex: 1; display: flex; gap: 0; padding: 4px 22px 22px;
+        align-items: stretch; min-height: 0;
+      }
+      .card {
+        background: var(--panel); border: 1px solid #262d47; border-radius: 12px;
+        overflow: hidden; box-shadow: 0 20px 60px -30px #000a;
+        display: flex; flex-direction: column; min-height: 0;
+      }
+      .card .cap {
+        padding: 8px 12px; color: var(--muted); font-size: 12px;
+        border-bottom: 1px solid #262d47; flex: 0 0 auto;
+      }
+      .editor-pane {
+        flex: 0 0 var(--editor-pct); min-width: 240px; max-width: calc(100% - 210px);
+      }
+      .view-pane { flex: 1 1 auto; min-width: 200px; }
+      .splitter {
+        flex: 0 0 10px; margin: 0 2px; cursor: col-resize; touch-action: none;
+        position: relative; align-self: stretch; border-radius: 6px;
+        background: transparent;
+      }
+      .splitter::before {
+        content: ""; position: absolute; top: 12px; bottom: 12px; left: 3px; right: 3px;
+        border-radius: 3px; background: #262d47; transition: background 0.12s ease;
+      }
+      .splitter:hover::before,
+      .splitter:focus-visible::before,
+      body.splitting .splitter::before {
+        background: var(--accent);
+      }
+      .splitter:focus-visible { outline: none; }
+      body.splitting { cursor: col-resize; user-select: none; }
+      body.splitting iframe, body.splitting canvas { pointer-events: none; }
+      #editor { flex: 1; min-height: 280px; width: 100%; height: 100%; }
+      .stage { padding: 14px; flex: 1; min-width: 0; }
+      canvas {
+        display: block; image-rendering: pixelated;
+        width: 100%; max-width: 100%; height: auto; aspect-ratio: 16 / 9;
+        border-radius: 8px; background: #0a0e1a;
+      }
+      canvas.square { aspect-ratio: 1 / 1; image-rendering: auto; }
+      .controls { color: var(--muted); font-size: 12.5px; margin-top: 10px; }
+      .hint { color: var(--muted); font-size: 12px; padding: 0 22px 18px; }
+      .hint code, .hint a { color: var(--accent); }
+      main.no-editor .editor-pane,
+      main.no-editor .splitter { display: none; }
+      main.no-editor .view-pane { flex: 1 1 auto; max-width: none; }
+      @media (max-width: 900px) {
+        main { flex-direction: column; gap: 14px; }
+        .editor-pane { flex: none; width: 100%; max-width: none; min-width: 0; }
+        .view-pane { flex: none; width: 100%; min-width: 0; }
+        .splitter { display: none; }
+        #editor { height: 50vh; flex: none; }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Ranger v2 — live editor</h1>
+      <p class="sub">
+        Staged <code>ComponentEngine</code> + live registry transport.
+        Edit the guest <code>.tsx</code> and it rebuilds in place.
+        <a href="../">v1 games editor</a>
+      </p>
+    </header>
+
+    <div class="toolbar">
+      <label>Game <select id="game"></select></label>
+      <label class="chk"><input type="checkbox" id="autoreload" checked /> Auto-reload on edit</label>
+      <button id="reload">Reload now</button>
+      <button id="restart">Restart</button>
+      <button id="pause">Pause</button>
+      <span class="status" id="status">loading…</span>
+    </div>
+
+    <main id="split">
+      <section class="card editor-pane">
+        <div class="cap" id="filecap">script</div>
+        <div id="editor"></div>
+      </section>
+      <div
+        class="splitter"
+        id="splitter"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize editor and game view"
+        aria-valuemin="20"
+        aria-valuemax="80"
+        aria-valuenow="55"
+        tabindex="0"
+      ></div>
+      <section class="card view-pane">
+        <div class="cap">canvas — v2 interpreter</div>
+        <div class="stage">
+          <canvas id="screen" width="480" height="270" tabindex="0"></canvas>
+          <div class="controls" id="controls"></div>
+        </div>
+      </section>
+    </main>
+
+    <p class="hint">
+      Live2d games use <code>ranger:core</code> / <code>ranger:2d</code>; live3d
+      guests import <code>ranger:three</code>. Edits rebuild a fresh host (state
+      resets). Standalone view-only demos remain under each game folder.
+    </p>
+
+    <script src="./vfs.js"></script>
+    <script src="./engine-host.js"></script>
+    <script src="./live2d-viewer.js"></script>
+    <script src="./live3d-viewer.js"></script>
+    <script src="./editor.bundle.js"></script>
+    <script src="./live-editor.js"></script>
+  </body>
+</html>

--- a/gallery/game_engine/v2/web/src/editor.entry.mjs
+++ b/gallery/game_engine/v2/web/src/editor.entry.mjs
@@ -12,12 +12,15 @@
 import * as monaco from "monaco-editor";
 
 // Workers are emitted next to this bundle by the esbuild build step.
+// Pages that load the editor from a parent folder (per-demo URLs) set
+// self.RangerEditorBase = "../" before this script runs.
+const EDITOR_BASE = (typeof self !== "undefined" && self.RangerEditorBase) || "./";
 self.MonacoEnvironment = {
   getWorker(_moduleId, label) {
     if (label === "typescript" || label === "javascript") {
-      return new Worker("./ts.worker.js");
+      return new Worker(EDITOR_BASE + "ts.worker.js");
     }
-    return new Worker("./editor.worker.js");
+    return new Worker(EDITOR_BASE + "editor.worker.js");
   },
 };
 

--- a/gallery/game_engine/v2/web/src/live-editor.js
+++ b/gallery/game_engine/v2/web/src/live-editor.js
@@ -1,0 +1,277 @@
+// ============================================================================
+// live-editor.js — Monaco shell boot for v2 live2d / live3d demos.
+// ============================================================================
+//
+// Loads demos.json, lets you pick a game, mounts its scene.zip into a VFS,
+// runs WebLive2dHost / WebLive3dHost, and hot-reloads the editable .tsx when
+// Monaco changes (full host rebuild — same pattern as tsx3d-gl-viewer).
+// ============================================================================
+
+(function () {
+  "use strict";
+
+  const statusEl = document.getElementById("status");
+  const selectEl = document.getElementById("game");
+  const controlsEl = document.getElementById("controls");
+  const fileCapEl = document.getElementById("filecap");
+  const autoEl = document.getElementById("autoreload");
+  const splitEl = document.getElementById("split");
+  const splitterEl = document.getElementById("splitter");
+  let canvas = document.getElementById("screen");
+
+  let registry = [];
+  let session = null;
+  let editor = null;
+  let paused = false;
+  let editTimer = 0;
+  let suppressChange = false;
+  let assetBase = "./"; // where demos/<id>/ lives relative to this page
+
+  const SPLIT_KEY = "ranger-v2-editor-pct";
+  const SPLIT_DEFAULT = 55;
+  const SPLIT_MIN = 20;
+  const SPLIT_MAX = 80;
+
+  const setStatus = (msg, ok) =>
+    (statusEl.innerHTML = ok ? '<span class="ok">' + msg + "</span>" : msg);
+
+  function setEditorPct(pct) {
+    const n = Math.min(SPLIT_MAX, Math.max(SPLIT_MIN, Math.round(pct)));
+    splitEl.style.setProperty("--editor-pct", n + "%");
+    splitterEl.setAttribute("aria-valuenow", String(n));
+    try {
+      localStorage.setItem(SPLIT_KEY, String(n));
+    } catch (_) {}
+    return n;
+  }
+
+  function initSplitter() {
+    let saved = SPLIT_DEFAULT;
+    try {
+      const raw = localStorage.getItem(SPLIT_KEY);
+      if (raw != null && raw !== "") saved = Number(raw);
+    } catch (_) {}
+    if (!Number.isFinite(saved)) saved = SPLIT_DEFAULT;
+    setEditorPct(saved);
+
+    let dragging = false;
+    const onMove = (clientX) => {
+      const rect = splitEl.getBoundingClientRect();
+      if (rect.width <= 0) return;
+      setEditorPct(((clientX - rect.left) / rect.width) * 100);
+    };
+    splitterEl.addEventListener("pointerdown", (e) => {
+      if (window.matchMedia("(max-width: 900px)").matches) return;
+      dragging = true;
+      document.body.classList.add("splitting");
+      splitterEl.setPointerCapture(e.pointerId);
+      e.preventDefault();
+    });
+    splitterEl.addEventListener("pointermove", (e) => {
+      if (!dragging) return;
+      onMove(e.clientX);
+    });
+    const endDrag = (e) => {
+      if (!dragging) return;
+      dragging = false;
+      document.body.classList.remove("splitting");
+      try {
+        splitterEl.releasePointerCapture(e.pointerId);
+      } catch (_) {}
+    };
+    splitterEl.addEventListener("pointerup", endDrag);
+    splitterEl.addEventListener("pointercancel", endDrag);
+    splitterEl.addEventListener("dblclick", () => setEditorPct(SPLIT_DEFAULT));
+    splitterEl.addEventListener("keydown", (e) => {
+      const cur = Number(splitterEl.getAttribute("aria-valuenow")) || SPLIT_DEFAULT;
+      if (e.key === "ArrowLeft") {
+        setEditorPct(cur - 2);
+        e.preventDefault();
+      } else if (e.key === "ArrowRight") {
+        setEditorPct(cur + 2);
+        e.preventDefault();
+      } else if (e.key === "Home") {
+        setEditorPct(SPLIT_MIN);
+        e.preventDefault();
+      } else if (e.key === "End") {
+        setEditorPct(SPLIT_MAX);
+        e.preventDefault();
+      }
+    });
+  }
+
+  async function fetchText(u) {
+    const r = await fetch(u);
+    if (!r.ok) throw new Error("fetch " + u + " -> " + r.status);
+    return r.text();
+  }
+  async function fetchBuffer(u) {
+    const r = await fetch(u);
+    if (!r.ok) throw new Error("fetch " + u + " -> " + r.status);
+    return r.arrayBuffer();
+  }
+
+  function ensureEditor(value) {
+    if (!window.RangerEditor) return null;
+    if (!editor) {
+      editor = window.RangerEditor.create(document.getElementById("editor"), value, {});
+      editor.onDidChangeModelContent(() => {
+        if (suppressChange) return;
+        if (!autoEl.checked) {
+          setStatus("edited — press Reload now");
+          return;
+        }
+        clearTimeout(editTimer);
+        editTimer = setTimeout(applyEdit, 400);
+      });
+    } else {
+      suppressChange = true;
+      editor.setValue(value);
+      suppressChange = false;
+    }
+    return editor;
+  }
+
+  function applyEdit() {
+    if (!session || !editor || typeof session.reload !== "function") return;
+    try {
+      const rebuilt = session.reload(editor.getValue());
+      setStatus(rebuilt ? "reloaded ✓ (scene rebuilt)" : "reloaded ✓", true);
+    } catch (e) {
+      setStatus("reload error: " + e.message);
+      console.error(e);
+    }
+  }
+
+  function freshCanvas(width, height, square) {
+    const old = document.getElementById("screen");
+    const c = document.createElement("canvas");
+    c.id = "screen";
+    c.width = width || 480;
+    c.height = height || 270;
+    c.tabIndex = 0;
+    if (square) c.className = "square";
+    old.replaceWith(c);
+    canvas = c;
+    return c;
+  }
+
+  function demoUrl(entry, file) {
+    // Hub pages nest demos under <id>/; locked per-demo pages already sit inside
+    // that folder, so assets are siblings of index.html.
+    if (window.RANGER_V2_LOCKED_DEMO) return assetBase + file;
+    return assetBase + entry.id + "/" + file;
+  }
+
+  async function loadGame(entry) {
+    if (session) {
+      session.stop();
+      if (typeof session.dispose === "function") session.dispose();
+    }
+    setStatus("loading " + entry.title + "…");
+    controlsEl.textContent = entry.controls || "";
+    fileCapEl.textContent = entry.editPath || entry.id;
+    const square = entry.kind === "live3d";
+    const w = entry.width || (square ? 480 : 480);
+    const h = entry.height || (square ? 480 : 270);
+    freshCanvas(w, h, square);
+
+    const bundleSource = await fetchText(demoUrl(entry, entry.bundle || "live3d.bundle.js"));
+    const zipBuffer = await fetchBuffer(demoUrl(entry, "scene.zip"));
+    const scene = JSON.parse(await fetchText(demoUrl(entry, "scene.json")));
+
+    if (entry.kind === "live2d") {
+      session = await window.RangerLive2d.launch({
+        bundleSource,
+        zipBuffer,
+        canvas,
+        width: scene.width || w,
+        height: scene.height || h,
+        clearRgb: scene.clearRgb || entry.clearRgb || 0,
+        gameDir: scene.gameDir || entry.gameDir,
+        gameFile: scene.gameFile || entry.gameFile || "index.tsx",
+      });
+    } else if (entry.kind === "live3d") {
+      session = await window.RangerLive3d.launch({
+        bundleSource,
+        zipBuffer,
+        canvas,
+        size: scene.size || w,
+        facadeDir: scene.facadeDir,
+        facadeFile: scene.facadeFile,
+        guestDir: scene.guestDir,
+        guestFile: scene.guestFile,
+        packageDir: scene.packageDir || "",
+      });
+    } else {
+      throw new Error("unknown demo kind: " + entry.kind);
+    }
+
+    ensureEditor(session.getSource());
+    paused = false;
+    document.getElementById("pause").textContent = "Pause";
+    canvas.focus();
+    setStatus(entry.title + " — edit the script; auto-reload rebuilds the scene", true);
+
+    // Keep the URL shareable per game.
+    try {
+      const u = new URL(window.location.href);
+      u.searchParams.set("demo", entry.id);
+      history.replaceState(null, "", u.pathname + u.search + u.hash);
+    } catch (_) {}
+  }
+
+  function pickInitialIndex() {
+    const locked = window.RANGER_V2_LOCKED_DEMO;
+    if (locked) {
+      const i = registry.findIndex((d) => d.id === locked);
+      return i >= 0 ? i : 0;
+    }
+    try {
+      const id = new URL(window.location.href).searchParams.get("demo");
+      if (id) {
+        const i = registry.findIndex((d) => d.id === id);
+        if (i >= 0) return i;
+      }
+    } catch (_) {}
+    return 0;
+  }
+
+  async function boot() {
+    try {
+      assetBase = window.RANGER_V2_ASSET_BASE || "./";
+      const demosPath = window.RANGER_V2_DEMOS_JSON || "./demos.json";
+      registry = JSON.parse(await fetchText(demosPath));
+      if (window.RANGER_V2_LOCKED_DEMO) {
+        selectEl.disabled = true;
+      }
+      selectEl.innerHTML = registry
+        .map((g, i) => '<option value="' + i + '">' + g.title + "</option>")
+        .join("");
+      const initial = pickInitialIndex();
+      selectEl.value = String(initial);
+      selectEl.onchange = () => loadGame(registry[+selectEl.value]);
+      document.getElementById("reload").onclick = applyEdit;
+      document.getElementById("restart").onclick = () => loadGame(registry[+selectEl.value]);
+      document.getElementById("pause").onclick = () => {
+        if (!session) return;
+        paused = !paused;
+        if (paused) session.stop();
+        else session.start();
+        document.getElementById("pause").textContent = paused ? "Resume" : "Pause";
+      };
+      initSplitter();
+      await loadGame(registry[initial]);
+      if (!window.RangerEditor) {
+        splitEl.classList.add("no-editor");
+        document.getElementById("editor").innerHTML =
+          '<p style="padding:16px;color:#97a0bd">Editor bundle not built — run <code>npm ci</code> in <code>gallery/game_engine/v2/web</code> then rebuild.</p>';
+      }
+    } catch (e) {
+      setStatus("error: " + e.message);
+      console.error(e);
+    }
+  }
+
+  boot();
+})();

--- a/gallery/game_engine/v2/web/src/live2d-viewer.js
+++ b/gallery/game_engine/v2/web/src/live2d-viewer.js
@@ -9,6 +9,9 @@
 // Arrow keys + space drive player 0's left/right/action through host.input().
 // Optional config.clearRgb (0xRRGGBB) sets the presenter clear colour (title
 // palettes stay in the viewer/demo, not the engine host).
+//
+// Live editor: getSource() / reload(src) write the guest into the VFS and rebuild
+// a fresh WebLive2dHost (RgGameHost.load already mints a new ComponentEngine).
 // ============================================================================
 
 (function (root) {
@@ -19,6 +22,10 @@
       this.canvas = config.canvas;
       this.ctx = this.canvas.getContext("2d");
       this.host = config.host; // engine WebLive2dHost instance
+      this.engine = config.engine; // Ranger engine module (for fresh hosts)
+      this.vfs = config.vfs;
+      this.gameDir = config.gameDir || "";
+      this.gameFile = config.gameFile || "index.tsx";
       this.w = config.width || 480;
       this.h = config.height || 270;
       this.clearRgb = config.clearRgb | 0;
@@ -28,7 +35,10 @@
       this._raf = 0;
       this._last = 0;
       this._keys = { left: false, right: false, action: false };
+      this._keysBound = false;
       this._tick = this._tick.bind(this);
+      this._onKeyDown = (e) => this._setKey(e, true);
+      this._onKeyUp = (e) => this._setKey(e, false);
     }
 
     // Register the ranger:* modules + evaluate the game + run __rgGameInit();
@@ -36,6 +46,8 @@
     // bridge packageDir to `dir` so pkg:// atlases + PNG sheets resolve against
     // the mounted VFS zip exactly like the headless boot. Render frame 0.
     load(dir, file) {
+      this.gameDir = dir;
+      this.gameFile = file;
       this.host.setup();
       if (this.host.setClearRgb) this.host.setClearRgb(this.clearRgb);
       const ok = this.host.loadFromVfs
@@ -46,6 +58,23 @@
       }
       this.renderOnce(0.016 * 1000);
       return ok;
+    }
+
+    getSource() {
+      if (!this.vfs || !this.gameDir) return "";
+      return this.vfs.readText(this.gameDir + "/" + this.gameFile);
+    }
+
+    // Persist edited source into the VFS and rebuild a fresh host.
+    reload(src) {
+      if (!this.vfs || !this.engine) throw new Error("live2d reload: missing vfs/engine");
+      this.vfs.writeText(this.gameDir + "/" + this.gameFile, src);
+      const wasRunning = !!this._raf;
+      this.stop();
+      this.host = new this.engine.WebLive2dHost();
+      this.load(this.gameDir, this.gameFile);
+      if (wasRunning) this.start();
+      return true;
     }
 
     _applyInput() {
@@ -67,20 +96,34 @@
       this.ctx.putImageData(this._image, 0, 0);
     }
 
+    _setKey(e, down) {
+      let hit = true;
+      switch (e.key) {
+        case "ArrowLeft": case "a": case "A": this._keys.left = down; break;
+        case "ArrowRight": case "d": case "D": this._keys.right = down; break;
+        case "ArrowUp": case " ": case "w": case "W": this._keys.action = down; break;
+        default: hit = false;
+      }
+      if (hit) e.preventDefault();
+    }
+
     bindKeys(target) {
-      const set = (e, down) => {
-        let hit = true;
-        switch (e.key) {
-          case "ArrowLeft": case "a": case "A": this._keys.left = down; break;
-          case "ArrowRight": case "d": case "D": this._keys.right = down; break;
-          case "ArrowUp": case " ": case "w": case "W": this._keys.action = down; break;
-          default: hit = false;
-        }
-        if (hit) e.preventDefault();
-      };
-      (target || root).addEventListener("keydown", (e) => set(e, true));
-      (target || root).addEventListener("keyup", (e) => set(e, false));
+      if (this._keysBound) return this;
+      const t = target || root;
+      t.addEventListener("keydown", this._onKeyDown);
+      t.addEventListener("keyup", this._onKeyUp);
+      this._keyTarget = t;
+      this._keysBound = true;
       return this;
+    }
+
+    dispose() {
+      this.stop();
+      if (this._keysBound && this._keyTarget) {
+        this._keyTarget.removeEventListener("keydown", this._onKeyDown);
+        this._keyTarget.removeEventListener("keyup", this._onKeyUp);
+        this._keysBound = false;
+      }
     }
 
     start() {
@@ -109,8 +152,15 @@
     const engine = root.RangerEngineHost.createEngine(config.bundleSource, vfs, {});
     const host = new engine.WebLive2dHost();
     const session = new Live2dSession({
-      canvas: config.canvas, host,
-      width: config.width, height: config.height,
+      canvas: config.canvas,
+      host,
+      engine,
+      vfs,
+      width: config.width,
+      height: config.height,
+      clearRgb: config.clearRgb | 0,
+      gameDir: config.gameDir,
+      gameFile: config.gameFile,
     });
     session.load(config.gameDir, config.gameFile);
     if (config.bindKeys !== false) session.bindKeys(root);

--- a/gallery/game_engine/v2/web/src/live3d-viewer.js
+++ b/gallery/game_engine/v2/web/src/live3d-viewer.js
@@ -8,6 +8,9 @@
 // scene once; each rAF we call host.frame(dtMs) — which runs the guest's tick()
 // then software-renders the live scene — and blit host.framePixels() (w*h*3 RGB)
 // onto the canvas. Same VFS + engine-host runtime as the software model viewer.
+//
+// Live editor: getSource() / reload(src) rebuild a fresh WebLive3dHost with the
+// edited guest text (facade unchanged).
 // ============================================================================
 
 (function (root) {
@@ -18,6 +21,15 @@
       this.canvas = config.canvas;
       this.ctx = this.canvas.getContext("2d");
       this.host = config.host; // engine WebLive3dHost instance
+      this.engine = config.engine;
+      this.vfs = config.vfs;
+      this.facadeDir = config.facadeDir || "";
+      this.facadeFile = config.facadeFile || "";
+      this.guestDir = config.guestDir || "";
+      this.guestFile = config.guestFile || "";
+      this.packageDir = config.packageDir || "";
+      this.facadeSrc = config.facadeSrc || "";
+      this.guestSrc = config.guestSrc || "";
       this.size = config.size || 480;
       this.canvas.width = this.size;
       this.canvas.height = this.size;
@@ -33,15 +45,55 @@
     // (init() runs the model load), so pkg:// resolves against the mounted VFS
     // zip exactly like an in-engine game. Primitive guests leave it "".
     load(facadeDir, facadeFile, guestDir, guestFile, packageDir) {
+      this.facadeDir = facadeDir;
+      this.facadeFile = facadeFile;
+      this.guestDir = guestDir;
+      this.guestFile = guestFile;
+      if (packageDir != null) this.packageDir = packageDir || "";
       this.host.setup();
-      if (packageDir) this.host.bridge.packageDir = packageDir;
+      if (this.packageDir) this.host.bridge.packageDir = this.packageDir;
       const ok = this.host.loadFromVfs(
         facadeDir, facadeFile, guestDir, guestFile, this.size, this.size);
       if (ok !== "ok" || this.host.errorCount() > 0) {
         throw new Error("live scene load failed: " + this.host.lastError());
       }
+      if (this.vfs) {
+        this.facadeSrc = this.vfs.readText(facadeDir + "/" + facadeFile);
+        this.guestSrc = this.vfs.readText(guestDir + "/" + guestFile);
+      }
       this.renderOnce(0.016 * 1000);
       return ok;
+    }
+
+    loadSources(facadeSrc, guestSrc) {
+      this.facadeSrc = facadeSrc;
+      this.guestSrc = guestSrc;
+      this.host.setup();
+      if (this.packageDir) this.host.bridge.packageDir = this.packageDir;
+      const ok = this.host.load(facadeSrc, guestSrc, this.size, this.size);
+      if (ok !== "ok" || this.host.errorCount() > 0) {
+        throw new Error("live scene load failed: " + this.host.lastError());
+      }
+      this.renderOnce(0.016 * 1000);
+      return ok;
+    }
+
+    getSource() {
+      return this.guestSrc || "";
+    }
+
+    reload(src) {
+      if (!this.engine) throw new Error("live3d reload: missing engine");
+      this.guestSrc = src;
+      if (this.vfs && this.guestDir && this.guestFile) {
+        this.vfs.writeText(this.guestDir + "/" + this.guestFile, src);
+      }
+      const wasRunning = !!this._raf;
+      this.stop();
+      this.host = new this.engine.WebLive3dHost();
+      this.loadSources(this.facadeSrc, this.guestSrc);
+      if (wasRunning) this.start();
+      return true;
     }
 
     renderOnce(dtMs) {
@@ -55,6 +107,10 @@
         out[i + 3] = 255;
       }
       this.ctx.putImageData(this._image, 0, 0);
+    }
+
+    dispose() {
+      this.stop();
     }
 
     start() {
@@ -82,8 +138,25 @@
     if (config.zipBuffer) vfs.mountZip(config.zipBuffer);
     const engine = root.RangerEngineHost.createEngine(config.bundleSource, vfs, {});
     const host = new engine.WebLive3dHost();
-    const session = new Live3dSession({ canvas: config.canvas, host, size: config.size });
-    session.load(config.facadeDir, config.facadeFile, config.guestDir, config.guestFile, config.packageDir);
+    const session = new Live3dSession({
+      canvas: config.canvas,
+      host,
+      engine,
+      vfs,
+      size: config.size,
+      facadeDir: config.facadeDir,
+      facadeFile: config.facadeFile,
+      guestDir: config.guestDir,
+      guestFile: config.guestFile,
+      packageDir: config.packageDir || "",
+    });
+    session.load(
+      config.facadeDir,
+      config.facadeFile,
+      config.guestDir,
+      config.guestFile,
+      config.packageDir || ""
+    );
     if (config.autostart !== false) session.start();
     return session;
   }

--- a/gallery/game_engine/v2/web/tests/browser_smoke.mjs
+++ b/gallery/game_engine/v2/web/tests/browser_smoke.mjs
@@ -17,10 +17,47 @@ import http from "node:http";
 import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
-const require = createRequire("/opt/node22/lib/node_modules/x");
-const { chromium } = require("playwright");
-const CHROME = "/opt/pw-browsers/chromium-1194/chrome-linux/chrome";
+function loadPlaywright() {
+  const anchors = [
+    "/opt/node22/lib/node_modules/x",
+    path.join(
+      path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../../.."),
+      "package.json"
+    ),
+    path.join(process.cwd(), "package.json"),
+    import.meta.url,
+  ];
+  let last;
+  for (const anchor of anchors) {
+    try {
+      return createRequire(anchor)("playwright");
+    } catch (e) {
+      last = e;
+    }
+  }
+  throw new Error("playwright not resolvable: " + (last && last.message));
+}
+
+function findChrome() {
+  const env = process.env.CHROME_PATH || process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+  const candidates = [
+    env,
+    "/opt/pw-browsers/chromium-1194/chrome-linux/chrome",
+    "/opt/google/chrome/chrome",
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+  ].filter(Boolean);
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p;
+  }
+  return undefined; // let Playwright pick its bundled Chromium
+}
+
+const { chromium } = loadPlaywright();
+const CHROME = findChrome();
 
 const argv = process.argv.slice(2);
 const DIR = path.resolve(argv[0] || "dist/tsx3d");
@@ -63,10 +100,11 @@ try {
   const port = server.address().port;
   const url = `http://127.0.0.1:${port}/`;
 
-  const browser = await chromium.launch({
-    executablePath: CHROME,
+  const launchOpts = {
     args: ["--use-gl=swiftshader", "--enable-webgl", "--ignore-gpu-blocklist", "--no-sandbox"],
-  });
+  };
+  if (CHROME) launchOpts.executablePath = CHROME;
+  const browser = await chromium.launch(launchOpts);
   const page = await browser.newPage({ viewport: { width: 640, height: 640 } });
   page.on("console", (m) => { if (m.type() === "error") consoleErrors.push(m.text()); });
   page.on("pageerror", (e) => consoleErrors.push("pageerror: " + e.message));

--- a/gallery/game_engine/v2/web/tests/pages_smoke.mjs
+++ b/gallery/game_engine/v2/web/tests/pages_smoke.mjs
@@ -5,21 +5,26 @@
 //   node gallery/game_engine/v2/web/build-pages.mjs --out dist/pages
 //   node gallery/game_engine/v2/web/tests/pages_smoke.mjs dist/pages
 //
-// Reads demos.json (or discovers child dirs with index.html) and runs
-// browser_smoke.mjs against each demo. Exit 0 only if every demo renders.
+// Serves the hub root (so per-demo pages can load ../editor.bundle.js etc.),
+// opens each /<id>/ editor page, and asserts #screen is non-blank.
 // ============================================================================
 
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import http from "node:http";
 import path from "node:path";
 import url from "node:url";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
 const HERE = path.dirname(url.fileURLToPath(import.meta.url));
 const DIR = path.resolve(process.argv[2] || path.join(HERE, "..", "dist", "pages"));
-const SMOKE = path.join(HERE, "browser_smoke.mjs");
 const MS = process.argv.includes("--ms")
   ? process.argv[process.argv.indexOf("--ms") + 1]
-  : "2200";
+  : "3500";
+const MIN_COLORS = process.argv.includes("--min-colors")
+  ? process.argv[process.argv.indexOf("--min-colors") + 1]
+  : "6";
 
 if (!fs.existsSync(DIR)) {
   console.error("[pages-smoke] missing dir:", DIR);
@@ -41,26 +46,226 @@ if (demos.length === 0) {
   process.exit(2);
 }
 
-console.log(`[pages-smoke] ${demos.length} demo(s) under ${DIR}`);
-let failed = 0;
-for (const id of demos) {
-  const demoDir = path.join(DIR, id);
-  const shot = path.join(demoDir, "_smoke.png");
-  console.log(`\n[pages-smoke] >>> ${id}`);
-  try {
-    execFileSync(
-      process.execPath,
-      [SMOKE, demoDir, "--canvas", "#screen", "--ms", MS, "--shot", shot, "--min-colors", "6"],
-      { stdio: "inherit" }
-    );
-  } catch {
-    failed += 1;
+function loadPlaywright() {
+  const anchors = [
+    "/opt/node22/lib/node_modules/x",
+    path.join(path.resolve(HERE, "../../../../.."), "package.json"),
+    path.join(process.cwd(), "package.json"),
+    import.meta.url,
+  ];
+  let last;
+  for (const anchor of anchors) {
+    try {
+      return createRequire(anchor)("playwright");
+    } catch (e) {
+      last = e;
+    }
   }
+  throw new Error("playwright not resolvable: " + (last && last.message));
 }
 
-if (failed) {
-  console.error(`\n[pages-smoke] FAILED ${failed}/${demos.length}`);
-  process.exit(1);
+function findChrome() {
+  const env = process.env.CHROME_PATH || process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+  for (const p of [
+    env,
+    "/opt/pw-browsers/chromium-1194/chrome-linux/chrome",
+    "/opt/google/chrome/chrome",
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium",
+  ].filter(Boolean)) {
+    if (fs.existsSync(p)) return p;
+  }
+  return undefined;
 }
-console.log(`\n[pages-smoke] ALL ${demos.length} RENDERED ✓`);
-process.exit(0);
+
+const MIME = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".mjs": "text/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".zip": "application/zip",
+  ".ppm": "application/octet-stream",
+  ".wasm": "application/wasm",
+  ".png": "image/png",
+  ".glb": "model/gltf-binary",
+  ".atlas": "text/plain",
+  ".tsx": "text/plain",
+  ".info": "text/plain",
+};
+
+function serve(dir) {
+  const server = http.createServer((req, res) => {
+    let p = decodeURIComponent(req.url.split("?")[0]);
+    if (p.endsWith("/")) p += "index.html";
+    if (p === "/") p = "/index.html";
+    const fp = path.join(dir, p);
+    if (!fp.startsWith(dir) || !fs.existsSync(fp) || fs.statSync(fp).isDirectory()) {
+      res.writeHead(404);
+      res.end("nf");
+      return;
+    }
+    res.writeHead(200, { "content-type": MIME[path.extname(fp)] || "application/octet-stream" });
+    fs.createReadStream(fp).pipe(res);
+  });
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve(server)));
+}
+
+const { chromium } = loadPlaywright();
+const CHROME = findChrome();
+const consoleErrors = [];
+let server;
+let failed = 0;
+
+try {
+  server = await serve(DIR);
+  const port = server.address().port;
+  const launchOpts = {
+    args: ["--use-gl=swiftshader", "--enable-webgl", "--ignore-gpu-blocklist", "--no-sandbox"],
+  };
+  if (CHROME) launchOpts.executablePath = CHROME;
+  const browser = await chromium.launch(launchOpts);
+
+  console.log(`[pages-smoke] ${demos.length} demo(s) under ${DIR}`);
+
+  for (const id of demos) {
+    console.log(`\n[pages-smoke] >>> ${id}`);
+    const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+    const errs = [];
+    page.on("console", (m) => {
+      if (m.type() === "error") errs.push(m.text());
+    });
+    page.on("pageerror", (e) => errs.push("pageerror: " + e.message));
+
+    const pageUrl = `http://127.0.0.1:${port}/${id}/`;
+    const shot = path.join(DIR, id, "_smoke.png");
+    try {
+      await page.goto(pageUrl, { waitUntil: "load", timeout: 45000 });
+      await page.waitForSelector("#screen", { timeout: 20000 });
+      // Wait until status shows ready / reload text, or timeout.
+      await page.waitForFunction(
+        () => {
+          const s = document.getElementById("status");
+          const t = (s && s.textContent) || "";
+          return t.includes("edit") || t.includes("reloaded") || t.includes("RENDER") || t.includes("interpreter");
+        },
+        { timeout: 20000 }
+      ).catch(() => {});
+      await page.waitForTimeout(parseInt(MS, 10));
+
+      const stats = await page.evaluate(() => {
+        const c = document.querySelector("#screen");
+        if (!c) return { ok: false };
+        const w = c.width, h = c.height;
+        let data = null;
+        try {
+          const g2 = c.getContext("2d");
+          if (g2) data = g2.getImageData(0, 0, w, h).data;
+        } catch (_) {}
+        if (!data) return { ok: true, webgl: true, w, h };
+        const seen = new Set();
+        let nonZero = 0;
+        for (let i = 0; i < data.length; i += 4) {
+          if (data[i + 3] === 0) continue;
+          const r = data[i] >> 5, g = data[i + 1] >> 5, b = data[i + 2] >> 5;
+          seen.add((r << 6) | (g << 3) | b);
+          if (data[i] + data[i + 1] + data[i + 2] > 24) nonZero++;
+        }
+        return { ok: true, webgl: false, w, h, colors: seen.size, nonZero, total: w * h };
+      });
+
+      const el = await page.$("#screen");
+      await el.screenshot({ path: shot });
+
+      let colors = stats.colors, nonZero = stats.nonZero, total = stats.total;
+      if (stats.webgl || colors === undefined) {
+        const png = fs.readFileSync(shot);
+        const b64 = png.toString("base64");
+        const s2 = await page.evaluate(async (dataB64) => {
+          const img = new Image();
+          await new Promise((res, rej) => {
+            img.onload = res;
+            img.onerror = rej;
+            img.src = "data:image/png;base64," + dataB64;
+          });
+          const cv = document.createElement("canvas");
+          cv.width = img.width;
+          cv.height = img.height;
+          const g = cv.getContext("2d");
+          g.drawImage(img, 0, 0);
+          const d = g.getImageData(0, 0, cv.width, cv.height).data;
+          const seen = new Set();
+          let nz = 0;
+          for (let i = 0; i < d.length; i += 4) {
+            const r = d[i] >> 5, gg = d[i + 1] >> 5, bb = d[i + 2] >> 5;
+            seen.add((r << 6) | (gg << 3) | bb);
+            if (d[i] + d[i + 1] + d[i + 2] > 24) nz++;
+          }
+          return { colors: seen.size, nonZero: nz, total: cv.width * cv.height };
+        }, b64);
+        colors = s2.colors;
+        nonZero = s2.nonZero;
+        total = s2.total;
+      }
+
+      const coverage = nonZero / total;
+      const rendered = colors >= parseInt(MIN_COLORS, 10) && coverage > 0.02;
+      console.log(
+        `  canvas #screen  distinct-colours=${colors} (need >=${MIN_COLORS})  coverage=${(coverage * 100).toFixed(1)}% (need >2%)`
+      );
+      console.log(`  screenshot: ${shot}`);
+      if (errs.length) {
+        console.log("  console errors:");
+        errs.slice(0, 8).forEach((e) => console.log("    " + e));
+      }
+      if (rendered) console.log("  RESULT: RENDERED ✓");
+      else {
+        console.log("  RESULT: BLANK / NOT RENDERED ✗");
+        failed += 1;
+      }
+    } catch (e) {
+      console.log("  RESULT: ERROR", e.message);
+      if (errs.length) errs.slice(0, 8).forEach((x) => console.log("    " + x));
+      failed += 1;
+    }
+    await page.close();
+  }
+
+  // Hub page smoke: Monaco present + first game renders.
+  console.log(`\n[pages-smoke] >>> hub`);
+  const hub = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+  try {
+    await hub.goto(`http://127.0.0.1:${port}/`, { waitUntil: "load", timeout: 45000 });
+    await hub.waitForSelector("#editor", { timeout: 15000 });
+    await hub.waitForSelector("#screen", { timeout: 15000 });
+    await hub.waitForTimeout(parseInt(MS, 10));
+    const hasMonaco = await hub.evaluate(() => !!(window.RangerEditor && document.querySelector(".monaco-editor")));
+    const hubShot = path.join(DIR, "_hub_smoke.png");
+    await hub.screenshot({ path: hubShot, fullPage: true });
+    console.log(`  monaco=${hasMonaco ? "yes" : "no"}  screenshot: ${hubShot}`);
+    if (!hasMonaco) {
+      console.log("  RESULT: NO MONACO ✗");
+      failed += 1;
+    } else {
+      console.log("  RESULT: HUB OK ✓");
+    }
+  } catch (e) {
+    console.log("  RESULT: ERROR", e.message);
+    failed += 1;
+  }
+  await hub.close();
+
+  await browser.close();
+  server.close();
+
+  if (failed) {
+    console.error(`\n[pages-smoke] FAILED ${failed} check(s)`);
+    process.exit(1);
+  }
+  console.log(`\n[pages-smoke] ALL ${demos.length} DEMOS + HUB OK ✓`);
+  process.exit(0);
+} catch (e) {
+  if (server) try { server.close(); } catch {}
+  console.error("[pages-smoke] ERROR:", e.message);
+  process.exit(2);
+}

--- a/gallery/game_engine/v2/web/tests/pages_smoke.mjs
+++ b/gallery/game_engine/v2/web/tests/pages_smoke.mjs
@@ -1,0 +1,66 @@
+// ============================================================================
+// pages_smoke.mjs — smoke every demo under a build-pages.mjs output dir.
+// ============================================================================
+//
+//   node gallery/game_engine/v2/web/build-pages.mjs --out dist/pages
+//   node gallery/game_engine/v2/web/tests/pages_smoke.mjs dist/pages
+//
+// Reads demos.json (or discovers child dirs with index.html) and runs
+// browser_smoke.mjs against each demo. Exit 0 only if every demo renders.
+// ============================================================================
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+
+const HERE = path.dirname(url.fileURLToPath(import.meta.url));
+const DIR = path.resolve(process.argv[2] || path.join(HERE, "..", "dist", "pages"));
+const SMOKE = path.join(HERE, "browser_smoke.mjs");
+const MS = process.argv.includes("--ms")
+  ? process.argv[process.argv.indexOf("--ms") + 1]
+  : "2200";
+
+if (!fs.existsSync(DIR)) {
+  console.error("[pages-smoke] missing dir:", DIR);
+  process.exit(2);
+}
+
+let demos = [];
+const manifest = path.join(DIR, "demos.json");
+if (fs.existsSync(manifest)) {
+  demos = JSON.parse(fs.readFileSync(manifest, "utf8")).map((d) => d.id);
+} else {
+  demos = fs
+    .readdirSync(DIR)
+    .filter((n) => fs.existsSync(path.join(DIR, n, "index.html")));
+}
+
+if (demos.length === 0) {
+  console.error("[pages-smoke] no demos in", DIR);
+  process.exit(2);
+}
+
+console.log(`[pages-smoke] ${demos.length} demo(s) under ${DIR}`);
+let failed = 0;
+for (const id of demos) {
+  const demoDir = path.join(DIR, id);
+  const shot = path.join(demoDir, "_smoke.png");
+  console.log(`\n[pages-smoke] >>> ${id}`);
+  try {
+    execFileSync(
+      process.execPath,
+      [SMOKE, demoDir, "--canvas", "#screen", "--ms", MS, "--shot", shot, "--min-colors", "6"],
+      { stdio: "inherit" }
+    );
+  } catch {
+    failed += 1;
+  }
+}
+
+if (failed) {
+  console.error(`\n[pages-smoke] FAILED ${failed}/${demos.length}`);
+  process.exit(1);
+}
+console.log(`\n[pages-smoke] ALL ${demos.length} RENDERED ✓`);
+process.exit(0);

--- a/gallery/game_engine/web/index.html
+++ b/gallery/game_engine/web/index.html
@@ -157,8 +157,8 @@
       keep the running state; edits to <code>initState</code>/<code>sprites</code>
       rebuild the scene. A connected <code>gamepad</code> works too (d-pad/stick +
       A), and sound is the engine's own synth played through Web Audio.
-      The staged <strong>v2 interpreter</strong> live demos (ylos2 + ranger:three)
-      are at <a href="./v2/"><code>/games/v2/</code></a>.
+      The staged <strong>v2 interpreter</strong> live editor (ylos2 + ranger:three,
+      Monaco + hot reload) is at <a href="./v2/"><code>/games/v2/</code></a>.
     </p>
 
     <script src="./vfs.js"></script>

--- a/gallery/game_engine/web/index.html
+++ b/gallery/game_engine/web/index.html
@@ -157,6 +157,8 @@
       keep the running state; edits to <code>initState</code>/<code>sprites</code>
       rebuild the scene. A connected <code>gamepad</code> works too (d-pad/stick +
       A), and sound is the engine's own synth played through Web Audio.
+      The staged <strong>v2 interpreter</strong> live demos (ylos2 + ranger:three)
+      are at <a href="./v2/"><code>/games/v2/</code></a>.
     </p>
 
     <script src="./vfs.js"></script>

--- a/package.json
+++ b/package.json
@@ -139,6 +139,8 @@
     "engine:v2:shot:ylos2": "bash gallery/game_engine/v2/tests/tools/ylos2_screenshot.sh",
     "engine:v2:pinball3d:build": "node gallery/game_engine/v2/web/build-pinball3d.mjs --out gallery/game_engine/v2/web/dist/pinball3d",
     "engine:v2:pinball3d:shot": "npm run engine:v2:pinball3d:build && node gallery/game_engine/v2/web/tests/browser_smoke.mjs gallery/game_engine/v2/web/dist/pinball3d --canvas '#screen' --ms 2000 --shot gallery/game_engine/v2/web/dist/pinball3d/pinball_gpu.png",
+    "engine:v2:pages:build": "node gallery/game_engine/v2/web/build-pages.mjs --out gallery/game_engine/v2/web/dist/pages",
+    "engine:v2:pages:smoke": "npm run engine:v2:pages:build && node gallery/game_engine/v2/web/tests/pages_smoke.mjs gallery/game_engine/v2/web/dist/pages",
     "engine:game-sdl": "bash gallery/game_engine/scripts/build-game-sdl.sh",
     "engine:game-sdl:run": "bash gallery/game_engine/scripts/build-game-sdl.sh --run",
     "engine:game-sdl:launcher": "bash gallery/game_engine/scripts/build-game-sdl.sh --run",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Publishes the staged **v2 TS interpreter** to GitHub Pages under **`/games/v2/`**, now with a **Monaco live editor for every game**.

### What lands on Pages

| Path | What |
|------|------|
| `/games/v2/` | Monaco hub — pick any v2 demo, edit + auto-reload |
| `/games/v2/live2d/` | Ylos2 editor (locked) |
| `/games/v2/live3d/` | Cube editor |
| `/games/v2/teapot/` | Teapot editor |
| `/games/v2/courtyard/` | Courtyard editor |
| `/games/v2/model/` | glTF model editor |

Edits rebuild a fresh host (state resets). The main `/games/` editor stays on the v1 GameRunner path and links to `/games/v2/`.

### How

- `build-pages.mjs` builds demos + Monaco, writes hub `editor.html` and a locked editor `index.html` per game
- `live2d-viewer.js` / `live3d-viewer.js` gain `getSource()` / `reload(src)`
- `deploy-pages.yml` runs `npm ci` in `v2/web` for Monaco/esbuild
- `pages_smoke` serves the hub root and checks each demo canvas + Monaco on the hub

### Verification

Local headless Chromium: **5/5 demos RENDERED + hub Monaco OK**. Manual reload probe: `reloaded ✓ (scene rebuilt)`.

[v2 Monaco editor — ylos2](https://cursor.com/agents/bc-019fcce3-6d9b-767b-ac42-83916cb361fc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fv2-editor-live2d.png)
[v2 Monaco hub — teapot](https://cursor.com/agents/bc-019fcce3-6d9b-767b-ac42-83916cb361fc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fv2-editor-hub-teapot.png)

### Test plan

- [x] `npm ci` in `gallery/game_engine/v2/web` + `engine:v2:pages:build`
- [x] `pages_smoke` → ALL 5 DEMOS + HUB OK
- [x] Edit guest source → Reload → status `reloaded ✓ (scene rebuilt)`
- [ ] After merge, confirm https://terotests.github.io/Ranger/games/v2/

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcce3-6d9b-767b-ac42-83916cb361fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcce3-6d9b-767b-ac42-83916cb361fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

