### PR TITLE
Research: shape AstNode probe — recommend against CodeNode rewrite

### DIFF
--- a/PLAN_COMPILER_V4.md
+++ b/PLAN_COMPILER_V4.md
@@ -1,27 +1,31 @@
 # PLAN: Compiler v4 — shape-based AST
 
-> **Status:** design + scaffolding + **compatibility assessment**. Stages
-> **C0–C1** under `compiler/v4/`. Live product compiler remains **3.3.x** in
-> `compiler/ng_*.rgr` — **untouched**, so the existing Ranger test set stays
-> the gate for shipping code.
+> **Status:** **research probe + go/no-go.** C0–C1 under `compiler/v4/` prove
+> a syntax AST *can* be a shape. Product compiler remains **3.3.x** (`ng_*`).
 >
-> **Question:** can we rewrite the AST with shapes, keep original code almost
-> unchanged, keep `npm test` green the whole time, and stay invisible to users
-> (including macros)?
+> **Hard gates (updated):** full **macro parity is required before any cutover**
+> (no 70% compiler); existing Ranger tests must pass; half-landed mid-ends are
+> not useful.
 >
-> **Short answer:** shapes *fit* CodeNode, but an **in-place** “just change
-> CodeNode to a shape” rewrite is **not** a small, invisible change. Macros,
-> plugins, VSCode introspection, and ~90 compiler files mutate fat `CodeNode`
-> fields in place. The path that respects “minimal original churn + tests
-> always green” is a **parallel v4** (what this tree does), with cutover only
-> when G1–G3 pass — not a gradual edit of `ng_CodeNode.rgr` under the host.
+> **Recommendation: do not proceed with replacing CodeNode in the shipping
+> compiler.** Under those gates this is not an “AST-only” tweak — it is a
+> second implementation of the hot path (~15k LOC: FlowParser + macro engine +
+> LiveCompiler + CodeNode APIs) with **no user-visible win until 100% parity**.
+> Shapes remain valuable elsewhere (`EvalValue` / domain tagged unions). Keep
+> the v4 AstNode probe as evidence; do **not** treat G1–G3-via-v4 as the plan.
 
 ---
 
-## 0. First goals (not “all gallery”)
+## 0. First goals (historical — superseded by §2.5 recommendation)
+
+> **Note:** G1–G3 below were useful stress targets *if* a parallel compiler
+> were pursued to 100% parity. Given mandatory full macro parity and “no
+> half-landed compiler,” §2.5 **recommends not pursuing** CodeNode→shape as
+> the product path. G1–G3 already run on `ng_*`; they do not require an AST
+> rewrite.
 
 v4 is **not** aimed at compiling every gallery demo next. The first success
-bar is three programs that already stress the shipping compiler:
+bar *would have been* three programs that already stress the shipping compiler:
 
 | # | Goal | Entry | ~size | Why first |
 |---|---|---|---|---|
@@ -166,59 +170,85 @@ them cannot: any in-place AST change must reimplement splice + re-walk +
 register lifting + recursion guards (`active_macros`, depth 512) or macros
 mis-expand / hang (see `tests/macro-recursion.test.ts`).
 
-**Estimate:** reimplementing the macro engine on shapes is a **dedicated
-mid-stage** of v4 (after parse/collect/type), not a free side effect of changing
-the node type. Until then, G1–G2 on v4 either (a) avoid relying on host macros
-by lowering operators differently, or (b) use strategy **C** and keep expansion
-on CodeNode.
+### Revised gate: full macro parity immediately (no “later”)
 
-### Bootstrap / chicken-egg
+If the port is only allowed to land when **`@macro` + `defn` + `r.*` + the
+existing test suite** all pass, then strategies that defer macros are out.
+That collapses the options:
 
