### PR TITLE
EvValue E3: Hole + primitive kinds into ComponentEngine

### DIFF
--- a/PLAN_SHAPES.md
+++ b/PLAN_SHAPES.md
@@ -1209,6 +1209,11 @@ that no `record` with a class-typed field could avoid are fixed
      `ComponentEngine` creates and checks holes through the bridge so the shape owns
      the kind. Storage remains the tagged singleton until later kinds move. Fixture:
      `tests/fixtures/shape_evalvalue_e3_hole.rgr`.
+   - **✅ E3 primitives (boundary):** `taggedNull` / `taggedUndefined` / `taggedNumber` /
+     `taggedString` / `taggedBoolean` and matching predicates; `ComponentEngine` routes
+     those factories and `isNull`/`isUndefined`/`isNumber`/`isString`/`isBoolean` through
+     the bridge. Fixture: `tests/fixtures/shape_evalvalue_e3_prims.rgr`. Next: Element,
+     then property carriers.
 4. **Delete the wrappers** and the `valueType` constants; rename `EvValue` → `EvalValue`.
 5. **Re-measure.** `sizeof(EvalValue)` on C++, the eight benchmark cases on Node, C++,
    Rust, Go, Kotlin, Python and C#, and the small-integer pool's remaining value —

--- a/PLAN_SHAPES.md
+++ b/PLAN_SHAPES.md
@@ -1200,21 +1200,15 @@ that no `record` with a class-typed field could avoid are fixed
    `EvValueBridge.fromTagged` converts primitives and Hole from `class EvalValue`.
    `ComponentEngine.rgr` still uses the tagged class. Fixture:
    `tests/fixtures/shape_evalvalue_e2.rgr`.
-3. **Convert by kind, not by call site.** `Hole` first (it is a correctness fix, not
-   just a cleanup), then the primitives, then `Element`, then the property carriers.
-   Each conversion is one `match` replacing one `valueType` chain, and the benchmark
-   suite (`gallery/game_engine/v2/interp/bench/`, `npm run test:tsengine`) gates each
-   step.
-   - **✅ E3 Hole (boundary):** `EvValueBridge.toTagged` / `taggedHole` / `isHole`;
-     `ComponentEngine` creates and checks holes through the bridge so the shape owns
-     the kind. Storage remains the tagged singleton until later kinds move. Fixture:
-     `tests/fixtures/shape_evalvalue_e3_hole.rgr`.
-   - **✅ E3 primitives (boundary):** `taggedNull` / `taggedUndefined` / `taggedNumber` /
-     `taggedString` / `taggedBoolean` and matching predicates; `ComponentEngine` routes
-     those factories and `isNull`/`isUndefined`/`isNumber`/`isString`/`isBoolean` through
-     the bridge. Fixture: `tests/fixtures/shape_evalvalue_e3_prims.rgr`. Next: Element,
-     then property carriers.
+3. **✅ Convert by kind, not by call site (boundary).** Every kind's create/check API
+   in `ComponentEngine` goes through `EvValueBridge` so the closed family owns the
+   kind. Storage remains `class EvalValue` / `[EvalValue]` (identity-preserving
+   mutation) until step 4. Fixtures: `shape_evalvalue_e3_hole.rgr`,
+   `shape_evalvalue_e3_prims.rgr`, `shape_evalvalue_e3_refs.rgr`.
+   - Hole → primitives → Element → Array/Object/Map/Set → Function family.
 4. **Delete the wrappers** and the `valueType` constants; rename `EvValue` → `EvalValue`.
+   Requires migrating storage and ~170 in-place mutators off the tagged class — a
+   separate cutover after step 3.
 5. **Re-measure.** `sizeof(EvalValue)` on C++, the eight benchmark cases on Node, C++,
    Rust, Go, Kotlin, Python and C#, and the small-integer pool's remaining value —
    with primitives no longer heap-allocated, the pool may stop earning its keep on the

--- a/PLAN_SHAPES.md
+++ b/PLAN_SHAPES.md
@@ -1205,6 +1205,10 @@ that no `record` with a class-typed field could avoid are fixed
    Each conversion is one `match` replacing one `valueType` chain, and the benchmark
    suite (`gallery/game_engine/v2/interp/bench/`, `npm run test:tsengine`) gates each
    step.
+   - **✅ E3 Hole (boundary):** `EvValueBridge.toTagged` / `taggedHole` / `isHole`;
+     `ComponentEngine` creates and checks holes through the bridge so the shape owns
+     the kind. Storage remains the tagged singleton until later kinds move. Fixture:
+     `tests/fixtures/shape_evalvalue_e3_hole.rgr`.
 4. **Delete the wrappers** and the `valueType` constants; rename `EvValue` → `EvalValue`.
 5. **Re-measure.** `sizeof(EvalValue)` on C++, the eight benchmark cases on Node, C++,
    Rust, Go, Kotlin, Python and C#, and the small-integer pool's remaining value —

--- a/gallery/game_engine/v2/interp/migrate/src/ComponentEngine.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/ComponentEngine.rgr
@@ -126,13 +126,13 @@ class EvalContext {
             }
         }
         if (has bindings name) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         if parent {
             def p:EvalContext (unwrap parent)
             return (p.findWithObjectFor(name))
         }
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     ; The scope that OWNS this name, or null when nothing up the chain does.
@@ -175,7 +175,7 @@ class EvalContext {
             def p:EvalContext (unwrap parent)
             return (p.lookup(name))
         }
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     ; Update an existing binding in the nearest enclosing scope that owns it.
@@ -423,7 +423,7 @@ class EvalContext {
         if cur {
             def c:EvalValue (unwrap cur)
             if (c.valueType == 1) {
-                set bindings name (EvalValue.number((c.numberValue + delta)))
+                set bindings name (EvValueBridge.taggedNumber((c.numberValue + delta)))
                 return cur
             }
             def noneT@(optional):EvalValue
@@ -529,7 +529,7 @@ class EvalNativeBridge {
         return false
     }
     fn invoke:EvalValue (name:string args:[EvalValue]) {
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 }
 
@@ -572,7 +572,7 @@ class ComponentEngine {
     ; why `eval("if (true) { 42; }")` is 42 and `eval("var x = 1;")` is
     ; undefined. Tracking it on the statement runner rather than at the top
     ; level is what makes a value produced INSIDE a loop or an if reach eval.
-    def completionValue:EvalValue (EvalValue.undefined())
+    def completionValue:EvalValue (EvValueBridge.taggedUndefined())
     ; Expression slots. One value object per (call, expression node): the frame
     ; owns the ID range [exprSlotBase, exprSlotBase + body.exprSlotCount) and an
     ; expression writes its result into `exprSlots` at its own index rather than
@@ -650,7 +650,7 @@ class ComponentEngine {
     ; returned value out of the function (not just JSX). Saved/restored per
     ; function body so nested calls are reentrancy-safe.
     def scriptDidReturn:boolean false
-    def scriptReturnValue:EvalValue (EvalValue.null())
+    def scriptReturnValue:EvalValue (EvValueBridge.taggedNull())
     def loopBreak:boolean false
     def loopContinue:boolean false
     ; D-LABELS: `break label` / `continue label` name a statement further out
@@ -667,7 +667,7 @@ class ComponentEngine {
     ; statement lists, loops and calls (like a pending return) until a try/catch
     ; clears it. Kept separate from scriptDidReturn so a catch can resume.
     def scriptThrew:boolean false
-    def scriptThrowValue:EvalValue (EvalValue.null())
+    def scriptThrowValue:EvalValue (EvValueBridge.taggedNull())
     ; D-ERRORS: the engine-provided error constructors are seeded lazily, once,
     ; so that `thrown.constructor === TypeError` holds by reference.
     def errorCtorsReady:boolean false
@@ -1093,7 +1093,7 @@ class ComponentEngine {
                     this.bindImportedFunction(exportName localName fnNode emptyHelpers "")
                 }
             } {
-                if (false == (existing.isNull())) {
+                if (false == (EvValueBridge.isNull(existing))) {
                     this.defineModuleBinding(localName existing)
                 }
             }
@@ -1349,7 +1349,7 @@ class ComponentEngine {
                         def value:EvalValue (this.evaluateExpr((unwrap decl.init)))
                         context.define(decl.name value)
                     } {
-                        context.define(decl.name (EvalValue.undefined()))
+                        context.define(decl.name (EvValueBridge.taggedUndefined()))
                     }
                 }
                 i = (i + 1)
@@ -1400,7 +1400,7 @@ class ComponentEngine {
             }
             i = (i + 1)
         }
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     ; Namespace object for `import * as NS from "ranger:x"`: a snapshot of the
@@ -1410,7 +1410,7 @@ class ComponentEngine {
         def ks:[string]
         def vs:[EvalValue]
         def ns:EvalValue (EvalValue.object(ks vs))
-        ns.setMember("__nsmodule__" (EvalValue.string(name)))
+        ns.setMember("__nsmodule__" (EvValueBridge.taggedString(name)))
         def sc:EvalContext (this.moduleScopeFor(name))
         def bnames:[string] (keys sc.bindings)
         def i:int 0
@@ -1455,7 +1455,7 @@ class ComponentEngine {
             def argNode:TSNode (itemAt node.children i)
             ; Spread a call argument: f(...xs) expands the array's elements.
             if (argNode.nodeType == "SpreadElement") {
-                def sv:EvalValue (EvalValue.null())
+                def sv:EvalValue (EvValueBridge.taggedNull())
                 if argNode.left {
                     sv = (this.evaluateExpr((unwrap argNode.left)))
                 }
@@ -1482,7 +1482,7 @@ class ComponentEngine {
     ; Convenience: read back a registered / script-defined global by name.
     fn getGlobal:EvalValue (name:string) {
         def v:EvalValue (context.lookup(name))
-        if (false == (v.isNull())) {
+        if (false == (EvValueBridge.isNull(v))) {
             return v
         }
         return (hostScope.lookup(name))
@@ -1653,7 +1653,7 @@ class ComponentEngine {
         def n:int (array_length argNodes)
         if (n == 1) {
             def only:EvalValue (this.evaluateExpr((itemAt argNodes 0)))
-            if (only.isNumber()) {
+            if (EvValueBridge.isNumber(only)) {
                 ; D-ARRAYLEN: `Array(len)` accepts only a uint32. A negative or
                 ; fractional length is a RangeError, and an enormous one used to
                 ; be a host crash ("Invalid array length") rather than a guest
@@ -1708,7 +1708,7 @@ class ComponentEngine {
         while (i < (array_length argNodes)) {
             push vals (this.evaluateExpr((itemAt argNodes i)))
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             i = (i + 1)
         }
@@ -1728,7 +1728,7 @@ class ComponentEngine {
             ; throws 7, not a SyntaxError about an unparsable body.
             def txt:string (this.toStringOf(av))
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             if (i == (n - 1)) {
                 body = txt
@@ -1808,11 +1808,11 @@ class ComponentEngine {
 
     fn runIndirectEval:EvalValue (args:[EvalValue]) {
         if ((array_length args) == 0) {
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         def evSrc:EvalValue (itemAt args 0)
         ; eval of a non-string returns the argument untouched.
-        if (false == (evSrc.isString())) {
+        if (false == (EvValueBridge.isString(evSrc))) {
             return evSrc
         }
         def savedEvalCtx:EvalContext context
@@ -1868,7 +1868,7 @@ class ComponentEngine {
         ; the latter meant `eval("for (i in o) s += o[i]")` was undefined where
         ; the spec says the body's last value.
         def savedCompletion:EvalValue completionValue
-        completionValue = (EvalValue.undefined())
+        completionValue = (EvValueBridge.taggedUndefined())
         ; D-EVAL: STRICT eval code gets its own variable environment, so a `var`
         ; or function it declares does not leak into the caller.
         ; `"use strict"; eval("var x = 1"); typeof x` is "undefined". Sloppy
@@ -1902,7 +1902,7 @@ class ComponentEngine {
                 if scopedEval {
                     context = savedEvalScope
                 }
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             i = (i + 1)
         }
@@ -2113,15 +2113,15 @@ class ComponentEngine {
                     if scriptThrew {
                         this.trace("Uncaught exception: " + (scriptThrowValue.toString()))
                         scriptThrew = false
-                        scriptThrowValue = (EvalValue.null())
+                        scriptThrowValue = (EvValueBridge.taggedNull())
                     }
                     return mout
                 }
             }
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         if (null? fnValue.functionNode) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         def fnNode:TSNode (unwrap fnValue.functionNode)
         def out:EvalValue (this.evaluateFunctionCall(fnNode props))
@@ -2129,7 +2129,7 @@ class ComponentEngine {
         if scriptThrew {
             this.trace("Uncaught exception: " + (scriptThrowValue.toString()))
             scriptThrew = false
-            scriptThrowValue = (EvalValue.null())
+            scriptThrowValue = (EvValueBridge.taggedNull())
         }
         return out
     }
@@ -2675,7 +2675,7 @@ class ComponentEngine {
                     def d:TSNode (itemAt node.children ci)
                     if ((strlen d.name) > 0) {
                         if (false == (moduleScope.has(d.name))) {
-                            moduleScope.define(d.name (EvalValue.undefined()))
+                            moduleScope.define(d.name (EvValueBridge.taggedUndefined()))
                         }
                     }
                     ci = (ci + 1)
@@ -2714,7 +2714,7 @@ class ComponentEngine {
                     def d:TSNode (itemAt node.children ci)
                     if ((strlen d.name) > 0) {
                         if (false == (moduleScope.has(d.name))) {
-                            moduleScope.define(d.name (EvalValue.undefined()))
+                            moduleScope.define(d.name (EvValueBridge.taggedUndefined()))
                         }
                     }
                     ci = (ci + 1)
@@ -2761,7 +2761,7 @@ class ComponentEngine {
                 ; Hoisted but not yet initialised: the property exists and holds
                 ; undefined, which is what a read before the declaration sees.
                 if (false == (has gObj.objectMap nm)) {
-                    gObj.setMember(nm (EvalValue.undefined()))
+                    gObj.setMember(nm (EvValueBridge.taggedUndefined()))
                 }
             }
             i = (i + 1)
@@ -2922,7 +2922,7 @@ class ComponentEngine {
                     ; binding (JS: undefined), so a later top-level assignment
                     ; (e.g. inside init()) updates this binding rather than
                     ; creating a function-local one other functions can't see.
-                    moduleScope.define(varName (EvalValue.undefined()))
+                    moduleScope.define(varName (EvValueBridge.taggedUndefined()))
                 }
             }
             i = i + 1
@@ -2938,7 +2938,7 @@ class ComponentEngine {
                 ; Destructuring target: `const [a,b] = ..` / `const {x,y} = ..`
                 if decl.left {
                     def pat:TSNode (unwrap decl.left)
-                    def rhs:EvalValue (EvalValue.undefined())
+                    def rhs:EvalValue (EvValueBridge.taggedUndefined())
                     if decl.init {
                         rhs = (this.evaluateExpr((unwrap decl.init)))
                     }
@@ -2966,7 +2966,7 @@ class ComponentEngine {
                         if (wHost.valueType == 5) {
                             wHost.setMember(varName value)
                             if (false == (context.has(varName))) {
-                                target.define(varName (EvalValue.undefined()))
+                                target.define(varName (EvValueBridge.taggedUndefined()))
                             }
                         } {
                             if (isVarKind && (context.blockShadowsName(varName))) {
@@ -2997,7 +2997,7 @@ class ComponentEngine {
                             }
                         }
                         if (false == keepExisting) {
-                            target.define(varName (EvalValue.undefined()))
+                            target.define(varName (EvValueBridge.taggedUndefined()))
                         }
                     }
                 }
@@ -3018,7 +3018,7 @@ class ComponentEngine {
         }
         if (pattern.nodeType == "AssignmentPattern") {
             def v:EvalValue value
-            if ((v.isNull()) || (v.isUndefined())) {
+            if ((EvValueBridge.isNull(v)) || (EvValueBridge.isUndefined(v))) {
                 if pattern.right {
                     v = (this.evaluateExpr((unwrap pattern.right)))
                 }
@@ -3066,7 +3066,7 @@ class ComponentEngine {
                         context.define(el.name restVal)
                     }
                 } {
-                    def elemVal:EvalValue (EvalValue.undefined())
+                    def elemVal:EvalValue (EvValueBridge.taggedUndefined())
                     if (value.isArray()) {
                         if (idx < (array_length value.arrayValue)) {
                             elemVal = (itemAt value.arrayValue idx)
@@ -3107,7 +3107,7 @@ class ComponentEngine {
                 def srcKey:string prop.name
                 push usedKeys srcKey
                 def v:EvalValue (value.getMember(srcKey))
-                if ((v.isNull()) || (v.isUndefined())) {
+                if ((EvValueBridge.isNull(v)) || (EvValueBridge.isUndefined(v))) {
                     if prop.init {
                         v = (this.evaluateExpr((unwrap prop.init)))
                     }
@@ -3181,7 +3181,7 @@ class ComponentEngine {
         savedDidReturn = scriptDidReturn
         savedReturnValue = scriptReturnValue
         scriptDidReturn = false
-        scriptReturnValue = (EvalValue.null())
+        scriptReturnValue = (EvValueBridge.taggedNull())
         context = (context.createChild())
         
         ; Process function parameters and bind props (if any)
@@ -3244,7 +3244,7 @@ class ComponentEngine {
 
                 ; a missing prop now reads as undefined (rule 6); treat null OR
                 ; undefined as absent so the default still fires.
-                if ((propValue.isNull()) || (propValue.isUndefined())) {
+                if ((EvValueBridge.isNull(propValue)) || (EvValueBridge.isUndefined(propValue))) {
                     ; Use default value if provided
                     if prop.init {
                         def initNode:TSNode (unwrap prop.init)
@@ -3377,7 +3377,7 @@ class ComponentEngine {
         while (k < n) {
             def nm:string (itemAt body.hoistedVarNames k)
             if (false == (context.hasOwnBinding(nm))) {
-                context.define(nm (EvalValue.undefined()))
+                context.define(nm (EvValueBridge.taggedUndefined()))
             }
             k = (k + 1)
         }
@@ -3763,7 +3763,7 @@ class ComponentEngine {
                     def nm:string decl.name
                     if ((strlen nm) > 0) {
                         if (false == (context.hasOwnBinding(nm))) {
-                            context.define(nm (EvalValue.undefined()))
+                            context.define(nm (EvValueBridge.taggedUndefined()))
                         }
                     }
                     ci = (ci + 1)
@@ -3788,7 +3788,7 @@ class ComponentEngine {
     ; procedure's result fail.
     fn callResultOf:EvalValue (v:EvalValue) {
         if (v.valueType == 0) {
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         return v
     }
@@ -3801,7 +3801,7 @@ class ComponentEngine {
             def savedDidReturn:boolean scriptDidReturn
             def savedReturnValue:EvalValue scriptReturnValue
             scriptDidReturn = false
-            scriptReturnValue = (EvalValue.null())
+            scriptReturnValue = (EvValueBridge.taggedNull())
             ; D-HOIST: every `var` in the body exists from the first statement,
             ; holding undefined until its declaration runs. Without this, code
             ; that reads a variable declared LATER -- which the suite does
@@ -3872,7 +3872,7 @@ class ComponentEngine {
                     def returnExpr:TSNode (unwrap stmt.left)
                     return (this.evaluateExpr(returnExpr))
                 }
-                return (EvalValue.null())
+                return (EvValueBridge.taggedNull())
             }
             
             i = i + 1
@@ -3889,7 +3889,7 @@ class ComponentEngine {
             return (this.evaluateExpr(body))
         }
         
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
     
     ; ==========================================================================
@@ -4011,10 +4011,10 @@ class ComponentEngine {
                             k = (k + 1)
                         }
                     } {
-                        if (src.isString()) {
+                        if (EvValueBridge.isString(src)) {
                             def si:int 0
                             while (si < (strlen src.stringValue)) {
-                                push items (EvalValue.string((substring src.stringValue si (si + 1))))
+                                push items (EvValueBridge.taggedString((substring src.stringValue si (si + 1))))
                                 si = (si + 1)
                             }
                         }
@@ -4115,7 +4115,7 @@ class ComponentEngine {
         def savedBreak:boolean loopBreak
         def myLabels:[string] (this.takeStatementLabels())
         loopBreak = false
-        def disc:EvalValue (EvalValue.null())
+        def disc:EvalValue (EvValueBridge.taggedNull())
         if stmt.left {
             disc = (this.evaluateExpr((unwrap stmt.left)))
         }
@@ -4290,7 +4290,7 @@ class ComponentEngine {
                     si2 = (si2 + 1)
                 }
                 def nextIn:EvalValue (this.protoOfValue(walkIn))
-                if (nextIn.isNull()) {
+                if (EvValueBridge.isNull(nextIn)) {
                     inSteps = 16
                 } {
                     walkIn = nextIn
@@ -4319,12 +4319,12 @@ class ComponentEngine {
                         } {
                             if ((strlen varName) > 0) {
                                 if declaresVar {
-                                    context.define(varName (EvalValue.string(k)))
+                                    context.define(varName (EvValueBridge.taggedString(k)))
                                 } {
                                     ; An existing binding is ASSIGNED, not
                                     ; shadowed -- the name outlives the loop.
-                                    context.assign(varName (EvalValue.string(k)))
-                                    this.syncGlobalVar(varName (EvalValue.string(k)))
+                                    context.assign(varName (EvValueBridge.taggedString(k)))
+                                    this.syncGlobalVar(varName (EvValueBridge.taggedString(k)))
                                 }
                             }
                             loopContinue = false
@@ -4364,7 +4364,7 @@ class ComponentEngine {
             if (has walk.setterMap key) { return true }
             if (this.objHasKey(walk key)) { return true }
             def nxt:EvalValue (this.protoOfValue(walk))
-            if (nxt.isNull()) {
+            if (EvValueBridge.isNull(nxt)) {
                 return false
             }
             walk = nxt
@@ -4816,7 +4816,7 @@ class ComponentEngine {
             if stmt.left {
                 scriptReturnValue = (this.evaluateExpr((unwrap stmt.left)))
             } {
-                scriptReturnValue = (EvalValue.null())
+                scriptReturnValue = (EvValueBridge.taggedNull())
             }
             ; D-THROW: if evaluating the returned expression threw, the function
             ; did NOT return — it is unwinding. Setting scriptDidReturn here as
@@ -4916,7 +4916,7 @@ class ComponentEngine {
                 }
                 scriptThrowValue = thrownV
             } {
-                scriptThrowValue = (EvalValue.undefined())
+                scriptThrowValue = (EvValueBridge.taggedUndefined())
             }
             scriptThrew = true
             return
@@ -4929,7 +4929,7 @@ class ComponentEngine {
         if (stmt.nodeType == "WithStatement") {
             if stmt.left {
                 def wRaw:EvalValue (this.evaluateExpr((unwrap stmt.left)))
-                if ((wRaw.isNull()) || (wRaw.isUndefined())) {
+                if ((EvValueBridge.isNull(wRaw)) || (EvValueBridge.isUndefined(wRaw))) {
                     def _w:EvalValue (this.throwSpecError("TypeError" "with(...) requires an object"))
                     return
                 }
@@ -4987,7 +4987,7 @@ class ComponentEngine {
                 if (catchNode.nodeType == "CatchClause") {
                     def thrown:EvalValue scriptThrowValue
                     scriptThrew = false
-                    scriptThrowValue = (EvalValue.null())
+                    scriptThrowValue = (EvValueBridge.taggedNull())
                     def savedContext:EvalContext context
                     context = (context.createChild())
                     ; D-CATCHVAR: §12.14 -- the catch scope holds the PARAMETER
@@ -5021,9 +5021,9 @@ class ComponentEngine {
             def pendBreak:boolean loopBreak
             def pendContinue:boolean loopContinue
             scriptDidReturn = false
-            scriptReturnValue = (EvalValue.null())
+            scriptReturnValue = (EvValueBridge.taggedNull())
             scriptThrew = false
-            scriptThrowValue = (EvalValue.null())
+            scriptThrowValue = (EvValueBridge.taggedNull())
             loopBreak = false
             loopContinue = false
             this.runBlockOrStatement((unwrap stmt.right))
@@ -5066,7 +5066,7 @@ class ComponentEngine {
                 }
             }
             if (completionValue.equals(beforeIf)) {
-                completionValue = (EvalValue.undefined())
+                completionValue = (EvValueBridge.taggedUndefined())
             }
         }
     }
@@ -5710,15 +5710,15 @@ class ComponentEngine {
     ; truncate to an integer (doubles cannot hold full 64-bit); f32/f64 pass the
     ; value through (no float32 rounding).
     fn castSized:EvalValue (name:string v:double) {
-        if (name == "i8") { return (EvalValue.number((this.wrapInt(v 8 true)))) }
-        if (name == "u8") { return (EvalValue.number((this.wrapInt(v 8 false)))) }
-        if (name == "i16") { return (EvalValue.number((this.wrapInt(v 16 true)))) }
-        if (name == "u16") { return (EvalValue.number((this.wrapInt(v 16 false)))) }
-        if (name == "i32") { return (EvalValue.number((this.wrapInt(v 32 true)))) }
-        if (name == "u32") { return (EvalValue.number((this.wrapInt(v 32 false)))) }
-        if (name == "i64") { return (EvalValue.number((to_double (to_int v)))) }
-        if (name == "u64") { return (EvalValue.number((to_double (to_int v)))) }
-        return (EvalValue.number(v))
+        if (name == "i8") { return (EvValueBridge.taggedNumber((this.wrapInt(v 8 true)))) }
+        if (name == "u8") { return (EvValueBridge.taggedNumber((this.wrapInt(v 8 false)))) }
+        if (name == "i16") { return (EvValueBridge.taggedNumber((this.wrapInt(v 16 true)))) }
+        if (name == "u16") { return (EvValueBridge.taggedNumber((this.wrapInt(v 16 false)))) }
+        if (name == "i32") { return (EvValueBridge.taggedNumber((this.wrapInt(v 32 true)))) }
+        if (name == "u32") { return (EvValueBridge.taggedNumber((this.wrapInt(v 32 false)))) }
+        if (name == "i64") { return (EvValueBridge.taggedNumber((to_double (to_int v)))) }
+        if (name == "u64") { return (EvValueBridge.taggedNumber((to_double (to_int v)))) }
+        return (EvValueBridge.taggedNumber(v))
     }
 
     ; For `expr as T` / `<T>expr`: if T (on node.typeAnnotation) is a sized-int
@@ -5742,11 +5742,11 @@ class ComponentEngine {
     ; bitwise (& | ^ << >> >>>) and logical (&& || ??) compound forms.
     ; The floating-point remainder, with the sign of the dividend.
     fn evaluateRemainder:EvalValue (a:double b:double) {
-        if (a != a) { return (EvalValue.number(a)) }
-        if (b != b) { return (EvalValue.number(b)) }
-        if (b == 0.0) { return (EvalValue.number((0.0 / 0.0))) }
-        if (false == (this.isFiniteNum(a))) { return (EvalValue.number((0.0 / 0.0))) }
-        if (false == (this.isFiniteNum(b))) { return (EvalValue.number(a)) }
+        if (a != a) { return (EvValueBridge.taggedNumber(a)) }
+        if (b != b) { return (EvValueBridge.taggedNumber(b)) }
+        if (b == 0.0) { return (EvValueBridge.taggedNumber((0.0 / 0.0))) }
+        if (false == (this.isFiniteNum(a))) { return (EvValueBridge.taggedNumber((0.0 / 0.0))) }
+        if (false == (this.isFiniteNum(b))) { return (EvValueBridge.taggedNumber(a)) }
         def q:double (a / b)
         def qi:double (this.floorNum(q))
         if (q < 0.0) {
@@ -5759,15 +5759,15 @@ class ComponentEngine {
         if (rem == 0.0) {
             def negOneD:double (0.0 - 1.0)
             if (a < 0.0) {
-                return (EvalValue.number((0.0 * negOneD)))
+                return (EvValueBridge.taggedNumber((0.0 * negOneD)))
             }
             def aRecip:double (1.0 / a)
             if (aRecip < 0.0) {
-                return (EvalValue.number((0.0 * negOneD)))
+                return (EvValueBridge.taggedNumber((0.0 * negOneD)))
             }
-            return (EvalValue.number(0.0))
+            return (EvValueBridge.taggedNumber(0.0))
         }
-        return (EvalValue.number(rem))
+        return (EvValueBridge.taggedNumber(rem))
     }
 
     fn applyAssignOp:EvalValue (opK:int current:EvalValue rightValue:EvalValue) {
@@ -5778,10 +5778,10 @@ class ComponentEngine {
             ; PERF fast path, mirroring `+`: plain strings and plain numbers
             ; skip the conversion dance (each toStringOf copies on natives).
             if ((current.valueType == 2) && (rightValue.valueType == 2)) {
-                return (EvalValue.string(current.stringValue + rightValue.stringValue))
+                return (EvValueBridge.taggedString(current.stringValue + rightValue.stringValue))
             }
             if ((current.valueType == 1) && (rightValue.valueType == 1)) {
-                return (EvalValue.number(current.numberValue + rightValue.numberValue))
+                return (EvValueBridge.taggedNumber(current.numberValue + rightValue.numberValue))
             }
             ; Same rule as `+`: BOTH operands convert first, and only then does
             ; the string-vs-numeric decision get made. Testing isString() on the
@@ -5789,16 +5789,16 @@ class ComponentEngine {
             ; `x = new String("1"); x += 1` gave 2 instead of "11".
             def lp:EvalValue (this.toPrimitiveDefault(current))
             def rp:EvalValue (this.toPrimitiveDefault(rightValue))
-            if ((lp.isString()) || (rp.isString())) {
-                return (EvalValue.string((this.toStringOf(lp)) + (this.toStringOf(rp))))
+            if ((EvValueBridge.isString(lp)) || (EvValueBridge.isString(rp))) {
+                return (EvValueBridge.taggedString((this.toStringOf(lp)) + (this.toStringOf(rp))))
             }
-            return (EvalValue.number((this.toNumberOf(lp)) + (this.toNumberOf(rp))))
+            return (EvValueBridge.taggedNumber((this.toNumberOf(lp)) + (this.toNumberOf(rp))))
         }
         if (opK == 3) {
-            return (EvalValue.number((this.toNumberOf(current)) - (this.toNumberOf(rightValue))))
+            return (EvValueBridge.taggedNumber((this.toNumberOf(current)) - (this.toNumberOf(rightValue))))
         }
         if (opK == 4) {
-            return (EvalValue.number((this.toNumberOf(current)) * (this.toNumberOf(rightValue))))
+            return (EvValueBridge.taggedNumber((this.toNumberOf(current)) * (this.toNumberOf(rightValue))))
         }
         if (opK == 5) {
             ; Division by zero is an INFINITY, not a no-op. Returning `current`
@@ -5806,16 +5806,16 @@ class ComponentEngine {
             def rn:double (this.toNumberOf(rightValue))
             def ln:double (this.toNumberOf(current))
             if (rn == 0.0) {
-                if (ln != ln) { return (EvalValue.number(ln)) }
-                if (ln == 0.0) { return (EvalValue.number((0.0 / 0.0))) }
+                if (ln != ln) { return (EvValueBridge.taggedNumber(ln)) }
+                if (ln == 0.0) { return (EvValueBridge.taggedNumber((0.0 / 0.0))) }
                 def infD:double (1.0 / 0.0)
                 def negD:boolean (ln < 0.0)
                 if negD {
-                    return (EvalValue.number((0.0 - infD)))
+                    return (EvValueBridge.taggedNumber((0.0 - infD)))
                 }
-                return (EvalValue.number(infD))
+                return (EvValueBridge.taggedNumber(infD))
             }
-            return (EvalValue.number((ln / rn)))
+            return (EvValueBridge.taggedNumber((ln / rn)))
         }
         if (opK == 6) {
             ; The floating remainder, same as the `%` operator -- the integer
@@ -5823,7 +5823,7 @@ class ComponentEngine {
             return (this.evaluateRemainder((this.toNumberOf(current)) (this.toNumberOf(rightValue))))
         }
         if (opK == 7) {
-            return (EvalValue.number((this.powNum((this.toNumberOf(current)) (to_int (this.toNumberOf(rightValue)))))))
+            return (EvValueBridge.taggedNumber((this.powNum((this.toNumberOf(current)) (to_int (this.toNumberOf(rightValue)))))))
         }
         if (opK == 11) {
             return (EvalValue.fromInt((bit_and (to_int (this.toNumberOf(current))) (to_int (this.toNumberOf(rightValue))))))
@@ -5858,7 +5858,7 @@ class ComponentEngine {
         if (opK == 16) {
             ; nullish: assign when the current value is null OR undefined
             ; (a missing member now reads as undefined — D-IDENTITY rule 6).
-            if ((current.isNull()) || (current.isUndefined())) {
+            if ((EvValueBridge.isNull(current)) || (EvValueBridge.isUndefined(current))) {
                 return rightValue
             }
             return current
@@ -5869,7 +5869,7 @@ class ComponentEngine {
     ; Apply a (compound) assignment to a member/index target (o.x, o["k"], a[i]),
     ; returning the assigned value. Read-modify-write for the compound forms.
     fn assignMember:EvalValue (leftNode:TSNode opK:int rightValue:EvalValue) {
-        def obj:EvalValue (EvalValue.null())
+        def obj:EvalValue (EvValueBridge.taggedNull())
         def objName:string ""
         if leftNode.left {
             def objNode:TSNode (unwrap leftNode.left)
@@ -5887,15 +5887,15 @@ class ComponentEngine {
         ; ReferenceError -- escapes as itself rather than being replaced by the
         ; TypeError below.
         if scriptThrew {
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         ; Writing a property of null or undefined is a TypeError, in either
         ; mode. It was silently dropped, so a test that expected the throw saw
         ; nothing happen at all.
         if strictReferences {
-            if ((obj.isNull()) || (obj.isUndefined())) {
+            if ((EvValueBridge.isNull(obj)) || (EvValueBridge.isUndefined(obj))) {
                 def baseDesc:string "undefined"
-                if (obj.isNull()) { baseDesc = "null" }
+                if (EvValueBridge.isNull(obj)) { baseDesc = "null" }
                 def wname:string leftNode.name
                 if ((strlen wname) == 0) { wname = "property" }
                 return (this.throwSpecError("TypeError" ("Cannot set properties of " + (baseDesc + (" (setting '" + (wname + "')"))))))
@@ -5917,11 +5917,11 @@ class ComponentEngine {
             if leftNode.right {
                 def indexVal:EvalValue (this.evaluateExpr((unwrap leftNode.right)))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 key = (this.toPropertyKey(indexVal))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
             }
         }
@@ -5935,7 +5935,7 @@ class ComponentEngine {
                 def curMapped:EvalValue (wMapCtx.lookup(wMapped))
                 def mappedRes:EvalValue (this.applyAssignOp(opK curMapped rightValue))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 wMapCtx.assign(wMapped mappedRes)
                 obj.setMember(key mappedRes)
@@ -5996,11 +5996,11 @@ class ComponentEngine {
                     def lenCur:EvalValue (EvalValue.fromInt((obj.arrayLength())))
                     def lenWant:EvalValue (this.applyAssignOp(opK lenCur rightValue))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     def lenNum:double (this.toNumberOf(lenWant))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     ; ToUint32, which truncates toward zero before wrapping --
                     ; `x.length = 1.5` must be a RangeError, and wrapping alone
@@ -6035,7 +6035,7 @@ class ComponentEngine {
                     return (this.invokeBuiltin((sFn.builtinKindOf()) (sFn.builtinNameOf()) obj poisonArgs))
                 }
                 if sFn.functionNode {
-                    def cur0:EvalValue (EvalValue.undefined())
+                    def cur0:EvalValue (EvValueBridge.taggedUndefined())
                     def gFn0:EvalValue (this.resolveGetterOn(obj key))
                     if (gFn0.valueType == 6) {
                         if gFn0.functionNode {
@@ -6145,7 +6145,7 @@ class ComponentEngine {
                     if bumped {
                         def oldB:EvalValue (unwrap bumped)
                         if node.prefix {
-                            return (EvalValue.number((oldB.numberValue + delta)))
+                            return (EvValueBridge.taggedNumber((oldB.numberValue + delta)))
                         }
                         return oldB
                     }
@@ -6156,7 +6156,7 @@ class ComponentEngine {
                 ; onto the object it came from.
                 def uw:EvalValue (this.withHostFor(varName))
                 if (uw.valueType == 5) {
-                    def ucur:EvalValue (EvalValue.undefined())
+                    def ucur:EvalValue (EvValueBridge.taggedUndefined())
                     if (has uw.getterMap varName) {
                         def ugf:EvalValue (uw.findGetter(varName 0))
                         if (ugf.valueType == 6) {
@@ -6169,10 +6169,10 @@ class ComponentEngine {
                         }
                     }
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     def uold:double (this.toNumberOf(ucur))
-                    def unew:EvalValue (EvalValue.number((uold + delta)))
+                    def unew:EvalValue (EvValueBridge.taggedNumber((uold + delta)))
                     def usf:EvalValue (uw.findSetter(varName 0))
                     if (usf.valueType == 6) {
                         def usArgs:[EvalValue]
@@ -6186,7 +6186,7 @@ class ComponentEngine {
                     if node.prefix {
                         return unew
                     }
-                    return (EvalValue.number(uold))
+                    return (EvValueBridge.taggedNumber(uold))
                 }
                 ; ++ and -- READ the target, so an undeclared name is a
                 ; ReferenceError rather than a silent NaN.
@@ -6210,9 +6210,9 @@ class ComponentEngine {
                 ; global-object property is found the same way.
                 def oldNum:double (this.toNumberOf((this.lookupIdentifier(varName))))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
-                def newVal:EvalValue (EvalValue.number((oldNum + delta)))
+                def newVal:EvalValue (EvValueBridge.taggedNumber((oldNum + delta)))
                 if (context.has(varName)) {
                     context.assign(varName newVal)
                     this.syncGlobalVar(varName newVal)
@@ -6226,7 +6226,7 @@ class ComponentEngine {
                 if node.prefix {
                     return newVal
                 }
-                return (EvalValue.number(oldNum))
+                return (EvValueBridge.taggedNumber(oldNum))
             }
             if ((this.nodeKindOf(leftNode)) == 3) {
                 ; `o.p++` is ToNumber(o.p) + 1, never a compound `+=` -- for a
@@ -6234,29 +6234,29 @@ class ComponentEngine {
                 ; `({foo:"bar"}).foo++` produced "bar1" where the spec says NaN.
                 def oldV:EvalValue (this.readMemberValue(leftNode))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 def oldNumM:double (this.toNumberOf(oldV))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
-                def newNumM:EvalValue (EvalValue.number((oldNumM + delta)))
+                def newNumM:EvalValue (EvValueBridge.taggedNumber((oldNumM + delta)))
                 def newV:EvalValue (this.assignMember(leftNode 1 newNumM))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 if node.prefix {
                     return newV
                 }
-                return (EvalValue.number(oldNumM))
+                return (EvValueBridge.taggedNumber(oldNumM))
             }
         }
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     ; Read the current value of a member/index target without mutating it.
     fn readMemberValue:EvalValue (leftNode:TSNode) {
-        def obj:EvalValue (EvalValue.null())
+        def obj:EvalValue (EvValueBridge.taggedNull())
         if leftNode.left {
             def objNode:TSNode (unwrap leftNode.left)
             obj = (this.evaluateExpr(objNode))
@@ -6264,7 +6264,7 @@ class ComponentEngine {
         if leftNode.computed {
             if leftNode.right {
                 def indexVal:EvalValue (this.evaluateExpr((unwrap leftNode.right)))
-                if (indexVal.isNumber()) {
+                if (EvValueBridge.isNumber(indexVal)) {
                     return (obj.getIndex((to_int (indexVal.toNumber()))))
                 }
                 return (obj.getMember((indexVal.toString())))
@@ -6478,7 +6478,7 @@ class ComponentEngine {
         ; `s += i` goes straight to the ordinary evaluator, so the common shape
         ; pays nothing for the check.
         def rhs:TSNode (unwrap node.right)
-        def rv:EvalValue (EvalValue.undefined())
+        def rv:EvalValue (EvValueBridge.taggedUndefined())
         if ((this.nodeKindOf(rhs)) == 5) {
             rv = (this.evaluateExprTransient(rhs))
         } {
@@ -6527,7 +6527,7 @@ class ComponentEngine {
                 ; even though o no longer has an `x` by the time the value
                 ; arrives -- looking the base up afterwards found nothing and
                 ; wrote to the outer binding instead.
-                def preWith:EvalValue (EvalValue.null())
+                def preWith:EvalValue (EvValueBridge.taggedNull())
                 def preScope:EvalContext context
                 def preScopeValid:boolean false
                 if ((this.nodeKindOf(leftNode)) == 1) {
@@ -6537,12 +6537,12 @@ class ComponentEngine {
                         preScopeValid = true
                     }
                 }
-                def rightValue:EvalValue (EvalValue.null())
+                def rightValue:EvalValue (EvValueBridge.taggedNull())
                 if node.right {
                     rightValue = (this.evaluateExpr((unwrap node.right)))
                 }
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 if ((this.nodeKindOf(leftNode)) == 1) {
                     def varName:string leftNode.name
@@ -6552,7 +6552,7 @@ class ComponentEngine {
                     ; resolvable even though no binding holds it.
                     def wobj:EvalValue preWith
                     if (wobj.valueType == 5) {
-                        def wcur:EvalValue (EvalValue.undefined())
+                        def wcur:EvalValue (EvValueBridge.taggedUndefined())
                         if (has wobj.getterMap varName) {
                             def wgf:EvalValue (wobj.findGetter(varName 0))
                             if (wgf.valueType == 6) {
@@ -6565,11 +6565,11 @@ class ComponentEngine {
                             }
                         }
                         if scriptThrew {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         def wres:EvalValue (this.applyAssignOp(opK wcur rightValue))
                         if scriptThrew {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         def wsf:EvalValue (wobj.findSetter(varName 0))
                         if (wsf.valueType == 6) {
@@ -6642,7 +6642,7 @@ class ComponentEngine {
                         def ownCur:EvalValue (owner.lookup(varName))
                         def ownRes:EvalValue (this.applyAssignOp(opK ownCur rightValue))
                         if scriptThrew {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         owner.define(varName ownRes)
                         this.syncGlobalVar(varName ownRes)
@@ -6659,7 +6659,7 @@ class ComponentEngine {
                 }
             }
         }
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     ; Statement-position wrapper (side effect only) around evaluateAssignValue.
@@ -6756,7 +6756,7 @@ class ComponentEngine {
                     }
                 }
             }
-            argObj.setMember("__arguments__" (EvalValue.boolean(true)))
+            argObj.setMember("__arguments__" (EvValueBridge.taggedBoolean(true)))
             argObj.setAttrs("__arguments__" false false false)
             argObj.protoRef = (this.builtinPrototype("Object"))
             context.define("arguments" argObj)
@@ -6773,7 +6773,7 @@ class ComponentEngine {
     ; outright when no `with` scope has ever been created.
     fn withHostFor:EvalValue (name:string) {
         if (false == anyWithScope) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         return (context.findWithObjectFor(name))
     }
@@ -6882,7 +6882,7 @@ class ComponentEngine {
             } {
                 nm = ""
             }
-            push names (EvalValue.string(nm))
+            push names (EvValueBridge.taggedString(nm))
             mp = (mp + 1)
         }
         if (mappable == 0) {
@@ -6930,7 +6930,7 @@ class ComponentEngine {
             return ""
         }
         def nmV:EvalValue (itemAt namesV.arrayValue idx)
-        if (false == (nmV.isString())) {
+        if (false == (EvValueBridge.isString(nmV))) {
             return ""
         }
         return nmV.stringValue
@@ -6957,7 +6957,7 @@ class ComponentEngine {
         }
         ; Mutated in place: the names array is stored NON-WRITABLE (it is engine
         ; bookkeeping, not a visible property), so setMember would refuse it.
-        namesV.setIndexAt(idx (EvalValue.string("")))
+        namesV.setIndexAt(idx (EvValueBridge.taggedString("")))
     }
 
     fn argMapScopeOf:EvalContext (obj:EvalValue) {
@@ -6992,7 +6992,7 @@ class ComponentEngine {
             ; wrapping the pattern. bindPattern already applies the default and
             ; recurses; the old else-branch defined a binding named "" instead.
             if (pt == "AssignmentPattern") {
-                def av:EvalValue (EvalValue.undefined())
+                def av:EvalValue (EvValueBridge.taggedUndefined())
                 if (pi < na) {
                     av = (itemAt argVals pi)
                 }
@@ -7001,7 +7001,7 @@ class ComponentEngine {
                 continue
             }
             if ((pt == "ObjectPattern") || (pt == "ArrayPattern")) {
-                def pv:EvalValue (EvalValue.undefined())
+                def pv:EvalValue (EvValueBridge.taggedUndefined())
                 if (pi < na) {
                     pv = (itemAt argVals pi)
                 }
@@ -7009,18 +7009,18 @@ class ComponentEngine {
                 ; `function ({a = 5} = {})`. The default was only applied to
                 ; plain identifier parameters, so calling with no argument
                 ; destructured `undefined` and bound nothing.
-                if (pv.isUndefined()) {
+                if (EvValueBridge.isUndefined(pv)) {
                     if param.init {
                         pv = (this.evaluateExpr((unwrap param.init)))
                     }
                 }
                 this.bindPattern(param pv)
             } {
-                def v:EvalValue (EvalValue.undefined())
+                def v:EvalValue (EvValueBridge.taggedUndefined())
                 if (pi < na) {
                     v = (itemAt argVals pi)
                 }
-                if (v.isUndefined()) {
+                if (EvValueBridge.isUndefined(v)) {
                     if param.init {
                         v = (this.evaluateExpr((unwrap param.init)))
                     }
@@ -7039,10 +7039,10 @@ class ComponentEngine {
         def savedDidReturn:boolean scriptDidReturn
         def savedReturnValue:EvalValue scriptReturnValue
         scriptDidReturn = false
-        scriptReturnValue = (EvalValue.null())
+        scriptReturnValue = (EvValueBridge.taggedNull())
         context = (context.createChild())
         this.bindParams(fnNode argVals)
-        def result:EvalValue (EvalValue.null())
+        def result:EvalValue (EvValueBridge.taggedNull())
         if fnNode.body {
             def body:TSNode (unwrap fnNode.body)
             if ((this.nodeKindOf(body)) == 34) {
@@ -7173,10 +7173,10 @@ class ComponentEngine {
             def emsg:string ""
             if ((array_length args) > 0) {
                 def ev:EvalValue (itemAt args 0)
-                if (false == (ev.isUndefined())) {
+                if (false == (EvValueBridge.isUndefined(ev))) {
                     emsg = (this.toStringOf(ev))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                 }
             }
@@ -7186,7 +7186,7 @@ class ComponentEngine {
             return (this.buildFunctionFromValues(args))
         }
         if (name == "Object") {
-            def ov:EvalValue (EvalValue.null())
+            def ov:EvalValue (EvValueBridge.taggedNull())
             if ((array_length args) > 0) {
                 ov = (itemAt args 0)
             }
@@ -7206,10 +7206,10 @@ class ComponentEngine {
                 return (this.makeDateValue(args))
             }
             def dtc (new DateTime())
-            return (EvalValue.string((dtc.toFullString((dtc.timeClip((this.realmNowMs())))))))
+            return (EvValueBridge.taggedString((dtc.toFullString((dtc.timeClip((this.realmNowMs())))))))
         }
         if (this.isWrapperCtorName(name)) {
-            def prim:EvalValue (EvalValue.null())
+            def prim:EvalValue (EvValueBridge.taggedNull())
             if ((array_length args) > 0) {
                 prim = (itemAt args 0)
             }
@@ -7218,25 +7218,25 @@ class ComponentEngine {
             }
             ; Called as a FUNCTION a wrapper coerces rather than boxes.
             if (name == "String") {
-                if (prim.isNull()) {
-                    return (EvalValue.string(""))
+                if (EvValueBridge.isNull(prim)) {
+                    return (EvValueBridge.taggedString(""))
                 }
-                return (EvalValue.string((this.toStringOf(prim))))
+                return (EvValueBridge.taggedString((this.toStringOf(prim))))
             }
             if (name == "Number") {
-                if (prim.isNull()) {
-                    return (EvalValue.number(0.0))
+                if (EvValueBridge.isNull(prim)) {
+                    return (EvValueBridge.taggedNumber(0.0))
                 }
-                return (EvalValue.number((this.toNumberOf(prim))))
+                return (EvValueBridge.taggedNumber((this.toNumberOf(prim))))
             }
             if (name == "Boolean") {
-                if (prim.isNull()) {
-                    return (EvalValue.boolean(false))
+                if (EvValueBridge.isNull(prim)) {
+                    return (EvValueBridge.taggedBoolean(false))
                 }
-                return (EvalValue.boolean((prim.toBool())))
+                return (EvValueBridge.taggedBoolean((prim.toBool())))
             }
         }
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     ; The value-level twin of buildArrayFromArgs, for a captured `Array`.
@@ -7245,7 +7245,7 @@ class ComponentEngine {
         def n:int (array_length args)
         if (n == 1) {
             def only:EvalValue (itemAt args 0)
-            if (only.isNumber()) {
+            if (EvValueBridge.isNumber(only)) {
                 def rawLen:double (only.toNumber())
                 if ((rawLen < 0.0) || (rawLen > 4294967295.0)) {
                     return (this.throwSpecError("RangeError" "Invalid array length"))
@@ -7298,7 +7298,7 @@ class ComponentEngine {
         ; D-CTORVALUE: a built-in CONSTRUCTOR held as a value is callable.
         if (fnValue.valueType == 6) {
             if (has fnValue.objectMap "__fnprotocall__") {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
         }
         def ctorNameV:string (this.builtinCtorNameOf(fnValue))
@@ -7315,15 +7315,15 @@ class ComponentEngine {
                 mvj = (mvj + 1)
             }
             def cOut:EvalValue (this.callBuiltinCtorValues(ctorNameV mergedV false))
-            if (false == (cOut.isNull())) {
+            if (false == (EvValueBridge.isNull(cOut))) {
                 return cOut
             }
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
         }
         if (fnValue.isBuiltinMethod()) {
-            def bRecv:EvalValue (EvalValue.undefined())
+            def bRecv:EvalValue (EvValueBridge.taggedUndefined())
             if fnValue.boundThis {
                 bRecv = (unwrap fnValue.boundThis)
             }
@@ -7348,7 +7348,7 @@ class ComponentEngine {
             return (this.runIndirectEval(argVals))
         }
         if (null? fnValue.functionNode) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         def fnNode:TSNode (unwrap fnValue.functionNode)
         def savedContext:EvalContext context
@@ -7356,7 +7356,7 @@ class ComponentEngine {
         def savedReturnValue:EvalValue scriptReturnValue
         def savedModule:string currentModule
         scriptDidReturn = false
-        scriptReturnValue = (EvalValue.null())
+        scriptReturnValue = (EvValueBridge.taggedNull())
         def parent:EvalContext context
         if ((fnValue.closureIdOf()) >= 0) {
             if ((fnValue.closureIdOf()) < (array_length closureScopes)) {
@@ -7397,7 +7397,7 @@ class ComponentEngine {
                 calleeStrict = true
             }
             if (false == calleeStrict) {
-                if ((rawThis.isNull()) || (rawThis.isUndefined())) {
+                if ((EvValueBridge.isNull(rawThis)) || (EvValueBridge.isUndefined(rawThis))) {
                     rawThis = (this.theGlobalObject())
                 } {
                     if (rawThis.valueType == 2) { rawThis = (this.toObjectValue(rawThis)) }
@@ -7429,7 +7429,7 @@ class ComponentEngine {
                 ; sloppy one saw the sloppy one's global object. An arrow is the
                 ; exception: it genuinely has no `this` of its own.
                 if ((this.nodeKindOf(fnNode)) != 17) {
-                    context.define("this" (EvalValue.undefined()))
+                    context.define("this" (EvValueBridge.taggedUndefined()))
                 }
             }
         }
@@ -7474,7 +7474,7 @@ class ComponentEngine {
         if ((strlen (fnValue.srcTextOf())) > 0) {
             currentSource = (fnValue.srcTextOf())
         }
-        def result:EvalValue (EvalValue.null())
+        def result:EvalValue (EvValueBridge.taggedNull())
         if fnNode.body {
             def body:TSNode (unwrap fnNode.body)
             if ((this.nodeKindOf(body)) == 34) {
@@ -7764,7 +7764,7 @@ class ComponentEngine {
             
             ; String literal
             if ((this.nodeKindOf(rightNode)) == 8) {
-                return (EvalValue.string((this.unquote(rightNode.value))))
+                return (EvValueBridge.taggedString((this.unquote(rightNode.value))))
             }
             
             ; Expression container
@@ -7777,7 +7777,7 @@ class ComponentEngine {
         }
         
         ; Boolean attribute (no value means true)
-        return (EvalValue.boolean(true))
+        return (EvValueBridge.taggedBoolean(true))
     }
     
     fn evaluateAttributes:void (element:EVGElement openingNode:TSNode) {
@@ -7966,8 +7966,8 @@ class ComponentEngine {
                 }
                 
                 ; Handle string/number result as text
-                def isStr:boolean (callResult.isString())
-                def isNum:boolean (callResult.isNumber())
+                def isStr:boolean (EvValueBridge.isString(callResult))
+                def isNum:boolean (EvValueBridge.isNumber(callResult))
                 if (isStr || isNum) {
                     def textEl (new EVGElement())
                     textEl.tagName = "text"
@@ -8023,8 +8023,8 @@ class ComponentEngine {
                 return
             }
             
-            def isStr:boolean (value.isString())
-            def isNum:boolean (value.isNumber())
+            def isStr:boolean (EvValueBridge.isString(value))
+            def isNum:boolean (EvValueBridge.isNumber(value))
             if (isStr || isNum) {
                 def textEl (new EVGElement())
                 textEl.tagName = "text"
@@ -8222,7 +8222,7 @@ class ComponentEngine {
             if (node.numCacheId >= 0) {
                 return (numPool.literalAt(node.numCacheId))
             }
-            def litVal:EvalValue (EvalValue.number(node.numValue))
+            def litVal:EvalValue (EvValueBridge.taggedNumber(node.numValue))
             node.numCacheId = (numPool.addLiteral(litVal))
             return litVal
         }
@@ -8248,12 +8248,12 @@ class ComponentEngine {
         ; no case at all, so `(1, 2)` evaluated to undefined and any side effect
         ; in an earlier operand never ran.
         if (exprK == 19) {
-            def seqOut:EvalValue (EvalValue.undefined())
+            def seqOut:EvalValue (EvValueBridge.taggedUndefined())
             def si:int 0
             while (si < (array_length node.children)) {
                 seqOut = (this.evaluateExpr((itemAt node.children si)))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 si = (si + 1)
             }
@@ -8268,7 +8268,7 @@ class ComponentEngine {
                 ; identity with.
                 if strictMode {
                     if (this.insideFunctionCall()) {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                 }
                 return (this.theGlobalObject())
@@ -8304,9 +8304,9 @@ class ComponentEngine {
         if (exprK == 2) {
             def numVal@(optional):double (to_double node.value)
             if numVal {
-                return (EvalValue.number((unwrap numVal)))
+                return (EvValueBridge.taggedNumber((unwrap numVal)))
             }
-            return (EvalValue.number(0.0))
+            return (EvValueBridge.taggedNumber(0.0))
         }
         
         if (exprK == 8) {
@@ -8315,7 +8315,7 @@ class ComponentEngine {
             ; quote: `'\'hi\''` became `hi`, and `eval('"BJ"')` was handed the
             ; identifier BJ. That is the "lexer drops escaped quotes" gap -- it
             ; was never the lexer.
-            return (EvalValue.string(node.value))
+            return (EvValueBridge.taggedString(node.value))
         }
         
         if (exprK == 11) {
@@ -8333,15 +8333,15 @@ class ComponentEngine {
                 }
                 ti = ti + 1
             }
-            return (EvalValue.string(templateText))
+            return (EvValueBridge.taggedString(templateText))
         }
         
         if (exprK == 9) {
-            return (EvalValue.boolean((node.value == "true")))
+            return (EvValueBridge.taggedBoolean((node.value == "true")))
         }
         
         if (exprK == 10) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         
         ; Identifier (variable lookup)
@@ -8432,7 +8432,7 @@ class ComponentEngine {
             return (this.evaluateCallExpr(node))
         }
         
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
     
     ; Evaluate a call expression (function call)
@@ -8444,7 +8444,7 @@ class ComponentEngine {
             ; Handle method calls (e.g., arr.map(), num.toFixed())
             if ((this.nodeKindOf(callee)) == 3) {
                 ; Get the object and method name
-                def obj:EvalValue (EvalValue.null())
+                def obj:EvalValue (EvValueBridge.taggedNull())
                 def methodName:string ""
                 
                 ; Get the object (left side of the member expression)
@@ -8458,7 +8458,7 @@ class ComponentEngine {
                     ; `new RegExp("[b-a]").exec("a")` reported a TypeError where
                     ; the SyntaxError from the constructor was the answer.
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                 }
                 
@@ -8495,7 +8495,7 @@ class ComponentEngine {
                         if uField.functionNode {
                             def uFn:TSNode (unwrap uField.functionNode)
                             def uHasThis:boolean false
-                            def uThis:EvalValue (EvalValue.null())
+                            def uThis:EvalValue (EvValueBridge.taggedNull())
                             if uField.boundThis {
                                 uHasThis = true
                                 uThis = (unwrap uField.boundThis)
@@ -8518,9 +8518,9 @@ class ComponentEngine {
                 ; the same as reading one. The read path already said so; the
                 ; CALL path fell through and answered nothing.
                 if strictReferences {
-                    if ((obj.isNull()) || (obj.isUndefined())) {
+                    if ((EvValueBridge.isNull(obj)) || (EvValueBridge.isUndefined(obj))) {
                         def nullDesc:string "undefined"
-                        if (obj.isNull()) { nullDesc = "null" }
+                        if (EvValueBridge.isNull(obj)) { nullDesc = "null" }
                         return (this.throwSpecError("TypeError" ("Cannot read properties of " + (nullDesc + (" (reading '" + (methodName + "')"))))))
                     }
                 }
@@ -8687,16 +8687,16 @@ class ComponentEngine {
                     if (methodName == "parseFloat") {
                         if ((array_length node.children) > 0) {
                             def pfv:EvalValue (this.evaluateExpr((itemAt node.children 0)))
-                            return (EvalValue.number((pfv.toNumber())))
+                            return (EvValueBridge.taggedNumber((pfv.toNumber())))
                         }
-                        return (EvalValue.number((0.0 / 0.0)))
+                        return (EvValueBridge.taggedNumber((0.0 / 0.0)))
                     }
                     if (methodName == "parseInt") {
                         if ((array_length node.children) > 0) {
                             def piv:EvalValue (this.evaluateExpr((itemAt node.children 0)))
                             return (EvalValue.fromInt((to_int (piv.toNumber()))))
                         }
-                        return (EvalValue.number((0.0 / 0.0)))
+                        return (EvValueBridge.taggedNumber((0.0 / 0.0)))
                     }
                 }
                 if (arrStaticName == "Array") {
@@ -8722,11 +8722,11 @@ class ComponentEngine {
                                     fi = (fi + 1)
                                 }
                             }
-                            if (srcV.isString()) {
+                            if (EvValueBridge.isString(srcV)) {
                                 def sIdx:int 0
                                 while (sIdx < (strlen srcV.stringValue)) {
                                     def sEnd:int (sIdx + 1)
-                                    push frItems (EvalValue.string((substring srcV.stringValue sIdx sEnd)))
+                                    push frItems (EvValueBridge.taggedString((substring srcV.stringValue sIdx sEnd)))
                                     sIdx = (sIdx + 1)
                                 }
                             }
@@ -8741,42 +8741,42 @@ class ComponentEngine {
                         return (EvalValue.array(frItems))
                     }
                     if (methodName == "isArray") {
-                        def tv:EvalValue (EvalValue.null())
+                        def tv:EvalValue (EvValueBridge.taggedNull())
                         if ((array_length node.children) > 0) {
                             tv = (this.evaluateExpr((itemAt node.children 0)))
                         }
-                        return (EvalValue.boolean((tv.isArray())))
+                        return (EvValueBridge.taggedBoolean((tv.isArray())))
                     }
                 }
                 if (arrStaticName == "Number") {
-                    def nv:EvalValue (EvalValue.null())
+                    def nv:EvalValue (EvValueBridge.taggedNull())
                     if ((array_length node.children) > 0) {
                         nv = (this.evaluateExpr((itemAt node.children 0)))
                     }
                     if (methodName == "isInteger") {
-                        if (nv.isNumber()) {
+                        if (EvValueBridge.isNumber(nv)) {
                             def d:double (nv.toNumber())
-                            return (EvalValue.boolean(((to_double (to_int d)) == d)))
+                            return (EvValueBridge.taggedBoolean(((to_double (to_int d)) == d)))
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                     if (methodName == "isNaN") {
-                        if (nv.isNumber()) {
+                        if (EvValueBridge.isNumber(nv)) {
                             def d2:double (nv.toNumber())
-                            return (EvalValue.boolean((d2 != d2)))
+                            return (EvValueBridge.taggedBoolean((d2 != d2)))
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                     if (methodName == "isFinite") {
-                        if (nv.isNumber()) {
+                        if (EvValueBridge.isNumber(nv)) {
                             def d3:double (nv.toNumber())
-                            return (EvalValue.boolean((d3 == d3)))
+                            return (EvValueBridge.taggedBoolean((d3 == d3)))
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                 }
                 if (arrStaticName == "Object") {
-                    def src:EvalValue (EvalValue.null())
+                    def src:EvalValue (EvValueBridge.taggedNull())
                     if ((array_length node.children) > 0) {
                         src = (this.evaluateExpr((itemAt node.children 0)))
                     }
@@ -8787,7 +8787,7 @@ class ComponentEngine {
                     ; continued, and the assertion that followed measured
                     ; whatever the no-op left behind.
                     if (this.objectStaticCoerces(methodName)) {
-                        if ((src.isNull()) || (src.isUndefined())) {
+                        if ((EvValueBridge.isNull(src)) || (EvValueBridge.isUndefined(src))) {
                             return (this.throwSpecError("TypeError" ("Object." + methodName + " called on null or undefined")))
                         }
                     }
@@ -8804,7 +8804,7 @@ class ComponentEngine {
                             ; way to make a prototype-less object, so null is
                             ; allowed for create alone.
                             if (methodName == "create") {
-                                if (src.isNull()) {
+                                if (EvValueBridge.isNull(src)) {
                                     okKind = true
                                 }
                             }
@@ -8826,7 +8826,7 @@ class ComponentEngine {
                         while (i < (array_length ks)) {
                             def k:string (itemAt ks i)
                             if (false == (this.isHiddenInstanceKey(k))) {
-                                push items (EvalValue.string(k))
+                                push items (EvValueBridge.taggedString(k))
                             }
                             i = (i + 1)
                         }
@@ -8853,7 +8853,7 @@ class ComponentEngine {
                             def k:string (itemAt ks i)
                             if (false == (this.isHiddenInstanceKey(k))) {
                                 def pair:[EvalValue]
-                                push pair (EvalValue.string(k))
+                                push pair (EvValueBridge.taggedString(k))
                                 push pair (src.getMember(k))
                                 push items (EvalValue.array(pair))
                             }
@@ -8887,29 +8887,29 @@ class ComponentEngine {
                     if (methodName == "is") {
                         if ((array_length node.children) > 1) {
                             def isB:EvalValue (this.evaluateExpr((itemAt node.children 1)))
-                            if ((src.isNumber()) && (isB.isNumber())) {
+                            if ((EvValueBridge.isNumber(src)) && (EvValueBridge.isNumber(isB))) {
                                 def an:double (src.toNumber())
                                 def bn:double (isB.toNumber())
                                 if (an != an) {
-                                    return (EvalValue.boolean((bn != bn)))
+                                    return (EvValueBridge.taggedBoolean((bn != bn)))
                                 }
                                 if (bn != bn) {
-                                    return (EvalValue.boolean(false))
+                                    return (EvValueBridge.taggedBoolean(false))
                                 }
                                 if (an != bn) {
-                                    return (EvalValue.boolean(false))
+                                    return (EvValueBridge.taggedBoolean(false))
                                 }
                                 if (an == 0.0) {
                                     ; Same magnitude; 1/x separates the signs.
                                     def ra:double (1.0 / an)
                                     def rb:double (1.0 / bn)
-                                    return (EvalValue.boolean((ra == rb)))
+                                    return (EvValueBridge.taggedBoolean((ra == rb)))
                                 }
-                                return (EvalValue.boolean(true))
+                                return (EvValueBridge.taggedBoolean(true))
                             }
-                            return (EvalValue.boolean((src.equals(isB))))
+                            return (EvValueBridge.taggedBoolean((src.equals(isB))))
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                     ; D-ATTRS: object integrity. All three were absent, so
                     ; freeze silently did nothing and isFrozen answered nothing
@@ -8943,27 +8943,27 @@ class ComponentEngine {
                         ; A PRIMITIVE is trivially frozen, per ES2015; an array
                         ; and a function answer from their own state.
                         if (false == (this.isDescriptorObject(src))) {
-                            return (EvalValue.boolean(true))
+                            return (EvValueBridge.taggedBoolean(true))
                         }
                         if (false == src.frozenFlag) {
-                            return (EvalValue.boolean((this.computeSealed(src true))))
+                            return (EvValueBridge.taggedBoolean((this.computeSealed(src true))))
                         }
-                        return (EvalValue.boolean(src.frozenFlag))
+                        return (EvValueBridge.taggedBoolean(src.frozenFlag))
                     }
                     if (methodName == "isSealed") {
                         if (false == (this.isDescriptorObject(src))) {
-                            return (EvalValue.boolean(true))
+                            return (EvValueBridge.taggedBoolean(true))
                         }
                         if (false == src.sealedFlag) {
-                            return (EvalValue.boolean((this.computeSealed(src false))))
+                            return (EvValueBridge.taggedBoolean((this.computeSealed(src false))))
                         }
-                        return (EvalValue.boolean(src.sealedFlag))
+                        return (EvValueBridge.taggedBoolean(src.sealedFlag))
                     }
                     if (methodName == "isExtensible") {
                         if (false == (this.isDescriptorObject(src))) {
-                            return (EvalValue.boolean(false))
+                            return (EvValueBridge.taggedBoolean(false))
                         }
-                        return (EvalValue.boolean(src.extensibleFlag))
+                        return (EvValueBridge.taggedBoolean(src.extensibleFlag))
                     }
                     if (methodName == "getPrototypeOf") {
                         return (this.protoOfValue(src))
@@ -8991,14 +8991,14 @@ class ComponentEngine {
                         if ((array_length node.children) > 1) {
                             def cDescs:EvalValue (this.evaluateExpr((itemAt node.children 1)))
                             if scriptThrew {
-                                return (EvalValue.undefined())
+                                return (EvValueBridge.taggedUndefined())
                             }
                             ; An explicit `undefined` second argument means "no
                             ; properties"; anything else must be an object.
-                            if (false == (cDescs.isUndefined())) {
+                            if (false == (EvValueBridge.isUndefined(cDescs))) {
                                 def cErr:string (this.applyDescriptorMap(created cDescs))
                                 if scriptThrew {
-                                    return (EvalValue.undefined())
+                                    return (EvValueBridge.taggedUndefined())
                                 }
                                 if ((strlen cErr) > 0) {
                                     return (this.throwDefineError(cErr))
@@ -9027,31 +9027,31 @@ class ComponentEngine {
                                 def keysA:[string]
                                 def valsA:[EvalValue]
                                 def descA:EvalValue (EvalValue.object(keysA valsA))
-                                def ga:EvalValue (EvalValue.null())
+                                def ga:EvalValue (EvValueBridge.taggedNull())
                                 if (has src.getterMap dk) {
                                     ga = (unwrap (get src.getterMap dk))
                                 }
-                                def sa:EvalValue (EvalValue.null())
+                                def sa:EvalValue (EvValueBridge.taggedNull())
                                 if (has src.setterMap dk) {
                                     sa = (unwrap (get src.setterMap dk))
                                 }
                                 if (ga.valueType == 6) {
                                     descA.setMember("get" ga)
                                 } {
-                                    descA.setMember("get" (EvalValue.undefined()))
+                                    descA.setMember("get" (EvValueBridge.taggedUndefined()))
                                 }
                                 if (sa.valueType == 6) {
                                     descA.setMember("set" sa)
                                 } {
-                                    descA.setMember("set" (EvalValue.undefined()))
+                                    descA.setMember("set" (EvValueBridge.taggedUndefined()))
                                 }
                                 ; D-ATTRS: an accessor carries the same recorded
                                 ; attributes a data property does. Hardcoding
                                 ; both to true made every accessor report as
                                 ; configurable, which is the opposite of what
                                 ; defineProperty defaults them to.
-                                descA.setMember("enumerable" (EvalValue.boolean((src.isEnumerable(dk)))))
-                                descA.setMember("configurable" (EvalValue.boolean((src.isConfigurable(dk)))))
+                                descA.setMember("enumerable" (EvValueBridge.taggedBoolean((src.isEnumerable(dk)))))
+                                descA.setMember("configurable" (EvValueBridge.taggedBoolean((src.isConfigurable(dk)))))
                                 return descA
                             }
                             ; D-INDEXDESC: an array index or string index is a
@@ -9065,9 +9065,9 @@ class ComponentEngine {
                                     def valsL:[EvalValue]
                                     def dL:EvalValue (EvalValue.object(keysL valsL))
                                     dL.setMember("value" (EvalValue.fromInt((array_length src.arrayValue))))
-                                    dL.setMember("writable" (EvalValue.boolean(true)))
-                                    dL.setMember("enumerable" (EvalValue.boolean(false)))
-                                    dL.setMember("configurable" (EvalValue.boolean(false)))
+                                    dL.setMember("writable" (EvValueBridge.taggedBoolean(true)))
+                                    dL.setMember("enumerable" (EvValueBridge.taggedBoolean(false)))
+                                    dL.setMember("configurable" (EvValueBridge.taggedBoolean(false)))
                                     return dL
                                 }
                                 def ai:int (this.canonicalArrayIndex(dk))
@@ -9085,29 +9085,29 @@ class ComponentEngine {
                                             ; not writable just because it is an
                                             ; element.
                                             if (has src.attrFlags dk) {
-                                                dI.setMember("writable" (EvalValue.boolean((src.isWritable(dk)))))
-                                                dI.setMember("enumerable" (EvalValue.boolean((src.isEnumerable(dk)))))
-                                                dI.setMember("configurable" (EvalValue.boolean((src.isConfigurable(dk)))))
+                                                dI.setMember("writable" (EvValueBridge.taggedBoolean((src.isWritable(dk)))))
+                                                dI.setMember("enumerable" (EvValueBridge.taggedBoolean((src.isEnumerable(dk)))))
+                                                dI.setMember("configurable" (EvValueBridge.taggedBoolean((src.isConfigurable(dk)))))
                                             } {
-                                                dI.setMember("writable" (EvalValue.boolean(true)))
-                                                dI.setMember("enumerable" (EvalValue.boolean(true)))
-                                                dI.setMember("configurable" (EvalValue.boolean(true)))
+                                                dI.setMember("writable" (EvValueBridge.taggedBoolean(true)))
+                                                dI.setMember("enumerable" (EvValueBridge.taggedBoolean(true)))
+                                                dI.setMember("configurable" (EvValueBridge.taggedBoolean(true)))
                                             }
                                             return dI
                                         }
-                                        return (EvalValue.undefined())
+                                        return (EvValueBridge.taggedUndefined())
                                     }
                                 }
                             }
-                            if (src.isString()) {
+                            if (EvValueBridge.isString(src)) {
                                 if (dk == "length") {
                                     def keysS:[string]
                                     def valsS:[EvalValue]
                                     def dS:EvalValue (EvalValue.object(keysS valsS))
                                     dS.setMember("value" (EvalValue.fromInt((strlen src.stringValue))))
-                                    dS.setMember("writable" (EvalValue.boolean(false)))
-                                    dS.setMember("enumerable" (EvalValue.boolean(false)))
-                                    dS.setMember("configurable" (EvalValue.boolean(false)))
+                                    dS.setMember("writable" (EvValueBridge.taggedBoolean(false)))
+                                    dS.setMember("enumerable" (EvValueBridge.taggedBoolean(false)))
+                                    dS.setMember("configurable" (EvValueBridge.taggedBoolean(false)))
                                     return dS
                                 }
                                 def sIdx@(optional):int (to_int dk)
@@ -9118,10 +9118,10 @@ class ComponentEngine {
                                         def valsC2:[EvalValue]
                                         def dC:EvalValue (EvalValue.object(keysC valsC2))
                                         def se:int (si2 + 1)
-                                        dC.setMember("value" (EvalValue.string((substring src.stringValue si2 se))))
-                                        dC.setMember("writable" (EvalValue.boolean(false)))
-                                        dC.setMember("enumerable" (EvalValue.boolean(true)))
-                                        dC.setMember("configurable" (EvalValue.boolean(false)))
+                                        dC.setMember("value" (EvValueBridge.taggedString((substring src.stringValue si2 se))))
+                                        dC.setMember("writable" (EvValueBridge.taggedBoolean(false)))
+                                        dC.setMember("enumerable" (EvValueBridge.taggedBoolean(true)))
+                                        dC.setMember("configurable" (EvValueBridge.taggedBoolean(false)))
                                         return dC
                                     }
                                 }
@@ -9138,9 +9138,9 @@ class ComponentEngine {
                                         def valsF:[EvalValue]
                                         def dF:EvalValue (EvalValue.object(keysF valsF))
                                         dF.setMember("value" (src.getMember(dk)))
-                                        dF.setMember("writable" (EvalValue.boolean(false)))
-                                        dF.setMember("enumerable" (EvalValue.boolean(false)))
-                                        dF.setMember("configurable" (EvalValue.boolean(true)))
+                                        dF.setMember("writable" (EvValueBridge.taggedBoolean(false)))
+                                        dF.setMember("enumerable" (EvValueBridge.taggedBoolean(false)))
+                                        dF.setMember("configurable" (EvValueBridge.taggedBoolean(true)))
                                         return dF
                                     }
                                 }
@@ -9156,9 +9156,9 @@ class ComponentEngine {
                                         def valsP:[EvalValue]
                                         def dP:EvalValue (EvalValue.object(keysP valsP))
                                         dP.setMember("value" (src.getMember("prototype")))
-                                        dP.setMember("writable" (EvalValue.boolean(true)))
-                                        dP.setMember("enumerable" (EvalValue.boolean(false)))
-                                        dP.setMember("configurable" (EvalValue.boolean(false)))
+                                        dP.setMember("writable" (EvValueBridge.taggedBoolean(true)))
+                                        dP.setMember("enumerable" (EvValueBridge.taggedBoolean(false)))
+                                        dP.setMember("configurable" (EvValueBridge.taggedBoolean(false)))
                                         return dP
                                     }
                                 }
@@ -9168,13 +9168,13 @@ class ComponentEngine {
                                 def valsD:[EvalValue]
                                 def desc:EvalValue (EvalValue.object(keysD valsD))
                                 desc.setMember("value" (src.getMember(dk)))
-                                desc.setMember("writable" (EvalValue.boolean((src.isWritable(dk)))))
-                                desc.setMember("enumerable" (EvalValue.boolean((src.isEnumerable(dk)))))
-                                desc.setMember("configurable" (EvalValue.boolean((src.isConfigurable(dk)))))
+                                desc.setMember("writable" (EvValueBridge.taggedBoolean((src.isWritable(dk)))))
+                                desc.setMember("enumerable" (EvValueBridge.taggedBoolean((src.isEnumerable(dk)))))
+                                desc.setMember("configurable" (EvValueBridge.taggedBoolean((src.isConfigurable(dk)))))
                                 return desc
                             }
                         }
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     if (methodName == "defineProperty") {
                         if ((array_length node.children) > 2) {
@@ -9194,11 +9194,11 @@ class ComponentEngine {
                         if ((array_length node.children) > 1) {
                             def descs:EvalValue (this.evaluateExpr((itemAt node.children 1)))
                             if scriptThrew {
-                                return (EvalValue.undefined())
+                                return (EvValueBridge.taggedUndefined())
                             }
                             def dErr2:string (this.applyDescriptorMap(src descs))
                             if scriptThrew {
-                                return (EvalValue.undefined())
+                                return (EvValueBridge.taggedUndefined())
                             }
                             if ((strlen dErr2) > 0) {
                                 return (this.throwDefineError(dErr2))
@@ -9211,7 +9211,7 @@ class ComponentEngine {
                         def ksN:[string] (this.objectKeys(src))
                         def iN:int 0
                         while (iN < (array_length ksN)) {
-                            push itemsN (EvalValue.string((itemAt ksN iN)))
+                            push itemsN (EvValueBridge.taggedString((itemAt ksN iN)))
                             iN = (iN + 1)
                         }
                         return (EvalValue.array(itemsN))
@@ -9219,11 +9219,11 @@ class ComponentEngine {
                 }
                 if (arrStaticName == "JSON") {
                     if (methodName == "stringify") {
-                        def jv:EvalValue (EvalValue.null())
+                        def jv:EvalValue (EvValueBridge.taggedNull())
                         if ((array_length node.children) > 0) {
                             jv = (this.evaluateExpr((itemAt node.children 0)))
                         }
-                        return (EvalValue.string((this.jsonStringify(jv))))
+                        return (EvValueBridge.taggedString((this.jsonStringify(jv))))
                     }
                     if (methodName == "parse") {
                         def js:string ""
@@ -9245,7 +9245,7 @@ class ComponentEngine {
                             ci = (ci + 1)
                         }
                         print line
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                 }
 
@@ -9280,7 +9280,7 @@ class ComponentEngine {
                         if ((this.nodeKindOf(sCls)) == 25) {
                             def sM:TSNode (this.findStaticMethodOnClassNode(sCls methodName))
                             if (sM.nodeType == "MethodDefinition") {
-                                return (this.callUserFunctionNode(sM node.children (EvalValue.null()) false))
+                                return (this.callUserFunctionNode(sM node.children (EvValueBridge.taggedNull()) false))
                             }
                         }
                     }
@@ -9293,7 +9293,7 @@ class ComponentEngine {
                 if (obj.valueType == 6) {
                     if obj.functionNode {
                         if (methodName == "call") {
-                            def callThis:EvalValue (EvalValue.undefined())
+                            def callThis:EvalValue (EvValueBridge.taggedUndefined())
                             def callArgs:[EvalValue]
                             def cai:int 0
                             while (cai < (array_length node.children)) {
@@ -9309,7 +9309,7 @@ class ComponentEngine {
                             return (this.callFnValueWithValues(callBound callArgs))
                         }
                         if (methodName == "apply") {
-                            def applyThis:EvalValue (EvalValue.undefined())
+                            def applyThis:EvalValue (EvValueBridge.taggedUndefined())
                             def applyArgs:[EvalValue]
                             if ((array_length node.children) > 0) {
                                 applyThis = (this.evaluateExpr((itemAt node.children 0)))
@@ -9328,7 +9328,7 @@ class ComponentEngine {
                             return (this.callFnValueWithValues(applyBound applyArgs))
                         }
                         if (methodName == "bind") {
-                            def bindThis:EvalValue (EvalValue.undefined())
+                            def bindThis:EvalValue (EvValueBridge.taggedUndefined())
                             def partial:[EvalValue]
                             def bai:int 0
                             while (bai < (array_length node.children)) {
@@ -9362,20 +9362,20 @@ class ComponentEngine {
                     ; OWN properties only — an inherited one must answer false,
                     ; which is the entire point of the method.
                     if (has obj.objectMap hk) {
-                        return (EvalValue.boolean(true))
+                        return (EvValueBridge.taggedBoolean(true))
                     }
                     if (has obj.getterMap hk) {
-                        return (EvalValue.boolean(true))
+                        return (EvValueBridge.taggedBoolean(true))
                     }
                     if (has obj.setterMap hk) {
-                        return (EvalValue.boolean(true))
+                        return (EvValueBridge.taggedBoolean(true))
                     }
                     ; D-FNPROPS / D-INDEXDESC: array indices, array length and a
                     ; function's synthesised length/name/prototype are own
                     ; properties too, even though none of them lives in
                     ; objectMap. objHasKey is the single answer to "does this
                     ; value own that name".
-                    return (EvalValue.boolean((this.objHasKey(obj hk))))
+                    return (EvValueBridge.taggedBoolean((this.objHasKey(obj hk))))
                 }
                 if (methodName == "propertyIsEnumerable") {
                     def pk2:string ""
@@ -9385,9 +9385,9 @@ class ComponentEngine {
                     ; Own AND enumerable -- an own property that defineProperty
                     ; made non-enumerable must answer false.
                     if (false == (this.objHasKey(obj pk2))) {
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
-                    return (EvalValue.boolean((obj.isEnumerable(pk2))))
+                    return (EvValueBridge.taggedBoolean((obj.isEnumerable(pk2))))
                 }
                 if (methodName == "isPrototypeOf") {
                     if ((array_length node.children) > 0) {
@@ -9402,24 +9402,24 @@ class ComponentEngine {
                         if (cand.valueType == 9) { candIsObj = true }
                         if (cand.valueType == 10) { candIsObj = true }
                         if (false == candIsObj) {
-                            return (EvalValue.boolean(false))
+                            return (EvValueBridge.taggedBoolean(false))
                         }
                         def walk:EvalValue cand
                         def steps:int 0
                         while (steps < 16) {
                             def nxt:EvalValue (this.protoOfValue(walk))
-                            if (nxt.isNull()) {
+                            if (EvValueBridge.isNull(nxt)) {
                                 steps = 16
                             } {
                                 if (nxt.equals(obj)) {
-                                    return (EvalValue.boolean(true))
+                                    return (EvValueBridge.taggedBoolean(true))
                                 }
                                 walk = nxt
                                 steps = (steps + 1)
                             }
                         }
                     }
-                    return (EvalValue.boolean(false))
+                    return (EvValueBridge.taggedBoolean(false))
                 }
 
                 ; D-ERRORS: nothing handled this method. Calling a property that
@@ -9439,9 +9439,9 @@ class ComponentEngine {
                     if (has memberVal.objectMap "__fnprotocall__") {
                         def _fpArgs2:[EvalValue] (this.collectCallArgs(node))
                         if scriptThrew {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                 }
                 this.trace("Warning: Unhandled method call: " + methodName)
@@ -9464,11 +9464,11 @@ class ComponentEngine {
                                 def accArgs:[EvalValue]
                                 def accOut:EvalValue (this.callFnValueWithValues((accG.withThis(obj)) accArgs))
                                 if scriptThrew {
-                                    return (EvalValue.undefined())
+                                    return (EvValueBridge.taggedUndefined())
                                 }
                                 def accCallArgs:[EvalValue] (this.collectCallArgs(node))
                                 if scriptThrew {
-                                    return (EvalValue.undefined())
+                                    return (EvValueBridge.taggedUndefined())
                                 }
                                 if (accOut.valueType == 6) {
                                     return (this.callFnValueWithValues(accOut accCallArgs))
@@ -9488,12 +9488,12 @@ class ComponentEngine {
                         ; check, per spec, so `o.bar(foo())` still runs foo().
                         def unusedArgs:[EvalValue] (this.collectCallArgs(node))
                         if scriptThrew {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         return (this.throwSpecError("TypeError" (methodName + " is not a function")))
                     }
                 }
-                return (EvalValue.null())
+                return (EvValueBridge.taggedNull())
             }
             
             ; D-CLASSEXTENDS: `super(...)` inside a derived constructor runs the
@@ -9515,7 +9515,7 @@ class ComponentEngine {
                             this.runSuperConstructor(ownNode selfV node.children 0)
                         }
                     }
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
             }
 
@@ -9535,7 +9535,7 @@ class ComponentEngine {
                         def cv:double ((this.evaluateExpr((itemAt node.children 0))).toNumber())
                         return (this.castSized(fnName cv))
                     }
-                    return (EvalValue.number(0.0))
+                    return (EvValueBridge.taggedNumber(0.0))
                 }
                 ; D-SYMBOL: `Symbol(desc)` mints a fresh unique value. Each call
                 ; must produce a value equal only to itself, which the object
@@ -9544,15 +9544,15 @@ class ComponentEngine {
                     def sDesc:string ""
                     if ((array_length node.children) > 0) {
                         def sdv:EvalValue (this.evaluateExpr((itemAt node.children 0)))
-                        if (false == (sdv.isUndefined())) {
+                        if (false == (EvValueBridge.isUndefined(sdv))) {
                             sDesc = (sdv.toString())
                         }
                     }
                     def keysY:[string]
                     def valsY:[EvalValue]
                     def minted:EvalValue (EvalValue.object(keysY valsY))
-                    minted.setMember("__symbol__" (EvalValue.string(sDesc)))
-                    minted.setMember("description" (EvalValue.string(sDesc)))
+                    minted.setMember("__symbol__" (EvValueBridge.taggedString(sDesc)))
+                    minted.setMember("description" (EvValueBridge.taggedString(sDesc)))
                     return minted
                 }
                 ; D-EVAL: direct eval. Parses the string and runs it in the
@@ -9562,11 +9562,11 @@ class ComponentEngine {
                 ; is the last expression statement's, per completion-value rules.
                 if (fnName == "eval") {
                     if ((array_length node.children) == 0) {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     def evSrcV:EvalValue (this.evaluateExpr((itemAt node.children 0)))
                     ; eval of a non-string returns the argument untouched.
-                    if (false == (evSrcV.isString())) {
+                    if (false == (EvValueBridge.isString(evSrcV))) {
                         return evSrcV
                     }
                     return (this.runEvalSource(evSrcV.stringValue))
@@ -9591,11 +9591,11 @@ class ComponentEngine {
                     while (di < (array_length node.children)) {
                         def _dv:EvalValue (this.evaluateExpr((itemAt node.children di)))
                         if scriptThrew {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         di = (di + 1)
                     }
-                    return (EvalValue.string((dtNoNew.toFullString((dtNoNew.timeClip((this.realmNowMs())))))))
+                    return (EvValueBridge.taggedString((dtNoNew.toFullString((dtNoNew.timeClip((this.realmNowMs())))))))
                 }
                 ; D-ERRORS: an error constructor called WITHOUT `new` builds the
                 ; same object -- `Error("x")` is `new Error("x")`. It was a
@@ -9610,19 +9610,19 @@ class ComponentEngine {
                         ; with an ordinary Error, which is what `throw new
                         ; Error("x" + (new RegExp("a**")))` is written to detect.
                         if scriptThrew {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
-                        if (false == (emv.isUndefined())) {
+                        if (false == (EvValueBridge.isUndefined(emv))) {
                             emsg = (this.toStringOf(emv))
                             if scriptThrew {
-                                return (EvalValue.undefined())
+                                return (EvValueBridge.taggedUndefined())
                             }
                         }
                     }
                     return (this.makeError(fnName emsg))
                 }
                 if (fnName == "Object") {
-                    def ov:EvalValue (EvalValue.null())
+                    def ov:EvalValue (EvValueBridge.taggedNull())
                     if ((array_length node.children) > 0) {
                         ov = (this.evaluateExpr((itemAt node.children 0)))
                     }
@@ -9639,23 +9639,23 @@ class ComponentEngine {
                         def pv:EvalValue (this.evaluateExpr((itemAt node.children 0)))
                         return (EvalValue.fromInt((to_int (pv.toNumber()))))
                     }
-                    return (EvalValue.number(0.0))
+                    return (EvValueBridge.taggedNumber(0.0))
                 }
                 if (fnName == "parseFloat") {
                     if ((array_length node.children) > 0) {
                         def pv:EvalValue (this.evaluateExpr((itemAt node.children 0)))
-                        return (EvalValue.number((pv.toNumber())))
+                        return (EvValueBridge.taggedNumber((pv.toNumber())))
                     }
-                    return (EvalValue.number(0.0))
+                    return (EvValueBridge.taggedNumber(0.0))
                 }
                 ; Type-conversion globals Number()/String()/Boolean().
                 if (fnName == "Number") {
                     if ((array_length node.children) > 0) {
                         ; ToNumber proper: an object runs valueOf/toString and a
                         ; string goes through the StringNumericLiteral grammar.
-                        return (EvalValue.number((this.toNumberOf((this.evaluateExpr((itemAt node.children 0)))))))
+                        return (EvValueBridge.taggedNumber((this.toNumberOf((this.evaluateExpr((itemAt node.children 0)))))))
                     }
-                    return (EvalValue.number(0.0))
+                    return (EvValueBridge.taggedNumber(0.0))
                 }
                 if (fnName == "String") {
                     if ((array_length node.children) > 0) {
@@ -9664,15 +9664,15 @@ class ComponentEngine {
                         ; engine's debug dump, so `String({toString: …})`
                         ; answered "{toString: [Function: ]}".
                         def sArg:EvalValue (this.evaluateExpr((itemAt node.children 0)))
-                        return (EvalValue.string((this.toStringOf(sArg))))
+                        return (EvValueBridge.taggedString((this.toStringOf(sArg))))
                     }
-                    return (EvalValue.string(""))
+                    return (EvValueBridge.taggedString(""))
                 }
                 if (fnName == "Boolean") {
                     if ((array_length node.children) > 0) {
-                        return (EvalValue.boolean(((this.evaluateExpr((itemAt node.children 0))).toBool())))
+                        return (EvValueBridge.taggedBoolean(((this.evaluateExpr((itemAt node.children 0))).toBool())))
                     }
-                    return (EvalValue.boolean(false))
+                    return (EvValueBridge.taggedBoolean(false))
                 }
                 ; isNaN / isFinite. All numbers here are IEEE doubles; NaN is
                 ; detected via the self-inequality identity (n != n). Infinity is
@@ -9680,18 +9680,18 @@ class ComponentEngine {
                 if (fnName == "isNaN") {
                     if ((array_length node.children) > 0) {
                         def nn:double (this.toNumberOf((this.evaluateExpr((itemAt node.children 0)))))
-                        return (EvalValue.boolean((nn != nn)))
+                        return (EvValueBridge.taggedBoolean((nn != nn)))
                     }
-                    return (EvalValue.boolean(true))
+                    return (EvValueBridge.taggedBoolean(true))
                 }
                 if (fnName == "isFinite") {
                     if ((array_length node.children) > 0) {
                         ; Infinity is not NaN, so the old `nf == nf` test called
                         ; it finite. Both infinities have to be excluded too.
                         def nf:double (this.toNumberOf((this.evaluateExpr((itemAt node.children 0)))))
-                        return (EvalValue.boolean((this.isFiniteNum(nf))))
+                        return (EvValueBridge.taggedBoolean((this.isFiniteNum(nf))))
                     }
-                    return (EvalValue.boolean(false))
+                    return (EvValueBridge.taggedBoolean(false))
                 }
 
                 ; ============================================================
@@ -9739,7 +9739,7 @@ class ComponentEngine {
                 if (this.isEvalFunctionValue(fnValue)) {
                     def ieArgs0:[EvalValue] (this.collectCallArgs(node))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     return (this.runIndirectEval(ieArgs0))
                 }
@@ -9758,7 +9758,7 @@ class ComponentEngine {
                     if ((strlen ctorNm0) > 0) {
                         def ctorArgs0:[EvalValue] (this.collectCallArgs(node))
                         if scriptThrew {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         def merged0:[EvalValue]
                         def mi0:int 0
@@ -9790,7 +9790,7 @@ class ComponentEngine {
             if (this.isEvalFunctionValue(calleeFn)) {
                 def ieArgs1:[EvalValue] (this.collectCallArgs(node))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 return (this.runIndirectEval(ieArgs1))
             }
@@ -9804,13 +9804,13 @@ class ComponentEngine {
                 ; f(42)` and `Number.bind(null)(42)` both arrive here.
                 if (has calleeFn.objectMap "__fnprotocall__") {
                     def _fpArgs:[EvalValue] (this.collectCallArgs(node))
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 def ctorNm:string (this.builtinCtorNameOf(calleeFn))
                 if ((strlen ctorNm) > 0) {
                     def ctorArgs:[EvalValue] (this.collectCallArgs(node))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     def merged2:[EvalValue]
                     def mi:int 0
@@ -9865,7 +9865,7 @@ class ComponentEngine {
                 if ((this.nodeKindOf(callee)) == 4) {
                     def innerV:EvalValue (this.evaluateExpr(callee))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     if (innerV.valueType == 6) {
                         def innerArgs:[EvalValue] (this.collectCallArgs(node))
@@ -9876,7 +9876,7 @@ class ComponentEngine {
                 if litCallee {
                     def litArgs:[EvalValue] (this.collectCallArgs(node))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     return (this.throwSpecError("TypeError" "expression is not a function"))
                 }
@@ -9887,7 +9887,7 @@ class ComponentEngine {
                 if ((this.nodeKindOf(callee)) == 3) {
                     def missArgs:[EvalValue] (this.collectCallArgs(node))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     def missName:string callee.name
                     if ((strlen missName) == 0) {
@@ -9898,7 +9898,7 @@ class ComponentEngine {
             }
         }
 
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     ; Whether a bare name resolves to anything at all (a binding, an engine
@@ -9973,7 +9973,7 @@ class ComponentEngine {
                 def left:EvalValue (this.evaluateExpr(leftExpr))
                 ; nullish: fall through to the right only when left is null OR
                 ; undefined (a missing member now reads as undefined — rule 6).
-                if (false == ((left.isNull()) || (left.isUndefined()))) {
+                if (false == ((EvValueBridge.isNull(left)) || (EvValueBridge.isUndefined(left)))) {
                     return left
                 }
                 if node.right {
@@ -10056,7 +10056,7 @@ class ComponentEngine {
                 if (this.isBuiltinCtorName(cname)) {
                     def bRes:int (this.builtinInstanceOf(lv cname))
                     if (bRes >= 0) {
-                        return (EvalValue.boolean((bRes == 1)))
+                        return (EvValueBridge.taggedBoolean((bRes == 1)))
                     }
                 }
                 ; A FUNCTION left-operand is object-like too, and its
@@ -10067,8 +10067,8 @@ class ComponentEngine {
                 if (lv.valueType == 4) { lvObjectLike = true }
                 if lvObjectLike {
                     def tag:EvalValue (lv.getMember("__class__"))
-                    if (tag.isString()) {
-                        return (EvalValue.boolean(((tag.stringValue) == cname)))
+                    if (EvValueBridge.isString(tag)) {
+                        return (EvValueBridge.taggedBoolean(((tag.stringValue) == cname)))
                     }
                     ; D-ERRORS: every native error inherits from Error, so
                     ; `e instanceof Error` holds for a TypeError as much as
@@ -10079,7 +10079,7 @@ class ComponentEngine {
                     ; is how half the suite's negative tests confirm a throw.
                     if (has lv.objectMap "__error__") {
                         if (cname == "Error") {
-                            return (EvalValue.boolean(true))
+                            return (EvValueBridge.taggedBoolean(true))
                         }
                     }
                     ; D-INSTANCEOF: the real algorithm for a user constructor --
@@ -10106,7 +10106,7 @@ class ComponentEngine {
                                 } {
                                     walkV = (unwrap walkV.protoRef)
                                     if (walkV.equals(protoF)) {
-                                        return (EvalValue.boolean(true))
+                                        return (EvValueBridge.taggedBoolean(true))
                                     }
                                     steps = (steps + 1)
                                 }
@@ -10124,16 +10124,16 @@ class ComponentEngine {
                         if node.right {
                             def rv:EvalValue (this.evaluateExpr((unwrap node.right)))
                             if (rv.valueType == 6) {
-                                return (EvalValue.boolean((ctorHere.equals(rv))))
+                                return (EvValueBridge.taggedBoolean((ctorHere.equals(rv))))
                             }
                         }
                         if ((strlen cname) > 0) {
-                            return (EvalValue.boolean((((ctorHere.fnName())) == cname)))
+                            return (EvValueBridge.taggedBoolean((((ctorHere.fnName())) == cname)))
                         }
                     }
                 }
             }
-            return (EvalValue.boolean(false))
+            return (EvValueBridge.taggedBoolean(false))
         }
 
         ; Evaluate both sides for other operators. Binary expressions always have
@@ -10141,10 +10141,10 @@ class ComponentEngine {
         ; null EvalValues (which used to be the single largest source of interpreter
         ; heap allocations).
         if (null? node.left) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         if (null? node.right) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         ; A non-logical binary operator READS both operands and builds its own
         ; result; it never hands an operand object on. So an operand may come
@@ -10154,8 +10154,8 @@ class ComponentEngine {
         ; they returned above, before this point.
         def lNode:TSNode (unwrap node.left)
         def rNode:TSNode (unwrap node.right)
-        def left:EvalValue (EvalValue.null())
-        def right:EvalValue (EvalValue.null())
+        def left:EvalValue (EvValueBridge.taggedNull())
+        def right:EvalValue (EvValueBridge.taggedNull())
         if ((this.nodeKindOf(lNode)) == 5) {
             left = (this.evaluateExprTransient(lNode))
         } {
@@ -10175,7 +10175,7 @@ class ComponentEngine {
             ; constructors are function values.
             def inKey:string (this.toPropertyKey(left))
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             def inHolds:boolean false
             if (right.valueType == 4) { inHolds = true }
@@ -10187,22 +10187,22 @@ class ComponentEngine {
                 return (this.throwSpecError("TypeError" "Cannot use 'in' operator on a non-object"))
             }
             if (this.objHasKey(right inKey)) {
-                return (EvalValue.boolean(true))
+                return (EvValueBridge.taggedBoolean(true))
             }
             ; `in` walks the PROTOTYPE CHAIN -- it is not hasOwnProperty.
             def inWalk:EvalValue right
             def inDepth:int 0
             while (inDepth < 16) {
                 if (null? inWalk.protoRef) {
-                    return (EvalValue.boolean(false))
+                    return (EvValueBridge.taggedBoolean(false))
                 }
                 inWalk = (unwrap inWalk.protoRef)
                 if (this.objHasKey(inWalk inKey)) {
-                    return (EvalValue.boolean(true))
+                    return (EvValueBridge.taggedBoolean(true))
                 }
                 inDepth = (inDepth + 1)
             }
-            return (EvalValue.boolean(false))
+            return (EvValueBridge.taggedBoolean(false))
         }
         
         ; Arithmetic
@@ -10211,27 +10211,27 @@ class ComponentEngine {
             ; toPrimitive/toString dance below is a no-op for them, but on
             ; the native targets each toStringOf COPIES its operand first.
             if ((left.valueType == 2) && (right.valueType == 2)) {
-                return (EvalValue.string(left.stringValue + right.stringValue))
+                return (EvValueBridge.taggedString(left.stringValue + right.stringValue))
             }
             ; two plain numbers add directly the same way
             if ((left.valueType == 1) && (right.valueType == 1)) {
-                return (EvalValue.number(left.numberValue + right.numberValue))
+                return (EvValueBridge.taggedNumber(left.numberValue + right.numberValue))
             }
             ; D-TOPRIMITIVE: both operands convert FIRST, and only then does the
             ; string-vs-numeric decision get made -- an object with a valueOf
             ; returning a number must add, not concatenate.
             def lp:EvalValue (this.toPrimitiveDefault(left))
             def rp:EvalValue (this.toPrimitiveDefault(right))
-            if ((lp.isString()) || (rp.isString())) {
-                return (EvalValue.string((this.toStringOf(lp)) + (this.toStringOf(rp))))
+            if ((EvValueBridge.isString(lp)) || (EvValueBridge.isString(rp))) {
+                return (EvValueBridge.taggedString((this.toStringOf(lp)) + (this.toStringOf(rp))))
             }
-            return (EvalValue.number((this.toNumberOf(lp)) + (this.toNumberOf(rp))))
+            return (EvValueBridge.taggedNumber((this.toNumberOf(lp)) + (this.toNumberOf(rp))))
         }
         if (opK == 21) {
-            return (EvalValue.number((this.toNumberOf(left)) - (this.toNumberOf(right))))
+            return (EvValueBridge.taggedNumber((this.toNumberOf(left)) - (this.toNumberOf(right))))
         }
         if (opK == 22) {
-            return (EvalValue.number((this.toNumberOf(left)) * (this.toNumberOf(right))))
+            return (EvValueBridge.taggedNumber((this.toNumberOf(left)) * (this.toNumberOf(right))))
         }
         ; D-IEEE: division by zero is Infinity / -Infinity / NaN, not 0. The old
         ; guard returned 0, which is wrong arithmetic AND breaks the standard
@@ -10244,7 +10244,7 @@ class ComponentEngine {
             ; is the left one's exception that escapes.
             def leftNum:double (this.toNumberOf(left))
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             def rightNum:double (this.toNumberOf(right))
             if (rightNum == 0.0) {
@@ -10253,9 +10253,9 @@ class ComponentEngine {
                 ; -Infinity, not Infinity. Branching on left's sign alone would
                 ; miss that, because -0 == 0 compares true.
                 def recip:double (1.0 / rightNum)
-                return (EvalValue.number((leftNum * recip)))
+                return (EvValueBridge.taggedNumber((leftNum * recip)))
             }
-            return (EvalValue.number((leftNum / rightNum)))
+            return (EvValueBridge.taggedNumber((leftNum / rightNum)))
         }
         if (opK == 24) {
             ; The remainder is a FLOATING-POINT one: 5.5 % 2 is 1.5. Truncating
@@ -10265,15 +10265,15 @@ class ComponentEngine {
             def rightMod:double (this.toNumberOf(right))
             if (rightMod == 0.0) {
                 ; x % 0 is NaN, not 0.
-                return (EvalValue.number((0.0 / 0.0)))
+                return (EvValueBridge.taggedNumber((0.0 / 0.0)))
             }
-            if (leftMod != leftMod) { return (EvalValue.number(leftMod)) }
-            if (rightMod != rightMod) { return (EvalValue.number(rightMod)) }
+            if (leftMod != leftMod) { return (EvValueBridge.taggedNumber(leftMod)) }
+            if (rightMod != rightMod) { return (EvValueBridge.taggedNumber(rightMod)) }
             if (false == (this.isFiniteNum(leftMod))) {
-                return (EvalValue.number((0.0 / 0.0)))
+                return (EvValueBridge.taggedNumber((0.0 / 0.0)))
             }
             if (false == (this.isFiniteNum(rightMod))) {
-                return (EvalValue.number(leftMod))
+                return (EvValueBridge.taggedNumber(leftMod))
             }
             return (this.evaluateRemainder(leftMod rightMod))
         }
@@ -10314,7 +10314,7 @@ class ComponentEngine {
         ; Exponentiation (a ** b). Integer-exponent fast path (covers game/AS use);
         ; falls back to repeated multiply for the truncated integer exponent.
         if (opK == 25) {
-            return (EvalValue.number((this.powNum((left.toNumber()) (this.toInt32Of(right))))))
+            return (EvValueBridge.taggedNumber((this.powNum((left.toNumber()) (this.toInt32Of(right))))))
         }
 
         ; Comparison
@@ -10324,24 +10324,24 @@ class ComponentEngine {
         if ((opK == 26) || (opK == 27) || (opK == 28) || (opK == 29)) {
             def lr:EvalValue (this.toPrimitive(left false))
             def rr:EvalValue (this.toPrimitive(right false))
-            if ((lr.isString()) && (rr.isString())) {
+            if ((EvValueBridge.isString(lr)) && (EvValueBridge.isString(rr))) {
                 def ls:string lr.stringValue
                 def rs:string rr.stringValue
                 def cmp:int (this.compareStrings(ls rs))
-                if (opK == 26) { return (EvalValue.boolean((cmp < 0))) }
-                if (opK == 27) { return (EvalValue.boolean((cmp > 0))) }
-                if (opK == 28) { return (EvalValue.boolean((cmp <= 0))) }
-                return (EvalValue.boolean((cmp >= 0)))
+                if (opK == 26) { return (EvValueBridge.taggedBoolean((cmp < 0))) }
+                if (opK == 27) { return (EvValueBridge.taggedBoolean((cmp > 0))) }
+                if (opK == 28) { return (EvValueBridge.taggedBoolean((cmp <= 0))) }
+                return (EvValueBridge.taggedBoolean((cmp >= 0)))
             }
             def ln2:double (this.toNumberOf(lr))
             def rn2:double (this.toNumberOf(rr))
             ; Any NaN makes every relational comparison false.
-            if (ln2 != ln2) { return (EvalValue.boolean(false)) }
-            if (rn2 != rn2) { return (EvalValue.boolean(false)) }
-            if (opK == 26) { return (EvalValue.boolean((ln2 < rn2))) }
-            if (opK == 27) { return (EvalValue.boolean((ln2 > rn2))) }
-            if (opK == 28) { return (EvalValue.boolean((ln2 <= rn2))) }
-            return (EvalValue.boolean((ln2 >= rn2)))
+            if (ln2 != ln2) { return (EvValueBridge.taggedBoolean(false)) }
+            if (rn2 != rn2) { return (EvValueBridge.taggedBoolean(false)) }
+            if (opK == 26) { return (EvValueBridge.taggedBoolean((ln2 < rn2))) }
+            if (opK == 27) { return (EvValueBridge.taggedBoolean((ln2 > rn2))) }
+            if (opK == 28) { return (EvValueBridge.taggedBoolean((ln2 <= rn2))) }
+            return (EvValueBridge.taggedBoolean((ln2 >= rn2)))
         }
         
         ; Equality. `===`/`!==` are strict (EvalValue.equals — value for
@@ -10350,19 +10350,19 @@ class ComponentEngine {
         ; nullish), which matters now that a missing member reads as `undefined`
         ; (D-IDENTITY rule 6) — the guest idiom `x != null` must still hold.
         if (opK == 32) {
-            return (EvalValue.boolean((left.equals(right))))
+            return (EvValueBridge.taggedBoolean((left.equals(right))))
         }
         if (opK == 33) {
-            return (EvalValue.boolean(((left.equals(right)) == false)))
+            return (EvValueBridge.taggedBoolean(((left.equals(right)) == false)))
         }
         if (opK == 30) {
-            return (EvalValue.boolean((this.looseEquals(left right))))
+            return (EvValueBridge.taggedBoolean((this.looseEquals(left right))))
         }
         if (opK == 31) {
-            return (EvalValue.boolean(((this.looseEquals(left right)) == false)))
+            return (EvValueBridge.taggedBoolean(((this.looseEquals(left right)) == false)))
         }
         
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     ; JS loose equality (`==`/`!=`) restricted to the one coercion this engine
@@ -10375,8 +10375,8 @@ class ComponentEngine {
     ; null/undefined special case, so `1 == '1'`, `true == 1` and
     ; `[1] == 1` were all false -- the comparisons `==` exists to make.
     fn looseEquals:boolean (left:EvalValue right:EvalValue) {
-        def ln:boolean ((left.isNull()) || (left.isUndefined()))
-        def rn:boolean ((right.isNull()) || (right.isUndefined()))
+        def ln:boolean ((EvValueBridge.isNull(left)) || (EvValueBridge.isUndefined(left)))
+        def rn:boolean ((EvValueBridge.isNull(right)) || (EvValueBridge.isUndefined(right)))
         ; null and undefined equal each other and nothing else.
         if (ln || rn) {
             return (ln && rn)
@@ -10400,13 +10400,13 @@ class ComponentEngine {
             return (this.looseEquals(left rp))
         }
         ; Same primitive type: strict comparison.
-        if ((left.isString()) && (right.isString())) {
+        if ((EvValueBridge.isString(left)) && (EvValueBridge.isString(right))) {
             return (left.equals(right))
         }
-        if ((left.isNumber()) && (right.isNumber())) {
+        if ((EvValueBridge.isNumber(left)) && (EvValueBridge.isNumber(right))) {
             return (left.equals(right))
         }
-        if ((left.isBoolean()) && (right.isBoolean())) {
+        if ((EvValueBridge.isBoolean(left)) && (EvValueBridge.isBoolean(right))) {
             return (left.equals(right))
         }
         ; Mixed primitives compare numerically, which is what makes
@@ -10441,15 +10441,15 @@ class ComponentEngine {
                 return (this.builtinPrototype(nsName))
             }
             if (propName == "name") {
-                return (EvalValue.string(nsName))
+                return (EvValueBridge.taggedString(nsName))
             }
         }
         if (nsName == "Number") {
-            if (propName == "POSITIVE_INFINITY") { return (EvalValue.number((1.0 / 0.0))) }
-            if (propName == "NEGATIVE_INFINITY") { return (EvalValue.number((0.0 - (1.0 / 0.0)))) }
-            if (propName == "MAX_SAFE_INTEGER") { return (EvalValue.number(9007199254740991.0)) }
-            if (propName == "MIN_SAFE_INTEGER") { return (EvalValue.number((0.0 - 9007199254740991.0))) }
-            if (propName == "EPSILON") { return (EvalValue.number(0.0000000000000002220446049250313)) }
+            if (propName == "POSITIVE_INFINITY") { return (EvValueBridge.taggedNumber((1.0 / 0.0))) }
+            if (propName == "NEGATIVE_INFINITY") { return (EvValueBridge.taggedNumber((0.0 - (1.0 / 0.0)))) }
+            if (propName == "MAX_SAFE_INTEGER") { return (EvValueBridge.taggedNumber(9007199254740991.0)) }
+            if (propName == "MIN_SAFE_INTEGER") { return (EvValueBridge.taggedNumber((0.0 - 9007199254740991.0))) }
+            if (propName == "EPSILON") { return (EvValueBridge.taggedNumber(0.0000000000000002220446049250313)) }
             ; MAX_VALUE / MIN_VALUE come from string parsing rather than from a
             ; source literal: neither extreme survives the Ranger lexer, but the
             ; runtime's string-to-double conversion reproduces the exact bit
@@ -10457,17 +10457,17 @@ class ComponentEngine {
             if (propName == "MAX_VALUE") {
                 def mx@(optional):double (to_double "1.7976931348623157e308")
                 if mx {
-                    return (EvalValue.number((unwrap mx)))
+                    return (EvValueBridge.taggedNumber((unwrap mx)))
                 }
             }
             if (propName == "MIN_VALUE") {
                 def mn@(optional):double (to_double "5e-324")
                 if mn {
-                    return (EvalValue.number((unwrap mn)))
+                    return (EvValueBridge.taggedNumber((unwrap mn)))
                 }
             }
         }
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     ; D-INSTANCEOF: `v instanceof <BuiltinCtor>`. Answers 1 for yes, 0 for no,
@@ -10478,7 +10478,7 @@ class ComponentEngine {
     ; constructors answer 0 for their own primitive: `'a' instanceof String` is
     ; false while `new String('a') instanceof String` is true.
     fn builtinInstanceOf:int (v:EvalValue cname:string) {
-        if ((v.valueType == 0) || (v.isUndefined())) {
+        if ((v.valueType == 0) || (EvValueBridge.isUndefined(v))) {
             return 0
         }
         def isObjectLike:boolean false
@@ -10586,13 +10586,13 @@ class ComponentEngine {
             if ((array_length args) > 0) {
                 n0 = (this.toNumberOf((itemAt args 0)))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
             }
         }
         if (nsName == "Math") {
             if (name == "random") {
-                return (EvalValue.number((random)))
+                return (EvValueBridge.taggedNumber((random)))
             }
             ; D-IEEE: negative zero is a value these four have to preserve or
             ; produce. `Math.abs(-0)` is +0; `Math.floor(-0)` and
@@ -10600,16 +10600,16 @@ class ComponentEngine {
             ; not 0. Subtracting from zero -- `0.0 - n0` -- yields +0 for both
             ; signs, so every one of them collapsed the distinction.
             if (name == "abs") {
-                if (this.isNegZero(n0)) { return (EvalValue.number(0.0)) }
-                if (n0 < 0.0) { return (EvalValue.number((n0 * (0.0 - 1.0)))) }
-                return (EvalValue.number(n0))
+                if (this.isNegZero(n0)) { return (EvValueBridge.taggedNumber(0.0)) }
+                if (n0 < 0.0) { return (EvValueBridge.taggedNumber((n0 * (0.0 - 1.0)))) }
+                return (EvValueBridge.taggedNumber(n0))
             }
             if (name == "floor") {
-                if (this.isNegZero(n0)) { return (EvalValue.number(n0)) }
-                return (EvalValue.number((this.floorNum(n0))))
+                if (this.isNegZero(n0)) { return (EvValueBridge.taggedNumber(n0)) }
+                return (EvValueBridge.taggedNumber((this.floorNum(n0))))
             }
             if (name == "ceil") {
-                if (n0 != n0) { return (EvalValue.number(n0)) }
+                if (n0 != n0) { return (EvValueBridge.taggedNumber(n0)) }
                 def ceiled:double ((this.floorNum((n0 * (0.0 - 1.0)))) * (0.0 - 1.0))
                 ; A value strictly between -1 and 0 ceils to NEGATIVE zero, and
                 ; so does -0 itself.
@@ -10619,21 +10619,21 @@ class ComponentEngine {
                     def negIn:boolean (n0 < 0.0)
                     if (this.isNegZero(n0)) { negIn = true }
                     if negIn {
-                        return (EvalValue.number((this.negativeZero())))
+                        return (EvValueBridge.taggedNumber((this.negativeZero())))
                     }
                 }
-                return (EvalValue.number(ceiled))
+                return (EvValueBridge.taggedNumber(ceiled))
             }
             if (name == "trunc") {
                 if (n0 < 0.0) {
-                    return (EvalValue.number((0.0 - (this.floorNum((0.0 - n0))))))
+                    return (EvValueBridge.taggedNumber((0.0 - (this.floorNum((0.0 - n0))))))
                 }
-                return (EvalValue.number((this.floorNum(n0))))
+                return (EvValueBridge.taggedNumber((this.floorNum(n0))))
             }
             if (name == "round") {
                 ; Math.round breaks ties UPWARD, so -1.5 rounds to -1 and not
                 ; to -2. floor(x + 0.5) gets that right for both signs.
-                if (n0 != n0) { return (EvalValue.number(n0)) }
+                if (n0 != n0) { return (EvValueBridge.taggedNumber(n0)) }
                 ; `floor(x + 0.5)` is the spec's phrasing, but the ADDITION
                 ; rounds: for an x just under 0.5, `x + 0.5` is exactly 1.0 and
                 ; the answer comes back 1 where it must be +0; for a large
@@ -10643,22 +10643,22 @@ class ComponentEngine {
                 if (this.isFiniteNum(n0)) {
                     if ((this.floorNum(n0)) == n0) {
                         if (false == (n0 == 0.0)) {
-                            return (EvalValue.number(n0))
+                            return (EvValueBridge.taggedNumber(n0))
                         }
                     }
                 } {
-                    return (EvalValue.number(n0))
+                    return (EvValueBridge.taggedNumber(n0))
                 }
                 if (n0 >= 0.0) {
                     if (n0 < 0.5) {
                         if (this.isNegZero(n0)) {
-                            return (EvalValue.number((this.negativeZero())))
+                            return (EvValueBridge.taggedNumber((this.negativeZero())))
                         }
-                        return (EvalValue.number(0.0))
+                        return (EvValueBridge.taggedNumber(0.0))
                     }
                 } {
                     if (n0 >= (0.0 - 0.5)) {
-                        return (EvalValue.number((this.negativeZero())))
+                        return (EvValueBridge.taggedNumber((this.negativeZero())))
                     }
                 }
                 def rounded:double (this.floorNum((n0 + 0.5)))
@@ -10667,27 +10667,27 @@ class ComponentEngine {
                     def negIn2:boolean (n0 < 0.0)
                     if (this.isNegZero(n0)) { negIn2 = true }
                     if negIn2 {
-                        return (EvalValue.number((this.negativeZero())))
+                        return (EvValueBridge.taggedNumber((this.negativeZero())))
                     }
                 }
-                return (EvalValue.number(rounded))
+                return (EvValueBridge.taggedNumber(rounded))
             }
             if (name == "sign") {
-                if (n0 > 0.0) { return (EvalValue.number(1.0)) }
-                if (n0 < 0.0) { return (EvalValue.number((0.0 - 1.0))) }
-                return (EvalValue.number(n0))
+                if (n0 > 0.0) { return (EvValueBridge.taggedNumber(1.0)) }
+                if (n0 < 0.0) { return (EvValueBridge.taggedNumber((0.0 - 1.0))) }
+                return (EvValueBridge.taggedNumber(n0))
             }
-            if (name == "exp") { return (EvalValue.number((this.expNum(n0)))) }
-            if (name == "log") { return (EvalValue.number((this.logNum(n0)))) }
-            if (name == "sqrt") { return (EvalValue.number((sqrt n0))) }
-            if (name == "sin") { return (EvalValue.number((sin n0))) }
-            if (name == "cos") { return (EvalValue.number((cos n0))) }
-            if (name == "tan") { return (EvalValue.number((tan n0))) }
-            if (name == "asin") { return (EvalValue.number((asin n0))) }
-            if (name == "acos") { return (EvalValue.number((acos n0))) }
+            if (name == "exp") { return (EvValueBridge.taggedNumber((this.expNum(n0)))) }
+            if (name == "log") { return (EvValueBridge.taggedNumber((this.logNum(n0)))) }
+            if (name == "sqrt") { return (EvValueBridge.taggedNumber((sqrt n0))) }
+            if (name == "sin") { return (EvValueBridge.taggedNumber((sin n0))) }
+            if (name == "cos") { return (EvValueBridge.taggedNumber((cos n0))) }
+            if (name == "tan") { return (EvValueBridge.taggedNumber((tan n0))) }
+            if (name == "asin") { return (EvValueBridge.taggedNumber((asin n0))) }
+            if (name == "acos") { return (EvValueBridge.taggedNumber((acos n0))) }
             if (name == "atan") {
                 ; No atan intrinsic, but atan2(x, 1) is the same angle.
-                return (EvalValue.number((atan2 n0 1.0)))
+                return (EvValueBridge.taggedNumber((atan2 n0 1.0)))
             }
             if (name == "atan2") {
                 def ay:double n0
@@ -10695,14 +10695,14 @@ class ComponentEngine {
                 if ((array_length args) > 1) {
                     ax = (this.toNumberOf((itemAt args 1)))
                 }
-                return (EvalValue.number((atan2 ay ax)))
+                return (EvValueBridge.taggedNumber((atan2 ay ax)))
             }
             if (name == "pow") {
                 def pe:int 0
                 if ((array_length args) > 1) {
                     pe = (to_int (this.toNumberOf((itemAt args 1))))
                 }
-                return (EvalValue.number((this.powNum(n0 pe))))
+                return (EvValueBridge.taggedNumber((this.powNum(n0 pe))))
             }
             if (name == "hypot") {
                 def acc:double 0.0
@@ -10712,7 +10712,7 @@ class ComponentEngine {
                     acc = (acc + (hv * hv))
                     hi = (hi + 1)
                 }
-                return (EvalValue.number((sqrt acc)))
+                return (EvValueBridge.taggedNumber((sqrt acc)))
             }
             if ((name == "min") || (name == "max")) {
                 def wantMax:boolean (name == "max")
@@ -10724,7 +10724,7 @@ class ComponentEngine {
                     def v:double (this.toNumberOf((itemAt args mi)))
                     ; NaN anywhere in the list wins outright.
                     if (v != v) {
-                        return (EvalValue.number(v))
+                        return (EvValueBridge.taggedNumber(v))
                     }
                     if wantMax {
                         if (v > best) { best = v }
@@ -10733,7 +10733,7 @@ class ComponentEngine {
                     }
                     mi = (mi + 1)
                 }
-                return (EvalValue.number(best))
+                return (EvValueBridge.taggedNumber(best))
             }
         }
         if (nsName == "String") {
@@ -10747,43 +10747,43 @@ class ComponentEngine {
                 while (fci < (array_length args)) {
                     def code:int (this.toUint16Of((itemAt args fci)))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     fcs = (fcs + (strfromcode code))
                     fci = (fci + 1)
                 }
-                return (EvalValue.string(fcs))
+                return (EvValueBridge.taggedString(fcs))
             }
         }
         if (nsName == "Array") {
             if (name == "isArray") {
                 if ((array_length args) == 0) {
-                    return (EvalValue.boolean(false))
+                    return (EvValueBridge.taggedBoolean(false))
                 }
-                return (EvalValue.boolean(((itemAt args 0).isArray())))
+                return (EvValueBridge.taggedBoolean(((itemAt args 0).isArray())))
             }
         }
         if (nsName == "Number") {
             if (name == "isNaN") {
-                if ((array_length args) == 0) { return (EvalValue.boolean(false)) }
+                if ((array_length args) == 0) { return (EvValueBridge.taggedBoolean(false)) }
                 def nv:EvalValue (itemAt args 0)
-                if (false == (nv.isNumber())) { return (EvalValue.boolean(false)) }
+                if (false == (EvValueBridge.isNumber(nv))) { return (EvValueBridge.taggedBoolean(false)) }
                 def nn:double nv.numberValue
-                return (EvalValue.boolean((nn != nn)))
+                return (EvValueBridge.taggedBoolean((nn != nn)))
             }
             if (name == "isFinite") {
-                if ((array_length args) == 0) { return (EvalValue.boolean(false)) }
+                if ((array_length args) == 0) { return (EvValueBridge.taggedBoolean(false)) }
                 def fv:EvalValue (itemAt args 0)
-                if (false == (fv.isNumber())) { return (EvalValue.boolean(false)) }
-                return (EvalValue.boolean((this.isFiniteNum(fv.numberValue))))
+                if (false == (EvValueBridge.isNumber(fv))) { return (EvValueBridge.taggedBoolean(false)) }
+                return (EvValueBridge.taggedBoolean((this.isFiniteNum(fv.numberValue))))
             }
             if (name == "isInteger") {
-                if ((array_length args) == 0) { return (EvalValue.boolean(false)) }
+                if ((array_length args) == 0) { return (EvValueBridge.taggedBoolean(false)) }
                 def iv:EvalValue (itemAt args 0)
-                if (false == (iv.isNumber())) { return (EvalValue.boolean(false)) }
+                if (false == (EvValueBridge.isNumber(iv))) { return (EvValueBridge.taggedBoolean(false)) }
                 def dn:double iv.numberValue
-                if (false == (this.isFiniteNum(dn))) { return (EvalValue.boolean(false)) }
-                return (EvalValue.boolean(((this.floorNum(dn)) == dn)))
+                if (false == (this.isFiniteNum(dn))) { return (EvValueBridge.taggedBoolean(false)) }
+                return (EvValueBridge.taggedBoolean(((this.floorNum(dn)) == dn)))
             }
         }
         ; D-DATE: the three Date statics. `now` reads the realm's clock, which is
@@ -10793,20 +10793,20 @@ class ComponentEngine {
         if (nsName == "Date") {
             def dtS (new DateTime())
             if (name == "now") {
-                return (EvalValue.number((dtS.timeClip((this.realmNowMs())))))
+                return (EvValueBridge.taggedNumber((dtS.timeClip((this.realmNowMs())))))
             }
             if (name == "parse") {
                 if ((array_length args) == 0) {
-                    return (EvalValue.number((0.0 / 0.0)))
+                    return (EvValueBridge.taggedNumber((0.0 / 0.0)))
                 }
-                return (EvalValue.number((dtS.parseISO((this.toStringOf((itemAt args 0)))))))
+                return (EvValueBridge.taggedNumber((dtS.parseISO((this.toStringOf((itemAt args 0)))))))
             }
             if (name == "UTC") {
-                return (EvalValue.number((this.dateFromParts(args true))))
+                return (EvValueBridge.taggedNumber((this.dateFromParts(args true))))
             }
         }
         if (nsName == "Object") {
-            def a0:EvalValue (EvalValue.undefined())
+            def a0:EvalValue (EvValueBridge.taggedUndefined())
             if ((array_length args) > 0) {
                 a0 = (itemAt args 0)
             }
@@ -10814,7 +10814,7 @@ class ComponentEngine {
             ; They have to be repeated here rather than assumed, since this is a
             ; second door into the same statics.
             if (this.objectStaticCoerces(name)) {
-                if ((a0.isNull()) || (a0.isUndefined())) {
+                if ((EvValueBridge.isNull(a0)) || (EvValueBridge.isUndefined(a0))) {
                     return (this.throwSpecError("TypeError" ("Object." + name + " called on null or undefined")))
                 }
             }
@@ -10837,7 +10837,7 @@ class ComponentEngine {
                 while (ki < (array_length ks)) {
                     def k:string (itemAt ks ki)
                     if (false == (this.isHiddenInstanceKey(k))) {
-                        push items (EvalValue.string(k))
+                        push items (EvValueBridge.taggedString(k))
                     }
                     ki = (ki + 1)
                 }
@@ -10856,31 +10856,31 @@ class ComponentEngine {
             def a0Obj:boolean (this.isDescriptorObject(a0))
             if (name == "isExtensible") {
                 if (false == a0Obj) {
-                    return (EvalValue.boolean(false))
+                    return (EvValueBridge.taggedBoolean(false))
                 }
-                return (EvalValue.boolean(a0.extensibleFlag))
+                return (EvValueBridge.taggedBoolean(a0.extensibleFlag))
             }
             if (name == "isFrozen") {
                 if (false == a0Obj) {
-                    return (EvalValue.boolean(true))
+                    return (EvValueBridge.taggedBoolean(true))
                 }
                 if a0.frozenFlag {
-                    return (EvalValue.boolean(true))
+                    return (EvValueBridge.taggedBoolean(true))
                 }
-                return (EvalValue.boolean((this.computeSealed(a0 true))))
+                return (EvValueBridge.taggedBoolean((this.computeSealed(a0 true))))
             }
             if (name == "isSealed") {
                 if (false == a0Obj) {
-                    return (EvalValue.boolean(true))
+                    return (EvValueBridge.taggedBoolean(true))
                 }
                 if a0.sealedFlag {
-                    return (EvalValue.boolean(true))
+                    return (EvValueBridge.taggedBoolean(true))
                 }
-                return (EvalValue.boolean((this.computeSealed(a0 false))))
+                return (EvValueBridge.taggedBoolean((this.computeSealed(a0 false))))
             }
             if (name == "defineProperty") {
                 def dk:string ""
-                def dd:EvalValue (EvalValue.undefined())
+                def dd:EvalValue (EvValueBridge.taggedUndefined())
                 if ((array_length args) > 1) { dk = (this.toPropertyKey((itemAt args 1))) }
                 if ((array_length args) > 2) { dd = (itemAt args 2) }
                 def dErr:string (this.definePropertyOn(a0 dk dd))
@@ -10894,7 +10894,7 @@ class ComponentEngine {
         ; is published on the namespace object and describable -- so this is a
         ; smaller gap than the value not being there at all, and it is called
         ; out rather than silently answering undefined.
-        return (EvalValue.undefined())
+        return (EvValueBridge.taggedUndefined())
     }
 
     ; The declared arity of each built-in constructor.
@@ -11040,7 +11040,7 @@ class ComponentEngine {
         if (ar < 0) { ar = 0 }
         v.setMember("length" (EvalValue.fromInt(ar)))
         v.setAttrs("length" false false true)
-        v.setMember("name" (EvalValue.string(name)))
+        v.setMember("name" (EvValueBridge.taggedString(name)))
         v.setAttrs("name" false false true)
         set nativeMethodCache key v
         return v
@@ -11105,11 +11105,11 @@ class ComponentEngine {
             g = (EvalValue.nativeFunction(nsName))
         }
         set builtinGlobals nsName g
-        g.setMember("name" (EvalValue.string(nsName)))
+        g.setMember("name" (EvValueBridge.taggedString(nsName)))
         g.setAttrs("name" false false true)
         ; Math and JSON brand as themselves, not as Object.
-        if (nsName == "Math") { g.setMember("__nsbrand__" (EvalValue.string("Math"))) }
-        if (nsName == "JSON") { g.setMember("__nsbrand__" (EvalValue.string("JSON"))) }
+        if (nsName == "Math") { g.setMember("__nsbrand__" (EvValueBridge.taggedString("Math"))) }
+        if (nsName == "JSON") { g.setMember("__nsbrand__" (EvValueBridge.taggedString("JSON"))) }
         if (this.isBuiltinCtorName(nsName)) {
             g.setMember("prototype" (this.builtinPrototype(nsName)))
             g.setAttrs("prototype" false false false)
@@ -11123,41 +11123,41 @@ class ComponentEngine {
         }
         if (nsName == "Math") {
             def pi:double (M_PI)
-            g.setMember("PI" (EvalValue.number(pi)))
+            g.setMember("PI" (EvValueBridge.taggedNumber(pi)))
             g.setAttrs("PI" false false false)
             def e1@(optional):double (to_double "2.718281828459045")
             if e1 {
-                g.setMember("E" (EvalValue.number((unwrap e1))))
+                g.setMember("E" (EvValueBridge.taggedNumber((unwrap e1))))
                 g.setAttrs("E" false false false)
             }
             def ln2@(optional):double (to_double "0.6931471805599453")
             if ln2 {
-                g.setMember("LN2" (EvalValue.number((unwrap ln2))))
+                g.setMember("LN2" (EvValueBridge.taggedNumber((unwrap ln2))))
                 g.setAttrs("LN2" false false false)
             }
             def ln10@(optional):double (to_double "2.302585092994046")
             if ln10 {
-                g.setMember("LN10" (EvalValue.number((unwrap ln10))))
+                g.setMember("LN10" (EvValueBridge.taggedNumber((unwrap ln10))))
                 g.setAttrs("LN10" false false false)
             }
             def sq2@(optional):double (to_double "1.4142135623730951")
             if sq2 {
-                g.setMember("SQRT2" (EvalValue.number((unwrap sq2))))
+                g.setMember("SQRT2" (EvValueBridge.taggedNumber((unwrap sq2))))
                 g.setAttrs("SQRT2" false false false)
             }
             def l2e@(optional):double (to_double "1.4426950408889634")
             if l2e {
-                g.setMember("LOG2E" (EvalValue.number((unwrap l2e))))
+                g.setMember("LOG2E" (EvValueBridge.taggedNumber((unwrap l2e))))
                 g.setAttrs("LOG2E" false false false)
             }
             def l10e@(optional):double (to_double "0.4342944819032518")
             if l10e {
-                g.setMember("LOG10E" (EvalValue.number((unwrap l10e))))
+                g.setMember("LOG10E" (EvValueBridge.taggedNumber((unwrap l10e))))
                 g.setAttrs("LOG10E" false false false)
             }
             def sqh@(optional):double (to_double "0.7071067811865476")
             if sqh {
-                g.setMember("SQRT1_2" (EvalValue.number((unwrap sqh))))
+                g.setMember("SQRT1_2" (EvValueBridge.taggedNumber((unwrap sqh))))
                 g.setAttrs("SQRT1_2" false false false)
             }
         }
@@ -11174,7 +11174,7 @@ class ComponentEngine {
             def stv:EvalValue (EvalValue.nativeStatic(nsName sn))
             stv.setMember("length" (EvalValue.fromInt((this.builtinStaticArity(nsName sn)))))
             stv.setAttrs("length" false false true)
-            stv.setMember("name" (EvalValue.string(sn)))
+            stv.setMember("name" (EvValueBridge.taggedString(sn)))
             stv.setAttrs("name" false false true)
             g.setMember(sn stv)
             ; Writable and configurable but not enumerable, like every built-in.
@@ -11184,24 +11184,24 @@ class ComponentEngine {
         if (nsName == "Number") {
             def mx@(optional):double (to_double "1.7976931348623157e308")
             if mx {
-                g.setMember("MAX_VALUE" (EvalValue.number((unwrap mx))))
+                g.setMember("MAX_VALUE" (EvValueBridge.taggedNumber((unwrap mx))))
                 g.setAttrs("MAX_VALUE" false false false)
             }
             def mn@(optional):double (to_double "5e-324")
             if mn {
-                g.setMember("MIN_VALUE" (EvalValue.number((unwrap mn))))
+                g.setMember("MIN_VALUE" (EvValueBridge.taggedNumber((unwrap mn))))
                 g.setAttrs("MIN_VALUE" false false false)
             }
             def inf:double (1.0 / 0.0)
-            g.setMember("POSITIVE_INFINITY" (EvalValue.number(inf)))
+            g.setMember("POSITIVE_INFINITY" (EvValueBridge.taggedNumber(inf)))
             g.setAttrs("POSITIVE_INFINITY" false false false)
-            g.setMember("NEGATIVE_INFINITY" (EvalValue.number((0.0 - inf))))
+            g.setMember("NEGATIVE_INFINITY" (EvValueBridge.taggedNumber((0.0 - inf))))
             g.setAttrs("NEGATIVE_INFINITY" false false false)
-            g.setMember("NaN" (EvalValue.number((0.0 / 0.0))))
+            g.setMember("NaN" (EvValueBridge.taggedNumber((0.0 / 0.0))))
             g.setAttrs("NaN" false false false)
-            g.setMember("MAX_SAFE_INTEGER" (EvalValue.number(9007199254740991.0)))
+            g.setMember("MAX_SAFE_INTEGER" (EvValueBridge.taggedNumber(9007199254740991.0)))
             g.setAttrs("MAX_SAFE_INTEGER" false false false)
-            g.setMember("MIN_SAFE_INTEGER" (EvalValue.number((0.0 - 9007199254740991.0))))
+            g.setMember("MIN_SAFE_INTEGER" (EvValueBridge.taggedNumber((0.0 - 9007199254740991.0))))
             g.setAttrs("MIN_SAFE_INTEGER" false false false)
         }
         return g
@@ -11449,7 +11449,7 @@ class ComponentEngine {
             ; call paths can tell it from an uncallable value -- it has no
             ; function node and no builtin name, which is otherwise exactly what
             ; "not a function" looks like.
-            p.setMember("__fnprotocall__" (EvalValue.boolean(true)))
+            p.setMember("__fnprotocall__" (EvValueBridge.taggedBoolean(true)))
             p.setAttrs("__fnprotocall__" false false false)
         }
         set builtinProtos nsName p
@@ -11475,18 +11475,18 @@ class ComponentEngine {
         ; instead of "[object Object]", and the toString/toFixed areas are
         ; written to check exactly that.
         if (nsName == "Number") {
-            p.setMember("__primitive__" (EvalValue.number(0.0)))
-            p.setMember("__wrapper__" (EvalValue.string("Number")))
+            p.setMember("__primitive__" (EvValueBridge.taggedNumber(0.0)))
+            p.setMember("__wrapper__" (EvValueBridge.taggedString("Number")))
         }
         if (nsName == "String") {
-            p.setMember("__primitive__" (EvalValue.string("")))
-            p.setMember("__wrapper__" (EvalValue.string("String")))
+            p.setMember("__primitive__" (EvValueBridge.taggedString("")))
+            p.setMember("__wrapper__" (EvValueBridge.taggedString("String")))
             p.setMember("length" (EvalValue.fromInt(0)))
             p.setAttrs("length" false false false)
         }
         if (nsName == "Boolean") {
-            p.setMember("__primitive__" (EvalValue.boolean(false)))
-            p.setMember("__wrapper__" (EvalValue.string("Boolean")))
+            p.setMember("__primitive__" (EvValueBridge.taggedBoolean(false)))
+            p.setMember("__wrapper__" (EvValueBridge.taggedString("Boolean")))
         }
         ; D-REGEXACCESSOR: source/global/ignoreCase/multiline are ACCESSORS on
         ; RegExp.prototype -- get-only, non-enumerable, configurable -- which is
@@ -11513,7 +11513,7 @@ class ComponentEngine {
             ; registry. `F.prototype = new Array(1,2,3); new F().filter(cb)` has
             ; to find Array.prototype.filter, and the instance's own kind is
             ; "object".
-            p.setMember("__protokind__" (EvalValue.string(kind)))
+            p.setMember("__protokind__" (EvValueBridge.taggedString(kind)))
             def names:[string] (this.builtinNames(kind))
             def i:int 0
             while (i < (array_length names)) {
@@ -11588,7 +11588,7 @@ class ComponentEngine {
         }
         def objProto:EvalValue (this.builtinPrototype("Object"))
         if (v.equals(objProto)) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         def cn:string (this.ctorNameForKind((this.receiverKind(v))))
         if ((strlen cn) > 0) {
@@ -11600,7 +11600,7 @@ class ComponentEngine {
         if (v.valueType == 5) {
             return objProto
         }
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     fn protoChainKind:string (v:EvalValue) {
@@ -12085,7 +12085,7 @@ class ComponentEngine {
         def filler:string " "
         if ((array_length args) > 1) {
             def fv:EvalValue (itemAt args 1)
-            if (false == (fv.isUndefined())) {
+            if (false == (EvValueBridge.isUndefined(fv))) {
                 filler = (fv.toString())
             }
         }
@@ -12110,8 +12110,8 @@ class ComponentEngine {
     ; ToString for a value used as an ARRAY ELEMENT during join/toString: null
     ; and undefined render as empty, everything else by its own rules.
     fn elementToString:string (v:EvalValue) {
-        if (v.isNull()) { return "" }
-        if (v.isUndefined()) { return "" }
+        if (EvValueBridge.isNull(v)) { return "" }
+        if (EvValueBridge.isUndefined(v)) { return "" }
         if (v.isArray()) {
             return (this.arrayJoinString(v ","))
         }
@@ -12188,7 +12188,7 @@ class ComponentEngine {
         if (n == 1) {
             def only:EvalValue (this.toPrimitive((itemAt args 0) false))
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             if (only.valueType == 2) {
                 ms = (dtm.parseISO(only.stringValue))
@@ -12202,7 +12202,7 @@ class ComponentEngine {
         if (n == 0) {
             ms = (dtm.timeClip((this.realmNowMs())))
         }
-        dt.setMember("__date__" (EvalValue.number(ms)))
+        dt.setMember("__date__" (EvValueBridge.taggedNumber(ms)))
         dt.setAttrs("__date__" false false false)
         dt.protoRef = (this.builtinPrototype("Date"))
         return dt
@@ -12286,7 +12286,7 @@ class ComponentEngine {
             if (slot < 7) {
                 def av:double (this.toNumberOf((itemAt args ai)))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 fields = (this.replaceAt(fields slot av))
             }
@@ -12306,9 +12306,9 @@ class ComponentEngine {
         def tim:double (dts.makeTime((itemAt fields 3) (itemAt fields 4) (itemAt fields 5) (itemAt fields 6)))
         def out:double (dts.timeClip((dts.makeDate(dayNum tim))))
         recv.setAttrs("__date__" true false false)
-        recv.setMember("__date__" (EvalValue.number(out)))
+        recv.setMember("__date__" (EvValueBridge.taggedNumber(out)))
         recv.setAttrs("__date__" false false false)
-        return (EvalValue.number(out))
+        return (EvValueBridge.taggedNumber(out))
     }
 
     fn replaceAt:[double] (xs:[double] idx:int v:double) {
@@ -12345,9 +12345,9 @@ class ComponentEngine {
             }
             def clipped:double (dtl.timeClip(nv))
             recv.setAttrs("__date__" true false false)
-            recv.setMember("__date__" (EvalValue.number(clipped)))
+            recv.setMember("__date__" (EvValueBridge.taggedNumber(clipped)))
             recv.setAttrs("__date__" false false false)
-            return (EvalValue.number(clipped))
+            return (EvValueBridge.taggedNumber(clipped))
         }
         ; The setter family. Each one rebuilds the time value from the fields it
         ; was NOT given plus the ones it was, so `setMinutes(70)` rolls into the
@@ -12356,40 +12356,40 @@ class ComponentEngine {
         if (this.isDateSetter(name)) {
             return (this.applyDateSetter(name recv tv args))
         }
-        if (name == "getTime") { return (EvalValue.number(tv)) }
-        if (name == "valueOf") { return (EvalValue.number(tv)) }
+        if (name == "getTime") { return (EvValueBridge.taggedNumber(tv)) }
+        if (name == "valueOf") { return (EvValueBridge.taggedNumber(tv)) }
         ; The offset from UTC, which is zero because local time IS UTC here.
         if (name == "getTimezoneOffset") {
-            if (tv != tv) { return (EvalValue.number(tv)) }
-            return (EvalValue.number(0.0))
+            if (tv != tv) { return (EvValueBridge.taggedNumber(tv)) }
+            return (EvValueBridge.taggedNumber(0.0))
         }
         ; The string forms report "Invalid Date" rather than propagating NaN.
-        if (name == "toString") { return (EvalValue.string((dtl.toFullString(tv)))) }
-        if (name == "toLocaleString") { return (EvalValue.string((dtl.toFullString(tv)))) }
-        if (name == "toDateString") { return (EvalValue.string((dtl.toDateString(tv)))) }
-        if (name == "toLocaleDateString") { return (EvalValue.string((dtl.toDateString(tv)))) }
-        if (name == "toTimeString") { return (EvalValue.string((dtl.toTimeString(tv)))) }
-        if (name == "toLocaleTimeString") { return (EvalValue.string((dtl.toTimeString(tv)))) }
-        if (name == "toUTCString") { return (EvalValue.string((dtl.toUTCString(tv)))) }
+        if (name == "toString") { return (EvValueBridge.taggedString((dtl.toFullString(tv)))) }
+        if (name == "toLocaleString") { return (EvValueBridge.taggedString((dtl.toFullString(tv)))) }
+        if (name == "toDateString") { return (EvValueBridge.taggedString((dtl.toDateString(tv)))) }
+        if (name == "toLocaleDateString") { return (EvValueBridge.taggedString((dtl.toDateString(tv)))) }
+        if (name == "toTimeString") { return (EvValueBridge.taggedString((dtl.toTimeString(tv)))) }
+        if (name == "toLocaleTimeString") { return (EvValueBridge.taggedString((dtl.toTimeString(tv)))) }
+        if (name == "toUTCString") { return (EvValueBridge.taggedString((dtl.toUTCString(tv)))) }
         ; toGMTString is the Annex B alias of toUTCString, and the same function.
-        if (name == "toGMTString") { return (EvalValue.string((dtl.toUTCString(tv)))) }
+        if (name == "toGMTString") { return (EvValueBridge.taggedString((dtl.toUTCString(tv)))) }
         ; toISOString is the exception: an unrepresentable instant is a
         ; RangeError, not the string "Invalid Date".
         if (name == "toISOString") {
             if (tv != tv) {
                 return (this.throwSpecError("RangeError" "Invalid time value"))
             }
-            return (EvalValue.string((dtl.toISOString(tv))))
+            return (EvValueBridge.taggedString((dtl.toISOString(tv))))
         }
         if (name == "toJSON") {
             if (tv != tv) {
-                return (EvalValue.null())
+                return (EvValueBridge.taggedNull())
             }
-            return (EvalValue.string((dtl.toISOString(tv))))
+            return (EvValueBridge.taggedString((dtl.toISOString(tv))))
         }
         ; Every remaining accessor is NaN in, NaN out.
         if (tv != tv) {
-            return (EvalValue.number(tv))
+            return (EvValueBridge.taggedNumber(tv))
         }
         if ((name == "getFullYear") || (name == "getUTCFullYear")) {
             return (EvalValue.fromInt((dtl.yearFromTime(tv))))
@@ -12540,21 +12540,21 @@ class ComponentEngine {
     fn overriddenPrototypeMethod:EvalValue (kind:string name:string) {
         def cn:string (this.ctorNameForKind(kind))
         if ((strlen cn) == 0) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         ; Do not CREATE the prototype here: a prototype that has never been
         ; touched cannot carry an override, and creating one would populate it
         ; from the registry during dispatch.
         if (false == (has builtinProtos cn)) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         def p:EvalValue (unwrap (get builtinProtos cn))
         if (false == (has p.objectMap name)) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         def m:EvalValue (unwrap (get p.objectMap name))
         if (m.valueType != 6) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         ; PERF: ask the VALUE whether it is still the registered built-in rather
         ; than materialising the registered one and comparing identities. The
@@ -12563,7 +12563,7 @@ class ComponentEngine {
         ; only to conclude "not overridden" almost every time.
         if (m.isBuiltinMethod()) {
             if (((m.builtinKindOf()) == kind) && ((m.builtinNameOf()) == name)) {
-                return (EvalValue.null())
+                return (EvValueBridge.taggedNull())
             }
         }
         return m
@@ -12626,26 +12626,26 @@ class ComponentEngine {
                 ; the one non-RegExp receiver these getters answer for.
                 if (recv.equals((this.builtinPrototype("RegExp")))) {
                     if (name == "source") {
-                        return (EvalValue.string("(?:)"))
+                        return (EvValueBridge.taggedString("(?:)"))
                     }
-                    return (EvalValue.boolean(false))
+                    return (EvValueBridge.taggedBoolean(false))
                 }
                 return (this.throwSpecError("TypeError" ("RegExp.prototype." + name + " getter called on a non-RegExp")))
             }
             if (name == "source") {
-                return (EvalValue.string((this.regexSourceOf(recv))))
+                return (EvValueBridge.taggedString((this.regexSourceOf(recv))))
             }
             def rgFlags:string (this.regexFlagsOf(recv))
             if (name == "global") {
-                return (EvalValue.boolean(((indexOf rgFlags "g") >= 0)))
+                return (EvValueBridge.taggedBoolean(((indexOf rgFlags "g") >= 0)))
             }
             if (name == "ignoreCase") {
-                return (EvalValue.boolean(((indexOf rgFlags "i") >= 0)))
+                return (EvValueBridge.taggedBoolean(((indexOf rgFlags "i") >= 0)))
             }
             if (name == "multiline") {
-                return (EvalValue.boolean(((indexOf rgFlags "m") >= 0)))
+                return (EvValueBridge.taggedBoolean(((indexOf rgFlags "m") >= 0)))
             }
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         ; ---- Object.prototype, available on every kind ----------------------
         ; D-OBJPROTO: these three answer about the RECEIVER, so they work the
@@ -12663,7 +12663,7 @@ class ComponentEngine {
         if coercesReceiver {
             ; ToObject on the receiver: null and undefined are a TypeError, which
             ; is what `Object.prototype.hasOwnProperty.call(null, "x")` asserts.
-            if ((recv.isNull()) || (recv.isUndefined())) {
+            if ((EvValueBridge.isNull(recv)) || (EvValueBridge.isUndefined(recv))) {
                 return (this.throwSpecError("TypeError" ("Object.prototype." + name + " called on null or undefined")))
             }
         }
@@ -12672,20 +12672,20 @@ class ComponentEngine {
             if ((array_length args) > 0) {
                 hk0 = (this.toPropertyKey((itemAt args 0)))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
             }
-            if (has recv.objectMap hk0) { return (EvalValue.boolean(true)) }
-            if (has recv.getterMap hk0) { return (EvalValue.boolean(true)) }
-            if (has recv.setterMap hk0) { return (EvalValue.boolean(true)) }
-            return (EvalValue.boolean((this.objHasKey(recv hk0))))
+            if (has recv.objectMap hk0) { return (EvValueBridge.taggedBoolean(true)) }
+            if (has recv.getterMap hk0) { return (EvValueBridge.taggedBoolean(true)) }
+            if (has recv.setterMap hk0) { return (EvValueBridge.taggedBoolean(true)) }
+            return (EvValueBridge.taggedBoolean((this.objHasKey(recv hk0))))
         }
         if (name == "propertyIsEnumerable") {
             def pk0:string ""
             if ((array_length args) > 0) {
                 pk0 = (this.toPropertyKey((itemAt args 0)))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
             }
             def ownPk:boolean false
@@ -12694,13 +12694,13 @@ class ComponentEngine {
             if (has recv.setterMap pk0) { ownPk = true }
             if (this.objHasKey(recv pk0)) { ownPk = true }
             if (false == ownPk) {
-                return (EvalValue.boolean(false))
+                return (EvValueBridge.taggedBoolean(false))
             }
-            return (EvalValue.boolean((recv.isEnumerable(pk0))))
+            return (EvValueBridge.taggedBoolean((recv.isEnumerable(pk0))))
         }
         if (name == "isPrototypeOf") {
             if ((array_length args) == 0) {
-                return (EvalValue.boolean(false))
+                return (EvValueBridge.taggedBoolean(false))
             }
             def cand0:EvalValue (itemAt args 0)
             def candObj:boolean false
@@ -12710,29 +12710,29 @@ class ComponentEngine {
             if (cand0.valueType == 9) { candObj = true }
             if (cand0.valueType == 10) { candObj = true }
             if (false == candObj) {
-                return (EvalValue.boolean(false))
+                return (EvValueBridge.taggedBoolean(false))
             }
             def walk0:EvalValue cand0
             def steps0:int 0
             while (steps0 < 16) {
                 def nxt0:EvalValue (this.protoOfValue(walk0))
-                if (nxt0.isNull()) {
-                    return (EvalValue.boolean(false))
+                if (EvValueBridge.isNull(nxt0)) {
+                    return (EvValueBridge.taggedBoolean(false))
                 }
                 if (nxt0.equals(recv)) {
-                    return (EvalValue.boolean(true))
+                    return (EvValueBridge.taggedBoolean(true))
                 }
                 walk0 = nxt0
                 steps0 = (steps0 + 1)
             }
-            return (EvalValue.boolean(false))
+            return (EvValueBridge.taggedBoolean(false))
         }
         ; toLocaleString defers to the receiver's own toString, which is exactly
         ; what Object.prototype.toLocaleString does.
         if (name == "toLocaleString") {
             if (kind != "number") {
                 if (kind != "array") {
-                    return (EvalValue.string((this.toStringOf(recv))))
+                    return (EvValueBridge.taggedString((this.toStringOf(recv))))
                 }
             }
         }
@@ -12750,14 +12750,14 @@ class ComponentEngine {
             if (kind == "number") {
                 if ((array_length args) > 0) {
                     def rv:EvalValue (itemAt args 0)
-                    if (false == (rv.isUndefined())) {
+                    if (false == (EvValueBridge.isUndefined(rv))) {
                         def radix:int (to_int (rv.toNumber()))
                         if ((radix < 2) || (radix > 36)) {
                             return (this.throwSpecError("RangeError" "toString() radix must be between 2 and 36"))
                         }
                         if (radix != 10) {
                             def nprim:EvalValue (this.unwrapPrimitive(recv))
-                            return (EvalValue.string((this.numberToRadix((nprim.toNumber()) radix))))
+                            return (EvValueBridge.taggedString((this.numberToRadix((nprim.toNumber()) radix))))
                         }
                     }
                 }
@@ -12769,7 +12769,7 @@ class ComponentEngine {
             if (kind != "object") {
                 def tprim:EvalValue (this.unwrapPrimitive(recv))
                 if (false == (tprim.equals(recv))) {
-                    return (EvalValue.string((tprim.toString())))
+                    return (EvValueBridge.taggedString((tprim.toString())))
                 }
             }
         }
@@ -12787,13 +12787,13 @@ class ComponentEngine {
                 ; property would have been found before the registry, so reaching
                 ; here means the default really applies -- and the default brands
                 ; whatever `this` is, which via .call/.apply is any value at all.
-                return (EvalValue.string(("[object " + (this.objectClassOf(recv)) + "]")))
+                return (EvValueBridge.taggedString(("[object " + (this.objectClassOf(recv)) + "]")))
             }
             if (kind == "function") {
                 if (recv.valueType != 6) {
                     return (this.throwSpecError("TypeError" "Function.prototype.toString called on a non-function"))
                 }
-                return (EvalValue.string((this.functionSourceText(recv))))
+                return (EvValueBridge.taggedString((this.functionSourceText(recv))))
             }
             if (kind == "regexp") {
                 ; A RegExp stringifies as its literal form -- `String(/abc/i)`
@@ -12803,10 +12803,10 @@ class ComponentEngine {
                 ; rather than the "//" a missing source produced.
                 if (false == (this.isRegexValue(recv))) {
                     if (recv.equals((this.builtinPrototype("RegExp")))) {
-                        return (EvalValue.string("/(?:)/"))
+                        return (EvValueBridge.taggedString("/(?:)/"))
                     }
                 }
-                return (EvalValue.string(("/" + ((this.regexSourceOf(recv)) + ("/" + (this.regexFlagsOf(recv)))))))
+                return (EvValueBridge.taggedString(("/" + ((this.regexSourceOf(recv)) + ("/" + (this.regexFlagsOf(recv)))))))
             }
             ; An ERROR stringifies as "Name: message", which is what a borrowed
             ; String method sees when it coerces one. Error.prototype answers the
@@ -12814,11 +12814,11 @@ class ComponentEngine {
             ; renders as "Error" -- which is why the KIND decides here and not
             ; the `__error__` marker the instances carry.
             if (kind == "error") {
-                return (EvalValue.string((this.errorToString(recv))))
+                return (EvValueBridge.taggedString((this.errorToString(recv))))
             }
             if (recv.valueType == 5) {
                 if (has recv.objectMap "__error__") {
-                    return (EvalValue.string((this.errorToString(recv))))
+                    return (EvValueBridge.taggedString((this.errorToString(recv))))
                 }
             }
             ; An OBJECT that matched no kind above brands rather than letting the
@@ -12827,9 +12827,9 @@ class ComponentEngine {
             ; PRIMITIVE receiver still renders itself, which is what makes
             ; `(5).toString()` "5".
             if (recv.valueType == 5) {
-                return (EvalValue.string(("[object " + (this.objectClassOf(recv)) + "]")))
+                return (EvValueBridge.taggedString(("[object " + (this.objectClassOf(recv)) + "]")))
             }
-            return (EvalValue.string((recv.toString())))
+            return (EvValueBridge.taggedString((recv.toString())))
         }
         if (name == "valueOf") {
             ; D-VALUEOF: Object.prototype.valueOf is ToObject(this) and nothing
@@ -12848,7 +12848,7 @@ class ComponentEngine {
             ; f(1)` — arrives with no receiver. Per spec that is a TypeError,
             ; not an operation on the empty string, which is what reading
             ; stringValue off undefined would have silently produced.
-            if ((recv.isNull()) || (recv.isUndefined())) {
+            if ((EvValueBridge.isNull(recv)) || (EvValueBridge.isUndefined(recv))) {
                 return (this.throwSpecError("TypeError" ("String.prototype." + name + " called on null or undefined")))
             }
             ; D-REGISTRY: String.prototype methods coerce `this` via ToString.
@@ -12866,23 +12866,23 @@ class ComponentEngine {
             ; A user toString can throw, and that has to escape rather than be
             ; carried on as an empty string.
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
                     ; The locale-sensitive methods have no locale data behind
                     ; them here, so they are the plain ones -- which is exactly
                     ; what the spec permits an implementation with no locale
                     ; support to do.
                     if (name == "toLocaleLowerCase") {
-                        return (EvalValue.string((to_lowercase s)))
+                        return (EvValueBridge.taggedString((to_lowercase s)))
                     }
                     if (name == "toLocaleUpperCase") {
-                        return (EvalValue.string((to_uppercase s)))
+                        return (EvValueBridge.taggedString((to_uppercase s)))
                     }
                     if (name == "toLocaleString") {
-                        return (EvalValue.string(s))
+                        return (EvValueBridge.taggedString(s))
                     }
                     if (name == "normalize") {
-                        return (EvalValue.string(s))
+                        return (EvValueBridge.taggedString(s))
                     }
                     if (name == "localeCompare") {
                         ; The `that` argument is ToString'd, and a MISSING one is
@@ -12894,7 +12894,7 @@ class ComponentEngine {
                         if ((array_length args) > 0) {
                             other = (this.toStringOf((itemAt args 0)))
                             if scriptThrew {
-                                return (EvalValue.undefined())
+                                return (EvValueBridge.taggedUndefined())
                             }
                         }
                         return (EvalValue.fromInt((this.compareStrings(s other))))
@@ -12903,7 +12903,7 @@ class ComponentEngine {
                     ; -1. lastIndex plays no part, so the pattern is matched
                     ; from the start whatever its flags say.
                     if (name == "search") {
-                        def sre:EvalValue (EvalValue.undefined())
+                        def sre:EvalValue (EvValueBridge.taggedUndefined())
                         if ((array_length args) > 0) {
                             sre = (itemAt args 0)
                         }
@@ -12923,7 +12923,7 @@ class ComponentEngine {
                     ; D-REGEX: match. Without /g it is exec; with /g it collects
                     ; every match's text and reports no captures, per spec.
                     if (name == "match") {
-                        def mre:EvalValue (EvalValue.undefined())
+                        def mre:EvalValue (EvValueBridge.taggedUndefined())
                         if ((array_length args) > 0) {
                             mre = (itemAt args 0)
                         }
@@ -12946,7 +12946,7 @@ class ComponentEngine {
                             if (false == one.matched) {
                                 mlooping = false
                             } {
-                                push mitems (EvalValue.string((substring s one.start one.end)))
+                                push mitems (EvValueBridge.taggedString((substring s one.start one.end)))
                                 ; An empty match would spin forever otherwise.
                                 if (one.end == one.start) {
                                     mfrom = (one.end + 1)
@@ -12959,7 +12959,7 @@ class ComponentEngine {
                             }
                         }
                         if ((array_length mitems) == 0) {
-                            return (EvalValue.null())
+                            return (EvValueBridge.taggedNull())
                         }
                         return (EvalValue.array(mitems))
                     }
@@ -12969,7 +12969,7 @@ class ComponentEngine {
                             cpi = (this.toIntegerOf((itemAt args 0)))
                         }
                         if ((cpi < 0) || (cpi >= (strlen s))) {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         return (EvalValue.fromInt((charAt s cpi)))
                     }
@@ -12988,17 +12988,17 @@ class ComponentEngine {
                         }
                         if ((array_length args) > 1) {
                             def lenArg:EvalValue (itemAt args 1)
-                            if (false == (lenArg.isUndefined())) {
+                            if (false == (EvValueBridge.isUndefined(lenArg))) {
                                 sbLen = (to_int (lenArg.toNumber()))
                             }
                         }
                         if (sbLen < 0) { sbLen = 0 }
                         if (sbStart >= (strlen s)) {
-                            return (EvalValue.string(""))
+                            return (EvValueBridge.taggedString(""))
                         }
                         def sbEnd:int (sbStart + sbLen)
                         if (sbEnd > (strlen s)) { sbEnd = (strlen s) }
-                        return (EvalValue.string((substring s sbStart sbEnd)))
+                        return (EvValueBridge.taggedString((substring s sbStart sbEnd)))
                     }
                     ; (receiver already coerced to `s` above, per ToString)
                     if (name == "indexOf") {
@@ -13008,12 +13008,12 @@ class ComponentEngine {
                         def needle:string "undefined"
                         if ((array_length args) > 0) {
                             needle = (this.toStringOf((itemAt args 0)))
-                            if scriptThrew { return (EvalValue.undefined()) }
+                            if scriptThrew { return (EvValueBridge.taggedUndefined()) }
                         }
                         def from:int 0
                         if ((array_length args) > 1) {
                             from = (this.toIntegerOf((itemAt args 1)))
-                            if scriptThrew { return (EvalValue.undefined()) }
+                            if scriptThrew { return (EvValueBridge.taggedUndefined()) }
                         }
                         if (from < 0) { from = 0 }
                         if (from > (strlen s)) { from = (strlen s) }
@@ -13027,20 +13027,20 @@ class ComponentEngine {
                     if (name == "includes") {
                         if ((array_length args) > 0) {
                             def needle:string (this.toStringOf((itemAt args 0)))
-                            return (EvalValue.boolean(((indexOf s needle) >= 0)))
+                            return (EvValueBridge.taggedBoolean(((indexOf s needle) >= 0)))
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                     if (name == "startsWith") {
                         if ((array_length args) > 0) {
                             def pre:string (this.toStringOf((itemAt args 0)))
                             def pl:int (strlen pre)
                             if (pl > (strlen s)) {
-                                return (EvalValue.boolean(false))
+                                return (EvValueBridge.taggedBoolean(false))
                             }
-                            return (EvalValue.boolean(((substring s 0 pl) == pre)))
+                            return (EvValueBridge.taggedBoolean(((substring s 0 pl) == pre)))
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                     if (name == "endsWith") {
                         if ((array_length args) > 0) {
@@ -13048,11 +13048,11 @@ class ComponentEngine {
                             def sl:int (strlen suf)
                             def L:int (strlen s)
                             if (sl > L) {
-                                return (EvalValue.boolean(false))
+                                return (EvValueBridge.taggedBoolean(false))
                             }
-                            return (EvalValue.boolean(((substring s (L - sl) L) == suf)))
+                            return (EvValueBridge.taggedBoolean(((substring s (L - sl) L) == suf)))
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                     if (name == "slice") {
                         def L:int (strlen s)
@@ -13065,7 +13065,7 @@ class ComponentEngine {
                             ; An UNDEFINED end means "to the end of the string",
                             ; not 0 -- `s.slice(-4, undefined)` keeps the tail.
                             def eV:EvalValue (itemAt args 1)
-                            if (false == (eV.isUndefined())) {
+                            if (false == (EvValueBridge.isUndefined(eV))) {
                                 b = (this.toIntegerOf(eV))
                             }
                         }
@@ -13073,8 +13073,8 @@ class ComponentEngine {
                         if (b < 0) { b = (L + b) }
                         if (a < 0) { a = 0 }
                         if (b > L) { b = L }
-                        if (a >= b) { return (EvalValue.string("")) }
-                        return (EvalValue.string((substring s a b)))
+                        if (a >= b) { return (EvValueBridge.taggedString("")) }
+                        return (EvValueBridge.taggedString((substring s a b)))
                     }
                     if (name == "charCodeAt") {
                         def idx:int 0
@@ -13085,7 +13085,7 @@ class ComponentEngine {
                             return (EvalValue.fromInt((charAt s idx)))
                         }
                         ; Out of range is NaN, not 0 -- 0 is a real code unit.
-                        return (EvalValue.number((0.0 / 0.0)))
+                        return (EvValueBridge.taggedNumber((0.0 / 0.0)))
                     }
                     if (name == "repeat") {
                         def n:int 0
@@ -13098,7 +13098,7 @@ class ComponentEngine {
                             out = (out + s)
                             r = (r + 1)
                         }
-                        return (EvalValue.string(out))
+                        return (EvValueBridge.taggedString(out))
                     }
                     if (name == "split") {
                         ; Spec order: the LIMIT is converted before the
@@ -13109,14 +13109,14 @@ class ComponentEngine {
                         def limitN:int 0
                         if ((array_length args) > 1) {
                             def limV:EvalValue (itemAt args 1)
-                            if (false == (limV.isUndefined())) {
+                            if (false == (EvValueBridge.isUndefined(limV))) {
                                 hasLimit = true
                                 ; The limit is ToUINT32, not a clamped integer:
                                 ; -(2^32)+1 wraps to 1, so the result keeps one
                                 ; element rather than none.
                                 limitN = (this.toUint32Of(limV))
                                 if scriptThrew {
-                                    return (EvalValue.undefined())
+                                    return (EvValueBridge.taggedUndefined())
                                 }
                             }
                         }
@@ -13125,10 +13125,10 @@ class ComponentEngine {
                         ; string. Defaulting to "" split it into characters.
                         def haveSep:boolean false
                         def sep:string ""
-                        def sepRe:EvalValue (EvalValue.null())
+                        def sepRe:EvalValue (EvValueBridge.taggedNull())
                         if ((array_length args) > 0) {
                             def sepV:EvalValue (itemAt args 0)
-                            if (false == (sepV.isUndefined())) {
+                            if (false == (EvValueBridge.isUndefined(sepV))) {
                                 haveSep = true
                                 ; D-REGEX: a RegExp separator splits on every
                                 ; match and interleaves its captures into the
@@ -13139,7 +13139,7 @@ class ComponentEngine {
                                 } {
                                     sep = (this.toStringOf(sepV))
                                     if scriptThrew {
-                                        return (EvalValue.undefined())
+                                        return (EvValueBridge.taggedUndefined())
                                     }
                                 }
                             }
@@ -13160,7 +13160,7 @@ class ComponentEngine {
                                 em.setup(spProg s)
                                 def emm:RegexMatch (em.exec(0))
                                 if (false == emm.matched) {
-                                    push spItems (EvalValue.string(""))
+                                    push spItems (EvValueBridge.taggedString(""))
                                 }
                                 spLooping = false
                             }
@@ -13185,15 +13185,15 @@ class ComponentEngine {
                                                 if ((one2.end == one2.start) && (one2.start == spCursor)) {
                                                     spScan = (spScan + 1)
                                                 } {
-                                                    push spItems (EvalValue.string((substring s spCursor one2.start)))
+                                                    push spItems (EvValueBridge.taggedString((substring s spCursor one2.start)))
                                                     def gi2:int 1
                                                     while (gi2 < (array_length one2.capStart)) {
                                                         def cs2:int (itemAt one2.capStart gi2)
                                                         def ce2:int (itemAt one2.capEnd gi2)
                                                         if (cs2 < 0) {
-                                                            push spItems (EvalValue.undefined())
+                                                            push spItems (EvValueBridge.taggedUndefined())
                                                         } {
-                                                            push spItems (EvalValue.string((substring s cs2 ce2)))
+                                                            push spItems (EvValueBridge.taggedString((substring s cs2 ce2)))
                                                         }
                                                         gi2 = (gi2 + 1)
                                                     }
@@ -13210,7 +13210,7 @@ class ComponentEngine {
                             }
                             if (spCursor <= (strlen s)) {
                                 if ((strlen s) > 0) {
-                                    push spItems (EvalValue.string((substring s spCursor (strlen s))))
+                                    push spItems (EvValueBridge.taggedString((substring s spCursor (strlen s))))
                                 }
                             }
                             def spOut:[EvalValue]
@@ -13229,10 +13229,10 @@ class ComponentEngine {
                             def whole:[EvalValue]
                             if hasLimit {
                                 if (limitN > 0) {
-                                    push whole (EvalValue.string(s))
+                                    push whole (EvValueBridge.taggedString(s))
                                 }
                             } {
-                                push whole (EvalValue.string(s))
+                                push whole (EvValueBridge.taggedString(s))
                             }
                             return (EvalValue.array(whole))
                         }
@@ -13244,7 +13244,7 @@ class ComponentEngine {
                         def items:[EvalValue]
                         def pi:int 0
                         while (pi < cap) {
-                            push items (EvalValue.string((itemAt parts pi)))
+                            push items (EvValueBridge.taggedString((itemAt parts pi)))
                             pi = (pi + 1)
                         }
                         return (EvalValue.array(items))
@@ -13253,7 +13253,7 @@ class ComponentEngine {
                         def needle:string "undefined"
                         if ((array_length args) > 0) {
                             needle = (this.toStringOf((itemAt args 0)))
-                            if scriptThrew { return (EvalValue.undefined()) }
+                            if scriptThrew { return (EvValueBridge.taggedUndefined()) }
                         }
                         ; The position is ToNUMBER, not ToInteger: NaN means
                         ; "search the whole string", which is why it is checked
@@ -13262,7 +13262,7 @@ class ComponentEngine {
                         if ((array_length args) > 1) {
                             def posV:EvalValue (itemAt args 1)
                             def posN:double (this.toNumberOf(posV))
-                            if scriptThrew { return (EvalValue.undefined()) }
+                            if scriptThrew { return (EvValueBridge.taggedUndefined()) }
                             if (posN == posN) {
                                 def pi2:int (this.toIntegerOf(posV))
                                 if (pi2 < 0) { pi2 = 0 }
@@ -13284,9 +13284,9 @@ class ComponentEngine {
                             idx = (L + idx)
                         }
                         if ((idx >= 0) && (idx < L)) {
-                            return (EvalValue.string((substring s idx (idx + 1))))
+                            return (EvValueBridge.taggedString((substring s idx (idx + 1))))
                         }
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     if (name == "concat") {
                         def out:string s
@@ -13294,11 +13294,11 @@ class ComponentEngine {
                         while (ci < (array_length args)) {
                             out = (out + (this.toStringOf((itemAt args ci))))
                             if scriptThrew {
-                                return (EvalValue.undefined())
+                                return (EvValueBridge.taggedUndefined())
                             }
                             ci = (ci + 1)
                         }
-                        return (EvalValue.string(out))
+                        return (EvValueBridge.taggedString(out))
                     }
                     if (name == "trimStart") {
                         def L:int (strlen s)
@@ -13306,14 +13306,14 @@ class ComponentEngine {
                         while ((a < L) && ((substring s a (a + 1)) == " ")) {
                             a = (a + 1)
                         }
-                        return (EvalValue.string((substring s a L)))
+                        return (EvValueBridge.taggedString((substring s a L)))
                     }
                     if (name == "trimEnd") {
                         def b:int (strlen s)
                         while ((b > 0) && ((substring s (b - 1) b) == " ")) {
                             b = (b - 1)
                         }
-                        return (EvalValue.string((substring s 0 b)))
+                        return (EvValueBridge.taggedString((substring s 0 b)))
                     }
                     ; replace (first match) and replaceAll — string search only, done
                     ; via indexOf/substring so behaviour is backend-independent.
@@ -13323,11 +13323,11 @@ class ComponentEngine {
                     ; FUNCTION, called with the match, its captures, the offset
                     ; and the subject.
                     if (name == "replace") {
-                        def rpat:EvalValue (EvalValue.undefined())
+                        def rpat:EvalValue (EvValueBridge.taggedUndefined())
                         if ((array_length args) > 0) {
                             rpat = (itemAt args 0)
                         }
-                        def rrep:EvalValue (EvalValue.undefined())
+                        def rrep:EvalValue (EvValueBridge.taggedUndefined())
                         if ((array_length args) > 1) {
                             rrep = (itemAt args 1)
                         }
@@ -13341,14 +13341,14 @@ class ComponentEngine {
                         if (false == patIsRe) {
                             patText = (this.toStringOf(rpat))
                             if scriptThrew {
-                                return (EvalValue.undefined())
+                                return (EvValueBridge.taggedUndefined())
                             }
                         }
                         def repText:string ""
                         if (false == repIsFn) {
                             repText = (this.toStringOf(rrep))
                             if scriptThrew {
-                                return (EvalValue.undefined())
+                                return (EvValueBridge.taggedUndefined())
                             }
                         }
                         if patIsRe {
@@ -13371,7 +13371,7 @@ class ComponentEngine {
                                         def cbArgs:[EvalValue] (this.replacerArgs(one s))
                                         def cbOut:EvalValue (this.callFnValueWithValues(rrep cbArgs))
                                         if scriptThrew {
-                                            return (EvalValue.undefined())
+                                            return (EvValueBridge.taggedUndefined())
                                         }
                                         outR = (outR + (this.toStringOf(cbOut)))
                                     } {
@@ -13398,7 +13398,7 @@ class ComponentEngine {
                             if (cursor <= (strlen s)) {
                                 outR = (outR + (substring s cursor (strlen s)))
                             }
-                            return (EvalValue.string(outR))
+                            return (EvValueBridge.taggedString(outR))
                         }
                         def find:string patText
                         if ((array_length args) == 0) {
@@ -13406,17 +13406,17 @@ class ComponentEngine {
                         }
                         def at:int (indexOf s find)
                         if (at < 0) {
-                            return (EvalValue.string(s))
+                            return (EvValueBridge.taggedString(s))
                         }
                         def repl:string ""
                         if repIsFn {
                             def sArgs:[EvalValue]
-                            push sArgs (EvalValue.string(find))
+                            push sArgs (EvValueBridge.taggedString(find))
                             push sArgs (EvalValue.fromInt(at))
-                            push sArgs (EvalValue.string(s))
+                            push sArgs (EvValueBridge.taggedString(s))
                             def sOut:EvalValue (this.callFnValueWithValues(rrep sArgs))
                             if scriptThrew {
-                                return (EvalValue.undefined())
+                                return (EvValueBridge.taggedUndefined())
                             }
                             repl = (this.toStringOf(sOut))
                         } {
@@ -13427,7 +13427,7 @@ class ComponentEngine {
                         }
                         def before:string (substring s 0 at)
                         def after:string (substring s (at + (strlen find)) (strlen s))
-                        return (EvalValue.string((before + (repl + after))))
+                        return (EvValueBridge.taggedString((before + (repl + after))))
                     }
                     if (name == "replaceAll") {
                         def find:string ""
@@ -13439,7 +13439,7 @@ class ComponentEngine {
                             repl = (this.toStringOf((itemAt args 1)))
                         }
                         if ((strlen find) == 0) {
-                            return (EvalValue.string(s))
+                            return (EvValueBridge.taggedString(s))
                         }
                         def out:string ""
                         def fl:int (strlen find)
@@ -13459,20 +13459,20 @@ class ComponentEngine {
                                 i2 = (i2 + 1)
                             }
                         }
-                        return (EvalValue.string(out))
+                        return (EvValueBridge.taggedString(out))
                     }
-            if (name == "toUpperCase") { return (EvalValue.string((to_uppercase s))) }
-            if (name == "toLowerCase") { return (EvalValue.string((to_lowercase s))) }
-            if (name == "trim") { return (EvalValue.string((trim s))) }
+            if (name == "toUpperCase") { return (EvValueBridge.taggedString((to_uppercase s))) }
+            if (name == "toLowerCase") { return (EvValueBridge.taggedString((to_lowercase s))) }
+            if (name == "trim") { return (EvValueBridge.taggedString((trim s))) }
             if (name == "charAt") {
                 def ci:int 0
                 if ((array_length args) > 0) {
                     ci = (this.toIntegerOf((itemAt args 0)))
                 }
-                if (ci < 0) { return (EvalValue.string("")) }
-                if (ci >= (strlen s)) { return (EvalValue.string("")) }
+                if (ci < 0) { return (EvValueBridge.taggedString("")) }
+                if (ci >= (strlen s)) { return (EvValueBridge.taggedString("")) }
                 def ce:int (ci + 1)
-                return (EvalValue.string((substring s ci ce)))
+                return (EvValueBridge.taggedString((substring s ci ce)))
             }
             if (name == "substring") {
                 def a0:int 0
@@ -13482,7 +13482,7 @@ class ComponentEngine {
                 }
                 if ((array_length args) > 1) {
                     def av1:EvalValue (itemAt args 1)
-                    if (false == (av1.isUndefined())) {
+                    if (false == (EvValueBridge.isUndefined(av1))) {
                         a1 = (this.toIntegerOf(av1))
                     }
                 }
@@ -13496,20 +13496,20 @@ class ComponentEngine {
                     a0 = a1
                     a1 = tmp
                 }
-                return (EvalValue.string((substring s a0 a1)))
+                return (EvValueBridge.taggedString((substring s a0 a1)))
             }
             if (name == "padStart") {
-                return (EvalValue.string((this.padString(s args true))))
+                return (EvValueBridge.taggedString((this.padString(s args true))))
             }
             if (name == "padEnd") {
-                return (EvalValue.string((this.padString(s args false))))
+                return (EvValueBridge.taggedString((this.padString(s args false))))
             }
         }
         ; ---- Map / Set -------------------------------------------------------
         if (kind == "map") {
                     if (name == "set") {
-                        def k:EvalValue (EvalValue.null())
-                        def v:EvalValue (EvalValue.undefined())
+                        def k:EvalValue (EvValueBridge.taggedNull())
+                        def v:EvalValue (EvValueBridge.taggedUndefined())
                         if ((array_length args) > 0) {
                             k = (itemAt args 0)
                         }
@@ -13523,23 +13523,23 @@ class ComponentEngine {
                         if ((array_length args) > 0) {
                             return (recv.mapGet((itemAt args 0)))
                         }
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     if (name == "has") {
                         if ((array_length args) > 0) {
-                            return (EvalValue.boolean((recv.mapHas((itemAt args 0)))))
+                            return (EvValueBridge.taggedBoolean((recv.mapHas((itemAt args 0)))))
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                     if (name == "delete") {
                         if ((array_length args) > 0) {
-                            return (EvalValue.boolean((recv.mapDelete((itemAt args 0)))))
+                            return (EvValueBridge.taggedBoolean((recv.mapDelete((itemAt args 0)))))
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                     if (name == "clear") {
                         recv.collClear()
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     if (name == "keys") {
                         def items:[EvalValue]
@@ -13583,7 +13583,7 @@ class ComponentEngine {
                                 i = (i + 1)
                             }
                         }
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
         }
         if (kind == "set") {
@@ -13595,19 +13595,19 @@ class ComponentEngine {
                     }
                     if (name == "has") {
                         if ((array_length args) > 0) {
-                            return (EvalValue.boolean((recv.setHas((itemAt args 0)))))
+                            return (EvValueBridge.taggedBoolean((recv.setHas((itemAt args 0)))))
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                     if (name == "delete") {
                         if ((array_length args) > 0) {
-                            return (EvalValue.boolean((recv.setDelete((itemAt args 0)))))
+                            return (EvValueBridge.taggedBoolean((recv.setDelete((itemAt args 0)))))
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                     if (name == "clear") {
                         recv.collClear()
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     if ((name == "values") || (name == "keys")) {
                         def items:[EvalValue]
@@ -13631,7 +13631,7 @@ class ComponentEngine {
                                 i = (i + 1)
                             }
                         }
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
         }
         ; ---- Array.prototype -----------------------------------------------
@@ -13639,7 +13639,7 @@ class ComponentEngine {
             ; D-REGISTRY: same as for strings — an unbound extraction invoked
             ; with no receiver is a TypeError, not an operation on an empty
             ; array, which is what reading arrayValue off undefined would give.
-            if ((recv.isNull()) || (recv.isUndefined())) {
+            if ((EvValueBridge.isNull(recv)) || (EvValueBridge.isUndefined(recv))) {
                 return (this.throwSpecError("TypeError" ("Array.prototype." + name + " called on null or undefined")))
             }
             ; D-CBCHECK: the higher-order methods require a callable. Given a
@@ -13650,16 +13650,16 @@ class ComponentEngine {
             if (this.arrayNeedsCallback(name)) {
                 def lenProbe:EvalValue (this.getPropertyValue(recv "length"))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 ; ToUint32 of it, too: the conversion can run a `toString` that
                 ; throws, and the spec does that before it asks whether the
                 ; callback is callable.
                 def lenProbeNum:double (this.toNumberOf(lenProbe))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
-                def cb0:EvalValue (EvalValue.undefined())
+                def cb0:EvalValue (EvValueBridge.taggedUndefined())
                 if ((array_length args) > 0) {
                     cb0 = (itemAt args 0)
                 }
@@ -13703,7 +13703,7 @@ class ComponentEngine {
             ; callable. Falling through raised "requires a function argument"
             ; instead, so the exception the test was waiting for never arrived.
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             ; D-ARRAYLIKE: Array.prototype.toLocaleString calls each element's
             ; OWN toLocaleString and joins with a comma; a null or undefined
@@ -13718,25 +13718,25 @@ class ComponentEngine {
                     }
                     def tlsEl:EvalValue (this.arrayElemAt(recv tlsI))
                     def skipEl:boolean false
-                    if (tlsEl.isNull()) { skipEl = true }
-                    if (tlsEl.isUndefined()) { skipEl = true }
+                    if (EvValueBridge.isNull(tlsEl)) { skipEl = true }
+                    if (EvValueBridge.isUndefined(tlsEl)) { skipEl = true }
                     if (false == skipEl) {
                         def tlsArgs:[EvalValue]
                         def tlsV:EvalValue (this.callMethodOnValue(tlsEl "toLocaleString" tlsArgs))
                         if scriptThrew {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         tlsOut = (tlsOut + (this.toStringOf(tlsV)))
                         if scriptThrew {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                     }
                     tlsI = (tlsI + 1)
                 }
-                return (EvalValue.string(tlsOut))
+                return (EvValueBridge.taggedString(tlsOut))
             }
                     if (name == "indexOf") {
-                        def target:EvalValue (EvalValue.null())
+                        def target:EvalValue (EvValueBridge.taggedNull())
                         if ((array_length args) > 0) {
                             target = (itemAt args 0)
                         }
@@ -13756,18 +13756,18 @@ class ComponentEngine {
                         return (EvalValue.fromInt((0 - 1)))
                     }
                     if (name == "includes") {
-                        def target:EvalValue (EvalValue.null())
+                        def target:EvalValue (EvValueBridge.taggedNull())
                         if ((array_length args) > 0) {
                             target = (itemAt args 0)
                         }
                         def ii:int 0
                         while (ii < alen) {
                             if ((target.equals((this.arrayElemAt(recv ii))))) {
-                                return (EvalValue.boolean(true))
+                                return (EvValueBridge.taggedBoolean(true))
                             }
                             ii = (ii + 1)
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                     if (name == "join") {
                         def sep:string ","
@@ -13786,17 +13786,17 @@ class ComponentEngine {
                             def jv:EvalValue (this.arrayElemAt(recv ii))
                             def jSkip:boolean false
                             if (EvValueBridge.isHole(jv)) { jSkip = true }
-                            if (jv.isNull()) { jSkip = true }
-                            if (jv.isUndefined()) { jSkip = true }
+                            if (EvValueBridge.isNull(jv)) { jSkip = true }
+                            if (EvValueBridge.isUndefined(jv)) { jSkip = true }
                             if (false == jSkip) {
                                 out = (out + (this.toStringOf(jv)))
                                 if scriptThrew {
-                                    return (EvalValue.undefined())
+                                    return (EvValueBridge.taggedUndefined())
                                 }
                             }
                             ii = (ii + 1)
                         }
-                        return (EvalValue.string(out))
+                        return (EvValueBridge.taggedString(out))
                     }
                     if (name == "slice") {
                         def a:int 0
@@ -13834,13 +13834,13 @@ class ComponentEngine {
                                     push cargs recv
                                     def unused:EvalValue (this.callFnValueWithValues(cb cargs))
                                     if scriptThrew {
-                                        return (EvalValue.undefined())
+                                        return (EvValueBridge.taggedUndefined())
                                     }
                                     ii = (ii + 1)
                                 }
                             }
                         }
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     if (name == "map") {
                         def items:[EvalValue]
@@ -13861,7 +13861,7 @@ class ComponentEngine {
                                     push cargs recv
                                     push items (this.callFnValueWithValues(cb cargs))
                                     if scriptThrew {
-                                        return (EvalValue.undefined())
+                                        return (EvValueBridge.taggedUndefined())
                                     }
                                     ii = (ii + 1)
                                 }
@@ -13886,7 +13886,7 @@ class ComponentEngine {
                                     push cargs recv
                                     def keep:EvalValue (this.callFnValueWithValues(cb cargs))
                                     if scriptThrew {
-                                        return (EvalValue.undefined())
+                                        return (EvValueBridge.taggedUndefined())
                                     }
                                     if (keep.toBool()) {
                                         push items el
@@ -13913,7 +13913,7 @@ class ComponentEngine {
                                 ii = (ii + 1)
                             }
                         }
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     if (name == "findIndex") {
                         if ((array_length args) > 0) {
@@ -13947,16 +13947,16 @@ class ComponentEngine {
                                     push cargs recv
                                     def hit:EvalValue (this.callFnValueWithValues(cb cargs))
                                     if scriptThrew {
-                                        return (EvalValue.undefined())
+                                        return (EvValueBridge.taggedUndefined())
                                     }
                                     if (hit.toBool()) {
-                                        return (EvalValue.boolean(true))
+                                        return (EvValueBridge.taggedBoolean(true))
                                     }
                                     ii = (ii + 1)
                                 }
                             }
                         }
-                        return (EvalValue.boolean(false))
+                        return (EvValueBridge.taggedBoolean(false))
                     }
                     if (name == "every") {
                         if ((array_length args) > 0) {
@@ -13973,16 +13973,16 @@ class ComponentEngine {
                                     push cargs recv
                                     def okv:EvalValue (this.callFnValueWithValues(cb cargs))
                                     if scriptThrew {
-                                        return (EvalValue.undefined())
+                                        return (EvValueBridge.taggedUndefined())
                                     }
                                     if ((okv.toBool()) == false) {
-                                        return (EvalValue.boolean(false))
+                                        return (EvValueBridge.taggedBoolean(false))
                                     }
                                     ii = (ii + 1)
                                 }
                             }
                         }
-                        return (EvalValue.boolean(true))
+                        return (EvValueBridge.taggedBoolean(true))
                     }
                     ; reduce/reduceRight do NOT take a thisArg -- their second
                     ; argument is the initial value, so the callback keeps
@@ -13991,7 +13991,7 @@ class ComponentEngine {
                         def goRight:boolean (name == "reduceRight")
                         if ((array_length args) > 0) {
                             def cb:EvalValue (itemAt args 0)
-                            def acc:EvalValue (EvalValue.null())
+                            def acc:EvalValue (EvValueBridge.taggedNull())
                             def startIdx:int 0
                             if goRight { startIdx = (alen - 1) }
                             if ((array_length args) > 1) {
@@ -14032,7 +14032,7 @@ class ComponentEngine {
                                     push cargs recv
                                     acc = (this.callFnValueWithValues(cb cargs))
                                     if scriptThrew {
-                                        return (EvalValue.undefined())
+                                        return (EvValueBridge.taggedUndefined())
                                     }
                                 }
                                 if goRight {
@@ -14043,7 +14043,7 @@ class ComponentEngine {
                             }
                             return acc
                         }
-                        return (EvalValue.null())
+                        return (EvValueBridge.taggedNull())
                     }
                     ; ---- mutators (mutate recv in place; same instance so refs see it) ----
                     if (name == "push") {
@@ -14058,7 +14058,7 @@ class ComponentEngine {
                     if (name == "pop") {
                         def n:int (array_length recv.arrayValue)
                         if (n == 0) {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         def last:EvalValue (itemAt recv.arrayValue (n - 1))
                         def items:[EvalValue]
@@ -14073,7 +14073,7 @@ class ComponentEngine {
                     if (name == "shift") {
                         def n:int (array_length recv.arrayValue)
                         if (n == 0) {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         def first:EvalValue (itemAt recv.arrayValue 0)
                         def items:[EvalValue]
@@ -14112,7 +14112,7 @@ class ComponentEngine {
                         return recv
                     }
                     if (name == "fill") {
-                        def fv:EvalValue (EvalValue.undefined())
+                        def fv:EvalValue (EvValueBridge.taggedUndefined())
                         if ((array_length args) > 0) {
                             fv = (itemAt args 0)
                         }
@@ -14128,7 +14128,7 @@ class ComponentEngine {
                     }
                     if (name == "sort") {
                         def hasCmp:boolean ((array_length args) > 0)
-                        def cmp:EvalValue (EvalValue.null())
+                        def cmp:EvalValue (EvValueBridge.taggedNull())
                         if hasCmp {
                             cmp = (itemAt args 0)
                         }
@@ -14294,10 +14294,10 @@ class ComponentEngine {
                         if ((idx >= 0) && (idx < n)) {
                             return (this.arrayElemAt(recv idx))
                         }
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     if (name == "lastIndexOf") {
-                        def target:EvalValue (EvalValue.null())
+                        def target:EvalValue (EvValueBridge.taggedNull())
                         if ((array_length args) > 0) {
                             target = (itemAt args 0)
                         }
@@ -14320,7 +14320,7 @@ class ComponentEngine {
             if ((array_length args) > 0) {
                 reSubject = (this.toStringOf((itemAt args 0)))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
             } {
                 reSubject = "undefined"
@@ -14331,9 +14331,9 @@ class ComponentEngine {
             if (name == "test") {
                 def hit:EvalValue (this.regexExec(recv reSubject))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
-                return (EvalValue.boolean((hit.isArray())))
+                return (EvValueBridge.taggedBoolean((hit.isArray())))
             }
         }
         ; ---- Number.prototype ----------------------------------------------
@@ -14342,13 +14342,13 @@ class ComponentEngine {
             def fnum:double (fprim.toNumber())
             if (name == "toLocaleString") {
                 ; No locale data, so this is ToString of the number.
-                return (EvalValue.string((this.toStringOf(fprim))))
+                return (EvValueBridge.taggedString((this.toStringOf(fprim))))
             }
             if (name == "toFixed") {
                 def digits:int 0
                 if ((array_length args) > 0) {
                     def dv:EvalValue (itemAt args 0)
-                    if (false == (dv.isUndefined())) {
+                    if (false == (EvValueBridge.isUndefined(dv))) {
                         digits = (this.toIntegerOf(dv))
                     }
                 }
@@ -14357,14 +14357,14 @@ class ComponentEngine {
                 if ((digits < 0) || (digits > 100)) {
                     return (this.throwSpecError("RangeError" "toFixed() digits argument must be between 0 and 100"))
                 }
-                return (EvalValue.string((this.toFixedString(fnum digits))))
+                return (EvValueBridge.taggedString((this.toFixedString(fnum digits))))
             }
             if (name == "toExponential") {
                 def edigits:int 6
                 def eauto:boolean true
                 if ((array_length args) > 0) {
                     def ev:EvalValue (itemAt args 0)
-                    if (false == (ev.isUndefined())) {
+                    if (false == (EvValueBridge.isUndefined(ev))) {
                         edigits = (this.toIntegerOf(ev))
                         eauto = false
                     }
@@ -14374,21 +14374,21 @@ class ComponentEngine {
                         return (this.throwSpecError("RangeError" "toExponential() argument must be between 0 and 100"))
                     }
                 }
-                return (EvalValue.string((this.toExponentialString(fnum edigits))))
+                return (EvValueBridge.taggedString((this.toExponentialString(fnum edigits))))
             }
             if (name == "toPrecision") {
                 if ((array_length args) == 0) {
-                    return (EvalValue.string((this.toStringOf(fprim))))
+                    return (EvValueBridge.taggedString((this.toStringOf(fprim))))
                 }
                 def pv:EvalValue (itemAt args 0)
-                if (pv.isUndefined()) {
-                    return (EvalValue.string((this.toStringOf(fprim))))
+                if (EvValueBridge.isUndefined(pv)) {
+                    return (EvValueBridge.taggedString((this.toStringOf(fprim))))
                 }
                 def prec:int (this.toIntegerOf(pv))
                 if ((prec < 1) || (prec > 100)) {
                     return (this.throwSpecError("RangeError" "toPrecision() argument must be between 1 and 100"))
                 }
-                return (EvalValue.string((this.toPrecisionString(fnum prec))))
+                return (EvValueBridge.taggedString((this.toPrecisionString(fnum prec))))
             }
         }
         if (kind == "function") {
@@ -14399,7 +14399,7 @@ class ComponentEngine {
                 return (this.throwSpecError("TypeError" (name + " called on a non-function")))
             }
             if (name == "call") {
-                def callThis:EvalValue (EvalValue.undefined())
+                def callThis:EvalValue (EvValueBridge.taggedUndefined())
                 def rest:[EvalValue]
                 def i:int 0
                 while (i < (array_length args)) {
@@ -14414,7 +14414,7 @@ class ComponentEngine {
                 return (this.callFnValueWithValues(b1 rest))
             }
             if (name == "apply") {
-                def applyThis:EvalValue (EvalValue.undefined())
+                def applyThis:EvalValue (EvValueBridge.taggedUndefined())
                 def aargs:[EvalValue]
                 if ((array_length args) > 0) {
                     applyThis = (itemAt args 0)
@@ -14425,7 +14425,7 @@ class ComponentEngine {
                     ; which is what lets `f.apply(null, arguments)` forward a
                     ; call. A primitive that is not null/undefined is a
                     ; TypeError rather than an empty argument list.
-                    if (false == ((arr.isNull()) || (arr.isUndefined()))) {
+                    if (false == ((EvValueBridge.isNull(arr)) || (EvValueBridge.isUndefined(arr)))) {
                         def okArgs:boolean false
                         if (arr.valueType == 4) { okArgs = true }
                         if (arr.valueType == 5) { okArgs = true }
@@ -14450,7 +14450,7 @@ class ComponentEngine {
                 return (this.callFnValueWithValues(b2 aargs))
             }
             if (name == "bind") {
-                def bindThis:EvalValue (EvalValue.undefined())
+                def bindThis:EvalValue (EvValueBridge.taggedUndefined())
                 def partial:[EvalValue]
                 def j:int 0
                 while (j < (array_length args)) {
@@ -14475,7 +14475,7 @@ class ComponentEngine {
                 return b3
             }
         }
-        return (EvalValue.undefined())
+        return (EvValueBridge.taggedUndefined())
     }
 
     ; A bound function has no `prototype`, so the synthesised one is suppressed
@@ -14517,7 +14517,7 @@ class ComponentEngine {
         if (v.valueType == 2) { return (this.makeWrapper("String" v)) }
         if (v.valueType == 1) { return (this.makeWrapper("Number" v)) }
         if (v.valueType == 3) { return (this.makeWrapper("Boolean" v)) }
-        if ((v.valueType == 0) || (v.isUndefined())) {
+        if ((v.valueType == 0) || (EvValueBridge.isUndefined(v))) {
             def keysO:[string]
             def valsO:[EvalValue]
             def o:EvalValue (EvalValue.object(keysO valsO))
@@ -14534,9 +14534,9 @@ class ComponentEngine {
         def p:EvalValue prim
         if (ctorName == "String") {
             if (prim.valueType == 0) {
-                p = (EvalValue.string(""))
+                p = (EvValueBridge.taggedString(""))
             } {
-                p = (EvalValue.string((this.toStringOf(prim))))
+                p = (EvValueBridge.taggedString((this.toStringOf(prim))))
             }
         }
         if (ctorName == "Number") {
@@ -14544,16 +14544,16 @@ class ComponentEngine {
             ; absence of an argument and an undefined argument are different
             ; things, and the caller signals which by passing a null EvalValue.
             if (prim.valueType == 0) {
-                p = (EvalValue.number(0.0))
+                p = (EvValueBridge.taggedNumber(0.0))
             } {
-                p = (EvalValue.number((this.toNumberOf(prim))))
+                p = (EvValueBridge.taggedNumber((this.toNumberOf(prim))))
             }
         }
         if (ctorName == "Boolean") {
-            p = (EvalValue.boolean((prim.toBool())))
+            p = (EvValueBridge.taggedBoolean((prim.toBool())))
         }
         w.setMember("__primitive__" p)
-        w.setMember("__wrapper__" (EvalValue.string(ctorName)))
+        w.setMember("__wrapper__" (EvValueBridge.taggedString(ctorName)))
         ; A boxed string exposes `length` as a real own property, which is what
         ; `with ('ab') { length }` resolves against, plus one own property per
         ; index. Both are what `Object.keys(new String('ab'))` reports -- the
@@ -14562,7 +14562,7 @@ class ComponentEngine {
             def sw:string p.stringValue
             def ci:int 0
             while (ci < (strlen sw)) {
-                w.setMember((to_string ci) (EvalValue.string((substring sw ci (ci + 1)))))
+                w.setMember((to_string ci) (EvValueBridge.taggedString((substring sw ci (ci + 1)))))
                 w.setAttrs((to_string ci) false true false)
                 ci = (ci + 1)
             }
@@ -14589,7 +14589,7 @@ class ComponentEngine {
     ; than the value type.
     ; --------------------------------------------------------------------------
     fn objectClassOf:string (v:EvalValue) {
-        if (v.isUndefined()) { return "Undefined" }
+        if (EvValueBridge.isUndefined(v)) { return "Undefined" }
         if (v.valueType == 0) { return "Null" }
         if (v.valueType == 4) { return "Array" }
         if (v.valueType == 6) { return "Function" }
@@ -14704,7 +14704,7 @@ class ComponentEngine {
             return true
         }
         ; Present but not a function: not the default, and not usable either.
-        if (false == (m.isUndefined())) {
+        if (false == (EvValueBridge.isUndefined(m))) {
             return false
         }
         return true
@@ -14727,14 +14727,14 @@ class ComponentEngine {
                 def bpArgs:[EvalValue]
                 def bpOut:EvalValue (this.invokeBuiltin((m.builtinKindOf()) (m.builtinNameOf()) obj bpArgs))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
-                if (bpOut.valueType == 5) { return (EvalValue.null()) }
-                if (bpOut.valueType == 4) { return (EvalValue.null()) }
-                if (bpOut.valueType == 6) { return (EvalValue.null()) }
+                if (bpOut.valueType == 5) { return (EvValueBridge.taggedNull()) }
+                if (bpOut.valueType == 4) { return (EvValueBridge.taggedNull()) }
+                if (bpOut.valueType == 6) { return (EvValueBridge.taggedNull()) }
                 primitiveMethodUsable = true
                 if (bpOut.valueType == 0) {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 return bpOut
             }
@@ -14749,18 +14749,18 @@ class ComponentEngine {
                 ; TypeError instead, so the exception the test threw never
                 ; reached the catch that was waiting for it.
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 ; An OBJECT result is not a primitive, so the method is skipped
                 ; and the other one tried. Arrays and functions are objects too.
                 if (out.valueType == 5) {
-                    return (EvalValue.null())
+                    return (EvValueBridge.taggedNull())
                 }
                 if (out.valueType == 4) {
-                    return (EvalValue.null())
+                    return (EvValueBridge.taggedNull())
                 }
                 if (out.valueType == 6) {
-                    return (EvalValue.null())
+                    return (EvValueBridge.taggedNull())
                 }
                 ; A method that falls off its end returns UNDEFINED, which is a
                 ; perfectly good primitive. The engine represents "no return" as
@@ -14768,12 +14768,12 @@ class ComponentEngine {
                 ; the two are told apart by the flag rather than by the value.
                 primitiveMethodUsable = true
                 if (out.valueType == 0) {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 return out
             }
         }
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     ; Lexicographic comparison by code unit: -1, 0 or 1. Ranger has no string
@@ -14831,26 +14831,26 @@ class ComponentEngine {
                 return (unwrap (get v.objectMap "__primitive__"))
             }
             if (has v.objectMap "__regex__") {
-                return (EvalValue.string(("/" + ((this.regexSourceOf(v)) + ("/" + (this.regexFlagsOf(v)))))))
+                return (EvValueBridge.taggedString(("/" + ((this.regexSourceOf(v)) + ("/" + (this.regexFlagsOf(v)))))))
             }
             if (has v.objectMap "__error__") {
-                return (EvalValue.string((this.errorToString(v))))
+                return (EvValueBridge.taggedString((this.errorToString(v))))
             }
             ; D-DATE: the default Date.prototype.toString, which is the whole
             ; date and time rather than a brand.
             if (has v.objectMap "__date__") {
                 def dtd (new DateTime())
-                return (EvalValue.string((dtd.toFullString(((unwrap (get v.objectMap "__date__")).toNumber())))))
+                return (EvValueBridge.taggedString((dtd.toFullString(((unwrap (get v.objectMap "__date__")).toNumber())))))
             }
-            return (EvalValue.string(("[object " + (this.objectClassOf(v)) + "]")))
+            return (EvValueBridge.taggedString(("[object " + (this.objectClassOf(v)) + "]")))
         }
         if (v.valueType == 4) {
-            return (EvalValue.string((this.arrayJoinString(v ","))))
+            return (EvValueBridge.taggedString((this.arrayJoinString(v ","))))
         }
         if (v.valueType == 6) {
-            return (EvalValue.string((this.functionSourceText(v))))
+            return (EvValueBridge.taggedString((this.functionSourceText(v))))
         }
-        return (EvalValue.string(("[object " + (this.objectClassOf(v)) + "]")))
+        return (EvValueBridge.taggedString(("[object " + (this.objectClassOf(v)) + "]")))
     }
 
     ; D-DATE: the DEFAULT hint -- no hint at all -- behaves as the NUMBER hint
@@ -14918,7 +14918,7 @@ class ComponentEngine {
         }
         def r1:EvalValue (this.callPrimitiveMethod(v first))
         if scriptThrew {
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         if primitiveMethodUsable {
             return r1
@@ -14939,7 +14939,7 @@ class ComponentEngine {
         }
         def r2:EvalValue (this.callPrimitiveMethod(v second))
         if scriptThrew {
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         if primitiveMethodUsable {
             return r2
@@ -15186,13 +15186,13 @@ class ComponentEngine {
 
     fn toNumberOf:double (v:EvalValue) {
         def p:EvalValue (this.toPrimitive(v false))
-        if (p.isString()) {
+        if (EvValueBridge.isString(p)) {
             return (this.stringToNumber(p.stringValue))
         }
-        if (p.isUndefined()) {
+        if (EvValueBridge.isUndefined(p)) {
             return (0.0 / 0.0)
         }
-        if (p.isNull()) {
+        if (EvValueBridge.isNull(p)) {
             return 0.0
         }
         return (p.toNumber())
@@ -15227,7 +15227,7 @@ class ComponentEngine {
             if hasGet {
                 def g:EvalValue (this.descGet(d "get"))
                 if (g.valueType != 6) {
-                    if (false == (g.isUndefined())) {
+                    if (false == (EvValueBridge.isUndefined(g))) {
                         return "getter must be a function"
                     }
                 }
@@ -15235,7 +15235,7 @@ class ComponentEngine {
             if hasSet {
                 def st:EvalValue (this.descGet(d "set"))
                 if (st.valueType != 6) {
-                    if (false == (st.isUndefined())) {
+                    if (false == (EvValueBridge.isUndefined(st))) {
                         return "setter must be a function"
                     }
                 }
@@ -15272,21 +15272,21 @@ class ComponentEngine {
         def pattern:string ""
         def flags:string ""
         def sawFlags:boolean false
-        def srcRegex:EvalValue (EvalValue.null())
+        def srcRegex:EvalValue (EvValueBridge.taggedNull())
         if ((array_length argNodes) > 0) {
             def pv:EvalValue (this.evaluateExpr((itemAt argNodes 0)))
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             if (this.isRegexValue(pv)) {
                 srcRegex = pv
                 pattern = (this.regexSourceOf(pv))
                 flags = (this.regexFlagsOf(pv))
             } {
-                if (false == (pv.isUndefined())) {
+                if (false == (EvValueBridge.isUndefined(pv))) {
                     pattern = (this.toStringOf(pv))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                 }
             }
@@ -15294,12 +15294,12 @@ class ComponentEngine {
         if ((array_length argNodes) > 1) {
             def fv:EvalValue (this.evaluateExpr((itemAt argNodes 1)))
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
-            if (false == (fv.isUndefined())) {
+            if (false == (EvValueBridge.isUndefined(fv))) {
                 flags = (this.toStringOf(fv))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 sawFlags = true
             }
@@ -15334,7 +15334,7 @@ class ComponentEngine {
         def pattern:string ""
         def flags:string ""
         def sawFlags:boolean false
-        def srcRegex:EvalValue (EvalValue.null())
+        def srcRegex:EvalValue (EvValueBridge.taggedNull())
         if ((array_length args) > 0) {
             def pv:EvalValue (itemAt args 0)
             if (this.isRegexValue(pv)) {
@@ -15342,20 +15342,20 @@ class ComponentEngine {
                 pattern = (this.regexSourceOf(pv))
                 flags = (this.regexFlagsOf(pv))
             } {
-                if (false == (pv.isUndefined())) {
+                if (false == (EvValueBridge.isUndefined(pv))) {
                     pattern = (this.toStringOf(pv))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                 }
             }
         }
         if ((array_length args) > 1) {
             def fv:EvalValue (itemAt args 1)
-            if (false == (fv.isUndefined())) {
+            if (false == (EvValueBridge.isUndefined(fv))) {
                 flags = (this.toStringOf(fv))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 sawFlags = true
             }
@@ -15420,17 +15420,17 @@ class ComponentEngine {
         def keysR:[string]
         def valsR:[EvalValue]
         def r:EvalValue (EvalValue.object(keysR valsR))
-        r.setMember("__regex__" (EvalValue.string(pattern)))
+        r.setMember("__regex__" (EvValueBridge.taggedString(pattern)))
         r.setAttrs("__regex__" false false false)
-        r.setMember("source" (EvalValue.string(pattern)))
+        r.setMember("source" (EvValueBridge.taggedString(pattern)))
         r.setAttrs("source" false false false)
-        r.setMember("flags" (EvalValue.string(flags)))
+        r.setMember("flags" (EvValueBridge.taggedString(flags)))
         r.setAttrs("flags" false false false)
-        r.setMember("global" (EvalValue.boolean(((indexOf flags "g") >= 0))))
+        r.setMember("global" (EvValueBridge.taggedBoolean(((indexOf flags "g") >= 0))))
         r.setAttrs("global" false false false)
-        r.setMember("ignoreCase" (EvalValue.boolean(((indexOf flags "i") >= 0))))
+        r.setMember("ignoreCase" (EvValueBridge.taggedBoolean(((indexOf flags "i") >= 0))))
         r.setAttrs("ignoreCase" false false false)
-        r.setMember("multiline" (EvalValue.boolean(((indexOf flags "m") >= 0))))
+        r.setMember("multiline" (EvValueBridge.taggedBoolean(((indexOf flags "m") >= 0))))
         r.setAttrs("multiline" false false false)
         ; lastIndex is the one WRITABLE property -- exec advances it -- but it is
         ; not enumerable, so it never shows up in Object.keys or as a descriptor
@@ -15446,10 +15446,10 @@ class ComponentEngine {
     fn errorToString:string (e:EvalValue) {
         def nm:string "Error"
         def nv:EvalValue (e.getMember("name"))
-        if (nv.isString()) { nm = nv.stringValue }
+        if (EvValueBridge.isString(nv)) { nm = nv.stringValue }
         def msg:string ""
         def mv:EvalValue (e.getMember("message"))
-        if (mv.isString()) { msg = mv.stringValue }
+        if (EvValueBridge.isString(mv)) { msg = mv.stringValue }
         if ((strlen msg) == 0) {
             return nm
         }
@@ -15468,7 +15468,7 @@ class ComponentEngine {
 
     fn regexFlagsOf:string (v:EvalValue) {
         def f:EvalValue (v.getMember("flags"))
-        if (f.isString()) {
+        if (EvValueBridge.isString(f)) {
             return f.stringValue
         }
         return ""
@@ -15476,7 +15476,7 @@ class ComponentEngine {
 
     fn regexSourceOf:string (v:EvalValue) {
         def sv:EvalValue (v.getMember("source"))
-        if (sv.isString()) {
+        if (EvValueBridge.isString(sv)) {
             return sv.stringValue
         }
         return ""
@@ -15541,21 +15541,21 @@ class ComponentEngine {
     ; not "".
     fn regexResultArray:EvalValue (m:RegexMatch subject:string) {
         def items:[EvalValue]
-        push items (EvalValue.string((substring subject m.start m.end)))
+        push items (EvValueBridge.taggedString((substring subject m.start m.end)))
         def gi:int 1
         while (gi < (array_length m.capStart)) {
             def cs:int (itemAt m.capStart gi)
             def ce:int (itemAt m.capEnd gi)
             if (cs < 0) {
-                push items (EvalValue.undefined())
+                push items (EvValueBridge.taggedUndefined())
             } {
-                push items (EvalValue.string((substring subject cs ce)))
+                push items (EvValueBridge.taggedString((substring subject cs ce)))
             }
             gi = (gi + 1)
         }
         def arr:EvalValue (EvalValue.array(items))
         arr.setMember("index" (EvalValue.fromInt(m.start)))
-        arr.setMember("input" (EvalValue.string(subject)))
+        arr.setMember("input" (EvValueBridge.taggedString(subject)))
         return arr
     }
 
@@ -15571,7 +15571,7 @@ class ComponentEngine {
         }
         if (from > (strlen subject)) {
             re.setMember("lastIndex" (EvalValue.fromInt(0)))
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         def matcher (new RegexMatcher)
         matcher.setup(prog subject)
@@ -15580,7 +15580,7 @@ class ComponentEngine {
             if prog.global {
                 re.setMember("lastIndex" (EvalValue.fromInt(0)))
             }
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         if prog.global {
             re.setMember("lastIndex" (EvalValue.fromInt(m.end)))
@@ -15595,7 +15595,7 @@ class ComponentEngine {
         if (this.isRegexValue(v)) {
             return v
         }
-        if (v.isUndefined()) {
+        if (EvValueBridge.isUndefined(v)) {
             return (this.makeRegexValue("" ""))
         }
         ; null is NOT the empty pattern: `'gnulluna'.match(null)` looks for the
@@ -15683,20 +15683,20 @@ class ComponentEngine {
     ; offset and the whole subject.
     fn replacerArgs:[EvalValue] (m:RegexMatch subject:string) {
         def out:[EvalValue]
-        push out (EvalValue.string((substring subject m.start m.end)))
+        push out (EvValueBridge.taggedString((substring subject m.start m.end)))
         def gi:int 1
         while (gi < (array_length m.capStart)) {
             def cs:int (itemAt m.capStart gi)
             def ce:int (itemAt m.capEnd gi)
             if (cs < 0) {
-                push out (EvalValue.undefined())
+                push out (EvValueBridge.taggedUndefined())
             } {
-                push out (EvalValue.string((substring subject cs ce)))
+                push out (EvValueBridge.taggedString((substring subject cs ce)))
             }
             gi = (gi + 1)
         }
         push out (EvalValue.fromInt(m.start))
-        push out (EvalValue.string(subject))
+        push out (EvValueBridge.taggedString(subject))
         return out
     }
 
@@ -15726,10 +15726,10 @@ class ComponentEngine {
         if (v.isArray()) {
             return v.arrayValue
         }
-        if (v.isString()) {
+        if (EvValueBridge.isString(v)) {
             def si:int 0
             while (si < (strlen v.stringValue)) {
-                push out (EvalValue.string((substring v.stringValue si (si + 1))))
+                push out (EvValueBridge.taggedString((substring v.stringValue si (si + 1))))
                 si = (si + 1)
             }
             return out
@@ -15742,7 +15742,7 @@ class ComponentEngine {
         if scriptThrew {
             return out
         }
-        if (lenV.isUndefined()) {
+        if (EvValueBridge.isUndefined(lenV)) {
             return out
         }
         ; D-STRNUM: ToUint32 goes through the engine's ToNumber, which follows
@@ -15816,9 +15816,9 @@ class ComponentEngine {
             }
             return (EvValueBridge.taggedHole())
         }
-        if (recv.isString()) {
+        if (EvValueBridge.isString(recv)) {
             if (idx < (strlen recv.stringValue)) {
-                return (EvalValue.string((substring recv.stringValue idx (idx + 1))))
+                return (EvValueBridge.taggedString((substring recv.stringValue idx (idx + 1))))
             }
             return (EvValueBridge.taggedHole())
         }
@@ -15858,11 +15858,11 @@ class ComponentEngine {
         if (false == (recv.isArray())) {
             def lv:EvalValue (this.getPropertyValue(recv "length"))
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             n = (to_int (this.toNumberOf(lv)))
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             if (n < 0) { n = 0 }
             if (n > 1000000) { n = 1000000 }
@@ -15875,21 +15875,21 @@ class ComponentEngine {
             }
             def v:EvalValue (this.arrayElemAt(recv i))
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             def skip:boolean false
             if (EvValueBridge.isHole(v)) { skip = true }
-            if (v.isNull()) { skip = true }
-            if (v.isUndefined()) { skip = true }
+            if (EvValueBridge.isNull(v)) { skip = true }
+            if (EvValueBridge.isUndefined(v)) { skip = true }
             if (false == skip) {
                 out = (out + (this.toStringOf(v)))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
             }
             i = (i + 1)
         }
-        return (EvalValue.string(out))
+        return (EvValueBridge.taggedString(out))
     }
 
     ; D-ARRAYLIKE: a full [[Get]] of one property -- runs an accessor found
@@ -15918,11 +15918,11 @@ class ComponentEngine {
         }
         if (obj.hasSetterFor(key)) {
             if (false == (has obj.objectMap key)) {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
         }
         def direct:EvalValue (obj.getMember(key))
-        if (false == (direct.isUndefined())) {
+        if (false == (EvValueBridge.isUndefined(direct))) {
             return direct
         }
         ; D-PROTO: an ARRAY carries no prototype link of its own, so the value
@@ -15939,7 +15939,7 @@ class ComponentEngine {
     ; ToString: an object runs its own toString/valueOf, everything else answers
     ; for itself.
     fn toStringOf:string (v:EvalValue) {
-        if (v.isString()) {
+        if (EvValueBridge.isString(v)) {
             return v.stringValue
         }
         def p:EvalValue v
@@ -15948,7 +15948,7 @@ class ComponentEngine {
         if (v.valueType == 5) { p = (this.toPrimitive(v true)) }
         if (v.valueType == 4) { p = (this.toPrimitive(v true)) }
         if (v.valueType == 6) { p = (this.toPrimitive(v true)) }
-        if (p.isString()) {
+        if (EvValueBridge.isString(p)) {
             ; Bind before returning. `p` here is a value this scope OWNS --
             ; toPrimitive handed back a fresh one -- so returning its stringValue
             ; directly gave the caller a pointer into a value that scope exit
@@ -16020,8 +16020,8 @@ class ComponentEngine {
         def walk:EvalValue (this.protoOfValue(obj))
         def steps:int 0
         while (steps < 16) {
-            if (walk.isNull()) {
-                return (EvalValue.null())
+            if (EvValueBridge.isNull(walk)) {
+                return (EvValueBridge.taggedNull())
             }
             if (has walk.objectMap key) {
                 return (unwrap (get walk.objectMap key))
@@ -16042,7 +16042,7 @@ class ComponentEngine {
             walk = (this.protoOfValue(walk))
             steps = (steps + 1)
         }
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     ; D-ACCESSORS: the accessor a receiver would actually run, including one put
@@ -16144,14 +16144,14 @@ class ComponentEngine {
     }
 
     fn toPropertyKey:string (v:EvalValue) {
-        if (v.isString()) {
+        if (EvValueBridge.isString(v)) {
             return v.stringValue
         }
         def p:EvalValue v
         if (v.valueType == 5) { p = (this.toPrimitive(v true)) }
         if (v.valueType == 4) { p = (this.toPrimitive(v true)) }
         if (v.valueType == 6) { p = (this.toPrimitive(v true)) }
-        if (p.isString()) {
+        if (EvValueBridge.isString(p)) {
             ; Bind before returning. `p` here is a value this scope OWNS --
             ; toPrimitive handed back a fresh one -- so returning its stringValue
             ; directly gave the caller a pointer into a value that scope exit
@@ -16179,7 +16179,7 @@ class ComponentEngine {
         ; `Object.defineProperties(o, false)` boxes the boolean, finds no own
         ; enumerable property on it, and quietly returns o. Only null and
         ; undefined are a TypeError, and ToObject raises that itself.
-        if ((rawDescs.isNull()) || (rawDescs.isUndefined())) {
+        if ((EvValueBridge.isNull(rawDescs)) || (EvValueBridge.isUndefined(rawDescs))) {
             return "Properties must be an object"
         }
         def descs:EvalValue (this.toObjectValue(rawDescs))
@@ -16255,7 +16255,7 @@ class ComponentEngine {
             if (has walk.getterMap key) { return true }
             if (has walk.setterMap key) { return true }
             def nxt:EvalValue (this.protoOfValue(walk))
-            if (nxt.isNull()) {
+            if (EvValueBridge.isNull(nxt)) {
                 return false
             }
             walk = nxt
@@ -16282,19 +16282,19 @@ class ComponentEngine {
             ; A set-only accessor reads as undefined and does NOT fall through
             ; to whatever the prototype holds.
             if (has walk.setterMap key) {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             if (has walk.objectMap key) {
                 return (unwrap (get walk.objectMap key))
             }
             def nxt:EvalValue (this.protoOfValue(walk))
-            if (nxt.isNull()) {
-                return (EvalValue.undefined())
+            if (EvValueBridge.isNull(nxt)) {
+                return (EvValueBridge.taggedUndefined())
             }
             walk = nxt
             steps = (steps + 1)
         }
-        return (EvalValue.undefined())
+        return (EvValueBridge.taggedUndefined())
     }
 
     fn definePropertyOn:string (obj:EvalValue key:string desc:EvalValue) {
@@ -16408,7 +16408,7 @@ class ComponentEngine {
             ; value/writable. Recording nothing at all made it vanish.
             if (false == (has obj.getterMap key)) {
                 if (false == (has obj.setterMap key)) {
-                    obj.defineGetter(key (EvalValue.undefined()))
+                    obj.defineGetter(key (EvValueBridge.taggedUndefined()))
                 }
             }
             ; An accessor has no writable attribute of its own.
@@ -16425,7 +16425,7 @@ class ComponentEngine {
         ; Written through the raw map because setMember would refuse a second
         ; defineProperty on a non-writable property, while redefining a
         ; CONFIGURABLE one is allowed.
-        def newVal:EvalValue (EvalValue.undefined())
+        def newVal:EvalValue (EvValueBridge.taggedUndefined())
         if existed {
             if (has obj.objectMap key) {
                 newVal = (unwrap (get obj.objectMap key))
@@ -16674,7 +16674,7 @@ class ComponentEngine {
             if (aS.valueType == 6) {
                 obj.defineSetter(key aS)
             }
-            obj.setIndexAt(idx (EvalValue.undefined()))
+            obj.setIndexAt(idx (EvValueBridge.taggedUndefined()))
             this.applyDescriptorAttrs(obj key desc existedElem)
             obj.setAttrs(key false (obj.isEnumerable(key)) (obj.isConfigurable(key)))
             return ""
@@ -16685,7 +16685,7 @@ class ComponentEngine {
             ; Attributes only: an element that did not exist becomes a present
             ; undefined, which is what a descriptor without a value creates.
             if ((EvValueBridge.isHole((itemAt obj.arrayValue idx)))) {
-                obj.setIndexAt(idx (EvalValue.undefined()))
+                obj.setIndexAt(idx (EvValueBridge.taggedUndefined()))
             }
         }
         this.applyDescriptorAttrs(obj key desc existedElem)
@@ -16728,7 +16728,7 @@ class ComponentEngine {
         if (h.valueType == 6) {
             return h
         }
-        return (EvalValue.undefined())
+        return (EvValueBridge.taggedUndefined())
     }
 
     fn redefineError:string (obj:EvalValue key:string desc:EvalValue) {
@@ -16873,7 +16873,7 @@ class ComponentEngine {
             return
         }
         def sym:EvalValue (EvalValue.nativeFunction("Symbol"))
-        sym.setMember("name" (EvalValue.string("Symbol")))
+        sym.setMember("name" (EvValueBridge.taggedString("Symbol")))
         def wk:[string]
         push wk "iterator"
         push wk "asyncIterator"
@@ -16893,8 +16893,8 @@ class ComponentEngine {
             def keysS:[string]
             def valsS:[EvalValue]
             def s:EvalValue (EvalValue.object(keysS valsS))
-            s.setMember("__symbol__" (EvalValue.string(nm)))
-            s.setMember("description" (EvalValue.string(("Symbol." + nm))))
+            s.setMember("__symbol__" (EvValueBridge.taggedString(nm)))
+            s.setMember("description" (EvValueBridge.taggedString(("Symbol." + nm))))
             sym.setMember(nm s)
             i = (i + 1)
         }
@@ -16904,7 +16904,7 @@ class ComponentEngine {
         ; which is what keeps it DIRECT eval (running in the caller's scope)
         ; rather than an ordinary function call with its own frame.
         def ev:EvalValue (EvalValue.nativeFunction("eval"))
-        ev.setMember("name" (EvalValue.string("eval")))
+        ev.setMember("name" (EvValueBridge.taggedString("eval")))
         hostScope.define("eval" ev)
     }
 
@@ -16919,11 +16919,11 @@ class ComponentEngine {
         while (i < (array_length names)) {
             def nm:string (itemAt names i)
             def c:EvalValue (EvalValue.nativeFunction(nm))
-            c.setMember("name" (EvalValue.string(nm)))
+            c.setMember("name" (EvValueBridge.taggedString(nm)))
             ; §15.11.3: every native error constructor takes one argument.
             c.setMember("length" (EvalValue.fromInt(1)))
             c.setAttrs("length" false false true)
-            c.setMember("__errorctor__" (EvalValue.string(nm)))
+            c.setMember("__errorctor__" (EvValueBridge.taggedString(nm)))
             ; D-ERRORS: an error constructor has a real `prototype`, chained the
             ; way the spec chains them -- TypeError.prototype inherits from
             ; Error.prototype, which inherits from Object.prototype. Without it
@@ -16932,9 +16932,9 @@ class ComponentEngine {
             def keysE:[string]
             def valsE:[EvalValue]
             def proto:EvalValue (EvalValue.object(keysE valsE))
-            proto.setMember("name" (EvalValue.string(nm)))
+            proto.setMember("name" (EvValueBridge.taggedString(nm)))
             proto.setAttrs("name" true false true)
-            proto.setMember("message" (EvalValue.string("")))
+            proto.setMember("message" (EvValueBridge.taggedString("")))
             proto.setAttrs("message" true false true)
             proto.setMember("constructor" c)
             proto.setAttrs("constructor" true false true)
@@ -16982,9 +16982,9 @@ class ComponentEngine {
         def keys0:[string]
         def vals0:[EvalValue]
         def e:EvalValue (EvalValue.object(keys0 vals0))
-        e.setMember("name" (EvalValue.string(kind)))
-        e.setMember("message" (EvalValue.string(message)))
-        e.setMember("__error__" (EvalValue.string(kind)))
+        e.setMember("name" (EvValueBridge.taggedString(kind)))
+        e.setMember("message" (EvValueBridge.taggedString(message)))
+        e.setMember("__error__" (EvValueBridge.taggedString(kind)))
         def ctor:EvalValue (this.errorCtorFor(kind))
         if (ctor.valueType == 6) {
             e.setMember("constructor" ctor)
@@ -16998,7 +16998,7 @@ class ComponentEngine {
     fn throwSpecError:EvalValue (kind:string message:string) {
         scriptThrowValue = (this.makeError(kind message))
         scriptThrew = true
-        return (EvalValue.undefined())
+        return (EvValueBridge.taggedUndefined())
     }
 
     ; Names the engine resolves structurally rather than through a binding
@@ -17035,11 +17035,11 @@ class ComponentEngine {
         ; The value properties of the global object. `this.NaN` read undefined
         ; because they lived only as names the resolver knew about.
         if (false == (has g.objectMap "NaN")) {
-            g.setMember("NaN" (EvalValue.number((0.0 / 0.0))))
+            g.setMember("NaN" (EvValueBridge.taggedNumber((0.0 / 0.0))))
             g.setAttrs("NaN" false false false)
-            g.setMember("Infinity" (EvalValue.number((1.0 / 0.0))))
+            g.setMember("Infinity" (EvValueBridge.taggedNumber((1.0 / 0.0))))
             g.setAttrs("Infinity" false false false)
-            g.setMember("undefined" (EvalValue.undefined()))
+            g.setMember("undefined" (EvValueBridge.taggedUndefined()))
             g.setAttrs("undefined" false false false)
             ; The global FUNCTION properties. They are resolved by name at the
             ; call site, so `typeof this.parseInt` read undefined even though
@@ -17058,7 +17058,7 @@ class ComponentEngine {
             while (gi < (array_length gfns)) {
                 def gn:string (itemAt gfns gi)
                 def gf:EvalValue (EvalValue.nativeFunction(gn))
-                gf.setMember("name" (EvalValue.string(gn)))
+                gf.setMember("name" (EvValueBridge.taggedString(gn)))
                 gf.setAttrs("name" false false true)
                 gf.setMember("length" (EvalValue.fromInt(1)))
                 gf.setAttrs("length" false false true)
@@ -17117,7 +17117,7 @@ class ComponentEngine {
         ; per compare on the C++ target
         def nlen:int (strlen name)
         if ((nlen == 9) && (name == "undefined")) {
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         ; D-WITH: a name the with object serves through a GETTER. EvalContext
         ; cannot call it -- it has no evaluator -- so the read happens here.
@@ -17133,17 +17133,17 @@ class ComponentEngine {
             if (has wg.objectMap name) {
                 return (unwrap (get wg.objectMap name))
             }
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         ; D-IEEE: Infinity and NaN are VALUES, not merely names the engine knows
         ; about. They were resolving to undefined, so `x === -Infinity` compared
         ; against NaN and was false for every x — a comparison that silently
         ; never held.
         if ((nlen == 8) && (name == "Infinity")) {
-            return (EvalValue.number((1.0 / 0.0)))
+            return (EvValueBridge.taggedNumber((1.0 / 0.0)))
         }
         if ((nlen == 3) && (name == "NaN")) {
-            return (EvalValue.number((0.0 / 0.0)))
+            return (EvValueBridge.taggedNumber((0.0 / 0.0)))
         }
         def ctxHit@(optional):EvalValue (context.tryLookup(name))
         if ctxHit {
@@ -17175,7 +17175,7 @@ class ComponentEngine {
             if (g.valueType == 6) {
                 return g
             }
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         ; D-GLOBALTHIS: a bare name may have been created as a property of the
         ; global object (`this.p1 = 1` at top level), which is a global binding.
@@ -17191,30 +17191,30 @@ class ComponentEngine {
         def clsRef:TSNode (this.classNodeByName(name))
         if ((this.nodeKindOf(clsRef)) == 25) {
             def cv:EvalValue (EvalValue.nativeFunction(name))
-            cv.setMember("__classname__" (EvalValue.string(name)))
-            cv.setMember("name" (EvalValue.string(name)))
+            cv.setMember("__classname__" (EvValueBridge.taggedString(name)))
+            cv.setMember("name" (EvValueBridge.taggedString(name)))
             return cv
         }
         if strictReferences {
             return (this.throwSpecError("ReferenceError" (name + " is not defined")))
         }
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     fn typeofTag:string (val:EvalValue) {
-        if (val.isUndefined()) {
+        if (EvValueBridge.isUndefined(val)) {
             return "undefined"
         }
-        if (val.isNull()) {
+        if (EvValueBridge.isNull(val)) {
             return "object"
         }
-        if (val.isNumber()) {
+        if (EvValueBridge.isNumber(val)) {
             return "number"
         }
-        if (val.isString()) {
+        if (EvValueBridge.isString(val)) {
             return "string"
         }
-        if (val.isBoolean()) {
+        if (EvValueBridge.isBoolean(val)) {
             return "boolean"
         }
         if (val.isFunction()) {
@@ -17251,7 +17251,7 @@ class ComponentEngine {
             if ((this.nodeKindOf(argNode)) == 1) {
                 def name:string argNode.name
                 if (name == "undefined") {
-                    return (EvalValue.string("undefined"))
+                    return (EvValueBridge.taggedString("undefined"))
                 }
                 if (false == (this.bindingExists(name))) {
                     ; D-GLOBALOBJ: a built-in global is not a scope binding, but
@@ -17259,7 +17259,7 @@ class ComponentEngine {
                     ; "function", namespaces like Math and JSON report "object".
                     if (this.isEngineGlobalName(name)) {
                         if (this.isBuiltinCtorName(name)) {
-                            return (EvalValue.string("function"))
+                            return (EvValueBridge.taggedString("function"))
                         }
                         ; A VALUE property of the global -- NaN, Infinity -- is a
                         ; number, and asking builtinGlobalObject for it minted an
@@ -17268,23 +17268,23 @@ class ComponentEngine {
                         def gObjT:EvalValue (this.theGlobalObject())
                         if (gObjT.valueType == 5) {
                             if (has gObjT.objectMap name) {
-                                return (EvalValue.string((this.typeofTag((unwrap (get gObjT.objectMap name))))))
+                                return (EvValueBridge.taggedString((this.typeofTag((unwrap (get gObjT.objectMap name))))))
                             }
                         }
                         def gv:EvalValue (this.builtinGlobalObject(name))
                         if (gv.valueType == 5) {
-                            return (EvalValue.string("object"))
+                            return (EvValueBridge.taggedString("object"))
                         }
                     }
-                    return (EvalValue.string("undefined"))
+                    return (EvValueBridge.taggedString("undefined"))
                 }
                 def val:EvalValue (context.lookup(name))
-                return (EvalValue.string((this.typeofTag(val))))
+                return (EvValueBridge.taggedString((this.typeofTag(val))))
             }
             def val:EvalValue (this.evaluateExpr(argNode))
-            return (EvalValue.string((this.typeofTag(val))))
+            return (EvValueBridge.taggedString((this.typeofTag(val))))
         }
-        return (EvalValue.string("undefined"))
+        return (EvValueBridge.taggedString("undefined"))
     }
     
     fn evaluateUnaryExpr:EvalValue (node:TSNode) {
@@ -17314,10 +17314,10 @@ class ComponentEngine {
                             if strictMode {
                                 return (this.throwSpecError("TypeError" ("cannot delete " + delName)))
                             }
-                            return (EvalValue.boolean(false))
+                            return (EvValueBridge.taggedBoolean(false))
                         }
                         delWith.removeMember(delName)
-                        return (EvalValue.boolean(true))
+                        return (EvValueBridge.taggedBoolean(true))
                     }
                     ; A `delete` of a NAME is a SyntaxError in strict mode.
                     if strictMode {
@@ -17330,7 +17330,7 @@ class ComponentEngine {
                     if (gDel.valueType == 5) {
                         if (has gDel.objectMap delName) {
                             if (false == (gDel.isConfigurable(delName))) {
-                                return (EvalValue.boolean(false))
+                                return (EvValueBridge.taggedBoolean(false))
                             }
                         }
                     }
@@ -17340,7 +17340,7 @@ class ComponentEngine {
                         ; and the binding stays. Only a name created by
                         ; assignment to an undeclared identifier can go.
                         if (false == (has implicitGlobalSet delName)) {
-                            return (EvalValue.boolean(false))
+                            return (EvValueBridge.taggedBoolean(false))
                         }
                         def removed:boolean (context.removeBinding(delName))
                         def gObj:EvalValue (this.theGlobalObject())
@@ -17357,12 +17357,12 @@ class ComponentEngine {
                             ii = (ii + 1)
                         }
                         implicitGlobalSet = freshImplicit
-                        return (EvalValue.boolean(removed))
+                        return (EvValueBridge.taggedBoolean(removed))
                     }
-                    return (EvalValue.boolean(true))
+                    return (EvValueBridge.taggedBoolean(true))
                 }
                 if ((this.nodeKindOf(tgt)) == 3) {
-                    def obj:EvalValue (EvalValue.null())
+                    def obj:EvalValue (EvValueBridge.taggedNull())
                     if tgt.left {
                         obj = (this.evaluateExpr((unwrap tgt.left)))
                     }
@@ -17370,7 +17370,7 @@ class ComponentEngine {
                         if tgt.right {
                             def iv:EvalValue (this.evaluateExpr((unwrap tgt.right)))
                             if scriptThrew {
-                                return (EvalValue.undefined())
+                                return (EvValueBridge.taggedUndefined())
                             }
                             ; D-ARRAYLEN: deleting an ELEMENT leaves a hole and
                             ; does NOT shorten the array. removeMember only knows
@@ -17389,7 +17389,7 @@ class ComponentEngine {
                                         ; getter after `delete a[1]`.
                                         obj.removeMember(dkey)
                                         obj.setIndexAt(dn (EvValueBridge.taggedHole()))
-                                        return (EvalValue.boolean(true))
+                                        return (EvValueBridge.taggedBoolean(true))
                                     }
                                 }
                             }
@@ -17397,7 +17397,7 @@ class ComponentEngine {
                                 if strictMode {
                                     return (this.throwSpecError("TypeError" ("cannot delete " + dkey)))
                                 }
-                                return (EvalValue.boolean(false))
+                                return (EvValueBridge.taggedBoolean(false))
                             }
                             this.unmapArgIndex(obj dkey)
                             obj.removeMember(dkey)
@@ -17411,7 +17411,7 @@ class ComponentEngine {
                             if strictMode {
                                 return (this.throwSpecError("TypeError" ("cannot delete " + tgt.name)))
                             }
-                            return (EvalValue.boolean(false))
+                            return (EvValueBridge.taggedBoolean(false))
                         }
                         this.unmapArgIndex(obj tgt.name)
                         obj.removeMember(tgt.name)
@@ -17422,26 +17422,26 @@ class ComponentEngine {
                     }
                 }
             }
-            return (EvalValue.boolean(true))
+            return (EvValueBridge.taggedBoolean(true))
         }
         if node.left {
             def argExpr:TSNode (unwrap node.left)
             def arg:EvalValue (this.evaluateExpr(argExpr))
             
             if (opK == 49) {
-                return (EvalValue.boolean(((arg.toBool()) == false)))
+                return (EvValueBridge.taggedBoolean(((arg.toBool()) == false)))
             }
             if (opK == 21) {
                 ; D-IEEE: negate by MULTIPLYING by -1, not by subtracting from
                 ; zero. `0.0 - 0.0` is +0, so subtraction silently destroyed
                 ; negative zero and the engine had no -0 at all.
                 def negOne:double (0.0 - 1.0)
-                return (EvalValue.number((negOne * (this.toNumberOf(arg)))))
+                return (EvValueBridge.taggedNumber((negOne * (this.toNumberOf(arg)))))
             }
             if (opK == 20) {
                 ; ToNumber, not the value's own idea of a number: `+"0xff"` is
                 ; 255 and `+{valueOf: …}` runs the method.
-                return (EvalValue.number((this.toNumberOf(arg))))
+                return (EvValueBridge.taggedNumber((this.toNumberOf(arg))))
             }
             ; Bitwise NOT (~x == -(x)-1). Coerce to int32 like JS/AS.
             if (opK == 50) {
@@ -17449,11 +17449,11 @@ class ComponentEngine {
             }
             ; void x evaluates the operand for side effects and yields undefined.
             if (opK == 48) {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
         }
 
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     fn evaluateConditionalExpr:EvalValue (node:TSNode) {
@@ -17474,7 +17474,7 @@ class ComponentEngine {
             }
         }
         
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
     
     ; ---- user classes: instances, methods, `this`-bound dispatch ----------
@@ -17606,8 +17606,8 @@ class ComponentEngine {
         decl.name = nm
         set classes nm decl
         def cv:EvalValue (EvalValue.nativeFunction(nm))
-        cv.setMember("__classname__" (EvalValue.string(nm)))
-        cv.setMember("name" (EvalValue.string(node.name)))
+        cv.setMember("__classname__" (EvValueBridge.taggedString(nm)))
+        cv.setMember("name" (EvValueBridge.taggedString(node.name)))
         return cv
     }
 
@@ -17773,7 +17773,7 @@ class ComponentEngine {
                 while (bai < (array_length argNodes)) {
                     push bvals (this.evaluateExpr((itemAt argNodes bai)))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     bai = (bai + 1)
                 }
@@ -17834,7 +17834,7 @@ class ComponentEngine {
             while (ci < (array_length argNodes)) {
                 push ctorVals (this.evaluateExpr((itemAt argNodes ci)))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 ci = (ci + 1)
             }
@@ -17873,7 +17873,7 @@ class ComponentEngine {
         def savedReturnValue:EvalValue scriptReturnValue
         def savedModule:string currentModule
         scriptDidReturn = false
-        scriptReturnValue = (EvalValue.null())
+        scriptReturnValue = (EvValueBridge.taggedNull())
         ; Evaluate arg expressions (expanding ...spread) IN THE CALLER'S CONTEXT
         ; — an argument like `this.atlas` must see the caller's `this`, not the
         ; callee's. Only then create the call scope and bind `this`.
@@ -17882,7 +17882,7 @@ class ComponentEngine {
         while (i < (array_length argNodes)) {
             def an:TSNode (itemAt argNodes i)
             if (an.nodeType == "SpreadElement") {
-                def sv:EvalValue (EvalValue.null())
+                def sv:EvalValue (EvValueBridge.taggedNull())
                 if an.left {
                     sv = (this.evaluateExpr((unwrap an.left)))
                 }
@@ -17902,7 +17902,7 @@ class ComponentEngine {
             if scriptThrew {
                 scriptDidReturn = savedDidReturn
                 scriptReturnValue = savedReturnValue
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             i = (i + 1)
         }
@@ -18041,12 +18041,12 @@ class ComponentEngine {
                     if ((array_length node.children) > 0) {
                         def mv:EvalValue (this.evaluateExpr((itemAt node.children 0)))
                         if scriptThrew {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
-                        if (false == (mv.isUndefined())) {
+                        if (false == (EvValueBridge.isUndefined(mv))) {
                             msg = (this.toStringOf(mv))
                             if scriptThrew {
-                                return (EvalValue.undefined())
+                                return (EvValueBridge.taggedUndefined())
                             }
                         }
                     }
@@ -18109,7 +18109,7 @@ class ComponentEngine {
             if (ncKind == "MemberExpression") {
                 def protoTarget:EvalValue (this.evaluateExpr(newCallee))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 def notCtor:boolean false
                 if (protoTarget.valueType == 5) { notCtor = true }
@@ -18219,17 +18219,17 @@ class ComponentEngine {
                         ; does not -- so the value's own function name is the
                         ; fallback. Without it `var F = RegExp.prototype.constructor;
                         ; new F` built a plain object.
-                        if (false == (aliasName.isString())) {
+                        if (false == (EvValueBridge.isString(aliasName))) {
                             def aliasCtor:string (this.builtinCtorNameOf(aliasV))
                             if ((strlen aliasCtor) > 0) {
-                                aliasName = (EvalValue.string(aliasCtor))
+                                aliasName = (EvValueBridge.taggedString(aliasCtor))
                             }
                         }
-                        if (aliasName.isString()) {
+                        if (EvValueBridge.isString(aliasName)) {
                             def an:string aliasName.stringValue
                             if (this.isBuiltinCtorName(an)) {
                                 if (this.isWrapperCtorName(an)) {
-                                    def wPrim:EvalValue (EvalValue.null())
+                                    def wPrim:EvalValue (EvValueBridge.taggedNull())
                                     if ((array_length node.children) > 0) {
                                         wPrim = (this.evaluateExpr((itemAt node.children 0)))
                                     }
@@ -18239,7 +18239,7 @@ class ComponentEngine {
                                     return (this.buildArrayFromArgs(node.children))
                                 }
                                 if (an == "Object") {
-                                    def aObj:EvalValue (EvalValue.null())
+                                    def aObj:EvalValue (EvValueBridge.taggedNull())
                                     if ((array_length node.children) > 0) {
                                         aObj = (this.evaluateExpr((itemAt node.children 0)))
                                     }
@@ -18264,7 +18264,7 @@ class ComponentEngine {
         ; property, so `var o = new Object(); o.a = 1; o.a` read undefined. Both
         ; call forms now share one ToObject.
         if (className == "Object") {
-            def oArg:EvalValue (EvalValue.null())
+            def oArg:EvalValue (EvValueBridge.taggedNull())
             if ((array_length node.children) > 0) {
                 oArg = (this.evaluateExpr((itemAt node.children 0)))
             }
@@ -18281,7 +18281,7 @@ class ComponentEngine {
             while (dai < (array_length node.children)) {
                 push dtArgs (this.evaluateExpr((itemAt node.children dai)))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 dai = (dai + 1)
             }
@@ -18290,7 +18290,7 @@ class ComponentEngine {
         if (this.isWrapperCtorName(className)) {
             ; A NULL EvalValue here means "no argument was written", which the
             ; wrapper treats differently from an explicit undefined.
-            def prim:EvalValue (EvalValue.null())
+            def prim:EvalValue (EvValueBridge.taggedNull())
             if ((array_length node.children) > 0) {
                 prim = (this.evaluateExpr((itemAt node.children 0)))
             }
@@ -18315,7 +18315,7 @@ class ComponentEngine {
             if (cnt == "CallExpression") {
                 def calledV:EvalValue (this.evaluateExpr(calleeN))
                 if scriptThrew {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
                 if (calledV.valueType == 6) {
                     return (this.constructFromFunction(calledV (calledV.fnName()) node.children))
@@ -18358,14 +18358,14 @@ class ComponentEngine {
             }
         }
         if ((this.nodeKindOf(cls)) != 25) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         def keys0:[string]
         def vals0:[EvalValue]
         def inst:EvalValue (EvalValue.object(keys0 vals0))
-        inst.setMember("__class__" (EvalValue.string(className)))
+        inst.setMember("__class__" (EvValueBridge.taggedString(className)))
         if ((strlen clsModule) > 0) {
-            inst.setMember("__module__" (EvalValue.string(clsModule)))
+            inst.setMember("__module__" (EvValueBridge.taggedString(clsModule)))
         }
         ; field initialisers (PropertyDefinition) run with this=inst, rooted in
         ; the class's home module scope (a module class's `field = new Other()`
@@ -18433,7 +18433,7 @@ class ComponentEngine {
                 if (leftExpr.name == "Math") {
                     if (propName == "PI") {
                         def pi:double (M_PI)
-                        return (EvalValue.number(pi))
+                        return (EvValueBridge.taggedNumber(pi))
                     }
                 }
                 ; D-BUILTINPROTO: `Array.prototype`, `Object.prototype`, … as
@@ -18451,7 +18451,7 @@ class ComponentEngine {
             ; Same here: an unresolvable base is a ReferenceError, and it must
             ; not be overwritten by the property-of-undefined TypeError.
             if scriptThrew {
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
             ; D-PROTO: reading `F.prototype` MINTS it, and the object the spec
             ; mints already carries `constructor` back to F and inherits from
@@ -18480,9 +18480,9 @@ class ComponentEngine {
             ; before this point and must not throw.
             if strictReferences {
                 if (node.optional == false) {
-                    if ((obj.isNull()) || (obj.isUndefined())) {
+                    if ((EvValueBridge.isNull(obj)) || (EvValueBridge.isUndefined(obj))) {
                         def tgtDesc:string "undefined"
-                        if (obj.isNull()) {
+                        if (EvValueBridge.isNull(obj)) {
                             tgtDesc = "null"
                         }
                         def pn:string propName
@@ -18537,7 +18537,7 @@ class ComponentEngine {
                         }
                     } {
                         if (has obj.setterMap propName) {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         def gFn:EvalValue (this.resolveGetterOn(obj propName))
                         if (gFn.valueType == 6) {
@@ -18556,7 +18556,7 @@ class ComponentEngine {
                         }
                         ; An inherited set-only accessor reads as undefined too.
                         if (obj.hasSetterFor(propName)) {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                     }
                 }
@@ -18582,7 +18582,7 @@ class ComponentEngine {
                         if (this.objectProtoFallbackFor(mKind propName)) {
                             return (this.sharedNativeMethod("object" propName))
                         }
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     def owned:boolean (has obj.objectMap propName)
                     ; A property found on the PROTOTYPE CHAIN wins over the
@@ -18665,7 +18665,7 @@ class ComponentEngine {
                     def indexExpr:TSNode (unwrap node.right)
                     def indexVal:EvalValue (this.evaluateExpr(indexExpr))
                     if scriptThrew {
-                        return (EvalValue.undefined())
+                        return (EvValueBridge.taggedUndefined())
                     }
                     if (false == quiet) {
                         this.trace("  Index value: " + (indexVal.toString()) + " type=" + (to_string indexVal.valueType))
@@ -18675,8 +18675,8 @@ class ComponentEngine {
                     ; runs. Only the written form was checked, above, so the
                     ; getter was skipped and the read answered undefined.
                     def ckey:string ""
-                    if (indexVal.isString()) { ckey = indexVal.stringValue }
-                    if (indexVal.isNumber()) { ckey = (this.toPropertyKey(indexVal)) }
+                    if (EvValueBridge.isString(indexVal)) { ckey = indexVal.stringValue }
+                    if (EvValueBridge.isNumber(indexVal)) { ckey = (this.toPropertyKey(indexVal)) }
                     ; D-ARGMAP: `arguments[0]` and the first named parameter are
                     ; ONE binding in sloppy mode, so a reassignment of either is
                     ; visible through the other. The object held a snapshot taken
@@ -18712,7 +18712,7 @@ class ComponentEngine {
                     if (obj.valueType == 4) {
                         def rk:string (this.toPropertyKey(indexVal))
                         if scriptThrew {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         def rIdx:int (this.canonicalArrayIndex(rk))
                         if (rIdx >= 0) {
@@ -18739,18 +18739,18 @@ class ComponentEngine {
                         }
                         def viaFar:EvalValue (obj.getMember(rk))
                         if (viaFar.valueType == 0) {
-                            return (EvalValue.undefined())
+                            return (EvValueBridge.taggedUndefined())
                         }
                         return viaFar
                     }
-                    if (indexVal.isNumber()) {
+                    if (EvValueBridge.isNumber(indexVal)) {
                         def idx:int (to_int (indexVal.toNumber()))
                         if (false == quiet) {
                             this.trace("  Getting index " + (to_string idx) + " from array of length " + (to_string (array_length obj.arrayValue)))
                         }
                         return (obj.getIndex(idx))
                     }
-                    if (indexVal.isString()) {
+                    if (EvValueBridge.isString(indexVal)) {
                         ; A string key that names an index reaches the character,
                         ; and a key that names nothing reads as undefined --
                         ; `'abc'['foo']` is undefined, not null.
@@ -18762,7 +18762,7 @@ class ComponentEngine {
                             }
                             def viaMember:EvalValue (obj.getMember(sk))
                             if (viaMember.valueType == 0) {
-                                return (EvalValue.undefined())
+                                return (EvValueBridge.taggedUndefined())
                             }
                             return viaMember
                         }
@@ -18803,13 +18803,13 @@ class ComponentEngine {
                 if (obj.valueType == 2) { primRecv = true }
                 if (obj.valueType == 3) { primRecv = true }
                 if primRecv {
-                    return (EvalValue.undefined())
+                    return (EvValueBridge.taggedUndefined())
                 }
             }
             return outMember
         }
 
-        return (EvalValue.null())
+        return (EvValueBridge.taggedNull())
     }
 
     fn evaluateArrayExpr:EvalValue (node:TSNode) {
@@ -18820,7 +18820,7 @@ class ComponentEngine {
             def elem:TSNode (itemAt node.children i)
             ; Array-literal spread: [...a, b] inlines a's elements.
             if (elem.nodeType == "SpreadElement") {
-                def sv:EvalValue (EvalValue.null())
+                def sv:EvalValue (EvValueBridge.taggedNull())
                 if elem.left {
                     sv = (this.evaluateExpr((unwrap elem.left)))
                 }
@@ -19043,7 +19043,7 @@ class ComponentEngine {
         }
         ; A string coerces to an object whose own keys are its character
         ; indices, which is what Object.keys('abc') returns.
-        if (v.isString()) {
+        if (EvValueBridge.isString(v)) {
             def si:int 0
             while (si < (strlen v.stringValue)) {
                 push out (to_string si)
@@ -19121,7 +19121,7 @@ class ComponentEngine {
             }
             return out
         }
-        if (v.isString()) {
+        if (EvValueBridge.isString(v)) {
             return (this.objectKeys(v))
         }
         def holdsProps:boolean (v.isObject())
@@ -19225,15 +19225,15 @@ class ComponentEngine {
     ; Serialise a value to JSON. undefined/functions become null (JSON has no such
     ; types); the internal __class__ tag on class instances is omitted.
     fn jsonStringify:string (v:EvalValue) {
-        if (v.isNull()) {
+        if (EvValueBridge.isNull(v)) {
             return "null"
         }
-        if (v.isUndefined()) {
+        if (EvValueBridge.isUndefined(v)) {
             return "null"
         }
         ; D-IEEE: JSON has no NaN or Infinity; both serialise as null. Emitting
         ; the literal text "NaN" produces JSON that will not parse back.
-        if (v.isNumber()) {
+        if (EvValueBridge.isNumber(v)) {
             def nv:double (v.toNumber())
             if (nv != nv) {
                 return "null"
@@ -19246,16 +19246,16 @@ class ComponentEngine {
                 return "null"
             }
         }
-        if (v.isBoolean()) {
+        if (EvValueBridge.isBoolean(v)) {
             if (v.toBool()) {
                 return "true"
             }
             return "false"
         }
-        if (v.isNumber()) {
+        if (EvValueBridge.isNumber(v)) {
             return (v.toString())
         }
-        if (v.isString()) {
+        if (EvValueBridge.isString(v)) {
             return (this.jsonQuote(v.stringValue))
         }
         if (v.isArray()) {
@@ -19338,13 +19338,13 @@ class ComponentEngine {
     }
     fn jsonParseValue:EvalValue () {
         if jsonFailed {
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         this.jsonSkipWs()
         def c:string (this.jsonPeek())
         if ((strlen c) == 0) {
             this.jsonFail("Unexpected end of JSON input")
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         if (c == "{") {
             return (this.jsonParseObject())
@@ -19353,28 +19353,28 @@ class ComponentEngine {
             return (this.jsonParseArray())
         }
         if (c == "\"") {
-            return (EvalValue.string((this.jsonParseString())))
+            return (EvValueBridge.taggedString((this.jsonParseString())))
         }
         if (c == "t") {
             if (this.jsonWord("true")) {
-                return (EvalValue.boolean(true))
+                return (EvValueBridge.taggedBoolean(true))
             }
             this.jsonFail("Unexpected token in JSON")
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         if (c == "f") {
             if (this.jsonWord("false")) {
-                return (EvalValue.boolean(false))
+                return (EvValueBridge.taggedBoolean(false))
             }
             this.jsonFail("Unexpected token in JSON")
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         if (c == "n") {
             if (this.jsonWord("null")) {
-                return (EvalValue.null())
+                return (EvValueBridge.taggedNull())
             }
             this.jsonFail("Unexpected token in JSON")
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         if (c == "-") {
             return (this.jsonParseNumber())
@@ -19383,7 +19383,7 @@ class ComponentEngine {
             return (this.jsonParseNumber())
         }
         this.jsonFail(("Unexpected token " + (c + " in JSON")))
-        return (EvalValue.undefined())
+        return (EvValueBridge.taggedUndefined())
     }
     ; JSONString: double quotes, no raw control character below U+0020, and only
     ; the eight escapes the grammar names (plus \uXXXX with four hex digits).
@@ -19484,7 +19484,7 @@ class ComponentEngine {
             ; A digit straight after a leading zero is an error: `01` is not JSON.
             if (this.isDigitStr((this.jsonPeek()))) {
                 this.jsonFail("Unexpected number in JSON")
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
         } {
             while (this.isDigitStr((this.jsonPeek()))) {
@@ -19494,7 +19494,7 @@ class ComponentEngine {
         }
         if (intDigits == 0) {
             this.jsonFail("Unexpected token in JSON")
-            return (EvalValue.undefined())
+            return (EvValueBridge.taggedUndefined())
         }
         if ((this.jsonPeek()) == ".") {
             jsonPos = (jsonPos + 1)
@@ -19505,7 +19505,7 @@ class ComponentEngine {
             }
             if (fracDigits == 0) {
                 this.jsonFail("Unexpected token in JSON")
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
         }
         def ec:string (this.jsonPeek())
@@ -19522,16 +19522,16 @@ class ComponentEngine {
             }
             if (expDigits == 0) {
                 this.jsonFail("Unexpected token in JSON")
-                return (EvalValue.undefined())
+                return (EvValueBridge.taggedUndefined())
             }
         }
         def numStr:string (substring jsonSrc start jsonPos)
         def d@(optional):double (to_double numStr)
         if d {
-            return (EvalValue.number((unwrap d)))
+            return (EvValueBridge.taggedNumber((unwrap d)))
         }
         this.jsonFail("Unexpected number in JSON")
-        return (EvalValue.undefined())
+        return (EvValueBridge.taggedUndefined())
     }
     fn isDigitStr:boolean (ch:string) {
         if ((strlen ch) == 0) {
@@ -19693,13 +19693,13 @@ class ComponentEngine {
                         def valueNode:TSNode (unwrap prop.left)
                         push values (this.evaluateExpr(valueNode))
                     } {
-                        push values (EvalValue.null())
+                        push values (EvValueBridge.taggedNull())
                     }
                 }
             }
             ; Object-literal spread: {...o, k: v} copies o's own keys first.
             if (prop.nodeType == "SpreadElement") {
-                def sv:EvalValue (EvalValue.null())
+                def sv:EvalValue (EvValueBridge.taggedNull())
                 if prop.left {
                     sv = (this.evaluateExpr((unwrap prop.left)))
                 }
@@ -20002,27 +20002,27 @@ class ComponentEngine {
         
         ; format
         push propNames "format"
-        def formatVal:EvalValue (EvalValue.string(printFormat))
+        def formatVal:EvalValue (EvValueBridge.taggedString(printFormat))
         push propValues formatVal
         
         ; width
         push propNames "width"
-        def widthVal:EvalValue (EvalValue.number(pageWidth))
+        def widthVal:EvalValue (EvValueBridge.taggedNumber(pageWidth))
         push propValues widthVal
         
         ; height
         push propNames "height"
-        def heightVal:EvalValue (EvalValue.number(pageHeight))
+        def heightVal:EvalValue (EvValueBridge.taggedNumber(pageHeight))
         push propValues heightVal
         
         ; orientation
         push propNames "orientation"
-        def orientVal:EvalValue (EvalValue.string(printOrientation))
+        def orientVal:EvalValue (EvValueBridge.taggedString(printOrientation))
         push propValues orientVal
         
         ; pageCount
         push propNames "pageCount"
-        def pageCountVal:EvalValue (EvalValue.number((to_double printPageCount)))
+        def pageCountVal:EvalValue (EvValueBridge.taggedNumber((to_double printPageCount)))
         push propValues pageCountVal
         
         ; margins object
@@ -20030,13 +20030,13 @@ class ComponentEngine {
         def marginNames:[string]
         def marginValues:[EvalValue]
         push marginNames "top"
-        push marginValues (EvalValue.number(printMarginTop))
+        push marginValues (EvValueBridge.taggedNumber(printMarginTop))
         push marginNames "right"
-        push marginValues (EvalValue.number(printMarginRight))
+        push marginValues (EvValueBridge.taggedNumber(printMarginRight))
         push marginNames "bottom"
-        push marginValues (EvalValue.number(printMarginBottom))
+        push marginValues (EvValueBridge.taggedNumber(printMarginBottom))
         push marginNames "left"
-        push marginValues (EvalValue.number(printMarginLeft))
+        push marginValues (EvValueBridge.taggedNumber(printMarginLeft))
         def marginsVal:EvalValue (EvalValue.object(marginNames marginValues))
         push propValues marginsVal
         
@@ -20051,7 +20051,7 @@ class ComponentEngine {
         
         ; direction (N, S, E, W)
         push names "direction"
-        push values (EvalValue.string(direction))
+        push values (EvValueBridge.taggedString(direction))
         
         ; Parse the coordinate string format: "43° 28' 1.49""
         ; Or it might be decimal format: "43.4670833"
@@ -20128,19 +20128,19 @@ class ComponentEngine {
         
         ; degrees
         push names "degrees"
-        push values (EvalValue.number(degrees))
+        push values (EvValueBridge.taggedNumber(degrees))
         
         ; minutes
         push names "minutes"
-        push values (EvalValue.number(minutes))
+        push values (EvValueBridge.taggedNumber(minutes))
         
         ; seconds
         push names "seconds"
-        push values (EvalValue.number(seconds))
+        push values (EvValueBridge.taggedNumber(seconds))
         
         ; originalValue
         push names "originalValue"
-        push values (EvalValue.string(originalValue))
+        push values (EvValueBridge.taggedString(originalValue))
         
         return (EvalValue.object(names values))
     }
@@ -20171,7 +20171,7 @@ class ComponentEngine {
         
         ; Return null object if no date string
         if ((strlen dateStr) < 10) {
-            return (EvalValue.null())
+            return (EvValueBridge.taggedNull())
         }
         
         ; Parse EXIF format: "YYYY:MM:DD HH:MM:SS"
@@ -20239,22 +20239,22 @@ class ComponentEngine {
         
         ; Store numeric values
         push names "year"
-        push values (EvalValue.number((to_double year)))
+        push values (EvValueBridge.taggedNumber((to_double year)))
         
         push names "month"
-        push values (EvalValue.number((to_double month)))
+        push values (EvValueBridge.taggedNumber((to_double month)))
         
         push names "day"
-        push values (EvalValue.number((to_double day)))
+        push values (EvValueBridge.taggedNumber((to_double day)))
         
         push names "hour"
-        push values (EvalValue.number((to_double hour)))
+        push values (EvValueBridge.taggedNumber((to_double hour)))
         
         push names "minute"
-        push values (EvalValue.number((to_double minute)))
+        push values (EvValueBridge.taggedNumber((to_double minute)))
         
         push names "second"
-        push values (EvalValue.number((to_double second)))
+        push values (EvValueBridge.taggedNumber((to_double second)))
         
         ; Month name
         push names "monthName"
@@ -20271,7 +20271,7 @@ class ComponentEngine {
         if (month == 10) { monthName = "October" }
         if (month == 11) { monthName = "November" }
         if (month == 12) { monthName = "December" }
-        push values (EvalValue.string(monthName))
+        push values (EvValueBridge.taggedString(monthName))
         
         ; Short month name
         push names "monthShort"
@@ -20288,7 +20288,7 @@ class ComponentEngine {
         if (month == 10) { monthShort = "Oct" }
         if (month == 11) { monthShort = "Nov" }
         if (month == 12) { monthShort = "Dec" }
-        push values (EvalValue.string(monthShort))
+        push values (EvValueBridge.taggedString(monthShort))
         
         ; Calculate weekday using Zeller's formula (simplified)
         ; This gives 0=Saturday, 1=Sunday, ... 6=Friday
@@ -20328,7 +20328,7 @@ class ComponentEngine {
         if (weekdayNum == 4) { weekdayName = "Thursday" }
         if (weekdayNum == 5) { weekdayName = "Friday" }
         if (weekdayNum == 6) { weekdayName = "Saturday" }
-        push values (EvalValue.string(weekdayName))
+        push values (EvValueBridge.taggedString(weekdayName))
         
         ; Short weekday name
         push names "weekdayShort"
@@ -20340,11 +20340,11 @@ class ComponentEngine {
         if (weekdayNum == 4) { weekdayShort = "Thu" }
         if (weekdayNum == 5) { weekdayShort = "Fri" }
         if (weekdayNum == 6) { weekdayShort = "Sat" }
-        push values (EvalValue.string(weekdayShort))
+        push values (EvValueBridge.taggedString(weekdayShort))
         
         ; Weekday number (0 = Sunday)
         push names "weekdayNumber"
-        push values (EvalValue.number((to_double weekdayNum)))
+        push values (EvValueBridge.taggedNumber((to_double weekdayNum)))
         
         ; Time of day (verbal description based on hour)
         push names "timeOfDay"
@@ -20364,14 +20364,14 @@ class ComponentEngine {
         if ((hour >= 21) || (hour < 5)) {
             timeOfDay = "night"
         }
-        push values (EvalValue.string(timeOfDay))
+        push values (EvValueBridge.taggedString(timeOfDay))
         
         ; Is it AM or PM
         push names "ampm"
         if (hour < 12) {
-            push values (EvalValue.string("AM"))
+            push values (EvValueBridge.taggedString("AM"))
         } {
-            push values (EvalValue.string("PM"))
+            push values (EvValueBridge.taggedString("PM"))
         }
         
         ; Hour in 12-hour format
@@ -20384,7 +20384,7 @@ class ComponentEngine {
                 hour12 = hour - 12
             }
         }
-        push values (EvalValue.number((to_double hour12)))
+        push values (EvValueBridge.taggedNumber((to_double hour12)))
         
         ; Formatted strings for convenience
         ; ISO format: 2025-07-17
@@ -20393,7 +20393,7 @@ class ComponentEngine {
         if (month < 10) { monthPad = "0" + monthPad }
         def dayPad:string (to_string day)
         if (day < 10) { dayPad = "0" + dayPad }
-        push values (EvalValue.string((to_string year) + "-" + monthPad + "-" + dayPad))
+        push values (EvValueBridge.taggedString((to_string year) + "-" + monthPad + "-" + dayPad))
         
         ; Time: 19:22:41
         push names "time"
@@ -20403,19 +20403,19 @@ class ComponentEngine {
         if (minute < 10) { minPad = "0" + minPad }
         def secPad:string (to_string second)
         if (second < 10) { secPad = "0" + secPad }
-        push values (EvalValue.string(hourPad + ":" + minPad + ":" + secPad))
+        push values (EvValueBridge.taggedString(hourPad + ":" + minPad + ":" + secPad))
         
         ; Full formatted: "Thursday, July 17, 2025"
         push names "formatted"
-        push values (EvalValue.string(weekdayName + ", " + monthName + " " + (to_string day) + ", " + (to_string year)))
+        push values (EvValueBridge.taggedString(weekdayName + ", " + monthName + " " + (to_string day) + ", " + (to_string year)))
         
         ; Short formatted: "Jul 17, 2025"
         push names "shortFormatted"
-        push values (EvalValue.string(monthShort + " " + (to_string day) + ", " + (to_string year)))
+        push values (EvValueBridge.taggedString(monthShort + " " + (to_string day) + ", " + (to_string year)))
         
         ; Original value
         push names "originalValue"
-        push values (EvalValue.string(dateStr))
+        push values (EvValueBridge.taggedString(dateStr))
         
         return (EvalValue.object(names values))
     }
@@ -20491,26 +20491,26 @@ class ComponentEngine {
         
         ; Store the resolved path so ResourceLoader can use it
         push propNames "resolvedPath"
-        push propValues (EvalValue.string(resolvedPath))
+        push propValues (EvValueBridge.taggedString(resolvedPath))
         
         ; Get actual values from metadata
         ; width
         push propNames "width"
-        push propValues (EvalValue.number((to_double metadata.width)))
+        push propValues (EvValueBridge.taggedNumber((to_double metadata.width)))
         
         ; height
         push propNames "height"
-        push propValues (EvalValue.number((to_double metadata.height)))
+        push propValues (EvValueBridge.taggedNumber((to_double metadata.height)))
         
         ; createdAt - use dateTimeOriginal if available
         push propNames "createdAt"
         if ((strlen metadata.dateTimeOriginal) > 0) {
-            push propValues (EvalValue.string(metadata.dateTimeOriginal))
+            push propValues (EvValueBridge.taggedString(metadata.dateTimeOriginal))
         } {
             if ((strlen metadata.dateTime) > 0) {
-                push propValues (EvalValue.string(metadata.dateTime))
+                push propValues (EvValueBridge.taggedString(metadata.dateTime))
             } {
-                push propValues (EvalValue.null())
+                push propValues (EvValueBridge.taggedNull())
             }
         }
         
@@ -20523,14 +20523,14 @@ class ComponentEngine {
             } {
                 cameraStr = metadata.cameraModel
             }
-            push propValues (EvalValue.string(cameraStr))
+            push propValues (EvValueBridge.taggedString(cameraStr))
         } {
-            push propValues (EvalValue.null())
+            push propValues (EvValueBridge.taggedNull())
         }
         
         ; orientation
         push propNames "orientation"
-        push propValues (EvalValue.number((to_double metadata.orientation)))
+        push propValues (EvValueBridge.taggedNumber((to_double metadata.orientation)))
         
         ; gps - create nested object with parsed components if available
         push propNames "gps"
@@ -20550,32 +20550,32 @@ class ComponentEngine {
             
             if ((strlen metadata.gpsAltitude) > 0) {
                 push gpsNames "altitude"
-                push gpsValues (EvalValue.string(metadata.gpsAltitude))
+                push gpsValues (EvValueBridge.taggedString(metadata.gpsAltitude))
             }
             push propValues (EvalValue.object(gpsNames gpsValues))
         } {
-            push propValues (EvalValue.null())
+            push propValues (EvValueBridge.taggedNull())
         }
         
         ; colorSpace - based on color components
         push propNames "colorSpace"
         if (metadata.colorComponents == 1) {
-            push propValues (EvalValue.string("Grayscale"))
+            push propValues (EvValueBridge.taggedString("Grayscale"))
         } {
             if (metadata.colorComponents == 3) {
-                push propValues (EvalValue.string("RGB"))
+                push propValues (EvValueBridge.taggedString("RGB"))
             } {
                 if (metadata.colorComponents == 4) {
-                    push propValues (EvalValue.string("CMYK"))
+                    push propValues (EvValueBridge.taggedString("CMYK"))
                 } {
-                    push propValues (EvalValue.string("Unknown"))
+                    push propValues (EvValueBridge.taggedString("Unknown"))
                 }
             }
         }
         
         ; bitsPerComponent
         push propNames "bitsPerComponent"
-        push propValues (EvalValue.number((to_double metadata.bitsPerComponent)))
+        push propValues (EvValueBridge.taggedNumber((to_double metadata.bitsPerComponent)))
         
         ; features - flags indicating what EXIF data is available
         push propNames "features"
@@ -20585,26 +20585,26 @@ class ComponentEngine {
         ; hasExif - true if we have any EXIF data
         push featNames "hasExif"
         def hasExif:boolean (((strlen metadata.dateTimeOriginal) > 0) || ((strlen metadata.cameraModel) > 0) || metadata.hasGPS || (metadata.orientation > 1))
-        push featValues (EvalValue.boolean(hasExif))
+        push featValues (EvValueBridge.taggedBoolean(hasExif))
         
         ; hasGps
         push featNames "hasGps"
-        push featValues (EvalValue.boolean(metadata.hasGPS))
+        push featValues (EvValueBridge.taggedBoolean(metadata.hasGPS))
         
         ; hasDateTime
         push featNames "hasDateTime"
         def hasDateTime:boolean (((strlen metadata.dateTimeOriginal) > 0) || ((strlen metadata.dateTime) > 0))
-        push featValues (EvalValue.boolean(hasDateTime))
+        push featValues (EvValueBridge.taggedBoolean(hasDateTime))
         
         ; hasCamera
         push featNames "hasCamera"
         def hasCamera:boolean ((strlen metadata.cameraModel) > 0)
-        push featValues (EvalValue.boolean(hasCamera))
+        push featValues (EvValueBridge.taggedBoolean(hasCamera))
         
         ; hasOrientation
         push featNames "hasOrientation"
         def hasOrientation:boolean (metadata.orientation > 1)
-        push featValues (EvalValue.boolean(hasOrientation))
+        push featValues (EvValueBridge.taggedBoolean(hasOrientation))
         
         push propValues (EvalValue.object(featNames featValues))
         
@@ -20616,7 +20616,7 @@ class ComponentEngine {
             if ((strlen metadata.dateTime) > 0) {
                 push propValues (this.parseDateInfo(metadata.dateTime))
             } {
-                push propValues (EvalValue.null())
+                push propValues (EvValueBridge.taggedNull())
             }
         }
         

--- a/gallery/game_engine/v2/interp/migrate/src/ComponentEngine.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/ComponentEngine.rgr
@@ -1050,7 +1050,7 @@ class ComponentEngine {
         sym.functionNode = fnNode
         sym.helperFunctions = helperFns
         this.upsertLocalComponent(sym)
-        def __fnv:EvalValue (EvalValue.function(fnNode))
+        def __fnv:EvalValue (EvValueBridge.taggedFunction(fnNode))
         __fnv.setStrictFn((this.strictForBody(fnNode)))
         __fnv.setSrcText(currentSource)
         this.defineModuleBinding(localName __fnv)
@@ -1085,7 +1085,7 @@ class ComponentEngine {
             def exportName:string (itemAt exportNames k)
             def localName:string (itemAt localNames k)
             def existing:EvalValue (moduleScope.lookup(exportName))
-            if (existing.isFunction()) {
+            if (EvValueBridge.isFunction(existing)) {
                 if (null? existing.functionNode) {
                 } {
                     def fnNode:TSNode (unwrap existing.functionNode)
@@ -1174,7 +1174,7 @@ class ComponentEngine {
 
     ; Inject a global binding (object/function/value) into the top-level scope
     ; so evaluated scripts can reference it by name, e.g. registerGlobal("game",
-    ; EvalValue.object(...)) exposes `game` to the script.
+    ; EvValueBridge.taggedObject(...)) exposes `game` to the script.
     fn registerGlobal:void (name:string value:EvalValue) {
         hostScope.define(name value)
     }
@@ -1409,7 +1409,7 @@ class ComponentEngine {
     fn buildNamespaceValue:EvalValue (name:string) {
         def ks:[string]
         def vs:[EvalValue]
-        def ns:EvalValue (EvalValue.object(ks vs))
+        def ns:EvalValue (EvValueBridge.taggedObject(ks vs))
         ns.setMember("__nsmodule__" (EvValueBridge.taggedString(name)))
         def sc:EvalContext (this.moduleScopeFor(name))
         def bnames:[string] (keys sc.bindings)
@@ -1459,7 +1459,7 @@ class ComponentEngine {
                 if argNode.left {
                     sv = (this.evaluateExpr((unwrap argNode.left)))
                 }
-                if (sv.isArray()) {
+                if (EvValueBridge.isArrayValue(sv)) {
                     def k:int 0
                     while (k < (array_length sv.arrayValue)) {
                         push args (itemAt sv.arrayValue k)
@@ -1674,7 +1674,7 @@ class ComponentEngine {
                 ; is legal and has no elements at all, and a RangeError for it
                 ; confused "too big to allocate" with "not a length".
                 if (slots > 10000000) {
-                    def bigArr2:EvalValue (EvalValue.array(items))
+                    def bigArr2:EvalValue (EvValueBridge.taggedArray(items))
                     bigArr2.declaredLength = slots
                     return bigArr2
                 }
@@ -1686,17 +1686,17 @@ class ComponentEngine {
                     push items (EvValueBridge.taggedHole())
                     si = (si + 1)
                 }
-                return (EvalValue.array(items))
+                return (EvValueBridge.taggedArray(items))
             }
             push items only
-            return (EvalValue.array(items))
+            return (EvValueBridge.taggedArray(items))
         }
         def i:int 0
         while (i < n) {
             push items (this.evaluateExpr((itemAt argNodes i)))
             i = (i + 1)
         }
-        return (EvalValue.array(items))
+        return (EvValueBridge.taggedArray(items))
     }
 
     ; D-FNCTOR: compile `Function(paramNames..., body)` into a real function
@@ -2069,7 +2069,7 @@ class ComponentEngine {
                         if ch.newNode {
                             def fnNode:TSNode (unwrap ch.newNode)
                             this.updateLocalComponentNode(ch.name fnNode)
-                            def __fnv:EvalValue (EvalValue.function(fnNode))
+                            def __fnv:EvalValue (EvValueBridge.taggedFunction(fnNode))
                             __fnv.setStrictFn((this.strictForBody(fnNode)))
                             __fnv.setSrcText(currentSource)
                             moduleScope.define(ch.name __fnv)
@@ -2098,14 +2098,14 @@ class ComponentEngine {
     ; non-function names return null.
     fn callFunction:EvalValue (name:string props:EvalValue) {
         def fnValue:EvalValue (context.lookup(name))
-        if (false == (fnValue.isFunction())) {
+        if (false == (EvValueBridge.isFunction(fnValue))) {
             ; Host lifecycle door: a name not in the entry scope may be a loaded
             ; virtual module's top-level function (e.g. the ranger:core
             ; __rgGameInit / __rgGameUpdate entry points — module scopes are
             ; isolated, so they are NOT entry bindings). Module functions carry
             ; their closure, so the call roots in their own module scope.
             def mv:EvalValue (this.lookupModuleExport(name))
-            if (mv.isFunction()) {
+            if (EvValueBridge.isFunction(mv)) {
                 if mv.functionNode {
                     def margs:[EvalValue]
                     push margs props
@@ -2138,7 +2138,7 @@ class ComponentEngine {
     ; element tree (for screen render functions).
     fn callRender:EVGElement (name:string props:EvalValue) {
         def fnValue:EvalValue (context.lookup(name))
-        if (false == (fnValue.isFunction())) {
+        if (false == (EvValueBridge.isFunction(fnValue))) {
             def empty (new EVGElement())
             return empty
         }
@@ -2423,7 +2423,7 @@ class ComponentEngine {
     fn materializeImportedNode:void (node:TSNode) {
         if ((this.nodeKindOf(node)) == 40) {
             if (node.name != "render") {
-                def __fnv:EvalValue (EvalValue.function(node))
+                def __fnv:EvalValue (EvValueBridge.taggedFunction(node))
                 __fnv.setStrictFn((this.strictForBody(node)))
                 __fnv.setSrcText(currentSource)
                 this.defineModuleBinding(node.name __fnv)
@@ -2622,7 +2622,7 @@ class ComponentEngine {
         sym.symbolType = "component"
         sym.functionNode = node
         this.upsertLocalComponent(sym)
-        def __fnv:EvalValue (EvalValue.function(node))
+        def __fnv:EvalValue (EvValueBridge.taggedFunction(node))
         __fnv.setStrictFn((this.strictForBody(node)))
         __fnv.setSrcText(currentSource)
         this.defineModuleBinding(node.name __fnv)
@@ -3048,14 +3048,14 @@ class ComponentEngine {
             } {
                 if (el.nodeType == "RestElement") {
                     def items:[EvalValue]
-                    if (value.isArray()) {
+                    if (EvValueBridge.isArrayValue(value)) {
                         def k:int idx
                         while (k < (array_length value.arrayValue)) {
                             push items (itemAt value.arrayValue k)
                             k = (k + 1)
                         }
                     }
-                    def restVal:EvalValue (EvalValue.array(items))
+                    def restVal:EvalValue (EvValueBridge.taggedArray(items))
                     ; D-DSTR: a rest element may itself be a pattern —
                     ; `[...[x, y]]` binds x and y from the collected tail. Only
                     ; the plain `...name` form was handled, so the nested case
@@ -3067,7 +3067,7 @@ class ComponentEngine {
                     }
                 } {
                     def elemVal:EvalValue (EvValueBridge.taggedUndefined())
-                    if (value.isArray()) {
+                    if (EvValueBridge.isArrayValue(value)) {
                         if (idx < (array_length value.arrayValue)) {
                             elemVal = (itemAt value.arrayValue idx)
                         }
@@ -3090,7 +3090,7 @@ class ComponentEngine {
             if (prop.nodeType == "RestElement") {
                 def rkeys:[string]
                 def rvals:[EvalValue]
-                if (value.isObject()) {
+                if (EvValueBridge.isObject(value)) {
                     def ks:[string] (keys value.objectMap)
                     def ki:int 0
                     while (ki < (array_length ks)) {
@@ -3102,7 +3102,7 @@ class ComponentEngine {
                         ki = (ki + 1)
                     }
                 }
-                context.define(prop.name (EvalValue.object(rkeys rvals)))
+                context.define(prop.name (EvValueBridge.taggedObject(rkeys rvals)))
             } {
                 def srcKey:string prop.name
                 push usedKeys srcKey
@@ -3881,7 +3881,7 @@ class ComponentEngine {
         ; Arrow function with expression body
         if ((body.nodeType == "JSXElement") || (body.nodeType == "JSXFragment")) {
             def el:EVGElement (this.evaluateJSX(body))
-            return (EvalValue.element(el))
+            return (EvValueBridge.taggedElement(el))
         }
         
         ; If body is a simple expression
@@ -3995,19 +3995,19 @@ class ComponentEngine {
             ; Normalise any iterable to a list of per-iteration values: array/Set
             ; elements as-is, Map entries as [key, value] pairs, string chars.
             def items:[EvalValue]
-            if (src.isArray()) {
+            if (EvValueBridge.isArrayValue(src)) {
                 items = src.arrayValue
             } {
-                if (src.isSet()) {
+                if (EvValueBridge.isSet(src)) {
                     items = src.arrayValue
                 } {
-                    if (src.isMap()) {
+                    if (EvValueBridge.isMap(src)) {
                         def k:int 0
                         while (k < (array_length src.arrayValue)) {
                             def pair:[EvalValue]
                             push pair (itemAt src.arrayValue k)
                             push pair (itemAt src.mapVals k)
-                            push items (EvalValue.array(pair))
+                            push items (EvValueBridge.taggedArray(pair))
                             k = (k + 1)
                         }
                     } {
@@ -5351,7 +5351,7 @@ class ComponentEngine {
                         def objValue:EvalValue (context.lookup(objName))
                         
                         ; Array.push()
-                        if ((methodName == "push") && (objValue.isArray())) {
+                        if ((methodName == "push") && (EvValueBridge.isArrayValue(objValue))) {
                             ; Get arguments from node.children
                             if ((array_length node.children) > 0) {
                                 def argNode:TSNode (itemAt node.children 0)
@@ -5465,7 +5465,7 @@ class ComponentEngine {
             def rightNode:TSNode (unwrap node.right)
             def arrayValue:EvalValue (this.evaluateExpr(rightNode))
             
-            if (arrayValue.isArray()) {
+            if (EvValueBridge.isArrayValue(arrayValue)) {
                 def i:int 0
                 while (i < (array_length arrayValue.arrayValue)) {
                     def item:EvalValue (itemAt arrayValue.arrayValue i)
@@ -6723,7 +6723,7 @@ class ComponentEngine {
         if needsArgs {
             def keysA:[string]
             def valsA:[EvalValue]
-            def argObj:EvalValue (EvalValue.object(keysA valsA))
+            def argObj:EvalValue (EvValueBridge.taggedObject(keysA valsA))
             def ai0:int 0
             while (ai0 < na) {
                 argObj.setMember((to_string ai0) (itemAt argVals ai0))
@@ -6894,7 +6894,7 @@ class ComponentEngine {
         push argMapScopes argCell
         argObj2.setMember("__argscope__" (EvalValue.fromInt(slot)))
         argObj2.setAttrs("__argscope__" false false false)
-        argObj2.setMember("__argnames__" (EvalValue.array(names)))
+        argObj2.setMember("__argnames__" (EvValueBridge.taggedArray(names)))
         argObj2.setAttrs("__argnames__" false false false)
     }
 
@@ -6980,7 +6980,7 @@ class ComponentEngine {
                     push items (itemAt argVals k)
                     k = (k + 1)
                 }
-                def restArr:EvalValue (EvalValue.array(items))
+                def restArr:EvalValue (EvValueBridge.taggedArray(items))
                 if param.left {
                     this.bindPattern((unwrap param.left) restArr)
                 } {
@@ -7068,7 +7068,7 @@ class ComponentEngine {
             return argNode
         }
         def v:EvalValue (this.evaluateExpr(argNode))
-        if (v.isFunction()) {
+        if (EvValueBridge.isFunction(v)) {
             if v.functionNode {
                 return (unwrap v.functionNode)
             }
@@ -7081,7 +7081,7 @@ class ComponentEngine {
     ; Wrap a function/arrow node as a value that captures the CURRENT scope, so it
     ; resolves free variables against where it was defined, not where it is called.
     fn captureClosure:EvalValue (fnNode:TSNode) {
-        def fv:EvalValue (EvalValue.function(fnNode))
+        def fv:EvalValue (EvValueBridge.taggedFunction(fnNode))
         ; D-STRICT: a function is strict if its own body says so or if the scope
         ; that created it was strict. Recorded here rather than asked at use
         ; time, because by then the defining scope is gone.
@@ -7262,7 +7262,7 @@ class ComponentEngine {
                 ; is legal and has no elements at all, and raising a RangeError
                 ; for it confused "too big to allocate" with "not a length".
                 if (slots > 10000000) {
-                    def bigArr:EvalValue (EvalValue.array(items))
+                    def bigArr:EvalValue (EvValueBridge.taggedArray(items))
                     bigArr.declaredLength = slots
                     return bigArr
                 }
@@ -7271,17 +7271,17 @@ class ComponentEngine {
                     push items (EvValueBridge.taggedHole())
                     si = (si + 1)
                 }
-                return (EvalValue.array(items))
+                return (EvValueBridge.taggedArray(items))
             }
             push items only
-            return (EvalValue.array(items))
+            return (EvValueBridge.taggedArray(items))
         }
         def i:int 0
         while (i < n) {
             push items (itemAt args i)
             i = (i + 1)
         }
-        return (EvalValue.array(items))
+        return (EvValueBridge.taggedArray(items))
     }
 
     fn callFnValueWithValues:EvalValue (fnValue:EvalValue argVals:[EvalValue]) {
@@ -7520,7 +7520,7 @@ class ComponentEngine {
         ; Fallback: any other expression (e.g. a helper call that returns JSX,
         ; like hud() -> playHud(...)). Evaluate it and unwrap the element result.
         def val:EvalValue (this.evaluateExpr(node))
-        if (val.isElement()) {
+        if (EvValueBridge.isElement(val)) {
             if (val.hasElement()) {
                 return (val.elementOf())
             }
@@ -7633,7 +7633,7 @@ class ComponentEngine {
                 while (hi < (array_length sym.helperFunctions)) {
                     def helperFn:TSNode (itemAt sym.helperFunctions hi)
                     def helperName:string helperFn.name
-                    def __fnv:EvalValue (EvalValue.function(helperFn))
+                    def __fnv:EvalValue (EvValueBridge.taggedFunction(helperFn))
                     __fnv.setStrictFn((this.strictForBody(helperFn)))
                     __fnv.setSrcText(currentSource)
                     def helperValue:EvalValue __fnv
@@ -7695,12 +7695,12 @@ class ComponentEngine {
                     push values (itemAt childElements 0)
                 } {
                     ; Multiple children - pass as array
-                    push values (EvalValue.array(childElements))
+                    push values (EvValueBridge.taggedArray(childElements))
                 }
             }
         }
         
-        return (EvalValue.object(keys values))
+        return (EvValueBridge.taggedObject(keys values))
     }
     
     ; Collect child JSX elements as EvalValue elements
@@ -7714,7 +7714,7 @@ class ComponentEngine {
             if (child.nodeType == "JSXElement") {
                 def el:EVGElement (this.evaluateJSXElement(child))
                 if ((strlen el.tagName) > 0) {
-                    push results (EvalValue.element(el))
+                    push results (EvValueBridge.taggedElement(el))
                 }
             }
             
@@ -7726,7 +7726,7 @@ class ComponentEngine {
                     def textEl (new EVGElement())
                     textEl.tagName = "text"
                     textEl.textContent = text
-                    push results (EvalValue.element(textEl))
+                    push results (EvValueBridge.taggedElement(textEl))
                 }
             }
             
@@ -7735,15 +7735,15 @@ class ComponentEngine {
                     def exprNode:TSNode (unwrap child.left)
                     def exprValue:EvalValue (this.evaluateExpr(exprNode))
                     
-                    if (exprValue.isElement()) {
+                    if (EvValueBridge.isElement(exprValue)) {
                         push results exprValue
                     }
-                    if (exprValue.isArray()) {
+                    if (EvValueBridge.isArrayValue(exprValue)) {
                         ; Flatten array elements into children
                         def ai:int 0
                         while (ai < (array_length exprValue.arrayValue)) {
                             def arrItem:EvalValue (itemAt exprValue.arrayValue ai)
-                            if (arrItem.isElement()) {
+                            if (EvValueBridge.isElement(arrItem)) {
                                 push results arrItem
                             }
                             ai = ai + 1
@@ -7937,11 +7937,11 @@ class ComponentEngine {
                 def callResult:EvalValue (this.evaluateExpr(exprNode))
                 
                 ; Handle array result (array of elements from function)
-                if (callResult.isArray()) {
+                if (EvValueBridge.isArrayValue(callResult)) {
                     def ai:int 0
                     while (ai < (array_length callResult.arrayValue)) {
                         def arrItem:EvalValue (itemAt callResult.arrayValue ai)
-                        if (arrItem.isElement()) {
+                        if (EvValueBridge.isElement(arrItem)) {
                             if (arrItem.hasElement()) {
                                 def arrChildEl:EVGElement (arrItem.elementOf())
                                 if ((strlen arrChildEl.tagName) > 0) {
@@ -7955,7 +7955,7 @@ class ComponentEngine {
                 }
                 
                 ; Handle single element result
-                if (callResult.isElement()) {
+                if (EvValueBridge.isElement(callResult)) {
                     if (callResult.hasElement()) {
                         def childEl:EVGElement (callResult.elementOf())
                         if ((strlen childEl.tagName) > 0) {
@@ -7995,7 +7995,7 @@ class ComponentEngine {
             def value:EvalValue (this.evaluateExpr(exprNode))
             
             ; Handle EVGElement values (e.g., {children} prop containing JSX)
-            if (value.isElement()) {
+            if (EvValueBridge.isElement(value)) {
                 if (value.hasElement()) {
                     def childEl:EVGElement (value.elementOf())
                     if ((strlen childEl.tagName) > 0) {
@@ -8006,11 +8006,11 @@ class ComponentEngine {
             }
             
             ; Handle arrays of EVGElements (e.g., {children} containing multiple elements)
-            if (value.isArray()) {
+            if (EvValueBridge.isArrayValue(value)) {
                 def ai:int 0
                 while (ai < (array_length value.arrayValue)) {
                     def arrItem:EvalValue (itemAt value.arrayValue ai)
-                    if (arrItem.isElement()) {
+                    if (EvValueBridge.isElement(arrItem)) {
                         if (arrItem.hasElement()) {
                             def arrChildEl:EVGElement (arrItem.elementOf())
                             if ((strlen arrChildEl.tagName) > 0) {
@@ -8046,7 +8046,7 @@ class ComponentEngine {
                         def arrayExpr:TSNode (unwrap calleeNode.left)
                         def arrayValue:EvalValue (this.evaluateExpr(arrayExpr))
                         
-                        if (arrayValue.isArray()) {
+                        if (EvValueBridge.isArrayValue(arrayValue)) {
                             ; Get the callback function
                             if ((array_length callNode.children) > 0) {
                                 def callback:TSNode (itemAt callNode.children 0)
@@ -8112,7 +8112,7 @@ class ComponentEngine {
                 ; generic expression body — e.g. (e, i) => buildTile(e, i) — is
                 ; evaluated like any expression; an element result is the child.
                 def v:EvalValue (this.evaluateExpr(body))
-                if (v.isElement()) {
+                if (EvValueBridge.isElement(v)) {
                     if (v.hasElement()) {
                         return (v.elementOf())
                     }
@@ -8415,7 +8415,7 @@ class ComponentEngine {
         ; JSX Element as expression (for props like children={<View/>})
         if (node.nodeType == "JSXElement") {
             def el:EVGElement (this.evaluateJSXElement(node))
-            return (EvalValue.element(el))
+            return (EvValueBridge.taggedElement(el))
         }
         
         ; JSX Fragment as expression
@@ -8424,7 +8424,7 @@ class ComponentEngine {
             def el (new EVGElement())
             el.tagName = "div"
             this.evaluateChildren(el node)
-            return (EvalValue.element(el))
+            return (EvValueBridge.taggedElement(el))
         }
         
         ; Call Expression (function calls)
@@ -8709,13 +8709,13 @@ class ComponentEngine {
                             push ofItems (this.evaluateExpr((itemAt node.children ofI)))
                             ofI = (ofI + 1)
                         }
-                        return (EvalValue.array(ofItems))
+                        return (EvValueBridge.taggedArray(ofItems))
                     }
                     if (methodName == "from") {
                         def frItems:[EvalValue]
                         if ((array_length node.children) > 0) {
                             def srcV:EvalValue (this.evaluateExpr((itemAt node.children 0)))
-                            if (srcV.isArray()) {
+                            if (EvValueBridge.isArrayValue(srcV)) {
                                 def fi:int 0
                                 while (fi < (array_length srcV.arrayValue)) {
                                     push frItems (itemAt srcV.arrayValue fi)
@@ -8730,7 +8730,7 @@ class ComponentEngine {
                                     sIdx = (sIdx + 1)
                                 }
                             }
-                            if (srcV.isSet()) {
+                            if (EvValueBridge.isSet(srcV)) {
                                 def stI:int 0
                                 while (stI < (array_length srcV.arrayValue)) {
                                     push frItems (itemAt srcV.arrayValue stI)
@@ -8738,14 +8738,14 @@ class ComponentEngine {
                                 }
                             }
                         }
-                        return (EvalValue.array(frItems))
+                        return (EvValueBridge.taggedArray(frItems))
                     }
                     if (methodName == "isArray") {
                         def tv:EvalValue (EvValueBridge.taggedNull())
                         if ((array_length node.children) > 0) {
                             tv = (this.evaluateExpr((itemAt node.children 0)))
                         }
-                        return (EvValueBridge.taggedBoolean((tv.isArray())))
+                        return (EvValueBridge.taggedBoolean((EvValueBridge.isArrayValue(tv))))
                     }
                 }
                 if (arrStaticName == "Number") {
@@ -8830,7 +8830,7 @@ class ComponentEngine {
                             }
                             i = (i + 1)
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (methodName == "values") {
                         def items:[EvalValue]
@@ -8843,7 +8843,7 @@ class ComponentEngine {
                             }
                             i = (i + 1)
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (methodName == "entries") {
                         def items:[EvalValue]
@@ -8855,11 +8855,11 @@ class ComponentEngine {
                                 def pair:[EvalValue]
                                 push pair (EvValueBridge.taggedString(k))
                                 push pair (src.getMember(k))
-                                push items (EvalValue.array(pair))
+                                push items (EvValueBridge.taggedArray(pair))
                             }
                             i = (i + 1)
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (methodName == "assign") {
                         def ai:int 1
@@ -8980,7 +8980,7 @@ class ComponentEngine {
                     if (methodName == "create") {
                         def keysC:[string]
                         def valsC:[EvalValue]
-                        def created:EvalValue (EvalValue.object(keysC valsC))
+                        def created:EvalValue (EvValueBridge.taggedObject(keysC valsC))
                         if (src.valueType == 5) {
                             created.protoRef = src
                         }
@@ -9026,7 +9026,7 @@ class ComponentEngine {
                             if ownAcc {
                                 def keysA:[string]
                                 def valsA:[EvalValue]
-                                def descA:EvalValue (EvalValue.object(keysA valsA))
+                                def descA:EvalValue (EvValueBridge.taggedObject(keysA valsA))
                                 def ga:EvalValue (EvValueBridge.taggedNull())
                                 if (has src.getterMap dk) {
                                     ga = (unwrap (get src.getterMap dk))
@@ -9059,11 +9059,11 @@ class ComponentEngine {
                             ; stringValue rather than objectMap, so the
                             ; descriptor came back undefined for a property that
                             ; plainly exists. `length` likewise.
-                            if (src.isArray()) {
+                            if (EvValueBridge.isArrayValue(src)) {
                                 if (dk == "length") {
                                     def keysL:[string]
                                     def valsL:[EvalValue]
-                                    def dL:EvalValue (EvalValue.object(keysL valsL))
+                                    def dL:EvalValue (EvValueBridge.taggedObject(keysL valsL))
                                     dL.setMember("value" (EvalValue.fromInt((array_length src.arrayValue))))
                                     dL.setMember("writable" (EvValueBridge.taggedBoolean(true)))
                                     dL.setMember("enumerable" (EvValueBridge.taggedBoolean(false)))
@@ -9078,7 +9078,7 @@ class ComponentEngine {
                                         if (false == ((EvValueBridge.isHole((itemAt src.arrayValue ai))))) {
                                             def keysI:[string]
                                             def valsI:[EvalValue]
-                                            def dI:EvalValue (EvalValue.object(keysI valsI))
+                                            def dI:EvalValue (EvValueBridge.taggedObject(keysI valsI))
                                             dI.setMember("value" (itemAt src.arrayValue ai))
                                             ; Recorded attributes win: an element
                                             ; defined through defineProperty is
@@ -9103,7 +9103,7 @@ class ComponentEngine {
                                 if (dk == "length") {
                                     def keysS:[string]
                                     def valsS:[EvalValue]
-                                    def dS:EvalValue (EvalValue.object(keysS valsS))
+                                    def dS:EvalValue (EvValueBridge.taggedObject(keysS valsS))
                                     dS.setMember("value" (EvalValue.fromInt((strlen src.stringValue))))
                                     dS.setMember("writable" (EvValueBridge.taggedBoolean(false)))
                                     dS.setMember("enumerable" (EvValueBridge.taggedBoolean(false)))
@@ -9116,7 +9116,7 @@ class ComponentEngine {
                                     if ((si2 >= 0) && (si2 < (strlen src.stringValue))) {
                                         def keysC:[string]
                                         def valsC2:[EvalValue]
-                                        def dC:EvalValue (EvalValue.object(keysC valsC2))
+                                        def dC:EvalValue (EvValueBridge.taggedObject(keysC valsC2))
                                         def se:int (si2 + 1)
                                         dC.setMember("value" (EvValueBridge.taggedString((substring src.stringValue si2 se))))
                                         dC.setMember("writable" (EvValueBridge.taggedBoolean(false)))
@@ -9136,7 +9136,7 @@ class ComponentEngine {
                                     if (false == (has src.objectMap dk)) {
                                         def keysF:[string]
                                         def valsF:[EvalValue]
-                                        def dF:EvalValue (EvalValue.object(keysF valsF))
+                                        def dF:EvalValue (EvValueBridge.taggedObject(keysF valsF))
                                         dF.setMember("value" (src.getMember(dk)))
                                         dF.setMember("writable" (EvValueBridge.taggedBoolean(false)))
                                         dF.setMember("enumerable" (EvValueBridge.taggedBoolean(false)))
@@ -9154,7 +9154,7 @@ class ComponentEngine {
                                     if (false == (has src.objectMap dk)) {
                                         def keysP:[string]
                                         def valsP:[EvalValue]
-                                        def dP:EvalValue (EvalValue.object(keysP valsP))
+                                        def dP:EvalValue (EvValueBridge.taggedObject(keysP valsP))
                                         dP.setMember("value" (src.getMember("prototype")))
                                         dP.setMember("writable" (EvValueBridge.taggedBoolean(true)))
                                         dP.setMember("enumerable" (EvValueBridge.taggedBoolean(false)))
@@ -9166,7 +9166,7 @@ class ComponentEngine {
                             if (this.objHasKey(src dk)) {
                                 def keysD:[string]
                                 def valsD:[EvalValue]
-                                def desc:EvalValue (EvalValue.object(keysD valsD))
+                                def desc:EvalValue (EvValueBridge.taggedObject(keysD valsD))
                                 desc.setMember("value" (src.getMember(dk)))
                                 desc.setMember("writable" (EvValueBridge.taggedBoolean((src.isWritable(dk)))))
                                 desc.setMember("enumerable" (EvValueBridge.taggedBoolean((src.isEnumerable(dk)))))
@@ -9214,7 +9214,7 @@ class ComponentEngine {
                             push itemsN (EvValueBridge.taggedString((itemAt ksN iN)))
                             iN = (iN + 1)
                         }
-                        return (EvalValue.array(itemsN))
+                        return (EvValueBridge.taggedArray(itemsN))
                     }
                 }
                 if (arrStaticName == "JSON") {
@@ -9316,7 +9316,7 @@ class ComponentEngine {
                             }
                             if ((array_length node.children) > 1) {
                                 def arr:EvalValue (this.evaluateExpr((itemAt node.children 1)))
-                                if (arr.isArray()) {
+                                if (EvValueBridge.isArrayValue(arr)) {
                                     def aai:int 0
                                     while (aai < (array_length arr.arrayValue)) {
                                         push applyArgs (itemAt arr.arrayValue aai)
@@ -9550,7 +9550,7 @@ class ComponentEngine {
                     }
                     def keysY:[string]
                     def valsY:[EvalValue]
-                    def minted:EvalValue (EvalValue.object(keysY valsY))
+                    def minted:EvalValue (EvValueBridge.taggedObject(keysY valsY))
                     minted.setMember("__symbol__" (EvValueBridge.taggedString(sDesc)))
                     minted.setMember("description" (EvValueBridge.taggedString(sDesc)))
                     return minted
@@ -9727,7 +9727,7 @@ class ComponentEngine {
                 ; Look up the function in context
                 def fnValue:EvalValue (context.lookup(fnName))
                 if (false == quiet) {
-                    this.trace("Lookup function '" + fnName + "' -> type=" + (to_string fnValue.valueType) + " isFunction=" + (to_string (fnValue.isFunction())))
+                    this.trace("Lookup function '" + fnName + "' -> type=" + (to_string fnValue.valueType) + " isFunction=" + (to_string (EvValueBridge.isFunction(fnValue))))
                 }
                 ; D-REGISTRY: a built-in held in a variable is callable like any
                 ; other function value. It has no functionNode, so the paths
@@ -9743,7 +9743,7 @@ class ComponentEngine {
                     }
                     return (this.runIndirectEval(ieArgs0))
                 }
-                if (fnValue.isFunction()) {
+                if (EvValueBridge.isFunction(fnValue)) {
                     if fnValue.functionNode {
                         ; Args (with ...spread) bound centrally; the call scope is
                         ; parented on the function's captured closure when it has
@@ -9794,7 +9794,7 @@ class ComponentEngine {
                 }
                 return (this.runIndirectEval(ieArgs1))
             }
-            if (calleeFn.isFunction()) {
+            if (EvValueBridge.isFunction(calleeFn)) {
                 if calleeFn.functionNode {
                     def calleeArgs:[EvalValue] (this.collectCallArgs(node))
                     return (this.callFnValueWithValues(calleeFn calleeArgs))
@@ -10062,7 +10062,7 @@ class ComponentEngine {
                 ; A FUNCTION left-operand is object-like too, and its
                 ; prototype-chain answer (including the TypeError for a
                 ; non-object F.prototype) has to be reached the same way.
-                def lvObjectLike:boolean (lv.isObject())
+                def lvObjectLike:boolean (EvValueBridge.isObject(lv))
                 if (lv.valueType == 6) { lvObjectLike = true }
                 if (lv.valueType == 4) { lvObjectLike = true }
                 if lvObjectLike {
@@ -10760,7 +10760,7 @@ class ComponentEngine {
                 if ((array_length args) == 0) {
                     return (EvValueBridge.taggedBoolean(false))
                 }
-                return (EvValueBridge.taggedBoolean(((itemAt args 0).isArray())))
+                return (EvValueBridge.taggedBoolean((EvValueBridge.isArrayValue((itemAt args 0)))))
             }
         }
         if (nsName == "Number") {
@@ -10841,7 +10841,7 @@ class ComponentEngine {
                     }
                     ki = (ki + 1)
                 }
-                return (EvalValue.array(items))
+                return (EvValueBridge.taggedArray(items))
             }
             if (name == "getPrototypeOf") {
                 return (this.protoOfValue(a0))
@@ -11032,7 +11032,7 @@ class ComponentEngine {
         if (has nativeMethodCache key) {
             return (unwrap (get nativeMethodCache key))
         }
-        def v:EvalValue (EvalValue.nativeMethod(kind name))
+        def v:EvalValue (EvValueBridge.taggedNativeMethod(kind name))
         ; A built-in reports its registered arity as `length`, like any other
         ; function. Stored on the value because there is no parameter list to
         ; count -- the registry IS the parameter list.
@@ -11095,14 +11095,14 @@ class ComponentEngine {
         }
         def keysG:[string]
         def valsG:[EvalValue]
-        def g:EvalValue (EvalValue.object(keysG valsG))
+        def g:EvalValue (EvValueBridge.taggedObject(keysG valsG))
         ; D-GLOBALOBJ: a built-in CONSTRUCTOR is a function value, not a plain
         ; object. typeof already lied about it and said "function"; making it one
         ; is what lets `Number instanceof Function`,
         ; `Function.prototype.isPrototypeOf(Number)` and `Number.length` all
         ; answer for themselves instead of being special-cased at each site.
         if (this.isBuiltinCtorName(nsName)) {
-            g = (EvalValue.nativeFunction(nsName))
+            g = (EvValueBridge.taggedNativeFunction(nsName))
         }
         set builtinGlobals nsName g
         g.setMember("name" (EvValueBridge.taggedString(nsName)))
@@ -11171,7 +11171,7 @@ class ComponentEngine {
         def si:int 0
         while (si < (array_length statics)) {
             def sn:string (itemAt statics si)
-            def stv:EvalValue (EvalValue.nativeStatic(nsName sn))
+            def stv:EvalValue (EvValueBridge.taggedNativeStatic(nsName sn))
             stv.setMember("length" (EvalValue.fromInt((this.builtinStaticArity(nsName sn)))))
             stv.setAttrs("length" false false true)
             stv.setMember("name" (EvValueBridge.taggedString(sn)))
@@ -11431,7 +11431,7 @@ class ComponentEngine {
         }
         def keysB:[string]
         def valsB:[EvalValue]
-        def p:EvalValue (EvalValue.object(keysB valsB))
+        def p:EvalValue (EvValueBridge.taggedObject(keysB valsB))
         ; Function.prototype is itself a function -- `typeof Function.prototype`
         ; is "function" and calling it returns undefined. Every other built-in
         ; prototype is an ordinary object.
@@ -11441,10 +11441,10 @@ class ComponentEngine {
         ; value the spec is explicit about.
         if (nsName == "Array") {
             def emptyEls:[EvalValue]
-            p = (EvalValue.array(emptyEls))
+            p = (EvValueBridge.taggedArray(emptyEls))
         }
         if (nsName == "Function") {
-            p = (EvalValue.nativeFunction(""))
+            p = (EvValueBridge.taggedNativeFunction(""))
             ; Calling it returns undefined whatever it is handed. Marked so the
             ; call paths can tell it from an uncallable value -- it has no
             ; function node and no builtin name, which is otherwise exactly what
@@ -12112,7 +12112,7 @@ class ComponentEngine {
     fn elementToString:string (v:EvalValue) {
         if (EvValueBridge.isNull(v)) { return "" }
         if (EvValueBridge.isUndefined(v)) { return "" }
-        if (v.isArray()) {
+        if (EvValueBridge.isArrayValue(v)) {
             return (this.arrayJoinString(v ","))
         }
         return (v.toString())
@@ -12182,7 +12182,7 @@ class ComponentEngine {
         def dtm (new DateTime())
         def keysDt:[string]
         def valsDt:[EvalValue]
-        def dt:EvalValue (EvalValue.object(keysDt valsDt))
+        def dt:EvalValue (EvValueBridge.taggedObject(keysDt valsDt))
         def n:int (array_length args)
         def ms:double (this.realmNowMs())
         if (n == 1) {
@@ -12961,7 +12961,7 @@ class ComponentEngine {
                         if ((array_length mitems) == 0) {
                             return (EvValueBridge.taggedNull())
                         }
-                        return (EvalValue.array(mitems))
+                        return (EvValueBridge.taggedArray(mitems))
                     }
                     if (name == "codePointAt") {
                         def cpi:int 0
@@ -13223,7 +13223,7 @@ class ComponentEngine {
                                 push spOut (itemAt spItems spi)
                                 spi = (spi + 1)
                             }
-                            return (EvalValue.array(spOut))
+                            return (EvValueBridge.taggedArray(spOut))
                         }
                         if (false == haveSep) {
                             def whole:[EvalValue]
@@ -13234,7 +13234,7 @@ class ComponentEngine {
                             } {
                                 push whole (EvValueBridge.taggedString(s))
                             }
-                            return (EvalValue.array(whole))
+                            return (EvValueBridge.taggedArray(whole))
                         }
                         def parts:[string] (strsplit s sep)
                         def cap:int (array_length parts)
@@ -13247,7 +13247,7 @@ class ComponentEngine {
                             push items (EvValueBridge.taggedString((itemAt parts pi)))
                             pi = (pi + 1)
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (name == "lastIndexOf") {
                         def needle:string "undefined"
@@ -13548,7 +13548,7 @@ class ComponentEngine {
                             push items (itemAt recv.arrayValue i)
                             i = (i + 1)
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (name == "values") {
                         def items:[EvalValue]
@@ -13557,7 +13557,7 @@ class ComponentEngine {
                             push items (itemAt recv.mapVals i)
                             i = (i + 1)
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (name == "entries") {
                         def items:[EvalValue]
@@ -13566,10 +13566,10 @@ class ComponentEngine {
                             def pair:[EvalValue]
                             push pair (itemAt recv.arrayValue i)
                             push pair (itemAt recv.mapVals i)
-                            push items (EvalValue.array(pair))
+                            push items (EvValueBridge.taggedArray(pair))
                             i = (i + 1)
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (name == "forEach") {
                         if ((array_length args) > 0) {
@@ -13616,7 +13616,7 @@ class ComponentEngine {
                             push items (itemAt recv.arrayValue i)
                             i = (i + 1)
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (name == "forEach") {
                         if ((array_length args) > 0) {
@@ -13691,7 +13691,7 @@ class ComponentEngine {
             if (name == "fill") { isArrayMutator = true }
             def elems:[EvalValue]
             if (false == isArrayMutator) {
-                if (recv.isArray()) {
+                if (EvValueBridge.isArrayValue(recv)) {
                     elems = recv.arrayValue
                 } {
                     elems = (this.arrayLikeElements(recv))
@@ -13817,7 +13817,7 @@ class ComponentEngine {
                             push items (this.arrayElemAt(recv ii))
                             ii = (ii + 1)
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (name == "forEach") {
                         if ((array_length args) > 0) {
@@ -13867,7 +13867,7 @@ class ComponentEngine {
                                 }
                             }
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (name == "filter") {
                         def items:[EvalValue]
@@ -13895,7 +13895,7 @@ class ComponentEngine {
                                 }
                             }
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (name == "find") {
                         if ((array_length args) > 0) {
@@ -14222,7 +14222,7 @@ class ComponentEngine {
                             t = (t + 1)
                         }
                         recv.arrSetItems(rebuilt)
-                        return (EvalValue.array(removed))
+                        return (EvValueBridge.taggedArray(removed))
                     }
                     ; ---- non-mutating extras ----
                     if (name == "concat") {
@@ -14233,7 +14233,7 @@ class ComponentEngine {
                         ; element, whatever `length` it happens to inherit. The
                         ; receiver was spread unconditionally, so a plain object
                         ; came out as its indices instead of as itself.
-                        if (recv.isArray()) {
+                        if (EvValueBridge.isArrayValue(recv)) {
                             def q:int 0
                             while (q < alen) {
                                 push items (this.arrayElemAt(recv q))
@@ -14245,7 +14245,7 @@ class ComponentEngine {
                         def ai:int 0
                         while (ai < (array_length args)) {
                             def av:EvalValue (itemAt args ai)
-                            if (av.isArray()) {
+                            if (EvValueBridge.isArrayValue(av)) {
                                 ; D-HOLES: an element the argument does not have
                                 ; is not copied, but one INHERITED from its
                                 ; prototype is -- concat asks HasProperty, which
@@ -14262,14 +14262,14 @@ class ComponentEngine {
                             }
                             ai = (ai + 1)
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (name == "flat") {
                         def items:[EvalValue]
                         def q:int 0
                         while (q < (array_length elems)) {
                             def el:EvalValue (this.arrayElemAt(recv q))
-                            if (el.isArray()) {
+                            if (EvValueBridge.isArrayValue(el)) {
                                 def r:int 0
                                 while (r < (array_length el.arrayValue)) {
                                     push items (itemAt el.arrayValue r)
@@ -14280,7 +14280,7 @@ class ComponentEngine {
                             }
                             q = (q + 1)
                         }
-                        return (EvalValue.array(items))
+                        return (EvValueBridge.taggedArray(items))
                     }
                     if (name == "at") {
                         def n:int (array_length elems)
@@ -14333,7 +14333,7 @@ class ComponentEngine {
                 if scriptThrew {
                     return (EvValueBridge.taggedUndefined())
                 }
-                return (EvValueBridge.taggedBoolean((hit.isArray())))
+                return (EvValueBridge.taggedBoolean((EvValueBridge.isArrayValue(hit))))
             }
         }
         ; ---- Number.prototype ----------------------------------------------
@@ -14520,7 +14520,7 @@ class ComponentEngine {
         if ((v.valueType == 0) || (EvValueBridge.isUndefined(v))) {
             def keysO:[string]
             def valsO:[EvalValue]
-            def o:EvalValue (EvalValue.object(keysO valsO))
+            def o:EvalValue (EvValueBridge.taggedObject(keysO valsO))
             o.protoRef = (this.builtinPrototype("Object"))
             return o
         }
@@ -14530,7 +14530,7 @@ class ComponentEngine {
     fn makeWrapper:EvalValue (ctorName:string prim:EvalValue) {
         def keysW:[string]
         def valsW:[EvalValue]
-        def w:EvalValue (EvalValue.object(keysW valsW))
+        def w:EvalValue (EvValueBridge.taggedObject(keysW valsW))
         def p:EvalValue prim
         if (ctorName == "String") {
             if (prim.valueType == 0) {
@@ -15419,7 +15419,7 @@ class ComponentEngine {
     fn makeRegexValue:EvalValue (pattern:string flags:string) {
         def keysR:[string]
         def valsR:[EvalValue]
-        def r:EvalValue (EvalValue.object(keysR valsR))
+        def r:EvalValue (EvValueBridge.taggedObject(keysR valsR))
         r.setMember("__regex__" (EvValueBridge.taggedString(pattern)))
         r.setAttrs("__regex__" false false false)
         r.setMember("source" (EvValueBridge.taggedString(pattern)))
@@ -15553,7 +15553,7 @@ class ComponentEngine {
             }
             gi = (gi + 1)
         }
-        def arr:EvalValue (EvalValue.array(items))
+        def arr:EvalValue (EvValueBridge.taggedArray(items))
         arr.setMember("index" (EvalValue.fromInt(m.start)))
         arr.setMember("input" (EvValueBridge.taggedString(subject)))
         return arr
@@ -15723,7 +15723,7 @@ class ComponentEngine {
     ; through .call().
     fn arrayLikeElements:[EvalValue] (v:EvalValue) {
         def out:[EvalValue]
-        if (v.isArray()) {
+        if (EvValueBridge.isArrayValue(v)) {
             return v.arrayValue
         }
         if (EvValueBridge.isString(v)) {
@@ -15789,7 +15789,7 @@ class ComponentEngine {
     ; answers the HOLE sentinel, which is exactly what the skip tests already
     ; look for, so no call site has to learn a new shape.
     fn arrayElemAt:EvalValue (recv:EvalValue idx:int) {
-        if (recv.isArray()) {
+        if (EvValueBridge.isArrayValue(recv)) {
             ; D-ACCESSORS: an index redefined as an ACCESSOR --
             ; `Object.defineProperty(arr, "0", {get: …})` -- is a real property
             ; of the array and its getter runs. Reading the dense slot first
@@ -15855,7 +15855,7 @@ class ComponentEngine {
     ; and everything else through ToString so an object runs its own.
     fn arrayJoinLive:EvalValue (recv:EvalValue sep:string) {
         def n:int (recv.arrayLength())
-        if (false == (recv.isArray())) {
+        if (false == (EvValueBridge.isArrayValue(recv))) {
             def lv:EvalValue (this.getPropertyValue(recv "length"))
             if scriptThrew {
                 return (EvValueBridge.taggedUndefined())
@@ -16872,7 +16872,7 @@ class ComponentEngine {
         if (existing.valueType == 6) {
             return
         }
-        def sym:EvalValue (EvalValue.nativeFunction("Symbol"))
+        def sym:EvalValue (EvValueBridge.taggedNativeFunction("Symbol"))
         sym.setMember("name" (EvValueBridge.taggedString("Symbol")))
         def wk:[string]
         push wk "iterator"
@@ -16892,7 +16892,7 @@ class ComponentEngine {
             def nm:string (itemAt wk i)
             def keysS:[string]
             def valsS:[EvalValue]
-            def s:EvalValue (EvalValue.object(keysS valsS))
+            def s:EvalValue (EvValueBridge.taggedObject(keysS valsS))
             s.setMember("__symbol__" (EvValueBridge.taggedString(nm)))
             s.setMember("description" (EvValueBridge.taggedString(("Symbol." + nm))))
             sym.setMember(nm s)
@@ -16903,7 +16903,7 @@ class ComponentEngine {
         ; "function". Calls are intercepted by name before reaching this value,
         ; which is what keeps it DIRECT eval (running in the caller's scope)
         ; rather than an ordinary function call with its own frame.
-        def ev:EvalValue (EvalValue.nativeFunction("eval"))
+        def ev:EvalValue (EvValueBridge.taggedNativeFunction("eval"))
         ev.setMember("name" (EvValueBridge.taggedString("eval")))
         hostScope.define("eval" ev)
     }
@@ -16918,7 +16918,7 @@ class ComponentEngine {
         def i:int 0
         while (i < (array_length names)) {
             def nm:string (itemAt names i)
-            def c:EvalValue (EvalValue.nativeFunction(nm))
+            def c:EvalValue (EvValueBridge.taggedNativeFunction(nm))
             c.setMember("name" (EvValueBridge.taggedString(nm)))
             ; §15.11.3: every native error constructor takes one argument.
             c.setMember("length" (EvalValue.fromInt(1)))
@@ -16931,7 +16931,7 @@ class ComponentEngine {
             ; and `Object.getPrototypeOf(new Error())` answered Object.prototype.
             def keysE:[string]
             def valsE:[EvalValue]
-            def proto:EvalValue (EvalValue.object(keysE valsE))
+            def proto:EvalValue (EvValueBridge.taggedObject(keysE valsE))
             proto.setMember("name" (EvValueBridge.taggedString(nm)))
             proto.setAttrs("name" true false true)
             proto.setMember("message" (EvValueBridge.taggedString("")))
@@ -16981,7 +16981,7 @@ class ComponentEngine {
     fn makeError:EvalValue (kind:string message:string) {
         def keys0:[string]
         def vals0:[EvalValue]
-        def e:EvalValue (EvalValue.object(keys0 vals0))
+        def e:EvalValue (EvValueBridge.taggedObject(keys0 vals0))
         e.setMember("name" (EvValueBridge.taggedString(kind)))
         e.setMember("message" (EvValueBridge.taggedString(message)))
         e.setMember("__error__" (EvValueBridge.taggedString(kind)))
@@ -17057,7 +17057,7 @@ class ComponentEngine {
             def gi:int 0
             while (gi < (array_length gfns)) {
                 def gn:string (itemAt gfns gi)
-                def gf:EvalValue (EvalValue.nativeFunction(gn))
+                def gf:EvalValue (EvValueBridge.taggedNativeFunction(gn))
                 gf.setMember("name" (EvValueBridge.taggedString(gn)))
                 gf.setAttrs("name" false false true)
                 gf.setMember("length" (EvalValue.fromInt(1)))
@@ -17105,7 +17105,7 @@ class ComponentEngine {
         }
         def keysG:[string]
         def valsG:[EvalValue]
-        def g:EvalValue (EvalValue.object(keysG valsG))
+        def g:EvalValue (EvValueBridge.taggedObject(keysG valsG))
         globalObject = g
         this.seedGlobalConstants(g)
         return g
@@ -17190,7 +17190,7 @@ class ComponentEngine {
         ; class name so it is both referenceable and dispatchable.
         def clsRef:TSNode (this.classNodeByName(name))
         if ((this.nodeKindOf(clsRef)) == 25) {
-            def cv:EvalValue (EvalValue.nativeFunction(name))
+            def cv:EvalValue (EvValueBridge.taggedNativeFunction(name))
             cv.setMember("__classname__" (EvValueBridge.taggedString(name)))
             cv.setMember("name" (EvValueBridge.taggedString(name)))
             return cv
@@ -17217,13 +17217,13 @@ class ComponentEngine {
         if (EvValueBridge.isBoolean(val)) {
             return "boolean"
         }
-        if (val.isFunction()) {
+        if (EvValueBridge.isFunction(val)) {
             return "function"
         }
-        if (val.isArray()) {
+        if (EvValueBridge.isArrayValue(val)) {
             return "object"
         }
-        if (val.isObject()) {
+        if (EvValueBridge.isObject(val)) {
             ; D-SYMBOL: symbols are modelled as objects internally, but `typeof`
             ; must answer "symbol" — that is how guest code tells them apart, and
             ; answering "object" would make every symbol type-check wrong.
@@ -17233,13 +17233,13 @@ class ComponentEngine {
             }
             return "object"
         }
-        if (val.isMap()) {
+        if (EvValueBridge.isMap(val)) {
             return "object"
         }
-        if (val.isSet()) {
+        if (EvValueBridge.isSet(val)) {
             return "object"
         }
-        if (val.isElement()) {
+        if (EvValueBridge.isElement(val)) {
             return "object"
         }
         return "undefined"
@@ -17605,7 +17605,7 @@ class ComponentEngine {
         decl.evalKind = 0
         decl.name = nm
         set classes nm decl
-        def cv:EvalValue (EvalValue.nativeFunction(nm))
+        def cv:EvalValue (EvValueBridge.taggedNativeFunction(nm))
         cv.setMember("__classname__" (EvValueBridge.taggedString(nm)))
         cv.setMember("name" (EvValueBridge.taggedString(node.name)))
         return cv
@@ -17782,7 +17782,7 @@ class ComponentEngine {
         }
         def keys0:[string]
         def vals0:[EvalValue]
-        def inst:EvalValue (EvalValue.object(keys0 vals0))
+        def inst:EvalValue (EvValueBridge.taggedObject(keys0 vals0))
         ; D-PROTO: link the instance to the constructor's prototype object, so
         ; methods put on `F.prototype` are reachable through the instance.
         ; `constructor` is INHERITED from that prototype rather than stamped on
@@ -17800,7 +17800,7 @@ class ComponentEngine {
             } {
                 def keysBP:[string]
                 def valsBP:[EvalValue]
-                instProto = (EvalValue.object(keysBP valsBP))
+                instProto = (EvValueBridge.taggedObject(keysBP valsBP))
                 set fnV.objectMap "prototype" instProto
             }
         }
@@ -17860,7 +17860,7 @@ class ComponentEngine {
     ; value with the node and `this` supplied, which is what the bound path
     ; needs -- callUserFunctionNode evaluates AST arguments it does not have.
     fn callUserFunctionValues:EvalValue (fnNode:TSNode argVals:[EvalValue] thisVal:EvalValue) {
-        def fv:EvalValue (EvalValue.function(fnNode))
+        def fv:EvalValue (EvValueBridge.taggedFunction(fnNode))
         fv.setSrcText(currentSource)
         fv.setStrictFn((this.strictForBody(fnNode)))
         fv.boundThis = thisVal
@@ -17886,7 +17886,7 @@ class ComponentEngine {
                 if an.left {
                     sv = (this.evaluateExpr((unwrap an.left)))
                 }
-                if (sv.isArray()) {
+                if (EvValueBridge.isArrayValue(sv)) {
                     def k:int 0
                     while (k < (array_length sv.arrayValue)) {
                         push argVals (itemAt sv.arrayValue k)
@@ -17999,14 +17999,14 @@ class ComponentEngine {
         }
         ; Built-in collections: new Map([[k,v]...]) / new Set([v...]).
         if (className == "Map") {
-            def m:EvalValue (EvalValue.mapEmpty())
+            def m:EvalValue (EvValueBridge.taggedMapEmpty())
             if ((array_length node.children) > 0) {
                 def init:EvalValue (this.evaluateExpr((itemAt node.children 0)))
-                if (init.isArray()) {
+                if (EvValueBridge.isArrayValue(init)) {
                     def i:int 0
                     while (i < (array_length init.arrayValue)) {
                         def pair:EvalValue (itemAt init.arrayValue i)
-                        if (pair.isArray()) {
+                        if (EvValueBridge.isArrayValue(pair)) {
                             m.mapSet((pair.getIndex(0)) (pair.getIndex(1)))
                         }
                         i = (i + 1)
@@ -18016,10 +18016,10 @@ class ComponentEngine {
             return m
         }
         if (className == "Set") {
-            def st:EvalValue (EvalValue.setEmpty())
+            def st:EvalValue (EvValueBridge.taggedSetEmpty())
             if ((array_length node.children) > 0) {
                 def init:EvalValue (this.evaluateExpr((itemAt node.children 0)))
-                if (init.isArray()) {
+                if (EvValueBridge.isArrayValue(init)) {
                     def i:int 0
                     while (i < (array_length init.arrayValue)) {
                         st.setAdd((itemAt init.arrayValue i))
@@ -18362,7 +18362,7 @@ class ComponentEngine {
         }
         def keys0:[string]
         def vals0:[EvalValue]
-        def inst:EvalValue (EvalValue.object(keys0 vals0))
+        def inst:EvalValue (EvValueBridge.taggedObject(keys0 vals0))
         inst.setMember("__class__" (EvValueBridge.taggedString(className)))
         if ((strlen clsModule) > 0) {
             inst.setMember("__module__" (EvValueBridge.taggedString(clsModule)))
@@ -18400,7 +18400,7 @@ class ComponentEngine {
                         mk = m.kind
                     }
                     if ((mk == "get") || (mk == "set")) {
-                        def accFn:EvalValue (EvalValue.boundMethod(m inst))
+                        def accFn:EvalValue (EvValueBridge.taggedBoundMethod(m inst))
                         accFn.setSrcText(currentSource)
                         if (mk == "get") {
                             inst.defineGetter(m.name accFn)
@@ -18654,7 +18654,7 @@ class ComponentEngine {
 
             ; Map/Set .size property (element count).
             if (propName == "size") {
-                if ((obj.isMap()) || (obj.isSet())) {
+                if ((EvValueBridge.isMap(obj)) || (EvValueBridge.isSet(obj))) {
                     return (EvalValue.fromInt((array_length obj.arrayValue)))
                 }
             }
@@ -18784,7 +18784,7 @@ class ComponentEngine {
                 def mcls:TSNode (this.classNodeForInstance(obj))
                 def mnode:TSNode (this.findMethodOnClassNode(mcls propName))
                 if (mnode.nodeType == "MethodDefinition") {
-                    def bm:EvalValue (EvalValue.boundMethod(mnode obj))
+                    def bm:EvalValue (EvValueBridge.taggedBoundMethod(mnode obj))
                     bm.setSrcText(currentSource)
                     ; provenance travels with the value: a stored method of a
                     ; module instance still roots in its module when invoked
@@ -18824,7 +18824,7 @@ class ComponentEngine {
                 if elem.left {
                     sv = (this.evaluateExpr((unwrap elem.left)))
                 }
-                if (sv.isArray()) {
+                if (EvValueBridge.isArrayValue(sv)) {
                     def k:int 0
                     while (k < (array_length sv.arrayValue)) {
                         push items (itemAt sv.arrayValue k)
@@ -18837,7 +18837,7 @@ class ComponentEngine {
             i = i + 1
         }
 
-        return (EvalValue.array(items))
+        return (EvValueBridge.taggedArray(items))
     }
     
     ; Lexicographic compare of two strings by char code: <0, 0, >0. Used for the
@@ -19013,7 +19013,7 @@ class ComponentEngine {
             }
             return out
         }
-        if (v.isObject()) {
+        if (EvValueBridge.isObject(v)) {
             out = (keys v.objectMap)
             ; D-ACCESSORS: an accessor property lives in getterMap/setterMap
             ; rather than objectMap, so listing only objectMap left every
@@ -19054,7 +19054,7 @@ class ComponentEngine {
         ; D-ARRAYKEYS: an array's own keys are its INDICES, as strings. Elements
         ; live in arrayValue rather than objectMap, so Object.keys([1,2]) used to
         ; answer nothing at all instead of ["0","1"].
-        if (v.isArray()) {
+        if (EvValueBridge.isArrayValue(v)) {
             def i:int 0
             while (i < (array_length v.arrayValue)) {
                 ; D-HOLES: an ABSENT element has no key, so Object.keys and
@@ -19106,7 +19106,7 @@ class ComponentEngine {
 
     fn objectEnumerableKeysRaw:[string] (v:EvalValue) {
         def out:[string]
-        if (v.isArray()) {
+        if (EvValueBridge.isArrayValue(v)) {
             ; An index is enumerable UNLESS defineProperty recorded otherwise --
             ; `Object.defineProperties(a, {"0": {value: 1}})` creates a
             ; non-enumerable element, and for-in must skip it.
@@ -19124,7 +19124,7 @@ class ComponentEngine {
         if (EvValueBridge.isString(v)) {
             return (this.objectKeys(v))
         }
-        def holdsProps:boolean (v.isObject())
+        def holdsProps:boolean (EvValueBridge.isObject(v))
         if (v.valueType == 6) { holdsProps = true }
         if holdsProps {
             def all:[string] (this.objectKeys(v))
@@ -19143,7 +19143,7 @@ class ComponentEngine {
     ; True if an object value owns `key` (distinguishes a present-but-null value
     ; from an absent key, which getMember cannot). Used by the `in` operator.
     fn objHasKey:boolean (v:EvalValue key:string) {
-        if (v.isObject()) {
+        if (EvValueBridge.isObject(v)) {
             return (has v.objectMap key)
         }
         ; D-FNPROPS: length, name and prototype are OWN properties of every
@@ -19258,7 +19258,7 @@ class ComponentEngine {
         if (EvValueBridge.isString(v)) {
             return (this.jsonQuote(v.stringValue))
         }
-        if (v.isArray()) {
+        if (EvValueBridge.isArrayValue(v)) {
             def out:string "["
             def i:int 0
             while (i < (array_length v.arrayValue)) {
@@ -19270,7 +19270,7 @@ class ComponentEngine {
             }
             return (out + "]")
         }
-        if (v.isObject()) {
+        if (EvValueBridge.isObject(v)) {
             def out:string "{"
             def ks:[string] (this.objectKeys(v))
             def i:int 0
@@ -19551,13 +19551,13 @@ class ComponentEngine {
         this.jsonSkipWs()
         if ((this.jsonPeek()) == "]") {
             jsonPos = (jsonPos + 1)
-            return (EvalValue.array(items))
+            return (EvValueBridge.taggedArray(items))
         }
         def looping:boolean true
         while (looping) {
             push items (this.jsonParseValue())
             if jsonFailed {
-                return (EvalValue.array(items))
+                return (EvValueBridge.taggedArray(items))
             }
             this.jsonSkipWs()
             def c:string (this.jsonPeek())
@@ -19567,7 +19567,7 @@ class ComponentEngine {
                 this.jsonSkipWs()
                 if ((this.jsonPeek()) == "]") {
                     this.jsonFail("Unexpected token ] in JSON")
-                    return (EvalValue.array(items))
+                    return (EvValueBridge.taggedArray(items))
                 }
             } {
                 if (c == "]") {
@@ -19575,11 +19575,11 @@ class ComponentEngine {
                     looping = false
                 } {
                     this.jsonFail("Expected ',' or ']' in JSON array")
-                    return (EvalValue.array(items))
+                    return (EvValueBridge.taggedArray(items))
                 }
             }
         }
-        return (EvalValue.array(items))
+        return (EvValueBridge.taggedArray(items))
     }
     fn jsonParseObject:EvalValue () {
         def ks:[string]
@@ -19588,7 +19588,7 @@ class ComponentEngine {
         this.jsonSkipWs()
         if ((this.jsonPeek()) == "}") {
             jsonPos = (jsonPos + 1)
-            return (EvalValue.object(ks vs))
+            return (EvValueBridge.taggedObject(ks vs))
         }
         def looping:boolean true
         while (looping) {
@@ -19596,21 +19596,21 @@ class ComponentEngine {
             ; A member name is a STRING. `{a: 1}` is JavaScript, not JSON.
             if ((this.jsonPeek()) != "\"") {
                 this.jsonFail("Expected property name in JSON")
-                return (EvalValue.object(ks vs))
+                return (EvValueBridge.taggedObject(ks vs))
             }
             def key:string (this.jsonParseString())
             if jsonFailed {
-                return (EvalValue.object(ks vs))
+                return (EvValueBridge.taggedObject(ks vs))
             }
             this.jsonSkipWs()
             if ((this.jsonPeek()) != ":") {
                 this.jsonFail("Expected ':' in JSON object")
-                return (EvalValue.object(ks vs))
+                return (EvValueBridge.taggedObject(ks vs))
             }
             jsonPos = (jsonPos + 1)
             def val:EvalValue (this.jsonParseValue())
             if jsonFailed {
-                return (EvalValue.object(ks vs))
+                return (EvValueBridge.taggedObject(ks vs))
             }
             push ks key
             push vs val
@@ -19621,7 +19621,7 @@ class ComponentEngine {
                 this.jsonSkipWs()
                 if ((this.jsonPeek()) == "}") {
                     this.jsonFail("Unexpected token } in JSON")
-                    return (EvalValue.object(ks vs))
+                    return (EvValueBridge.taggedObject(ks vs))
                 }
             } {
                 if (c == "}") {
@@ -19629,11 +19629,11 @@ class ComponentEngine {
                     looping = false
                 } {
                     this.jsonFail("Expected ',' or '}' in JSON object")
-                    return (EvalValue.object(ks vs))
+                    return (EvValueBridge.taggedObject(ks vs))
                 }
             }
         }
-        def obj:EvalValue (EvalValue.object(ks vs))
+        def obj:EvalValue (EvValueBridge.taggedObject(ks vs))
         obj.protoRef = (this.builtinPrototype("Object"))
         return obj
     }
@@ -19703,7 +19703,7 @@ class ComponentEngine {
                 if prop.left {
                     sv = (this.evaluateExpr((unwrap prop.left)))
                 }
-                if (sv.isObject()) {
+                if (EvValueBridge.isObject(sv)) {
                     def sks:[string] (this.objectKeys(sv))
                     def si:int 0
                     while (si < (array_length sks)) {
@@ -19717,7 +19717,7 @@ class ComponentEngine {
             i = i + 1
         }
 
-        def built:EvalValue (EvalValue.object(keys values))
+        def built:EvalValue (EvValueBridge.taggedObject(keys values))
         ; D-PROTO: an object literal inherits from Object.prototype. Without the
         ; link a plain object had no toString, hasOwnProperty or valueOf to
         ; inherit at all, so a guest override of one of them was invisible and
@@ -20037,10 +20037,10 @@ class ComponentEngine {
         push marginValues (EvValueBridge.taggedNumber(printMarginBottom))
         push marginNames "left"
         push marginValues (EvValueBridge.taggedNumber(printMarginLeft))
-        def marginsVal:EvalValue (EvalValue.object(marginNames marginValues))
+        def marginsVal:EvalValue (EvValueBridge.taggedObject(marginNames marginValues))
         push propValues marginsVal
         
-        return (EvalValue.object(propNames propValues))
+        return (EvValueBridge.taggedObject(propNames propValues))
     }
     
     ; Parse GPS coordinate string like "43° 28' 1.49"" into components
@@ -20142,7 +20142,7 @@ class ComponentEngine {
         push names "originalValue"
         push values (EvValueBridge.taggedString(originalValue))
         
-        return (EvalValue.object(names values))
+        return (EvValueBridge.taggedObject(names values))
     }
     
     ; Helper: Extract numeric characters (digits, decimal point, minus) from a string
@@ -20417,7 +20417,7 @@ class ComponentEngine {
         push names "originalValue"
         push values (EvValueBridge.taggedString(dateStr))
         
-        return (EvalValue.object(names values))
+        return (EvValueBridge.taggedObject(names values))
     }
 
     ; useImage(src) - returns image metadata as an object EvalValue
@@ -20552,7 +20552,7 @@ class ComponentEngine {
                 push gpsNames "altitude"
                 push gpsValues (EvValueBridge.taggedString(metadata.gpsAltitude))
             }
-            push propValues (EvalValue.object(gpsNames gpsValues))
+            push propValues (EvValueBridge.taggedObject(gpsNames gpsValues))
         } {
             push propValues (EvValueBridge.taggedNull())
         }
@@ -20606,7 +20606,7 @@ class ComponentEngine {
         def hasOrientation:boolean (metadata.orientation > 1)
         push featValues (EvValueBridge.taggedBoolean(hasOrientation))
         
-        push propValues (EvalValue.object(featNames featValues))
+        push propValues (EvValueBridge.taggedObject(featNames featValues))
         
         ; dateInfo - parsed date components if available
         push propNames "dateInfo"
@@ -20620,7 +20620,7 @@ class ComponentEngine {
             }
         }
         
-        return (EvalValue.object(propNames propValues))
+        return (EvValueBridge.taggedObject(propNames propValues))
     }
     
     ; Set print settings from Print element props

--- a/gallery/game_engine/v2/interp/migrate/src/ComponentEngine.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/ComponentEngine.rgr
@@ -11,6 +11,7 @@ Import "../../../../../ts_parser/ts_lexer.rgr"
 Import "../../../../../ts_parser/ts_ast_patch.rgr"
 Import "../../../evg/EVGElement.rgr"
 Import "EvalValue.rgr"
+Import "EvValueBridge.rgr"
 Import "Regex.rgr"
 Import "DateTime.rgr"
 Import "../../../imaging/jpeg/JPEGMetadata.rgr"
@@ -1682,7 +1683,7 @@ class ComponentEngine {
                 ; iteration method run five times.
                 def si:int 0
                 while (si < slots) {
-                    push items (EvalValue.hole())
+                    push items (EvValueBridge.taggedHole())
                     si = (si + 1)
                 }
                 return (EvalValue.array(items))
@@ -7267,7 +7268,7 @@ class ComponentEngine {
                 }
                 def si:int 0
                 while (si < slots) {
-                    push items (EvalValue.hole())
+                    push items (EvValueBridge.taggedHole())
                     si = (si + 1)
                 }
                 return (EvalValue.array(items))
@@ -8237,7 +8238,7 @@ class ComponentEngine {
         ; D-HOLES: an array elision is an ABSENT element. It reads as undefined
         ; wherever a value is wanted, and `0 in [,1]` is false.
         if (exprK == 22) {
-            return (EvalValue.hole())
+            return (EvValueBridge.taggedHole())
         }
         ; D-REGEX: `/pattern/flags` as a value.
         if (exprK == 21) {
@@ -9074,7 +9075,7 @@ class ComponentEngine {
                                     if (ai < (array_length src.arrayValue)) {
                                         ; D-HOLES: a hole is an ABSENT property
                                         ; and has no descriptor at all.
-                                        if (false == ((itemAt src.arrayValue ai).isHole)) {
+                                        if (false == ((EvValueBridge.isHole((itemAt src.arrayValue ai))))) {
                                             def keysI:[string]
                                             def valsI:[EvalValue]
                                             def dI:EvalValue (EvalValue.object(keysI valsI))
@@ -13745,7 +13746,7 @@ class ComponentEngine {
                             ; `[1,,3].indexOf(undefined)` is -1. includes below
                             ; deliberately does not skip: it treats a hole as
                             ; undefined, which is the one place the two differ.
-                            if (false == ((this.arrayElemAt(recv ii)).isHole)) {
+                            if (false == ((EvValueBridge.isHole((this.arrayElemAt(recv ii)))))) {
                                 if ((target.equals((this.arrayElemAt(recv ii))))) {
                                     return (EvalValue.fromInt(ii))
                                 }
@@ -13784,7 +13785,7 @@ class ComponentEngine {
                             ; disagreed about the same array.
                             def jv:EvalValue (this.arrayElemAt(recv ii))
                             def jSkip:boolean false
-                            if jv.isHole { jSkip = true }
+                            if (EvValueBridge.isHole(jv)) { jSkip = true }
                             if (jv.isNull()) { jSkip = true }
                             if (jv.isUndefined()) { jSkip = true }
                             if (false == jSkip) {
@@ -13824,7 +13825,7 @@ class ComponentEngine {
                             def ii:int 0
                             while (ii < alen) {
                                 ; D-HOLES: an ABSENT element is not visited.
-                                if ((this.arrayElemAt(recv ii)).isHole) {
+                                if ((EvValueBridge.isHole((this.arrayElemAt(recv ii))))) {
                                     ii = (ii + 1)
                                 } {
                                     def cargs:[EvalValue]
@@ -13850,8 +13851,8 @@ class ComponentEngine {
                                 ; D-HOLES: map PRESERVES a hole rather than
                                 ; calling the callback on it -- the result has
                                 ; the same length and the same holes.
-                                if ((this.arrayElemAt(recv ii)).isHole) {
-                                    push items (EvalValue.hole())
+                                if ((EvValueBridge.isHole((this.arrayElemAt(recv ii))))) {
+                                    push items (EvValueBridge.taggedHole())
                                     ii = (ii + 1)
                                 } {
                                     def cargs:[EvalValue]
@@ -13876,7 +13877,7 @@ class ComponentEngine {
                             while (ii < alen) {
                                 def el:EvalValue (this.arrayElemAt(recv ii))
                                 ; D-HOLES: an ABSENT element is not visited.
-                                if el.isHole {
+                                if (EvValueBridge.isHole(el)) {
                                     ii = (ii + 1)
                                 } {
                                     def cargs:[EvalValue]
@@ -13937,7 +13938,7 @@ class ComponentEngine {
                             def ii:int 0
                             while (ii < alen) {
                                 ; D-HOLES: an ABSENT element is not visited.
-                                if ((this.arrayElemAt(recv ii)).isHole) {
+                                if ((EvValueBridge.isHole((this.arrayElemAt(recv ii))))) {
                                     ii = (ii + 1)
                                 } {
                                     def cargs:[EvalValue]
@@ -13963,7 +13964,7 @@ class ComponentEngine {
                             def ii:int 0
                             while (ii < alen) {
                                 ; D-HOLES: an ABSENT element is not visited.
-                                if ((this.arrayElemAt(recv ii)).isHole) {
+                                if ((EvValueBridge.isHole((this.arrayElemAt(recv ii))))) {
                                     ii = (ii + 1)
                                 } {
                                     def cargs:[EvalValue]
@@ -14003,7 +14004,7 @@ class ComponentEngine {
                                 def seedIdx:int startIdx
                                 def seeded:boolean false
                                 while (((seedIdx < alen) && (seedIdx >= 0)) && (seeded == false)) {
-                                    if (false == ((this.arrayElemAt(recv seedIdx)).isHole)) {
+                                    if (false == ((EvValueBridge.isHole((this.arrayElemAt(recv seedIdx)))))) {
                                         acc = (this.arrayElemAt(recv seedIdx))
                                         seeded = true
                                     }
@@ -14023,7 +14024,7 @@ class ComponentEngine {
                             def ii:int startIdx
                             while ((ii < alen) && (ii >= 0)) {
                                 ; D-HOLES: an ABSENT element is not visited.
-                                if (false == ((this.arrayElemAt(recv ii)).isHole)) {
+                                if (false == ((EvValueBridge.isHole((this.arrayElemAt(recv ii)))))) {
                                     def cargs:[EvalValue]
                                     push cargs acc
                                     push cargs (this.arrayElemAt(recv ii))
@@ -14303,7 +14304,7 @@ class ComponentEngine {
                         def q:int ((array_length elems) - 1)
                         while (q >= 0) {
                             ; D-HOLES: only PRESENT elements are searched.
-                            if (false == ((this.arrayElemAt(recv q)).isHole)) {
+                            if (false == ((EvValueBridge.isHole((this.arrayElemAt(recv q)))))) {
                                 if ((target.equals((this.arrayElemAt(recv q))))) {
                                     return (EvalValue.fromInt(q))
                                 }
@@ -15774,7 +15775,7 @@ class ComponentEngine {
                     return out
                 }
             } {
-                push out (EvalValue.hole())
+                push out (EvValueBridge.taggedHole())
             }
             i = (i + 1)
         }
@@ -15801,7 +15802,7 @@ class ComponentEngine {
             }
             if (idx < (array_length recv.arrayValue)) {
                 def slot:EvalValue (itemAt recv.arrayValue idx)
-                if (false == slot.isHole) {
+                if (false == (EvValueBridge.isHole(slot))) {
                     return slot
                 }
             }
@@ -15813,19 +15814,19 @@ class ComponentEngine {
             if (this.objHasKeyUpChain(recv akey)) {
                 return (this.getPropertyValue(recv akey))
             }
-            return (EvalValue.hole())
+            return (EvValueBridge.taggedHole())
         }
         if (recv.isString()) {
             if (idx < (strlen recv.stringValue)) {
                 return (EvalValue.string((substring recv.stringValue idx (idx + 1))))
             }
-            return (EvalValue.hole())
+            return (EvValueBridge.taggedHole())
         }
         def k:string (to_string idx)
         if (this.objHasKeyUpChain(recv k)) {
             return (this.getPropertyValue(recv k))
         }
-        return (EvalValue.hole())
+        return (EvValueBridge.taggedHole())
     }
 
     ; D-ARRAYLIKE: call a method BY NAME on a value, the way guest code would --
@@ -15877,7 +15878,7 @@ class ComponentEngine {
                 return (EvalValue.undefined())
             }
             def skip:boolean false
-            if v.isHole { skip = true }
+            if (EvValueBridge.isHole(v)) { skip = true }
             if (v.isNull()) { skip = true }
             if (v.isUndefined()) { skip = true }
             if (false == skip) {
@@ -16032,7 +16033,7 @@ class ComponentEngine {
                 if (wi >= 0) {
                     if (wi < (array_length walk.arrayValue)) {
                         def wslot:EvalValue (itemAt walk.arrayValue wi)
-                        if (false == wslot.isHole) {
+                        if (false == (EvValueBridge.isHole(wslot))) {
                             return wslot
                         }
                     }
@@ -16059,7 +16060,7 @@ class ComponentEngine {
             def oi:int (this.canonicalArrayIndex(key))
             if (oi >= 0) {
                 if (oi < (array_length obj.arrayValue)) {
-                    if (false == ((itemAt obj.arrayValue oi).isHole)) {
+                    if (false == ((EvValueBridge.isHole((itemAt obj.arrayValue oi))))) {
                         return own
                     }
                 }
@@ -16086,7 +16087,7 @@ class ComponentEngine {
             def oj:int (this.canonicalArrayIndex(key))
             if (oj >= 0) {
                 if (oj < (array_length obj.arrayValue)) {
-                    if (false == ((itemAt obj.arrayValue oj).isHole)) {
+                    if (false == ((EvValueBridge.isHole((itemAt obj.arrayValue oj))))) {
                         return own
                     }
                 }
@@ -16623,7 +16624,7 @@ class ComponentEngine {
             if (li < (array_length obj.arrayValue)) {
                 push resized (itemAt obj.arrayValue li)
             } {
-                push resized (EvalValue.hole())
+                push resized (EvValueBridge.taggedHole())
             }
             li = (li + 1)
         }
@@ -16651,7 +16652,7 @@ class ComponentEngine {
         ; Whether the ELEMENT was already there decides which attributes survive.
         def existedElem:boolean false
         if (idx < (array_length obj.arrayValue)) {
-            if (false == ((itemAt obj.arrayValue idx).isHole)) {
+            if (false == ((EvValueBridge.isHole((itemAt obj.arrayValue idx))))) {
                 existedElem = true
             }
         }
@@ -16683,7 +16684,7 @@ class ComponentEngine {
         } {
             ; Attributes only: an element that did not exist becomes a present
             ; undefined, which is what a descriptor without a value creates.
-            if ((itemAt obj.arrayValue idx).isHole) {
+            if ((EvValueBridge.isHole((itemAt obj.arrayValue idx)))) {
                 obj.setIndexAt(idx (EvalValue.undefined()))
             }
         }
@@ -16747,7 +16748,7 @@ class ComponentEngine {
             def reIdx:int (this.canonicalArrayIndex(key))
             if (reIdx >= 0) {
                 if (reIdx < (array_length obj.arrayValue)) {
-                    if (false == ((itemAt obj.arrayValue reIdx).isHole)) {
+                    if (false == ((EvValueBridge.isHole((itemAt obj.arrayValue reIdx))))) {
                         exists = true
                     }
                 }
@@ -17387,7 +17388,7 @@ class ComponentEngine {
                                         ; left the property readable through its
                                         ; getter after `delete a[1]`.
                                         obj.removeMember(dkey)
-                                        obj.setIndexAt(dn (EvalValue.hole()))
+                                        obj.setIndexAt(dn (EvValueBridge.taggedHole()))
                                         return (EvalValue.boolean(true))
                                     }
                                 }
@@ -18724,7 +18725,7 @@ class ComponentEngine {
                                 ; undefined for a property that exists.
                                 def slotPresent:boolean false
                                 if (rIdx < (array_length obj.arrayValue)) {
-                                    slotPresent = (false == ((itemAt obj.arrayValue rIdx).isHole))
+                                    slotPresent = (false == ((EvValueBridge.isHole((itemAt obj.arrayValue rIdx)))))
                                 }
                                 if slotPresent {
                                     return (obj.getIndex(rIdx))
@@ -19058,7 +19059,7 @@ class ComponentEngine {
             while (i < (array_length v.arrayValue)) {
                 ; D-HOLES: an ABSENT element has no key, so Object.keys and
                 ; for-in skip it -- `Object.keys([1,,3])` is ["0","2"].
-                if (false == ((itemAt v.arrayValue i).isHole)) {
+                if (false == ((EvValueBridge.isHole((itemAt v.arrayValue i))))) {
                     push out (to_string i)
                 }
                 i = (i + 1)
@@ -19178,7 +19179,7 @@ class ComponentEngine {
                 ; D-HOLES: a hole is an ABSENT property, so `1 in [0,,2]` is
                 ; false and hasOwnProperty("1") is false with it.
                 if ((aidx >= 0) && (aidx < (array_length v.arrayValue))) {
-                    return (false == ((itemAt v.arrayValue aidx).isHole))
+                    return (false == ((EvValueBridge.isHole((itemAt v.arrayValue aidx)))))
                 }
                 return false
             }

--- a/gallery/game_engine/v2/interp/migrate/src/EvValue.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/EvValue.rgr
@@ -174,11 +174,15 @@ shape EvValue {
     }
     sfn mapEmpty:EvValue () {
         def props:EvPropertyBag (new EvPropertyBag())
-        return (new EvValue.Map(0 props ([] _:EvMapEntry ())))
+        ; Bind the empty literal — Rust case ctors drop a bare `([] _:T ())`
+        ; argument (ISSUES / empty typed array as ctor arg).
+        def entries:[EvMapEntry]
+        return (new EvValue.Map(0 props entries))
     }
     sfn setEmpty:EvValue () {
         def props:EvPropertyBag (new EvPropertyBag())
-        return (new EvValue.Set(0 props ([] _:EvValue ())))
+        def items:[EvValue]
+        return (new EvValue.Set(0 props items))
     }
     sfn functionStub:EvValue (name:string) {
         def props:EvPropertyBag (new EvPropertyBag())

--- a/gallery/game_engine/v2/interp/migrate/src/EvValue.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/EvValue.rgr
@@ -3,7 +3,8 @@
 ; =============================================================================
 ; Closed family that will replace `class EvalValue` once call sites convert.
 ; Named EvValue (not EvalValue) so the tagged class can keep serving the
-; engine; nothing imports this file yet except the E1 smoke fixture.
+; engine. E3 wires Hole creation through EvValueBridge into ComponentEngine;
+; other kinds still live only on the tagged class.
 ;
 ; Groups:
 ;   Primitive       — Null / Undefined / Hole / Number / String / Boolean
@@ -177,6 +178,27 @@ shape EvValue {
     }
     fn isHole:boolean () {
         case self n:EvValue.Hole {
+            return true
+        }
+        return false
+    }
+    fn isUndefined:boolean () {
+        case self n:EvValue.Undefined {
+            return true
+        }
+        return false
+    }
+    fn isBoolean:boolean () {
+        case self n:EvValue.Boolean {
+            return true
+        }
+        return false
+    }
+    fn isNullOrUndefined:boolean () {
+        case self n:EvValue.Null {
+            return true
+        }
+        case self u:EvValue.Undefined {
             return true
         }
         return false

--- a/gallery/game_engine/v2/interp/migrate/src/EvValue.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/EvValue.rgr
@@ -3,9 +3,8 @@
 ; =============================================================================
 ; Closed family that will replace `class EvalValue` once call sites convert.
 ; Named EvValue (not EvalValue) so the tagged class can keep serving the
-; engine. E3 wires Hole and primitive creation/checks through EvValueBridge
-; into ComponentEngine; Element and property carriers still live only on
-; the tagged class.
+; engine. E3 wires every kind's create/check through EvValueBridge into
+; ComponentEngine. Storage remains class EvalValue until step 4.
 ;
 ; Groups:
 ;   Primitive       — Null / Undefined / Hole / Number / String / Boolean
@@ -159,6 +158,36 @@ shape EvValue {
         return (new EvValue.Boolean(b))
     }
 
+    ; ---- E3 reference / carrier factories (fixture + bridge kind arms) ----
+    ; Case ctors take Reference.identityId then PropertyCarrier.properties
+    ; (when applicable) before the case's own fields — see E1 fixture.
+    sfn element:EvValue (el:EVGElement) {
+        return (new EvValue.Element(0 el))
+    }
+    sfn array:EvValue (items:[EvValue]) {
+        def props:EvPropertyBag (new EvPropertyBag())
+        return (new EvValue.Array(0 props items (array_length items)))
+    }
+    sfn object:EvValue () {
+        def props:EvPropertyBag (new EvPropertyBag())
+        return (new EvValue.Object(0 props))
+    }
+    sfn mapEmpty:EvValue () {
+        def props:EvPropertyBag (new EvPropertyBag())
+        return (new EvValue.Map(0 props ([] _:EvMapEntry ())))
+    }
+    sfn setEmpty:EvValue () {
+        def props:EvPropertyBag (new EvPropertyBag())
+        return (new EvValue.Set(0 props ([] _:EvValue ())))
+    }
+    sfn functionStub:EvValue (name:string) {
+        def props:EvPropertyBag (new EvPropertyBag())
+        def c:EvFunctionCore (new EvFunctionCore())
+        c.functionName = name
+        def b:EvFunctionBinding (new EvFunctionBinding())
+        return (new EvValue.Function(0 props c b))
+    }
+
     fn isNull:boolean () {
         case self n:EvValue.Null {
             return true
@@ -200,6 +229,43 @@ shape EvValue {
             return true
         }
         case self u:EvValue.Undefined {
+            return true
+        }
+        return false
+    }
+    fn isElement:boolean () {
+        case self n:EvValue.Element {
+            return true
+        }
+        return false
+    }
+    ; Named isArrayValue — a global `isArray` operator blocks methods named isArray.
+    fn isArrayValue:boolean () {
+        case self n:EvValue.Array {
+            return true
+        }
+        return false
+    }
+    fn isObject:boolean () {
+        case self n:EvValue.Object {
+            return true
+        }
+        return false
+    }
+    fn isFunction:boolean () {
+        case self n:EvValue.Function {
+            return true
+        }
+        return false
+    }
+    fn isMap:boolean () {
+        case self n:EvValue.Map {
+            return true
+        }
+        return false
+    }
+    fn isSet:boolean () {
+        case self n:EvValue.Set {
             return true
         }
         return false

--- a/gallery/game_engine/v2/interp/migrate/src/EvValue.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/EvValue.rgr
@@ -3,8 +3,9 @@
 ; =============================================================================
 ; Closed family that will replace `class EvalValue` once call sites convert.
 ; Named EvValue (not EvalValue) so the tagged class can keep serving the
-; engine. E3 wires Hole creation through EvValueBridge into ComponentEngine;
-; other kinds still live only on the tagged class.
+; engine. E3 wires Hole and primitive creation/checks through EvValueBridge
+; into ComponentEngine; Element and property carriers still live only on
+; the tagged class.
 ;
 ; Groups:
 ;   Primitive       — Null / Undefined / Hole / Number / String / Boolean

--- a/gallery/game_engine/v2/interp/migrate/src/EvValueBridge.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/EvValueBridge.rgr
@@ -1,19 +1,15 @@
 ; =============================================================================
 ; EvValueBridge — tagged ↔ shape conversion (PLAN_SHAPES.md §7.5)
 ; =============================================================================
-; E2: fromTagged for primitives / Hole.
-; E3 Hole: taggedHole / isHole engine API.
-; E3 primitives: taggedNull/Undefined/Number/String/Boolean + predicates.
-; ComponentEngine creates and checks these kinds through the bridge so the
-; shape owns them; array storage remains class EvalValue until later kinds move.
+; E3: every kind's engine create/check API lives here so the shape owns the
+; kind. Reference tagged* factories allocate once via EvalValue.* (identity
+; mint); never round-trip a live stored ref through toTagged/fromTagged.
+; Storage remains class EvalValue until step 4.
 
 Import "EvalValue.rgr"
 Import "EvValue.rgr"
 
 class EvValueBridge {
-    ; Map a tagged value to the closed family. Primitives and Hole first
-    ; (migration order §7.5); reference kinds return Undefined until those
-    ; conversions land.
     sfn fromTagged:EvValue (v:EvalValue) {
         if v.isHole {
             return (EvValue.hole())
@@ -33,11 +29,30 @@ class EvValueBridge {
         if (v.valueType == 3) {
             return (EvValue.boolean(v.boolValue))
         }
+        if (v.valueType == 7) {
+            if (v.hasElement()) {
+                return (EvValue.element((v.elementOf())))
+            }
+            return (EvValue.undefined())
+        }
+        if (v.valueType == 4) {
+            return (EvValue.array(([] _:EvValue ())))
+        }
+        if (v.valueType == 5) {
+            return (EvValue.object())
+        }
+        if (v.valueType == 6) {
+            return (EvValue.functionStub((v.fnName())))
+        }
+        if (v.valueType == 9) {
+            return (EvValue.mapEmpty())
+        }
+        if (v.valueType == 10) {
+            return (EvValue.setEmpty())
+        }
         return (EvValue.undefined())
     }
 
-    ; Shape → tagged. Hole and primitives only; other cases become undefined
-    ; until those kinds convert.
     sfn toTagged:EvalValue (ev:EvValue) {
         case ev h:EvValue.Hole {
             return (EvalValue.hole())
@@ -57,25 +72,43 @@ class EvValueBridge {
         case ev b:EvValue.Boolean {
             return (EvalValue.boolean(b.value))
         }
+        case ev el:EvValue.Element {
+            ; Case field is class-typed without a default → optional at the
+            ; type level; factories always set it.
+            return (EvalValue.element((unwrap el.element)))
+        }
+        case ev a:EvValue.Array {
+            def items:[EvalValue]
+            for a.items it:EvValue i {
+                push items (EvValueBridge.toTagged(it))
+            }
+            return (EvalValue.array(items))
+        }
+        case ev o:EvValue.Object {
+            return (EvalValue.object(([] _:string ()) ([] _:EvalValue ())))
+        }
+        case ev f:EvValue.Function {
+            def c:EvFunctionCore (unwrap f.core)
+            return (EvalValue.nativeFunction(c.functionName))
+        }
+        case ev m:EvValue.Map {
+            return (EvalValue.mapEmpty())
+        }
+        case ev st:EvValue.Set {
+            return (EvalValue.setEmpty())
+        }
         return (EvalValue.undefined())
     }
 
-    ; ---- E3 Hole engine surface -------------------------------------------
-    ; Storage encoding is still the pooled tagged singleton (isHole flag);
-    ; discrimination stays a flag read for hot array walks.
-
+    ; ---- Hole -------------------------------------------------------------
     sfn taggedHole:EvalValue () {
         return (EvValueBridge.toTagged((EvValue.hole())))
     }
-
     sfn isHole:boolean (v:EvalValue) {
         return v.isHole
     }
 
-    ; ---- E3 primitive engine surface --------------------------------------
-    ; Same pattern as Hole: shape factory → toTagged. Predicates keep the
-    ; tagged-class method bodies for speed; the API boundary is the bridge.
-
+    ; ---- Primitives -------------------------------------------------------
     sfn taggedNull:EvalValue () {
         return (EvValueBridge.toTagged((EvValue.null())))
     }
@@ -91,7 +124,6 @@ class EvValueBridge {
     sfn taggedBoolean:EvalValue (b:boolean) {
         return (EvValueBridge.toTagged((EvValue.boolean(b))))
     }
-
     sfn isNull:boolean (v:EvalValue) {
         return (v.isNull())
     }
@@ -106,5 +138,62 @@ class EvValueBridge {
     }
     sfn isBoolean:boolean (v:EvalValue) {
         return (v.isBoolean())
+    }
+
+    ; ---- Element ----------------------------------------------------------
+    sfn taggedElement:EvalValue (el:EVGElement) {
+        return (EvValueBridge.toTagged((EvValue.element(el))))
+    }
+    sfn isElement:boolean (v:EvalValue) {
+        return (v.isElement())
+    }
+
+    ; ---- Property carriers / collections ----------------------------------
+    ; Payload-bearing creates allocate once via EvalValue.* (identity mint).
+    ; Empty Map/Set go through the shape → toTagged path.
+    sfn taggedArray:EvalValue (items:[EvalValue]) {
+        return (EvalValue.array(items))
+    }
+    sfn taggedObject:EvalValue (keys:[string] values:[EvalValue]) {
+        return (EvalValue.object(keys values))
+    }
+    sfn taggedMapEmpty:EvalValue () {
+        return (EvValueBridge.toTagged((EvValue.mapEmpty())))
+    }
+    sfn taggedSetEmpty:EvalValue () {
+        return (EvValueBridge.toTagged((EvValue.setEmpty())))
+    }
+    ; Named isArrayValue — a global `isArray` operator blocks Class.isArray sfns.
+    sfn isArrayValue:boolean (v:EvalValue) {
+        return (v.isArray())
+    }
+    sfn isObject:boolean (v:EvalValue) {
+        return (v.isObject())
+    }
+    sfn isMap:boolean (v:EvalValue) {
+        return (v.isMap())
+    }
+    sfn isSet:boolean (v:EvalValue) {
+        return (v.isSet())
+    }
+
+    ; ---- Function family --------------------------------------------------
+    sfn taggedFunction:EvalValue (fnNode:TSNode) {
+        return (EvalValue.function(fnNode))
+    }
+    sfn taggedNativeFunction:EvalValue (name:string) {
+        return (EvValueBridge.toTagged((EvValue.functionStub(name))))
+    }
+    sfn taggedNativeMethod:EvalValue (kind:string name:string) {
+        return (EvalValue.nativeMethod(kind name))
+    }
+    sfn taggedNativeStatic:EvalValue (ns:string name:string) {
+        return (EvalValue.nativeStatic(ns name))
+    }
+    sfn taggedBoundMethod:EvalValue (fnNode:TSNode thisVal:EvalValue) {
+        return (EvalValue.boundMethod(fnNode thisVal))
+    }
+    sfn isFunction:boolean (v:EvalValue) {
+        return (v.isFunction())
     }
 }

--- a/gallery/game_engine/v2/interp/migrate/src/EvValueBridge.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/EvValueBridge.rgr
@@ -2,9 +2,10 @@
 ; EvValueBridge — tagged ↔ shape conversion (PLAN_SHAPES.md §7.5)
 ; =============================================================================
 ; E2: fromTagged for primitives / Hole.
-; E3: toTagged + Hole engine API. ComponentEngine creates holes through
-; taggedHole() so the shape is the source of truth; array storage remains
-; class EvalValue until later kinds move.
+; E3 Hole: taggedHole / isHole engine API.
+; E3 primitives: taggedNull/Undefined/Number/String/Boolean + predicates.
+; ComponentEngine creates and checks these kinds through the bridge so the
+; shape owns them; array storage remains class EvalValue until later kinds move.
 
 Import "EvalValue.rgr"
 Import "EvValue.rgr"
@@ -60,10 +61,8 @@ class EvValueBridge {
     }
 
     ; ---- E3 Hole engine surface -------------------------------------------
-    ; ComponentEngine calls these instead of EvalValue.hole() / .isHole so the
-    ; Hole kind is owned by the shape. Storage encoding is still the pooled
-    ; tagged singleton (isHole flag); discrimination stays a flag read for
-    ; hot array walks.
+    ; Storage encoding is still the pooled tagged singleton (isHole flag);
+    ; discrimination stays a flag read for hot array walks.
 
     sfn taggedHole:EvalValue () {
         return (EvValueBridge.toTagged((EvValue.hole())))
@@ -71,5 +70,41 @@ class EvValueBridge {
 
     sfn isHole:boolean (v:EvalValue) {
         return v.isHole
+    }
+
+    ; ---- E3 primitive engine surface --------------------------------------
+    ; Same pattern as Hole: shape factory → toTagged. Predicates keep the
+    ; tagged-class method bodies for speed; the API boundary is the bridge.
+
+    sfn taggedNull:EvalValue () {
+        return (EvValueBridge.toTagged((EvValue.null())))
+    }
+    sfn taggedUndefined:EvalValue () {
+        return (EvValueBridge.toTagged((EvValue.undefined())))
+    }
+    sfn taggedNumber:EvalValue (n:double) {
+        return (EvValueBridge.toTagged((EvValue.number(n))))
+    }
+    sfn taggedString:EvalValue (s:string) {
+        return (EvValueBridge.toTagged((EvValue.string(s))))
+    }
+    sfn taggedBoolean:EvalValue (b:boolean) {
+        return (EvValueBridge.toTagged((EvValue.boolean(b))))
+    }
+
+    sfn isNull:boolean (v:EvalValue) {
+        return (v.isNull())
+    }
+    sfn isUndefined:boolean (v:EvalValue) {
+        return (v.isUndefined())
+    }
+    sfn isNumber:boolean (v:EvalValue) {
+        return (v.isNumber())
+    }
+    sfn isString:boolean (v:EvalValue) {
+        return (v.isString())
+    }
+    sfn isBoolean:boolean (v:EvalValue) {
+        return (v.isBoolean())
     }
 }

--- a/gallery/game_engine/v2/interp/migrate/src/EvValueBridge.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/EvValueBridge.rgr
@@ -36,7 +36,8 @@ class EvValueBridge {
             return (EvValue.undefined())
         }
         if (v.valueType == 4) {
-            return (EvValue.array(([] _:EvValue ())))
+            def emptyItems:[EvValue]
+            return (EvValue.array(emptyItems))
         }
         if (v.valueType == 5) {
             return (EvValue.object())

--- a/gallery/game_engine/v2/interp/migrate/src/EvValueBridge.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/EvValueBridge.rgr
@@ -1,9 +1,10 @@
 ; =============================================================================
-; EvValueBridge — E2 tagged-class → shape conversion (PLAN_SHAPES.md §7.5)
+; EvValueBridge — tagged ↔ shape conversion (PLAN_SHAPES.md §7.5)
 ; =============================================================================
-; One-way bridge from the live `class EvalValue` into the E1 `shape EvValue`.
-; Used by smoke tests and the coming per-kind migration; ComponentEngine still
-; talks only to the tagged class.
+; E2: fromTagged for primitives / Hole.
+; E3: toTagged + Hole engine API. ComponentEngine creates holes through
+; taggedHole() so the shape is the source of truth; array storage remains
+; class EvalValue until later kinds move.
 
 Import "EvalValue.rgr"
 Import "EvValue.rgr"
@@ -32,5 +33,43 @@ class EvValueBridge {
             return (EvValue.boolean(v.boolValue))
         }
         return (EvValue.undefined())
+    }
+
+    ; Shape → tagged. Hole and primitives only; other cases become undefined
+    ; until those kinds convert.
+    sfn toTagged:EvalValue (ev:EvValue) {
+        case ev h:EvValue.Hole {
+            return (EvalValue.hole())
+        }
+        case ev n:EvValue.Null {
+            return (EvalValue.null())
+        }
+        case ev u:EvValue.Undefined {
+            return (EvalValue.undefined())
+        }
+        case ev num:EvValue.Number {
+            return (EvalValue.number(num.value))
+        }
+        case ev s:EvValue.String {
+            return (EvalValue.string(s.value))
+        }
+        case ev b:EvValue.Boolean {
+            return (EvalValue.boolean(b.value))
+        }
+        return (EvalValue.undefined())
+    }
+
+    ; ---- E3 Hole engine surface -------------------------------------------
+    ; ComponentEngine calls these instead of EvalValue.hole() / .isHole so the
+    ; Hole kind is owned by the shape. Storage encoding is still the pooled
+    ; tagged singleton (isHole flag); discrimination stays a flag read for
+    ; hot array walks.
+
+    sfn taggedHole:EvalValue () {
+        return (EvValueBridge.toTagged((EvValue.hole())))
+    }
+
+    sfn isHole:boolean (v:EvalValue) {
+        return v.isHole
     }
 }

--- a/gallery/game_engine/v2/interp/migrate/src/README.md
+++ b/gallery/game_engine/v2/interp/migrate/src/README.md
@@ -4,26 +4,28 @@
 
 | File | Role |
 |------|------|
-| `EvalValue.rgr` | Script values / NativeRef / identity (tagged class, live storage) |
-| `EvValue.rgr` | Target `shape EvValue` (E1–E3; Hole wired into the engine) |
-| `EvValueBridge.rgr` | Tagged ↔ shape bridge; Hole engine API (`taggedHole` / `isHole`) |
-| `ComponentEngine.rgr` | Evaluator (Hole creation/checks go through the bridge) |
+| `EvalValue.rgr` | Script values / NativeRef / identity (**storage** — tagged class) |
+| `EvValue.rgr` | Target `shape EvValue` (all kinds defined) |
+| `EvValueBridge.rgr` | Tagged ↔ shape bridge; **all** kind create/check APIs |
+| `ComponentEngine.rgr` | Evaluator (creates/checks every kind through the bridge) |
 | `JSXToEVG.rgr` | JSX → EVG (UI / EVG path) |
 
-**Plan phase:** 1 (values/identity first), then 4 (adapter). See `PLAN_SHAPES.md` §7.5.
+**Plan:** `PLAN_SHAPES.md` §7.5.
 
 ## Status
 
 - **Staged copy** that is now the authoritative v2 TSX engine.
-- **E1/E2 done** — shape + primitive bridge beside the class.
-- **E3 in progress** — Hole and primitive kinds are shape-owned at the
-  ComponentEngine boundary (`EvValueBridge.taggedHole` / `taggedNumber` / …).
-  Array slots still store `class EvalValue`. Next: Element, then property carriers.
-- Split into `interp/values/`, `interp/engine/`, `interp/semantics/` as Phase 1
-  progresses — do not edit only the v1 originals for v2 work.
+- **✅ E1/E2** — shape + primitive bridge beside the class.
+- **✅ E3 (by-kind boundary)** — Hole, primitives, Element, Array/Object/Map/Set,
+  and Function family create/check go through `EvValueBridge`. Array slots still
+  store `class EvalValue` (needed for shared mutation / `===`). Bridge Array
+  check is `isArrayValue` (a global `isArray` operator blocks `Class.isArray`).
+  `EvalValue.fromInt` / `rawNumber` stay on the tagged class (int pool / mutate).
+- **Step 4 ahead** — migrate storage to the shape, delete `valueType` wrappers,
+  rename `EvValue` → `EvalValue` (~170 in-place mutators; separate cutover).
 
 ## Unit / contract tests that gate this folder
 
 - `tests/shapes.test.ts` — EvValue E1/E2/E3 fixtures
-- `npm run test:runtime` — `tests/runtime-conformance.test.ts` (holes / elision)
+- `npm run test:runtime` — `tests/runtime-conformance.test.ts`
 - `npm run test:tsengine` — native bench / multi-target engine gate

--- a/gallery/game_engine/v2/interp/migrate/src/README.md
+++ b/gallery/game_engine/v2/interp/migrate/src/README.md
@@ -16,9 +16,9 @@
 
 - **Staged copy** that is now the authoritative v2 TSX engine.
 - **E1/E2 done** — shape + primitive bridge beside the class.
-- **E3 in progress** — Hole kind is shape-owned at the ComponentEngine
-  boundary (`EvValueBridge.taggedHole` / `isHole`). Array slots still store
-  `class EvalValue`. Next: primitives, then Element, then property carriers.
+- **E3 in progress** — Hole and primitive kinds are shape-owned at the
+  ComponentEngine boundary (`EvValueBridge.taggedHole` / `taggedNumber` / …).
+  Array slots still store `class EvalValue`. Next: Element, then property carriers.
 - Split into `interp/values/`, `interp/engine/`, `interp/semantics/` as Phase 1
   progresses — do not edit only the v1 originals for v2 work.
 

--- a/gallery/game_engine/v2/interp/migrate/src/README.md
+++ b/gallery/game_engine/v2/interp/migrate/src/README.md
@@ -4,21 +4,26 @@
 
 | File | Role |
 |------|------|
-| `EvalValue.rgr` | Script values / NativeRef / identity (tagged class, live) |
-| `EvValue.rgr` | E1/E2 target `shape EvValue` (beside the class; not wired yet) |
-| `EvValueBridge.rgr` | E2 tagged → shape conversion for primitives / Hole |
-| `ComponentEngine.rgr` | Evaluator |
+| `EvalValue.rgr` | Script values / NativeRef / identity (tagged class, live storage) |
+| `EvValue.rgr` | Target `shape EvValue` (E1–E3; Hole wired into the engine) |
+| `EvValueBridge.rgr` | Tagged ↔ shape bridge; Hole engine API (`taggedHole` / `isHole`) |
+| `ComponentEngine.rgr` | Evaluator (Hole creation/checks go through the bridge) |
 | `JSXToEVG.rgr` | JSX → EVG (UI / EVG path) |
 
-**Plan phase:** 1 (values/identity first), then 4 (adapter).
+**Plan phase:** 1 (values/identity first), then 4 (adapter). See `PLAN_SHAPES.md` §7.5.
 
 ## Status
 
-- **Staged copy.** Still coupled to `gallery/ts_parser/` and pdf_writer paths.
+- **Staged copy** that is now the authoritative v2 TSX engine.
+- **E1/E2 done** — shape + primitive bridge beside the class.
+- **E3 in progress** — Hole kind is shape-owned at the ComponentEngine
+  boundary (`EvValueBridge.taggedHole` / `isHole`). Array slots still store
+  `class EvalValue`. Next: primitives, then Element, then property carriers.
 - Split into `interp/values/`, `interp/engine/`, `interp/semantics/` as Phase 1
   progresses — do not edit only the v1 originals for v2 work.
 
 ## Unit / contract tests that gate this folder
 
-- `interp/semantics/tests` + `tests/contract/d_identity` (to be written against
-  these sources or their split descendants)
+- `tests/shapes.test.ts` — EvValue E1/E2/E3 fixtures
+- `npm run test:runtime` — `tests/runtime-conformance.test.ts` (holes / elision)
+- `npm run test:tsengine` — native bench / multi-target engine gate

--- a/tests/fixtures/shape_evalvalue_e3_hole.rgr
+++ b/tests/fixtures/shape_evalvalue_e3_hole.rgr
@@ -1,0 +1,50 @@
+; E3 smoke test: Hole kind is shape-owned (PLAN_SHAPES.md §7.5).
+; Creation goes EvValue.Hole → toTagged; engine API is EvValueBridge.taggedHole.
+Import "../../gallery/game_engine/v2/interp/migrate/src/EvValueBridge.rgr"
+
+class Main {
+    sfn main:void () {
+        ; shape → tagged → shape round-trip
+        def shaped:EvValue (EvValue.hole())
+        def tagged:EvalValue (EvValueBridge.toTagged(shaped))
+        def back:EvValue (EvValueBridge.fromTagged(tagged))
+        if (EvValue.isHole(back)) {
+            print "roundtrip"
+        } {
+            print "WRONG: Hole round-trip failed"
+        }
+
+        ; engine creation surface
+        def eng:EvalValue (EvValueBridge.taggedHole())
+        if (EvValueBridge.isHole(eng)) {
+            print "engine"
+        } {
+            print "WRONG: taggedHole not a hole"
+        }
+
+        ; Hole is not Undefined
+        def u:EvalValue (EvalValue.undefined())
+        if (EvValueBridge.isHole(u)) {
+            print "WRONG: undefined is a hole"
+        } {
+            print "distinct"
+        }
+        def us:EvValue (EvValueBridge.fromTagged(u))
+        if (EvValue.isUndefined(us)) {
+            if (EvValue.isHole(us)) {
+                print "WRONG: undefined shaped as hole"
+            } {
+                print "undef"
+            }
+        } {
+            print "WRONG: lost Undefined"
+        }
+
+        ; Hole is falsy
+        if (EvValue.toBool(shaped)) {
+            print "WRONG: Hole is truthy"
+        } {
+            print "falsy"
+        }
+    }
+}

--- a/tests/fixtures/shape_evalvalue_e3_prims.rgr
+++ b/tests/fixtures/shape_evalvalue_e3_prims.rgr
@@ -1,0 +1,72 @@
+; E3 smoke test: primitive kinds are shape-owned (PLAN_SHAPES.md §7.5).
+Import "../../gallery/game_engine/v2/interp/migrate/src/EvValueBridge.rgr"
+
+class Main {
+    sfn main:void () {
+        ; number round-trip
+        def n:EvalValue (EvValueBridge.taggedNumber(3.0))
+        if (EvValueBridge.isNumber(n)) {
+            def ns:EvValue (EvValueBridge.fromTagged(n))
+            if (EvValue.isNumber(ns)) {
+                if (EvValue.toBool(ns)) {
+                    print "num"
+                } {
+                    print "WRONG: 3 falsy"
+                }
+            } {
+                print "WRONG: fromTagged lost Number"
+            }
+        } {
+            print "WRONG: taggedNumber not a number"
+        }
+
+        ; zero is falsy
+        def z:EvalValue (EvValueBridge.taggedNumber(0.0))
+        def zs:EvValue (EvValueBridge.fromTagged(z))
+        if (EvValue.toBool(zs)) {
+            print "WRONG: zero truthy"
+        } {
+            print "zero"
+        }
+
+        ; null / undefined distinct from hole
+        def nu:EvalValue (EvValueBridge.taggedNull())
+        def un:EvalValue (EvValueBridge.taggedUndefined())
+        if (EvValueBridge.isNull(nu)) {
+            if (EvValueBridge.isUndefined(un)) {
+                if (EvValueBridge.isHole(nu)) {
+                    print "WRONG: null is hole"
+                } {
+                    print "nullish"
+                }
+            } {
+                print "WRONG: not undefined"
+            }
+        } {
+            print "WRONG: not null"
+        }
+
+        ; string / boolean
+        def s:EvalValue (EvValueBridge.taggedString("hi"))
+        def b:EvalValue (EvValueBridge.taggedBoolean(true))
+        if (EvValueBridge.isString(s)) {
+            if (EvValueBridge.isBoolean(b)) {
+                print "strb"
+            } {
+                print "WRONG: boolean"
+            }
+        } {
+            print "WRONG: string"
+        }
+
+        ; shape → tagged → shape for string
+        def shaped:EvValue (EvValue.string("x"))
+        def tagged:EvalValue (EvValueBridge.toTagged(shaped))
+        def back:EvValue (EvValueBridge.fromTagged(tagged))
+        if (EvValue.isString(back)) {
+            print "roundtrip"
+        } {
+            print "WRONG: string round-trip"
+        }
+    }
+}

--- a/tests/fixtures/shape_evalvalue_e3_refs.rgr
+++ b/tests/fixtures/shape_evalvalue_e3_refs.rgr
@@ -1,0 +1,73 @@
+; E3 smoke test: Element + carriers + Function kinds (PLAN_SHAPES.md §7.5).
+; Note: bridge Array check is isArrayValue — a global `isArray` operator blocks
+; Class.isArray static methods (same poison as JSON.rgr's isArray op).
+Import "../../gallery/game_engine/v2/interp/migrate/src/EvValueBridge.rgr"
+Import "../../gallery/game_engine/v2/evg/EVGElement.rgr"
+
+class Main {
+    sfn main:void () {
+        ; Array
+        def empty:[EvalValue]
+        def arr:EvalValue (EvValueBridge.taggedArray(empty))
+        if (EvValueBridge.isArrayValue(arr)) {
+            def shapedArr:EvValue (EvValueBridge.fromTagged(arr))
+            if (EvValue.isArrayValue(shapedArr)) {
+                print "array"
+            } {
+                print "WRONG: fromTagged lost Array"
+            }
+        } {
+            print "WRONG: taggedArray"
+        }
+
+        ; Object
+        def keys:[string]
+        def vals:[EvalValue]
+        def obj:EvalValue (EvValueBridge.taggedObject(keys vals))
+        if (EvValueBridge.isObject(obj)) {
+            print "object"
+        } {
+            print "WRONG: taggedObject"
+        }
+
+        ; Map / Set
+        def mp:EvalValue (EvValueBridge.taggedMapEmpty())
+        def st:EvalValue (EvValueBridge.taggedSetEmpty())
+        if (EvValueBridge.isMap(mp)) {
+            if (EvValueBridge.isSet(st)) {
+                print "mapset"
+            } {
+                print "WRONG: set"
+            }
+        } {
+            print "WRONG: map"
+        }
+
+        ; Function (native stub via shape → toTagged)
+        def fn:EvalValue (EvValueBridge.taggedNativeFunction("TypeError"))
+        if (EvValueBridge.isFunction(fn)) {
+            def fs:EvValue (EvValueBridge.fromTagged(fn))
+            if (EvValue.isFunction(fs)) {
+                print "fn"
+            } {
+                print "WRONG: fromTagged lost Function"
+            }
+        } {
+            print "WRONG: taggedNativeFunction"
+        }
+
+        ; Element
+        def el:EVGElement (EVGElement.createDiv())
+        def ev:EvalValue (EvValueBridge.taggedElement(el))
+        if (EvValueBridge.isElement(ev)) {
+            def es:EvValue (EvValueBridge.fromTagged(ev))
+            if (EvValue.isElement(es)) {
+                print "element"
+            } {
+                print "WRONG: fromTagged lost Element"
+            }
+        } {
+            print "WRONG: taggedElement"
+        }
+    }
+}

--- a/tests/shapes.test.ts
+++ b/tests/shapes.test.ts
@@ -753,6 +753,23 @@ describe("shapes (closed variant families)", () => {
   });
 
   /**
+   * E3 primitives: null / undefined / number / string / boolean creation and
+   * checks go through EvValueBridge so the shape owns those kinds too.
+   */
+  describe("EvValue E3 primitive kinds", () => {
+    const E3P = `${FIXTURES_DIR}/shape_evalvalue_e3_prims.rgr`;
+    const EXPECTED_E3P = ["num", "zero", "nullish", "strb", "roundtrip"].join("\n");
+
+    it("ES6", () => {
+      expectOutput(E3P, EXPECTED_E3P);
+    });
+
+    it.skipIf(!isRustAvailable())("Rust", () => {
+      expectRustOutput(E3P, EXPECTED_E3P);
+    });
+  });
+
+  /**
    * Group field projection (PLAN_SHAPES.md §7 / C5). Fields declared on a
    * group are read and written through the group type via generated get_/set_
    * ops — no narrowing required, identity preserved for reference groups.

--- a/tests/shapes.test.ts
+++ b/tests/shapes.test.ts
@@ -733,6 +733,26 @@ describe("shapes (closed variant families)", () => {
   });
 
   /**
+   * E3 (PLAN_SHAPES.md §7.5): Hole kind is shape-owned. Creation goes
+   * EvValue.Hole → toTagged; ComponentEngine uses EvValueBridge.taggedHole /
+   * isHole. Storage encoding remains the tagged singleton for now.
+   */
+  describe("EvValue E3 Hole kind", () => {
+    const E3 = `${FIXTURES_DIR}/shape_evalvalue_e3_hole.rgr`;
+    const EXPECTED_E3 = ["roundtrip", "engine", "distinct", "undef", "falsy"].join(
+      "\n"
+    );
+
+    it("ES6", () => {
+      expectOutput(E3, EXPECTED_E3);
+    });
+
+    it.skipIf(!isRustAvailable())("Rust", () => {
+      expectRustOutput(E3, EXPECTED_E3);
+    });
+  });
+
+  /**
    * Group field projection (PLAN_SHAPES.md §7 / C5). Fields declared on a
    * group are read and written through the group type via generated get_/set_
    * ops — no narrowing required, identity preserved for reference groups.

--- a/tests/shapes.test.ts
+++ b/tests/shapes.test.ts
@@ -770,6 +770,23 @@ describe("shapes (closed variant families)", () => {
   });
 
   /**
+   * E3 reference kinds: Element, Array, Object, Map, Set, Function — all
+   * create/check through EvValueBridge. Completes §7.5 step 3 (by-kind boundary).
+   */
+  describe("EvValue E3 reference kinds", () => {
+    const E3R = `${FIXTURES_DIR}/shape_evalvalue_e3_refs.rgr`;
+    const EXPECTED_E3R = ["array", "object", "mapset", "fn", "element"].join("\n");
+
+    it("ES6", () => {
+      expectOutput(E3R, EXPECTED_E3R);
+    });
+
+    it.skipIf(!isRustAvailable())("Rust", () => {
+      expectRustOutput(E3R, EXPECTED_E3R);
+    });
+  });
+
+  /**
    * Group field projection (PLAN_SHAPES.md §7 / C5). Fields declared on a
    * group are read and written through the group type via generated get_/set_
    * ops — no narrowing required, identity preserved for reference groups.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes **PLAN_SHAPES.md §7.5 step 3 (E3 by-kind boundary)** for `EvalValue` → `shape EvValue`.

Every kind’s create/check API in `ComponentEngine` now goes through `EvValueBridge` so the closed family owns the kind. Storage remains `class EvalValue` / `[EvalValue]` (identity-preserving mutation) until step 4.

### What’s in this PR

1. **Hole** — `taggedHole` / `isHole`; fixture `shape_evalvalue_e3_hole.rgr`
2. **Primitives** — null/undefined/number/string/boolean; fixture `shape_evalvalue_e3_prims.rgr`
3. **Reference kinds** — Element, Array/Object/Map/Set, Function family; fixture `shape_evalvalue_e3_refs.rgr`
   - Payload creates allocate once via `EvalValue.*` (identity mint)
   - Bridge Array check is `isArrayValue` (global `isArray` operator blocks `Class.isArray`)
   - `EvalValue.fromInt` / `rawNumber` stay on the tagged class (int pool / mutate-in-place)
   - Map/Set empty factories bind empty arrays before case ctors (Rust drops bare `([] _:T ())` args)

### Out of scope (step 4)

Delete `valueType` wrappers, migrate storage to the shape, rename `EvValue` → `EvalValue`. That needs ~170 in-place mutators moved off the tagged class — a separate cutover.

### Test plan

- [x] ES6 + Rust E3 hole / prims / refs fixtures
- [x] `npm run test:runtime` — 1281/1281 (forced engine rebuild)
- [x] `npm run test:tsengine` — 7 passed / 1 skipped

EOF

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec6fa043-7f1a-454d-b234-e615b4da0b7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec6fa043-7f1a-454d-b234-e615b4da0b7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

