### PR TITLE
Fix Pages Jekyll failure: require GitHub Actions source

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -14,6 +14,16 @@
 # deploy-playground.yml). GitHub Pages allows one deployment per repository, so
 # both surfaces are assembled into one artifact here to avoid clobbering.
 #
+# REQUIRED repo setting (Settings → Pages → Build and deployment → Source):
+#   GitHub Actions
+# If Source is still "Deploy from a branch" (master /), GitHub also runs the
+# automatic pages-build-deployment / jekyll-build-pages job on every push. That
+# legacy Jekyll pass reads docs/site/**/*.astro `---` blocks as YAML and fails
+# (Invalid YAML front matter). Do not "fix" that by adding a root .nojekyll or
+# a Jekyll _config.yml that makes the branch builder succeed — it would publish
+# the raw master tree and clobber this workflow's artifact. Switch Source to
+# GitHub Actions so only this workflow deploys.
+#
 # Runs automatically on pushes to master that touch the site, and can be run
 # independently at any time from the Actions tab (workflow_dispatch).
 name: Deploy site (playground + games) to GitHub Pages

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,9 @@ The Ranger documentation, published at
 and the games site holds `/games/`; one GitHub Pages deployment assembles all
 three (`.github/workflows/deploy-pages.yml`).
 
+Pages **Source** must be **GitHub Actions**. A branch/Jekyll source makes
+`pages-build-deployment` parse Astro `---` front matter as YAML and fail.
+
 The operator reference is generated. It is not written by hand and it is not a
 copy of the sources: the examples are compiled by the compiler of the commit
 that publishes the site, so the documentation cannot drift from the release.

--- a/playground/README.md
+++ b/playground/README.md
@@ -31,6 +31,12 @@ Outputs static files to `playground/dist/`. The build:
 
 ## GitHub Pages
 
-`.github/workflows/deploy-playground.yml` runs on push to `main` or `master`, builds the playground, and publishes `playground/dist`.
+`.github/workflows/deploy-pages.yml` builds the playground (plus `/games/` and
+`/docs/`) and publishes the combined artifact.
 
 In the repository: **Settings → Pages → Build and deployment → Source: GitHub Actions**.
+
+If Source is left on **Deploy from a branch**, GitHub's legacy Jekyll builder
+(`pages-build-deployment`) also runs against `master` and fails on Astro
+front matter under `docs/site/`. That job is not this workflow; flip Source to
+**GitHub Actions** so only `deploy-pages.yml` publishes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Every push to `master` runs the automatic `pages-build-deployment` workflow (`jekyll-build-pages`), which fails with:

```text
Invalid YAML front matter in docs/site/src/components/Footer.astro
YAML Exception reading …/TargetOutput.astro: mapping values are not allowed in this context
```

## Cause

Repo Pages is still on **legacy branch deploy** (`build_type: legacy`, source `master` `/`). Jekyll treats Astro `---` script blocks as YAML front matter.

The real site is already built correctly by `.github/workflows/deploy-pages.yml` (live playground + `/docs/` are fine). The red failure is the competing legacy builder.

## Fix (repo setting — not in this PR)

A token available to agents cannot change Pages settings (`403` on the Pages API). A repo admin needs to:

1. Open https://github.com/terotests/Ranger/settings/pages
2. **Build and deployment → Source → GitHub Actions**
3. Save

That stops `pages-build-deployment` / `jekyll-build-pages`.

**Do not** add a root `.nojekyll` or a Jekyll `_config.yml` that makes the branch builder succeed — it would publish the raw `master` tree and clobber the Actions-built site.

## This PR

Documents the required Pages Source setting in:

- `.github/workflows/deploy-pages.yml`
- `playground/README.md` (also corrects the old `deploy-playground.yml` name)
- `docs/README.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd195-c865-70a9-a884-dc8d210dbbd9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd195-c865-70a9-a884-dc8d210dbbd9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