-- Generation N (class `CodeNode` in `bin/output.js`) can compile source that
-  *declares* shapes — that is how shapes work today.
-- Making the **host** AST itself a shape is a **generational** cutover (N
-  compiles N+1), not an edit inside one running compiler.
-- Therefore: v4 **uses** shapes while still being compiled by ng_; only G3
-  flips the host.
+| Path | With full macro parity as day-one cutover gate |
+|---|---|
+| **A Parallel v4, land at 100%** | Allowed in theory, but you must rebuild **parse + collect + walk + `buildMacro` + `TransformOpFn` + writers + plugins/API façade`** before anything replaces `ng_`. Intermediate `compiler/v4/` is not a product. Cost ≈ **second compiler**. |
+| **A Parallel v4, land at 70%** | **Rejected** — not useful. |
+| **B In-place** | Still forces the same rewrite on the live tree; tests go red for a long window. **Rejected.** |
+| **C Bridge only** | Keeps macros on CodeNode — **no shape rewrite of the AST that matters.** |
 
-### Realistic estimate (effort shape, not calendar)
+So the honest framing is no longer “AST shape rewrite with deferred macros.”
+It is: **rewrite the compiler mid-end on shapes, offline, until full parity,
+then flip.** That can keep `npm test` green on `ng_*` during the work, but it
+does not reduce the work, and it delivers **zero** product value until the
+flip.
 
-| Work | Invasiveness | Notes |
-|---|---|---|
-| Keep `ng_*` frozen; grow `compiler/v4/` | Low on original tree | Meets “tests always green” for the product suite |
-| C0–C1 AstNode + parser | Done / small | No user visibility |
-| C2–C4 collect + type + ES6 writer (no `@macro` yet) | Medium **new** code | Enough for a jpeg *subset* if operators are built-in or copied as non-macro |
-| Macro / `defn` engine on AstNode | **High** new code | Port of `buildMacro` + `TransformOpFn` + `rebuildWithType` |
-| Full FlowParser feature parity | **Very high** new code | This is most of “the compiler,” even if framed as AST-driven |
-| In-place edit of `ng_CodeNode` + call sites | **Very high** on original | Conflicts with constraints; expect long red test windows |
+### Is that useful? Recommendation
 
-**Bottom line for the constraints:**
+**No — not as a near-term product project.**
 
-- **Possible to keep original code and tests green?** Yes — only via **parallel
-  v4** (A), not via in-place shape-ification of CodeNode (B).
-- **Invisible to users?** Yes until cutover; at cutover, language should match
-  if acceptance is “same output on G1–G3 + `npm test`.”
-- **“Just AST, not full rewrite”?** The *type* change is local; the *call-site*
-  change is not. Expect the bulk of work to be walkers/macros/writers that
-  today assume one fat node — whether that work lives in new `compiler/v4/`
-  files or as edits to `ng_*` is a packaging choice; the volume is similar.
-- **Macros?** Hardest compatibility cliff after the parser. Plan for an
-  explicit port; do not assume they keep working “for free.”
+Reasons:
 
-### Chosen approach under these constraints
+1. **Payoff is back-loaded.** Exhaustiveness / smaller nodes help maintainers
+   only after FlowParser, macros, and writers all speak `match`. Users see
+   nothing until cutover.
+2. **Macros are the substrate, not a feature flag.** `if`, `??`, many
+   `Lang.rgr` ops, `TNodeFactory`, and `defn` in `stdops` all go through
+   CodeNode mutation. “Full macro parity” ≈ “full operator + sugar parity.”
+3. **Volume.** Hot path tied to CodeNode is on the order of **15k LOC**
+   (FlowParser ~7k, FlowWork ~4k, std_match2 ~1k, LiveCompiler ~1.5k,
+   CodeNode(+ext) ~1.7k), plus writers and `Lang.rgr` behavior. That is the
+   compiler, not a node-class swap.
+4. **Shapes already pay off elsewhere** with far less risk: closed domain
+   unions (`EvalPayload`, future `PropertySlot`, etc.) where one fat class
+   is local. CodeNode is the opposite — global substrate.
+5. **Chicken-egg.** The compiler that *implements* shapes is written against
+   class CodeNode. Hosting the AST as a shape is a generational rewrite, not
+   a refactor.
 
-1. **Do not modify `compiler/ng_*.rgr` for the AST experiment** (except unrelated
-   bugfixes). Product `npm test` remains the ng_ suite.
-2. Continue **A**: `compiler/v4/` with shape `AstNode`.
-3. Allow optional **C** later if we need to parse real G1 sources before the v4
-   mid-end exists (AstNode → CodeNode → existing pipeline) — experiment only.
-4. Port macros only when v4 has a walk that needs them; gate G1 on either
-   non-macro operator coverage or a working macro port.
-5. Cutover (replace `ng_Compiler` entry) only when G1 + G2 smoke + G3a and the
-   **existing** test suite run through the v4-built host (or a documented
-   subset with explicit gaps).
+**When it would become worth reconsidering**
+
+- A committed effort to build a **second** compiler to full `npm test` parity
+  (accepting a long parallel period with no intermediate merge to product), or
+- Language changes that make a façade viable (e.g. stable node API that is not
+  field-mutation based) — not available today.
+
+**What to do instead (recommended)**
+
+1. **Stop treating CodeNode→shape as the v4 product plan.** Leave C0–C1 as a
+   feasibility probe (shapes can model syntax kinds).
+2. **Keep investing shapes in domain values** (EvalValue migration, other
+   tagged unions) where tests and scope stay local.
+3. **Optional hygiene on the existing AST** without shapes: more use of
+   `CodeNodeLiteral` / `cleanNode`, move analysis into side tables where
+   incremental compile needs it (`INCREMENTAL_PLAN.md`) — only if each change
+   keeps `npm test` green.
+4. **Do not** chase G1/G2/G3 by rewriting the AST representation; those goals
+   already run on today’s compiler.
+
+### Bootstrap note
+
+Generation N (class CodeNode) compiling shape *source* is fine and already
+ships. Making the **host AST** a shape is a different project (generational
+cutover) and is what this recommendation declines for now.
+
+### Effort if someone insisted anyway
+
+| Work | Reality under full-parity gate |
+|---|---|
+| C0–C1 AstNode + parser | Done — research only |
+| Everything to first useful cutover | Port macro engine + FlowParser behavior + ES6 writer + pass `npm test` |
+| “AST-only” framing | Misleading — call-site volume dominates |
 
 ---
+
+
 
 ## 3. Design: split the layers
 
@@ -426,8 +456,8 @@ The product entry `compiler/ng_Compiler.rgr` is untouched until G3b.
 
 1. ~~Land C0: plan + AstNode probe + test~~
 2. ~~Implement C1 parser emitting AstNode (subset)~~
-3. ~~Pin first goals: G1 jpeg_scaler, G2 TS engine, G3 self-host~~
-4. ~~Compatibility assessment: reject in-place CodeNode→shape under “always green”~~
-5. Keep **`ng_*` frozen**; extend C1 (annotations, file API) then C2 collect for G1
-6. Document which G1 operators need `@macro` vs can be direct writer templates
-7. Keep `tests/compiler-v4-ast.test.ts` green; never gate product `npm test` on v4 until cutover
+3. ~~Compatibility + go/no-go under full macro parity~~
+4. **Do not** continue C2–C7 / G1–G3-via-v4 as product work unless explicitly
+   commissioned as a full second-compiler project
+5. Prefer shapes on domain tagged unions; keep `ng_*` as the compiler
+6. Leave `compiler/v4/` as a research probe (or drop in a follow-up if clutter)

--- a/PLAN_COMPILER_V4.md
+++ b/PLAN_COMPILER_V4.md
@@ -1,18 +1,20 @@
 # PLAN: Compiler v4 — shape-based AST
 
-> **Status:** design + scaffolding. Stages **C0–C1** are under `compiler/v4/`
-> (shape `AstNode` + Lisp parser). The live product compiler remains **3.3.x**
-> in `compiler/ng_*.rgr`.
+> **Status:** design + scaffolding + **compatibility assessment**. Stages
+> **C0–C1** under `compiler/v4/`. Live product compiler remains **3.3.x** in
+> `compiler/ng_*.rgr` — **untouched**, so the existing Ranger test set stays
+> the gate for shipping code.
 >
-> **Question this plan answers:** can the Ranger compiler be rewritten using
-> `shape` / `case` / `group` / `match`, especially to replace the overloaded
-> `CodeNode` structure?
+> **Question:** can we rewrite the AST with shapes, keep original code almost
+> unchanged, keep `npm test` green the whole time, and stay invisible to users
+> (including macros)?
 >
-> **Verdict: yes — and CodeNode is the highest-leverage place to start.**
-> Shapes were designed for exactly this kind of fat tagged object
-> (`PLAN_SHAPES.md`, `EvalValue` migration). CodeNode is the same pattern at
-> compiler scale: one class, an integer/`RangerNodeType` tag, dozens of fields
-> that only some nodes use, plus analysis and target scratchpads bolted on.
+> **Short answer:** shapes *fit* CodeNode, but an **in-place** “just change
+> CodeNode to a shape” rewrite is **not** a small, invisible change. Macros,
+> plugins, VSCode introspection, and ~90 compiler files mutate fat `CodeNode`
+> fields in place. The path that respects “minimal original churn + tests
+> always green” is a **parallel v4** (what this tree does), with cutover only
+> when G1–G3 pass — not a gradual edit of `ng_CodeNode.rgr` under the host.
 
 ---
 
@@ -105,6 +107,116 @@ should diverge — they just never became separate types in the main pipeline.
 Precedent: `gallery/game_engine/v2/interp/migrate/src/EvalValue.rgr` already
 split `EvalPayload` into a shape (`None | FnCore | ElemBox`) and cut
 `sizeof(EvalValue)` on C++ from 680 → 376 bytes.
+
+---
+
+## 2.5 Compatibility assessment — is an “AST-only” shape rewrite possible?
+
+### Constraint (from product goals)
+
+1. Change **as little as possible** of the original `compiler/ng_*` code.
+2. **Ranger test set keeps passing** the whole time (`npm test`, publish suite).
+3. Invisible to users in most parts (language semantics, macros, plugins, IDE).
+4. Not a “full rewrite of Ranger” — an AST representation change — but honest
+   about how much core that still forces.
+
+### What is coupled to fat `CodeNode` today
+
+| Surface | Coupling | Breaks if CodeNode becomes a shape in-place |
+|---|---|---|
+| **`@macro(true)`** (`buildMacro` in `ng_parser_std_match2.rgr`) | String expand → reparse → **clear/replace `callArgs.children`**, set `parent`, re-`WalkNode` | First to break: `if` / `??` / dozens of `Lang.rgr` macros |
+| **`defn` / `TransformOpFn`** | `rebuildWithType`, `getChildrenFrom`, `copyEvalResFrom`, in-place child splice | `lib/stdops.rgr` Map/ForEach and compiler-defined ops |
+| **`TNodeFactory` (`r.*`)** | `@macro` expanding to `CodeNode.op` / `vref` / … | Host cannot rebuild itself |
+| **Plugins** (`pre_flow`, `postprocess`, `generate_ast`) | JS/Ranger plugins walk `root:CodeNode` fields | External plugins |
+| **VSCode + `dist/api.d.ts` + introspection tests** | `children`, `vref`, `eval_type_name`, `sp`/`ep`, `value_type` | IDE / `tests/introspection.test.ts` |
+| **Source maps** | `CodeNode.code` / `sp` / `getLine()` | `-sourcemap` |
+| **Shape desugar itself** | `DesugarShapes` mutates CodeNode trees | Chicken-egg if host AST is already a shape mid-edit |
+
+Rough size: **~90 files / ~3.8k `CodeNode` mentions** under `compiler/`; hot path
+FlowParser + FlowWork + LiveCompiler alone is on the order of **15k LOC**.
+
+### Strategy options
+
+| Strategy | Original code churn | Tests stay green? | Macros / users | Verdict |
+|---|---|---|---|---|
+| **A. Parallel `compiler/v4/`** (current) | **None** on `ng_*` until cutover | **Yes** — shipping path unchanged; v4 has its own tests | Invisible until cutover | **Recommended** under the constraints above |
+| **B. In-place: `CodeNode` → shape** | Very high (FlowParser, macros, writers, API) | **No** through the migration — flag soup → `match` is a rewrite | Visible risk: macros first, then IDE/plugins | **Reject** for “minimal change / always green” |
+| **C. Dual: v4 AstNode → lower to today’s CodeNode** | Low (adapter only) | Yes on product path | Invisible | Optional bridge to parse real files early; **does not** deliver shape-based mid/backend |
+| **D. Split fields without shapes** (`CodeNodeLiteral` / side tables) | Low–medium | Medium risk if hot AST moves | Invisible if careful | Good hygiene for incremental/IDE; **not** the shapes payoff |
+
+**B fails the constraint even if framed as “just AST”:** a mega-shape that keeps
+every field gains nothing; a real case-split forces every `node.vref` /
+`node.children` / `value_type` site to become `match`/`case`. Shapes also do
+not preserve the call style macros and extensions rely on (`node.fn()` vs
+`Shape.fn(node)`, mutable weak `parent`, `@serialize` on shapes still open).
+
+### Macros specifically
+
+Macros are **not** a thin string layer over an opaque AST. They invent and
+mutate CodeNode:
+
+1. `@macro(true)` — ~111 sites in `compiler/` (mostly `Lang.rgr`): emit Ranger
+   text, reparse to CodeNode, splice into the call node, walk again.
+2. `defn` — AST-to-AST via `rebuildWithType` + in-place `getChildrenFrom`.
+3. Compiler `r.*` factories — macros that expand to CodeNode constructors.
+
+User-authored macro *templates* rarely name CodeNode fields (they use `(e N)` /
+`(block N)`), so **template source** can stay stable. The **engine** that runs
+them cannot: any in-place AST change must reimplement splice + re-walk +
+register lifting + recursion guards (`active_macros`, depth 512) or macros
+mis-expand / hang (see `tests/macro-recursion.test.ts`).
+
+**Estimate:** reimplementing the macro engine on shapes is a **dedicated
+mid-stage** of v4 (after parse/collect/type), not a free side effect of changing
+the node type. Until then, G1–G2 on v4 either (a) avoid relying on host macros
+by lowering operators differently, or (b) use strategy **C** and keep expansion
+on CodeNode.
+
+### Bootstrap / chicken-egg
+
+- Generation N (class `CodeNode` in `bin/output.js`) can compile source that
+  *declares* shapes — that is how shapes work today.
+- Making the **host** AST itself a shape is a **generational** cutover (N
+  compiles N+1), not an edit inside one running compiler.
+- Therefore: v4 **uses** shapes while still being compiled by ng_; only G3
+  flips the host.
+
+### Realistic estimate (effort shape, not calendar)
+
+| Work | Invasiveness | Notes |
+|---|---|---|
+| Keep `ng_*` frozen; grow `compiler/v4/` | Low on original tree | Meets “tests always green” for the product suite |
+| C0–C1 AstNode + parser | Done / small | No user visibility |
+| C2–C4 collect + type + ES6 writer (no `@macro` yet) | Medium **new** code | Enough for a jpeg *subset* if operators are built-in or copied as non-macro |
+| Macro / `defn` engine on AstNode | **High** new code | Port of `buildMacro` + `TransformOpFn` + `rebuildWithType` |
+| Full FlowParser feature parity | **Very high** new code | This is most of “the compiler,” even if framed as AST-driven |
+| In-place edit of `ng_CodeNode` + call sites | **Very high** on original | Conflicts with constraints; expect long red test windows |
+
+**Bottom line for the constraints:**
+
+- **Possible to keep original code and tests green?** Yes — only via **parallel
+  v4** (A), not via in-place shape-ification of CodeNode (B).
+- **Invisible to users?** Yes until cutover; at cutover, language should match
+  if acceptance is “same output on G1–G3 + `npm test`.”
+- **“Just AST, not full rewrite”?** The *type* change is local; the *call-site*
+  change is not. Expect the bulk of work to be walkers/macros/writers that
+  today assume one fat node — whether that work lives in new `compiler/v4/`
+  files or as edits to `ng_*` is a packaging choice; the volume is similar.
+- **Macros?** Hardest compatibility cliff after the parser. Plan for an
+  explicit port; do not assume they keep working “for free.”
+
+### Chosen approach under these constraints
+
+1. **Do not modify `compiler/ng_*.rgr` for the AST experiment** (except unrelated
+   bugfixes). Product `npm test` remains the ng_ suite.
+2. Continue **A**: `compiler/v4/` with shape `AstNode`.
+3. Allow optional **C** later if we need to parse real G1 sources before the v4
+   mid-end exists (AstNode → CodeNode → existing pipeline) — experiment only.
+4. Port macros only when v4 has a walk that needs them; gate G1 on either
+   non-macro operator coverage or a working macro port.
+5. Cutover (replace `ng_Compiler` entry) only when G1 + G2 smoke + G3a and the
+   **existing** test suite run through the v4-built host (or a documented
+   subset with explicit gaps).
 
 ---
 
@@ -315,6 +427,7 @@ The product entry `compiler/ng_Compiler.rgr` is untouched until G3b.
 1. ~~Land C0: plan + AstNode probe + test~~
 2. ~~Implement C1 parser emitting AstNode (subset)~~
 3. ~~Pin first goals: G1 jpeg_scaler, G2 TS engine, G3 self-host~~
-4. Extend C1: annotations (`@…`), file parse API, `Import` strings
-5. C2: collect `class` / `fn` / `Import` / `def` — driven by what G1’s AST needs
-6. Keep `tests/compiler-v4-ast.test.ts` green; add G1-slice fixtures as C4 lands
+4. ~~Compatibility assessment: reject in-place CodeNode→shape under “always green”~~
+5. Keep **`ng_*` frozen**; extend C1 (annotations, file API) then C2 collect for G1
+6. Document which G1 operators need `@macro` vs can be direct writer templates
+7. Keep `tests/compiler-v4-ast.test.ts` green; never gate product `npm test` on v4 until cutover

--- a/PLAN_COMPILER_V4.md
+++ b/PLAN_COMPILER_V4.md
@@ -1,0 +1,240 @@
+# PLAN: Compiler v4 — shape-based AST
+
+> **Status:** design + scaffolding. Stages **C0–C1** are under `compiler/v4/`
+> (shape `AstNode` + Lisp parser). The live product compiler remains **3.3.x**
+> in `compiler/ng_*.rgr`.
+>
+> **Question this plan answers:** can the Ranger compiler be rewritten using
+> `shape` / `case` / `group` / `match`, especially to replace the overloaded
+> `CodeNode` structure?
+>
+> **Verdict: yes — and CodeNode is the highest-leverage place to start.**
+> Shapes were designed for exactly this kind of fat tagged object
+> (`PLAN_SHAPES.md`, `EvalValue` migration). CodeNode is the same pattern at
+> compiler scale: one class, an integer/`RangerNodeType` tag, dozens of fields
+> that only some nodes use, plus analysis and target scratchpads bolted on.
+
+---
+
+## 1. The CodeNode overload (measured)
+
+| File | Role | Lines |
+|---|---|---|
+| `compiler/ng_CodeNode.rgr` | parse tree + syntax fields | 843 |
+| `compiler/ng_CodeNodeCompilerExtensions.rgr` | typing / flow / descriptor links | 828 |
+| Call sites of `CodeNode` under `compiler/` | — | ~2000+ mentions |
+
+One object is simultaneously:
+
+1. **S-expression tree node** — `children`, `expression`, `is_block_node`, atoms
+2. **Typed expression** — `eval_type*`, `evalTypeClass`, `paramDesc`, `fnDesc`, `clDesc`
+3. **Rewrite scratchpad** — registers, operator match, method chains
+4. **Per-target hints** — `rust_needs_preevaluate`, `rust_use_tmpvar`, …
+
+Illegal states are representable: a `Double` node can still carry `fnDesc`,
+`children`, and Rust borrow flags. Walkers test flags instead of variants;
+forgetting a kind is a silent fall-through, not a compile error.
+
+`CodeNodeLiteral` and `cleanNode()` already admit that syntax and analysis
+should diverge — they just never became separate types in the main pipeline.
+
+---
+
+## 2. Why shapes fit
+
+| Fat-class defect | Shape remedy |
+|---|---|
+| Every field on every node | Each `case` owns only its payload |
+| Tag + parallel booleans (`expression`, `hasFnCall`, …) | The case *is* the tag |
+| Missed kind in a walker | Exhaustive `match` |
+| Value vs reference equality hand-rolled | `@(value)` / `@(reference)` |
+| Native targets pay for unused fields | Scalar cases inline on C++/Rust (measured in PLAN_SHAPES) |
+
+Precedent: `gallery/game_engine/v2/interp/migrate/src/EvalValue.rgr` already
+split `EvalPayload` into a shape (`None | FnCore | ElemBox`) and cut
+`sizeof(EvalValue)` on C++ from 680 → 376 bytes.
+
+---
+
+## 3. Design: split the layers
+
+Do **not** put the whole of today's CodeNode into one mega-shape. Split by
+pipeline phase:
+
+```text
+Source
+  → Parser          →  AstNode          (shape: syntax only)
+  → Collect / Walk  →  TypedExpr + Env  (shape + tables; no AST mutation for types)
+  → Mid-end         →  MidOp            (optional later)
+  → Writers         →  target code
+```
+
+### 3.1 `AstNode` — syntax shape (C1)
+
+Closed family of what the Lisp parser can emit. Shared source span via a
+`group Located`. No `paramDesc`, no Rust flags, no `eval_type`.
+
+```ranger
+shape AstNode {
+    group Located {
+        def sp:int 0
+        def ep:int 0
+        def row:int 0
+        def col:int 0
+    }
+
+    case Integer@(value) does Located { def value:int 0 }
+    case Double@(value)  does Located { def value:double 0.0 }
+    case String@(value)  does Located { def value:string "" }
+    case Boolean@(value) does Located { def value:boolean false }
+    case Comment@(value) does Located { def text:string "" }
+    case VRef does Located {
+        def name:string ""
+        def ns:[string]
+        def typeName:string ""
+        def keyType:string ""
+        def arrayType:string ""
+        def kind:int 0
+    }
+    case Expression does Located {
+        def children:[AstNode]
+        def isBlock:boolean false
+    }
+}
+```
+
+Parent links stay on the **parser stack** (as today), not on every node — weak
+back-pointers on shape cases are untested and not required for walkers that
+carry context.
+
+### 3.2 Typed / analysis layer (C2+)
+
+Keep symbol tables (`RangerApp*Desc`) as today. Attach results either:
+
+- **A (preferred early):** side map `nodeId → TypedInfo`, AST stays immutable after parse
+- **B:** second shape `TypedExpr` produced by a lowering pass (bigger rewrite)
+
+Writers then match on `TypedExpr` / `AstNode` instead of reading 90 fields.
+
+### 3.3 What stays out of v4 initially
+
+- Full FlowParser / LiveCompiler port
+- All language writers
+- Incremental compile (`INCREMENTAL_PLAN.md`)
+- Replacing `ng_Compiler.rgr` as the shipped binary
+
+v4 is a **parallel tree** under `compiler/v4/` until it can parse + type a
+useful subset and emit at least one target.
+
+---
+
+## 4. Feasibility risks
+
+| Risk | Mitigation |
+|---|---|
+| Parser mutates `curr_node.children` | Expression case is `@(reference)` (non-scalar default); mutate the array after narrowing |
+| `match` is statement-only | Bind results to locals; helpers return via assigned out-params or small visitor class |
+| Shape methods cannot use virtual dispatch | Static `AstNode.asString(n)` ops — already the shape-method pattern |
+| Self-host: v4 is written in Ranger 3 | Compile v4 with the current `bin/output.js`; dogfood later |
+| Scope explosion (7k-line FlowParser) | Stage gates; v3 remains shipping |
+| `@(weak)` on shape fields untested | Avoid parent pointers on nodes; use walk context |
+| XML / lambda / expression-type nodes | Add cases when the parser subset needs them |
+
+---
+
+## 5. Stages
+
+### C0 — Plan + probe ✅
+
+- This document
+- `compiler/v4/AstNode.rgr`: shape + `asString` / constructors
+- Fixture + test: builds AstNodes, exhaustive match, runs on ES6/Python/Go/Rust
+
+### C1 — Shape-based Lisp parser ✅ (started)
+
+- `compiler/v4/Source.rgr`, `Parser.rgr`, `ParseProbe.rgr`
+- Parse subset: atoms, lists, blocks, comments, typed vrefs / array / hash types
+- Pretty-print tests in `tests/compiler-v4-ast.test.ts`
+- Not yet: annotations (`@…`), infix, expression-types, full file Import/class
+
+### C2 — Declarations + collect
+
+- Recognize `class` / `fn` / `sfn` / `Import` / `def` at top level
+- Build lightweight `Module` / `ClassInfo` / `FnInfo` tables (plain classes OK)
+- Drive from `AstNode` match, not CodeNode flags
+
+### C3 — Expression typing (subset)
+
+- Primitive ops, calls, `return`, `if`, `for`
+- Side-table or `TypedExpr` shape
+- Error messages with `Located` spans
+
+### C4 — One writer (ES6)
+
+- Emit JS for the typed subset
+- Compare output to ng_ compiler on the same fixtures
+
+### C5 — Grow surface + second target
+
+- Operators, lambdas, classes, optionals
+- Rust or C++ writer to validate native shape lowering benefits in the compiler itself
+
+### C6 — Bootstrapping decision
+
+- Only when C4/C5 cover enough to compile `compiler/v4/**`
+- Then consider replacing ng_ entry points
+
+---
+
+## 6. Directory layout
+
+```text
+compiler/v4/
+  README.md           # how to build / test the sketch
+  AstNode.rgr         # shape AstNode + helpers
+  Source.rgr          # SourceFile (C1)
+  Parser.rgr          # Lisp parser → AstNode (C1)
+  Probe.rgr           # small main used by tests
+
+PLAN_COMPILER_V4.md   # this file (repo root, with other PLAN_*)
+tests/fixtures/v4_ast_probe.rgr
+tests/compiler-v4-ast.test.ts
+```
+
+The product entry `compiler/ng_Compiler.rgr` is untouched.
+
+---
+
+## 7. Success criteria for "shapes can rewrite the compiler"
+
+| Criterion | How we know |
+|---|---|
+| AstNode shape compiles on ES6 / Python / Go / Rust | `tests/compiler-v4-ast.test.ts` |
+| Exhaustive walkers replace flag soup for syntax | `AstNode.asString` / parser use `match` |
+| Illegal payloads unrepresentable | no `children` on `Integer`, etc. |
+| Parser produces only AstNode cases | C1 fixture round-trips |
+| No regression to shipping 3.3.x | ng_ tree unchanged |
+
+A full self-hosting v4 is **not** a success criterion for C0–C1; it is the
+C6 decision after a working subset exists.
+
+---
+
+## 8. Relation to other plans
+
+| Plan | Relation |
+|---|---|
+| `PLAN_SHAPES.md` | Language feature v4 consumes; S0–S5 |
+| `PLAN_3.md` | Historical product 3.0; not an AST rewrite |
+| `INCREMENTAL_PLAN.md` | Builds on today's CodeNode; v4 should make invalidation easier (immutable AST + side tables) |
+| `EvalValue` shape migration | Same pattern; proof that production code can adopt shapes |
+
+---
+
+## 9. Immediate next actions
+
+1. ~~Land C0: plan + AstNode probe + test~~
+2. ~~Implement C1 parser emitting AstNode (subset)~~
+3. Extend C1: annotations, better block/statement handling, file parse API
+4. Start C2: collect `class` / `fn` / `Import` from AstNode trees
+5. Keep every stage green under `tests/compiler-v4-ast.test.ts`

--- a/PLAN_COMPILER_V4.md
+++ b/PLAN_COMPILER_V4.md
@@ -16,6 +16,58 @@
 
 ---
 
+## 0. First goals (not “all gallery”)
+
+v4 is **not** aimed at compiling every gallery demo next. The first success
+bar is three programs that already stress the shipping compiler:
+
+| # | Goal | Entry | ~size | Why first |
+|---|---|---|---|---|
+| **G1** | **JPEG scaler** | `gallery/pdf_writer/src/tools/jpeg_scaler.rgr` (+ `src/jpeg/*`, `src/core/Buffer.rgr`) | ~6.5k LOC | Real CLI app: classes, `buffer`, loops, optionals, file I/O. Already a known ES6/Go target (`jpegscaler:*`, `JPEG_SCALER_LLVM.md`). |
+| **G2** | **TypeScript engine** | `gallery/pdf_writer/src/jsx/ComponentEngine.rgr` + `gallery/ts_parser/*` | ~21k LOC | Interpreter + parser that run `.tsx` / `.as`. Pulls in `EvalValue` (already shape-migrating), AST patching, imports. |
+| **G3** | **Self-host the compiler** | First `compiler/v4/**`, then enough of `ng_*` / `VirtualCompiler` to rebuild the host | compiler tree | Dogfood: v4 compiles itself to ES6 (then a second target). Replaces “bootstrap decision” as a vague C6 with a hard acceptance test. |
+
+Later “compile the gallery” is allowed only after G1–G3 are green on at least
+one writer (ES6). LLVM/native for jpeg_scaler remains a *stretch* (today’s
+LLVM path hangs on decode — see `JPEG_SCALER_LLVM.md`); G1 means **ES6 and/or
+Go output that runs the scaler**, matching the supported product paths.
+
+### Milestone order
+
+```text
+C0–C1  AstNode + parser          ✅ started
+  ↓
+C2–C4  collect + type + ES6 writer for a growing subset
+  ↓
+G1     jpeg_scaler compiles & runs (ES6)     ← first external proof
+  ↓
+G2     ComponentEngine + ts_parser compile & run a smoke .tsx
+  ↓
+G3a    v4 compiles compiler/v4/** (self-host sketch)
+G3b    v4 compiles enough to emit bin/output.js (or equivalent)
+```
+
+JPEG before the TS engine because it is smaller and has almost no
+meta-programming surface. Self-host tracks in parallel once the ES6 writer
+exists: every feature jpeg needs is also a feature the compiler needs.
+
+### Language surface the goals force
+
+| Feature | G1 jpeg | G2 TS engine | G3 self-host |
+|---|---|---|---|
+| `class` / `fn` / `sfn` / `Import` / `def` | required | required | required |
+| `if` / `while` / `for` / `return` | required | required | required |
+| arrays, maps, strings, numbers | required | required | required |
+| `buffer` + file/shell ops | **required** | some | some (host FS) |
+| `@(optional)` / `unwrap` / `null?` | required | required | required |
+| `@(weak)` / ownership annos | light | heavy | heavy |
+| operators / `Lang.rgr` templates | stdlib + buffer | large | **full** |
+| `extension`, lambdas, `Enum` | light | yes | yes |
+| `shape` / `match` / `union` | no (today) | `EvalPayload` shape | v4 itself uses shapes |
+| writers beyond ES6 | Go nice-to-have | Go/Rust nice | ES6 first, then one native |
+
+---
+
 ## 1. The CodeNode overload (measured)
 
 | File | Role | Lines |
@@ -173,16 +225,34 @@ useful subset and emit at least one target.
 
 - Emit JS for the typed subset
 - Compare output to ng_ compiler on the same fixtures
+- Gate: small programs that are **slices of G1** (buffer read, class method, CLI args)
 
-### C5 — Grow surface + second target
+### C5 — Grow surface toward G1 (JPEG scaler)
 
-- Operators, lambdas, classes, optionals
-- Rust or C++ writer to validate native shape lowering benefits in the compiler itself
+- Operators used by jpeg (`buffer_*`, arithmetic, `shell_arg*`, `substring`, …)
+- Optionals, `while`, nested classes, `Import` graph resolution
+- **Acceptance:** v4 ES6 output of `jpeg_scaler.rgr` scales a fixture JPEG
+  (parity with `gallery/pdf_writer/bin/jpeg_scaler.js` behavior on one image)
 
-### C6 — Bootstrapping decision
+### C6 — Grow toward G2 (TypeScript engine)
 
-- Only when C4/C5 cover enough to compile `compiler/v4/**`
-- Then consider replacing ng_ entry points
+- Lambdas, maps, `extension`, richer optionals/weak, larger import graphs
+- Enough to compile `ts_parser_main.rgr` then `ComponentEngine.rgr`
+- **Acceptance:** compiled engine evaluates a tiny `.tsx` smoke (e.g. `1+1` /
+  one JSX node) under the existing test harness style
+
+### C7 — Self-host (G3)
+
+- **G3a:** v4 compiles `compiler/v4/**` to ES6 and the result still parses
+- **G3b:** v4 compiles a trimmed host (`ng_Compiler` path or a v4 CLI) that can
+  compile `jpeg_scaler` — closing the loop
+- Only then consider retiring `ng_*` as the shipped binary
+
+### C8 — Second target (optional, after G1)
+
+- Go or Rust writer; jpeg_scaler on Go is the natural check
+- LLVM for jpeg remains out of scope until the existing LLVM hang is fixed
+  independently
 
 ---
 
@@ -194,18 +264,21 @@ compiler/v4/
   AstNode.rgr         # shape AstNode + helpers
   Source.rgr          # SourceFile (C1)
   Parser.rgr          # Lisp parser → AstNode (C1)
-  Probe.rgr           # small main used by tests
+  Probe.rgr / ParseProbe.rgr
 
 PLAN_COMPILER_V4.md   # this file (repo root, with other PLAN_*)
 tests/fixtures/v4_ast_probe.rgr
+tests/fixtures/v4_parse_probe.rgr
 tests/compiler-v4-ast.test.ts
 ```
 
-The product entry `compiler/ng_Compiler.rgr` is untouched.
+The product entry `compiler/ng_Compiler.rgr` is untouched until G3b.
 
 ---
 
-## 7. Success criteria for "shapes can rewrite the compiler"
+## 7. Success criteria
+
+### Scaffolding (C0–C1) — done / in progress
 
 | Criterion | How we know |
 |---|---|
@@ -215,8 +288,13 @@ The product entry `compiler/ng_Compiler.rgr` is untouched.
 | Parser produces only AstNode cases | C1 fixture round-trips |
 | No regression to shipping 3.3.x | ng_ tree unchanged |
 
-A full self-hosting v4 is **not** a success criterion for C0–C1; it is the
-C6 decision after a working subset exists.
+### First product goals
+
+| Goal | Done when |
+|---|---|
+| **G1 JPEG scaler** | `node <v4-es6-out>/jpeg_scaler.js -width N in.jpg out.jpg` matches ng_ output on a fixture |
+| **G2 TS engine** | v4-built `ComponentEngine` (or `ts_parser_main`) runs a smoke script in CI |
+| **G3 Self-host** | v4-built compiler compiles G1 (and ideally `compiler/v4`) without the ng_ host |
 
 ---
 
@@ -227,7 +305,8 @@ C6 decision after a working subset exists.
 | `PLAN_SHAPES.md` | Language feature v4 consumes; S0–S5 |
 | `PLAN_3.md` | Historical product 3.0; not an AST rewrite |
 | `INCREMENTAL_PLAN.md` | Builds on today's CodeNode; v4 should make invalidation easier (immutable AST + side tables) |
-| `EvalValue` shape migration | Same pattern; proof that production code can adopt shapes |
+| `EvalValue` shape migration | Same pattern; G2 already depends on shapes in the engine |
+| `JPEG_SCALER_LLVM.md` | G1 tracks ES6/Go; LLVM hang is separate |
 
 ---
 
@@ -235,6 +314,7 @@ C6 decision after a working subset exists.
 
 1. ~~Land C0: plan + AstNode probe + test~~
 2. ~~Implement C1 parser emitting AstNode (subset)~~
-3. Extend C1: annotations, better block/statement handling, file parse API
-4. Start C2: collect `class` / `fn` / `Import` from AstNode trees
-5. Keep every stage green under `tests/compiler-v4-ast.test.ts`
+3. ~~Pin first goals: G1 jpeg_scaler, G2 TS engine, G3 self-host~~
+4. Extend C1: annotations (`@…`), file parse API, `Import` strings
+5. C2: collect `class` / `fn` / `Import` / `def` — driven by what G1’s AST needs
+6. Keep `tests/compiler-v4-ast.test.ts` green; add G1-slice fixtures as C4 lands

--- a/compiler/v4/AstNode.rgr
+++ b/compiler/v4/AstNode.rgr
@@ -1,0 +1,196 @@
+; =============================================================================
+; AstNode — syntax-only AST for compiler v4 (PLAN_COMPILER_V4.md, stage C0)
+; =============================================================================
+; Replaces the overloaded CodeNode (parse tree + typing + codegen scratch) with
+; a closed variant family. Each case carries only the fields that kind needs.
+; Analysis state and target hints stay OUT of this shape (C2+).
+;
+; Shared source span lives on group Located. Scalar-only cases default to
+; @(value) (immutable, compare by content); VRef / Expression hold arrays so
+; they are @(reference) and stay mutable for the parser.
+
+Import "stdlib.rgr"
+
+; How a VRef was written: bare name, name:T, name:[T], or name:[K:V].
+; Plain ints (not an Enum) so shape methods can compare without enum typing issues.
+; 0 = Name, 1 = Typed, 2 = Array, 3 = Hash
+
+shape AstNode {
+    group Located {
+        def sp:int 0
+        def ep:int 0
+        def row:int 0
+        def col:int 0
+    }
+
+    ; annotation goes on the case name: `case Name@(value) does Group`
+    case Integer@(value) does Located {
+        def value:int 0
+    }
+    case Double@(value) does Located {
+        def value:double 0.0
+    }
+    case String@(value) does Located {
+        def value:string ""
+    }
+    case Boolean@(value) does Located {
+        def value:boolean false
+    }
+    case Comment@(value) does Located {
+        def text:string ""
+    }
+    case VRef does Located {
+        def name:string ""
+        def ns:[string]
+        def typeName:string ""
+        def keyType:string ""
+        def arrayType:string ""
+        def kind:int 0
+    }
+    case Expression does Located {
+        def children:[AstNode]
+        def isBlock:boolean false
+    }
+
+    ; Pretty-print for tests and parser round-trips. Exhaustive match — adding
+    ; a case without updating this method is a compile error.
+    fn asString:string () {
+        match self {
+            Integer n {
+                return ("" + n.value)
+            }
+            Double n {
+                return (double2str n.value)
+            }
+            String s {
+                return ((strfromcode 34) + s.value + (strfromcode 34))
+            }
+            Boolean b {
+                if b.value {
+                    return "true"
+                }
+                return "false"
+            }
+            Comment c {
+                return (";" + c.text)
+            }
+            VRef v {
+                def out:string v.name
+                if (v.kind == 1) {
+                    out = (out + ":" + v.typeName)
+                }
+                if (v.kind == 2) {
+                    out = (out + ":[" + v.arrayType + "]")
+                }
+                if (v.kind == 3) {
+                    out = (out + ":[" + v.keyType + ":" + v.arrayType + "]")
+                }
+                return out
+            }
+            Expression e {
+                def out:string "("
+                if e.isBlock {
+                    out = "{"
+                }
+                for e.children ch:AstNode i {
+                    if (i > 0) {
+                        out = (out + " ")
+                    }
+                    out = (out + (AstNode.asString(ch)))
+                }
+                if e.isBlock {
+                    return (out + "}")
+                }
+                return (out + ")")
+            }
+        }
+        return "?"
+    }
+
+    ; True when the node is a list/block (not an atom).
+    fn isExpression:boolean () {
+        case self e:AstNode.Expression {
+            return true
+        }
+        return false
+    }
+
+    sfn emptyNs:[string] () {
+        def ns:[string]
+        return ns
+    }
+
+    sfn intNode:AstNode (sp:int ep:int value:int) {
+        return (new AstNode.Integer(sp ep 0 0 value))
+    }
+
+    sfn doubleNode:AstNode (sp:int ep:int value:double) {
+        return (new AstNode.Double(sp ep 0 0 value))
+    }
+
+    sfn stringNode:AstNode (sp:int ep:int value:string) {
+        return (new AstNode.String(sp ep 0 0 value))
+    }
+
+    sfn boolNode:AstNode (sp:int ep:int value:boolean) {
+        return (new AstNode.Boolean(sp ep 0 0 value))
+    }
+
+    sfn vrefNode:AstNode (sp:int ep:int name:string) {
+        return (new AstNode.VRef(sp ep 0 0 name (AstNode.emptyNs()) "" "" "" 0))
+    }
+
+    sfn typedVref:AstNode (sp:int ep:int name:string typeName:string) {
+        return (new AstNode.VRef(sp ep 0 0 name (AstNode.emptyNs()) typeName "" "" 1))
+    }
+
+    sfn exprNode:AstNode (sp:int ep:int children:[AstNode] isBlock:boolean) {
+        return (new AstNode.Expression(sp ep 0 0 children isBlock))
+    }
+
+    ; Push a child onto an Expression node. No-op (returns false) for atoms —
+    ; the type system already forbids children on Integer etc., but the parser
+    ; holds AstNode (the union) and must narrow before mutating.
+    sfn pushChild:boolean (node:AstNode child:AstNode) {
+        case node e:AstNode.Expression {
+            push e.children child
+            return true
+        }
+        return false
+    }
+
+    sfn childCount:int (node:AstNode) {
+        case node e:AstNode.Expression {
+            return (array_length e.children)
+        }
+        return 0
+    }
+
+    sfn isBlock:boolean (node:AstNode) {
+        case node e:AstNode.Expression {
+            return e.isBlock
+        }
+        return false
+    }
+
+    ; Update the end span on a reference Expression (value cases are immutable).
+    sfn setEnd:boolean (node:AstNode ep:int) {
+        case node e:AstNode.Expression {
+            e.ep = ep
+            return true
+        }
+        return false
+    }
+
+    sfn commentNode:AstNode (sp:int ep:int text:string) {
+        return (new AstNode.Comment(sp ep 0 0 text))
+    }
+
+    sfn arrayVref:AstNode (sp:int ep:int name:string arrayType:string) {
+        return (new AstNode.VRef(sp ep 0 0 name (AstNode.emptyNs()) "" "" arrayType 2))
+    }
+
+    sfn hashVref:AstNode (sp:int ep:int name:string keyType:string arrayType:string) {
+        return (new AstNode.VRef(sp ep 0 0 name (AstNode.emptyNs()) "" keyType arrayType 3))
+    }
+}

--- a/compiler/v4/ParseProbe.rgr
+++ b/compiler/v4/ParseProbe.rgr
@@ -1,0 +1,19 @@
+; C1 probe: parse Ranger S-expressions into shape AstNodes and pretty-print.
+; Expected:
+;   (def x:int 1)
+;   (+ 2 3.5)
+;   (print "hi")
+;   (f true false)
+;   {(print "hi")}
+
+Import "Parser.rgr"
+
+class Main {
+    sfn main:void () {
+        print (AstParser.childAsString((AstParser.parseString("(def x:int 1)")) 0))
+        print (AstParser.childAsString((AstParser.parseString("(+ 2 3.5)")) 0))
+        print (AstParser.childAsString((AstParser.parseString("(print \"hi\")")) 0))
+        print (AstParser.childAsString((AstParser.parseString("(f true false)")) 0))
+        print (AstParser.childAsString((AstParser.parseString("{ print \"hi\" }")) 0))
+    }
+}

--- a/compiler/v4/Parser.rgr
+++ b/compiler/v4/Parser.rgr
@@ -1,0 +1,333 @@
+; =============================================================================
+; Shape-based Lisp parser for compiler v4 (PLAN_COMPILER_V4.md, stage C1)
+; =============================================================================
+; Emits AstNode shapes instead of the fat CodeNode. Subset of ng_RangerLispParser:
+; atoms (int/double/string/bool), vrefs with :T / :[T] / :[K:V], lists, blocks,
+; line comments. Uses string + strlen/charAt (not charbuffer) for multi-target.
+
+Import "AstNode.rgr"
+Import "Source.rgr"
+
+class AstParser {
+    def src:SourceFile
+    def code:string ""
+    def len:int 0
+    def i:int 0
+    def parenCnt:int 0
+    def hadError:boolean false
+    def errorMsg:string ""
+    def parents:[AstNode]
+    ; Strong refs: no parent pointers on AstNode, so no cycle. (weak + shape
+    ; unions currently break on the Rust target when upgrading.)
+    def root@(optional):AstNode
+    def curr@(optional):AstNode
+
+    Constructor (file:SourceFile) {
+        src = file
+        code = file.code
+        len = (strlen code)
+        def kids:[AstNode]
+        def r:AstNode (AstNode.exprNode(0 0 kids true))
+        root = r
+        curr = r
+        push parents r
+        parenCnt = 1
+    }
+
+    sfn parseString:AstNode (text:string) {
+        def file:SourceFile (new SourceFile(text "<memory>"))
+        def p:AstParser (new AstParser(file))
+        p.parse()
+        return (unwrap p.root)
+    }
+
+    sfn childAsString:string (rootNode:AstNode index:int) {
+        case rootNode e:AstNode.Expression {
+            if ((array_length e.children) > index) {
+                return (AstNode.asString((itemAt e.children index)))
+            }
+        }
+        return ""
+    }
+
+    fn fail:void (msg:string) {
+        hadError = true
+        errorMsg = msg
+    }
+
+    fn skipSpace:boolean (blockParent:boolean) {
+        if (i >= len) {
+            return true
+        }
+        def c:int (charAt code i)
+        while ((i < len) && (c <= 32)) {
+            if (blockParent && ((c == 10) || (c == 13))) {
+                this.endExpression()
+                return true
+            }
+            i = (i + 1)
+            if (i >= len) {
+                return true
+            }
+            c = (charAt code i)
+        }
+        return false
+    }
+
+    fn endExpression:void () {
+        parenCnt = (parenCnt - 1)
+        if (parenCnt < 0) {
+            this.fail(") mismatch")
+            return
+        }
+        if (!null? curr) {
+            def ignored:boolean (AstNode.setEnd((unwrap curr) i))
+        }
+        removeLast parents
+        if ((array_length parents) > 0) {
+            curr = (itemAt parents ((array_length parents) - 1))
+        }
+    }
+
+    fn insert:void (node:AstNode) {
+        if (null? curr) {
+            this.fail("insert with no current node")
+            return
+        }
+        def ok:boolean (AstNode.pushChild((unwrap curr) node))
+        if (false == ok) {
+            this.fail("insert into non-expression")
+        }
+    }
+
+    fn isIdentStop:boolean (c:int) {
+        if (c <= 32) {
+            return true
+        }
+        if ((c == 40) || (c == 41) || (c == 58)) {
+            return true
+        }
+        if ((c == (charcode "}")) || (c == (charcode "{")) || (c == (charcode "[")) || (c == (charcode "]"))) {
+            return true
+        }
+        return false
+    }
+
+    fn parse:void () {
+        while (i < len) {
+            if hadError {
+                break
+            }
+            def blockParent:boolean false
+            if ((array_length parents) >= 2) {
+                def maybeParent:AstNode (itemAt parents ((array_length parents) - 2))
+                blockParent = (AstNode.isBlock(maybeParent))
+            } {
+                if (!null? curr) {
+                    blockParent = (AstNode.isBlock((unwrap curr)))
+                }
+            }
+            if (this.skipSpace(blockParent)) {
+                break
+            }
+            if (i >= len) {
+                break
+            }
+            def c:int (charAt code i)
+
+            if (c == 59) {
+                def csp:int (i + 1)
+                i = (i + 1)
+                while ((i < len) && ((charAt code i) > 31)) {
+                    i = (i + 1)
+                }
+                this.insert((AstNode.commentNode(csp i (substring code csp i))))
+                continue
+            }
+
+            if ((c == 40) || (c == (charcode "{"))) {
+                def isBlock:boolean (c == (charcode "{"))
+                def kids:[AstNode]
+                def node:AstNode (AstNode.exprNode(i i kids isBlock))
+                this.insert(node)
+                push parents node
+                curr = node
+                parenCnt = (parenCnt + 1)
+                i = (i + 1)
+                this.parse()
+                continue
+            }
+
+            if (c == 41) {
+                i = (i + 1)
+                this.endExpression()
+                break
+            }
+
+            if (c == (charcode "}")) {
+                i = (i + 1)
+                this.endExpression()
+                break
+            }
+
+            def fc:int c
+            def isNumStart:boolean false
+            if ((fc >= 48) && (fc <= 57)) {
+                isNumStart = true
+            }
+            if ((fc == 45) && (i < (len - 1))) {
+                def nc:int (charAt code (i + 1))
+                if ((nc >= 48) && (nc <= 57)) {
+                    isNumStart = true
+                }
+            }
+            if isNumStart {
+                def sp:int i
+                def isDouble:boolean false
+                i = (i + 1)
+                while (i < len) {
+                    def ch:int (charAt code i)
+                    if ((ch >= 48) && (ch <= 57)) {
+                        i = (i + 1)
+                        continue
+                    }
+                    if (ch == (charcode ".")) {
+                        isDouble = true
+                        i = (i + 1)
+                        continue
+                    }
+                    break
+                }
+                def ep:int i
+                def lit:string (substring code sp ep)
+                if isDouble {
+                    this.insert((AstNode.doubleNode(sp ep (unwrap (str2double lit)))))
+                } {
+                    this.insert((AstNode.intNode(sp ep (unwrap (str2int lit)))))
+                }
+                continue
+            }
+
+            if (fc == 34) {
+                def ssp:int (i + 1)
+                i = (i + 1)
+                while (i < len) {
+                    def sch:int (charAt code i)
+                    if (sch == 34) {
+                        break
+                    }
+                    if (sch == 92) {
+                        i = (i + 1)
+                    }
+                    i = (i + 1)
+                }
+                def sep:int i
+                this.insert((AstNode.stringNode(ssp sep (substring code ssp sep))))
+                if (i < len) {
+                    i = (i + 1)
+                }
+                continue
+            }
+
+            if ((fc == (charcode "t")) && ((i + 4) <= len)) {
+                def tw:string (substring code i (i + 4))
+                if (tw == "true") {
+                    def stopT:boolean true
+                    if ((i + 4) < len) {
+                        stopT = (this.isIdentStop((charAt code (i + 4))))
+                    }
+                    if stopT {
+                        this.insert((AstNode.boolNode(i (i + 4) true)))
+                        i = (i + 4)
+                        continue
+                    }
+                }
+            }
+
+            if ((fc == (charcode "f")) && ((i + 5) <= len)) {
+                def fw:string (substring code i (i + 5))
+                if (fw == "false") {
+                    def stopF:boolean true
+                    if ((i + 5) < len) {
+                        stopF = (this.isIdentStop((charAt code (i + 5))))
+                    }
+                    if stopF {
+                        this.insert((AstNode.boolNode(i (i + 5) false)))
+                        i = (i + 5)
+                        continue
+                    }
+                }
+            }
+
+            if (!null? curr) {
+                if ((AstNode.isBlock((unwrap curr))) && (fc > 32)) {
+                    if (false == (this.isIdentStop(fc))) {
+                        def kids2:[AstNode]
+                        def stmt:AstNode (AstNode.exprNode(i i kids2 false))
+                        this.insert(stmt)
+                        push parents stmt
+                        curr = stmt
+                        parenCnt = (parenCnt + 1)
+                        this.parse()
+                        continue
+                    }
+                }
+            }
+
+            def vsp:int i
+            while ((i < len) && (false == (this.isIdentStop((charAt code i))))) {
+                i = (i + 1)
+            }
+            def vep:int i
+            if (vep <= vsp) {
+                this.fail("empty token")
+                break
+            }
+            def name:string (substring code vsp vep)
+
+            while ((i < len) && ((charAt code i) <= 32) && ((charAt code i) != 10) && ((charAt code i) != 13)) {
+                i = (i + 1)
+            }
+
+            if ((i < len) && ((charAt code i) == 58)) {
+                i = (i + 1)
+                while ((i < len) && ((charAt code i) <= 32)) {
+                    i = (i + 1)
+                }
+                if ((i < len) && ((charAt code i) == (charcode "["))) {
+                    i = (i + 1)
+                    def tsp:int i
+                    def hashSep:int 0
+                    while ((i < len) && ((charAt code i) != (charcode "]"))) {
+                        if ((charAt code i) == 58) {
+                            hashSep = i
+                        }
+                        i = (i + 1)
+                    }
+                    def tep:int i
+                    if (i < len) {
+                        i = (i + 1)
+                    }
+                    if (hashSep > 0) {
+                        def kt:string (substring code tsp hashSep)
+                        def at:string (substring code (hashSep + 1) tep)
+                        this.insert((AstNode.hashVref(vsp tep name kt at)))
+                    } {
+                        def at2:string (substring code tsp tep)
+                        this.insert((AstNode.arrayVref(vsp tep name at2)))
+                    }
+                    continue
+                }
+                def tsp2:int i
+                while ((i < len) && (false == (this.isIdentStop((charAt code i))))) {
+                    i = (i + 1)
+                }
+                def typeName:string (substring code tsp2 i)
+                this.insert((AstNode.typedVref(vsp vep name typeName)))
+                continue
+            }
+
+            this.insert((AstNode.vrefNode(vsp vep name)))
+        }
+    }
+}

--- a/compiler/v4/Probe.rgr
+++ b/compiler/v4/Probe.rgr
@@ -1,0 +1,40 @@
+; C0 probe: build a small AstNode tree with the shape API and pretty-print it.
+; Expected output:
+;   (def x:int 1)
+;   (+ 2 3.5)
+;   children:2
+;   isExpr:true
+;   isExpr:false
+
+Import "AstNode.rgr"
+
+class Main {
+    sfn main:void () {
+        ; (def x:int 1)
+        def defKids:[AstNode]
+        push defKids (AstNode.vrefNode(0 3 "def"))
+        push defKids (AstNode.typedVref(4 9 "x" "int"))
+        push defKids (AstNode.intNode(10 11 1))
+        def defExpr:AstNode (AstNode.exprNode(0 12 defKids false))
+        print (AstNode.asString(defExpr))
+
+        ; (+ 2 3.5)
+        def addKids:[AstNode]
+        push addKids (AstNode.vrefNode(0 1 "+"))
+        push addKids (AstNode.intNode(2 3 2))
+        push addKids (AstNode.doubleNode(4 7 3.5))
+        def addExpr:AstNode (AstNode.exprNode(0 8 addKids false))
+        print (AstNode.asString(addExpr))
+
+        print ("children:" + (to_string (AstNode.childCount(addExpr))))
+        print ("isExpr:" + (to_string (AstNode.isExpression(addExpr))))
+        print ("isExpr:" + (to_string (AstNode.isExpression((AstNode.intNode(0 1 9))))))
+
+        ; Mutate via pushChild (parser will do this while curr_node is AstNode)
+        def blockKids:[AstNode]
+        def block:AstNode (AstNode.exprNode(0 0 blockKids true))
+        def ignored:boolean (AstNode.pushChild(block (AstNode.vrefNode(0 5 "print"))))
+        def ignored2:boolean (AstNode.pushChild(block (AstNode.stringNode(6 10 "hi"))))
+        print (AstNode.asString(block))
+    }
+}

--- a/compiler/v4/README.md
+++ b/compiler/v4/README.md
@@ -4,6 +4,9 @@ Parallel rewrite of the Ranger compiler using **shapes** for the AST.
 See [`PLAN_COMPILER_V4.md`](../../PLAN_COMPILER_V4.md).
 
 The shipping compiler remains `compiler/ng_*.rgr` (product 3.3.x).
+**`ng_*` stays frozen** so `npm test` keeps gating the product path. v4 is a
+parallel tree; an in-place `CodeNode`→shape edit is rejected under that
+constraint (macros / plugins / IDE all mutate fat CodeNode — see plan §2.5).
 Nothing here replaces `ng_Compiler.rgr` until self-host (G3).
 
 ## First goals

--- a/compiler/v4/README.md
+++ b/compiler/v4/README.md
@@ -1,47 +1,22 @@
-# Compiler v4 (sketch)
+# Compiler v4 (research probe)
 
-Parallel rewrite of the Ranger compiler using **shapes** for the AST.
-See [`PLAN_COMPILER_V4.md`](../../PLAN_COMPILER_V4.md).
+Feasibility sketch: can a Ranger syntax AST be a `shape`?
+See [`PLAN_COMPILER_V4.md`](../../PLAN_COMPILER_V4.md) §2.5.
 
-The shipping compiler remains `compiler/ng_*.rgr` (product 3.3.x).
-**`ng_*` stays frozen** so `npm test` keeps gating the product path. v4 is a
-parallel tree; an in-place `CodeNode`→shape edit is rejected under that
-constraint (macros / plugins / IDE all mutate fat CodeNode — see plan §2.5).
-Nothing here replaces `ng_Compiler.rgr` until self-host (G3).
+**Product recommendation: do not replace shipping `CodeNode` with shapes**
+under the gate “full macro parity + all tests green, no half-landed
+compiler.” That gate makes this a second mid-end, not an AST-local change.
+Shapes pay off better on domain tagged unions (`EvalPayload`, etc.).
 
-## First goals
+`compiler/ng_*.rgr` remains the product compiler. This tree is evidence only.
 
-Not “compile the whole gallery.” The first acceptance targets are:
+## What’s here
 
-| Goal | Program |
+| File | Role |
 |---|---|
-| **G1** | JPEG scaler — `gallery/pdf_writer/src/tools/jpeg_scaler.rgr` |
-| **G2** | TypeScript engine — `ComponentEngine.rgr` + `gallery/ts_parser/` |
-| **G3** | Self-host — v4 compiles `compiler/v4/**`, then a host that builds G1 |
-
-## Layout
-
-| File | Stage | Role |
-|---|---|---|
-| `AstNode.rgr` | C0 | `shape AstNode` — syntax-only closed family |
-| `Probe.rgr` | C0 | Builds nodes and pretty-prints via exhaustive `match` |
-| `Source.rgr` | C1 | Source buffer |
-| `Parser.rgr` | C1 | Lisp parser → `AstNode` |
-| `ParseProbe.rgr` | C1 | Parse strings and pretty-print |
-
-## Run probes
-
-From the repo root (uses the current host compiler):
-
-```bash
-node bin/output.js -es6 ./compiler/v4/Probe.rgr -d=./tests/.output -o=v4_probe.js
-node tests/.output/v4_probe.js
-
-node bin/output.js -es6 ./compiler/v4/ParseProbe.rgr -d=./tests/.output -o=v4_parse_probe.js
-node tests/.output/v4_parse_probe.js
-```
-
-Or via vitest:
+| `AstNode.rgr` | `shape AstNode` — syntax-only closed family |
+| `Parser.rgr` / `Source.rgr` | Small Lisp parser → AstNode |
+| `Probe.rgr` / `ParseProbe.rgr` | Smoke mains |
 
 ```bash
 npx vitest run tests/compiler-v4-ast.test.ts

--- a/compiler/v4/README.md
+++ b/compiler/v4/README.md
@@ -1,0 +1,32 @@
+# Compiler v4 (sketch)
+
+Parallel rewrite of the Ranger compiler using **shapes** for the AST.
+See [`PLAN_COMPILER_V4.md`](../../PLAN_COMPILER_V4.md).
+
+The shipping compiler remains `compiler/ng_*.rgr` (product 3.3.x).
+Nothing here replaces `ng_Compiler.rgr` yet.
+
+## Layout
+
+| File | Stage | Role |
+|---|---|---|
+| `AstNode.rgr` | C0 | `shape AstNode` — syntax-only closed family |
+| `Probe.rgr` | C0 | Builds nodes and pretty-prints via exhaustive `match` |
+| `Source.rgr` | C1 | Source buffer |
+| `Parser.rgr` | C1 | Lisp parser → `AstNode` |
+| `ParseProbe.rgr` | C1 | Parse strings and pretty-print |
+
+## Run the probe
+
+From the repo root (uses the current host compiler):
+
+```bash
+node bin/output.js -es6 ./compiler/v4/Probe.rgr -d=./tests/.output -o=v4_probe.js
+node tests/.output/v4_probe.js
+```
+
+Or via the vitest suite:
+
+```bash
+npx vitest run tests/compiler-v4-ast.test.ts
+```

--- a/compiler/v4/README.md
+++ b/compiler/v4/README.md
@@ -4,7 +4,17 @@ Parallel rewrite of the Ranger compiler using **shapes** for the AST.
 See [`PLAN_COMPILER_V4.md`](../../PLAN_COMPILER_V4.md).
 
 The shipping compiler remains `compiler/ng_*.rgr` (product 3.3.x).
-Nothing here replaces `ng_Compiler.rgr` yet.
+Nothing here replaces `ng_Compiler.rgr` until self-host (G3).
+
+## First goals
+
+Not “compile the whole gallery.” The first acceptance targets are:
+
+| Goal | Program |
+|---|---|
+| **G1** | JPEG scaler — `gallery/pdf_writer/src/tools/jpeg_scaler.rgr` |
+| **G2** | TypeScript engine — `ComponentEngine.rgr` + `gallery/ts_parser/` |
+| **G3** | Self-host — v4 compiles `compiler/v4/**`, then a host that builds G1 |
 
 ## Layout
 
@@ -16,16 +26,19 @@ Nothing here replaces `ng_Compiler.rgr` yet.
 | `Parser.rgr` | C1 | Lisp parser → `AstNode` |
 | `ParseProbe.rgr` | C1 | Parse strings and pretty-print |
 
-## Run the probe
+## Run probes
 
 From the repo root (uses the current host compiler):
 
 ```bash
 node bin/output.js -es6 ./compiler/v4/Probe.rgr -d=./tests/.output -o=v4_probe.js
 node tests/.output/v4_probe.js
+
+node bin/output.js -es6 ./compiler/v4/ParseProbe.rgr -d=./tests/.output -o=v4_parse_probe.js
+node tests/.output/v4_parse_probe.js
 ```
 
-Or via the vitest suite:
+Or via vitest:
 
 ```bash
 npx vitest run tests/compiler-v4-ast.test.ts

--- a/compiler/v4/Source.rgr
+++ b/compiler/v4/Source.rgr
@@ -1,0 +1,11 @@
+; Source buffer for compiler v4 (PLAN_COMPILER_V4.md, stage C1).
+
+class SourceFile {
+    def code:string ""
+    def filename:string ""
+
+    Constructor (code_str:string path:string) {
+        code = code_str
+        filename = path
+    }
+}

--- a/tests/compiler-v4-ast.test.ts
+++ b/tests/compiler-v4-ast.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import {
+  expectOutput,
+  expectPythonOutput,
+  expectGoOutput,
+  expectRustOutput,
+  getGeneratedCppCode,
+  isPythonAvailable,
+  isGoAvailable,
+  isRustAvailable,
+} from "./helpers/compiler";
+
+/**
+ * Compiler v4 — shape-based AstNode + Lisp parser (PLAN_COMPILER_V4.md).
+ *
+ * C0: construction, exhaustive match pretty-print, mutating Expression
+ * children through a union-typed handle.
+ * C1: AstParser emits AstNode shapes from source text (no CodeNode).
+ */
+const AST_PROBE = "tests/fixtures/v4_ast_probe.rgr";
+const PARSE_PROBE = "tests/fixtures/v4_parse_probe.rgr";
+
+const AST_EXPECTED = [
+  "(def x:int 1)",
+  "(+ 2 3.5)",
+  "children:3",
+  "isExpr:true",
+  "isExpr:false",
+  '{print "hi"}',
+].join("\n");
+
+const PARSE_EXPECTED = [
+  "(def x:int 1)",
+  "(+ 2 3.5)",
+  '(print "hi")',
+  "(f true false)",
+  '{(print "hi")}',
+].join("\n");
+
+describe("compiler v4 AstNode (shapes)", () => {
+  describe("C0 manual tree", () => {
+    it("ES6", () => {
+      expectOutput(AST_PROBE, AST_EXPECTED);
+    });
+
+    it.skipIf(!isPythonAvailable())("Python", () => {
+      expectPythonOutput(AST_PROBE, AST_EXPECTED);
+    });
+
+    it.skipIf(!isGoAvailable())("Go", () => {
+      expectGoOutput(AST_PROBE, AST_EXPECTED);
+    });
+
+    it.skipIf(!isRustAvailable())("Rust", () => {
+      expectRustOutput(AST_PROBE, AST_EXPECTED);
+    });
+
+    it("emits one class per AstNode case (C++)", () => {
+      const result = getGeneratedCppCode(AST_PROBE);
+      expect(result.success, `Compile failed: ${result.error}`).toBe(true);
+      for (const cls of [
+        "AstNode_Integer",
+        "AstNode_Double",
+        "AstNode_String",
+        "AstNode_Boolean",
+        "AstNode_VRef",
+        "AstNode_Expression",
+        "AstNode_Comment",
+      ]) {
+        expect(result.code).toContain(cls);
+      }
+      expect(result.code).toContain("r_union_AstNode");
+      expect(result.code).not.toMatch(/class AstNode\s*[:{]/);
+    });
+  });
+
+  describe("C1 shape-based parser", () => {
+    it("ES6 parses S-expressions into AstNode", () => {
+      expectOutput(PARSE_PROBE, PARSE_EXPECTED);
+    });
+
+    it.skipIf(!isPythonAvailable())("Python", () => {
+      expectPythonOutput(PARSE_PROBE, PARSE_EXPECTED);
+    });
+
+    it.skipIf(!isGoAvailable())("Go", () => {
+      expectGoOutput(PARSE_PROBE, PARSE_EXPECTED);
+    });
+
+    it.skipIf(!isRustAvailable())("Rust", () => {
+      expectRustOutput(PARSE_PROBE, PARSE_EXPECTED);
+    });
+  });
+});

--- a/tests/fixtures/v4_ast_probe.rgr
+++ b/tests/fixtures/v4_ast_probe.rgr
@@ -1,0 +1,30 @@
+; Re-export path for the test harness (same program as compiler/v4/Probe.rgr).
+Import "../../compiler/v4/AstNode.rgr"
+
+class Main {
+    sfn main:void () {
+        def defKids:[AstNode]
+        push defKids (AstNode.vrefNode(0 3 "def"))
+        push defKids (AstNode.typedVref(4 9 "x" "int"))
+        push defKids (AstNode.intNode(10 11 1))
+        def defExpr:AstNode (AstNode.exprNode(0 12 defKids false))
+        print (AstNode.asString(defExpr))
+
+        def addKids:[AstNode]
+        push addKids (AstNode.vrefNode(0 1 "+"))
+        push addKids (AstNode.intNode(2 3 2))
+        push addKids (AstNode.doubleNode(4 7 3.5))
+        def addExpr:AstNode (AstNode.exprNode(0 8 addKids false))
+        print (AstNode.asString(addExpr))
+
+        print ("children:" + (to_string (AstNode.childCount(addExpr))))
+        print ("isExpr:" + (to_string (AstNode.isExpression(addExpr))))
+        print ("isExpr:" + (to_string (AstNode.isExpression((AstNode.intNode(0 1 9))))))
+
+        def blockKids:[AstNode]
+        def block:AstNode (AstNode.exprNode(0 0 blockKids true))
+        def ignored:boolean (AstNode.pushChild(block (AstNode.vrefNode(0 5 "print"))))
+        def ignored2:boolean (AstNode.pushChild(block (AstNode.stringNode(6 10 "hi"))))
+        print (AstNode.asString(block))
+    }
+}

--- a/tests/fixtures/v4_parse_probe.rgr
+++ b/tests/fixtures/v4_parse_probe.rgr
@@ -1,0 +1,12 @@
+; C1: parse S-expressions into shape AstNodes (PLAN_COMPILER_V4.md).
+Import "../../compiler/v4/Parser.rgr"
+
+class Main {
+    sfn main:void () {
+        print (AstParser.childAsString((AstParser.parseString("(def x:int 1)")) 0))
+        print (AstParser.childAsString((AstParser.parseString("(+ 2 3.5)")) 0))
+        print (AstParser.childAsString((AstParser.parseString("(print \"hi\")")) 0))
+        print (AstParser.childAsString((AstParser.parseString("(f true false)")) 0))
+        print (AstParser.childAsString((AstParser.parseString("{ print \"hi\" }")) 0))
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Recommendation: **do not** replace shipping `CodeNode` with shapes

Under the hard gates — **full macro parity before any cutover**, existing tests green, **no half-landed compiler** — this is not an “AST-only” change. It is a **second implementation of the hot path** (~15k LOC: FlowParser + macro/`defn` engine + LiveCompiler + CodeNode APIs) with **no product value until 100%**.

Deferring macros is out of scope per product requirements. That removes the “grow v4 then port macros” story.

**Useful instead:** keep investing shapes in **domain** tagged unions (`EvalPayload`, etc.). Keep `ng_*` as the compiler. G1 jpeg / G2 TS engine / G3 self-host already run on today’s compiler and do not need an AST rewrite.

Details: `PLAN_COMPILER_V4.md` §2.5.

## What this PR still contains

- Research probe: `compiler/v4/` shape `AstNode` + small parser (C0–C1)
- Tests: `tests/compiler-v4-ast.test.ts` (does not touch product `npm test` path)
- **No** changes to `compiler/ng_*.rgr`

Safe to merge as documentation + probe, or close if the probe is not wanted in-tree.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd57d-a2e4-7e39-9345-ed4b9753334c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd57d-a2e4-7e39-9345-ed4b9753334c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

