### PR TITLE
Remeasure: Ranger vs QuickJS vs Duktape after #543

### DIFF
--- a/gallery/game_engine/v2/interp/bench/native/README.md
+++ b/gallery/game_engine/v2/interp/bench/native/README.md
@@ -148,25 +148,28 @@ started from a C++/QJS `array` ratio of 3451x:
 
 ```
 case      raw Node raw QuickJS   eng/ES6   eng/C++ | ES6/QJS   C++/QJS
-loop         0.768       0.740      19.8       8.0  |   26.8x     10.9x
-fib          0.512       0.840      17.8      13.8  |   21.2x     16.5x
-strcat       0.470      10.500      13.5      10.5  |    1.3x      1.0x
-array        1.476       2.289      50.7      24.3  |   22.1x     10.6x
-object       2.807       4.414      51.8      61.8  |   11.7x     14.0x
-method       2.258       5.188      87.9      71.2  |   17.0x     13.7x
-regex        1.878       7.203      67.1      79.4  |    9.3x     11.0x
-geomean      1.183       3.052      35.7      26.8  |   11.7x      8.8x
+loop         0.270       0.365     2.102     1.589  |    5.8x      4.4x
+fib          0.227       0.409     3.038     4.951  |    7.4x     12.1x
+strcat       0.243       6.172     0.532     1.544  |    0.1x      0.3x
+array        0.685       1.320     4.126     4.734  |    3.1x      3.6x
+object       1.144       2.137      10.6     7.748  |    5.0x      3.6x
+method       1.127       2.430      12.2      14.3  |    5.0x      5.9x
+regex        1.028       3.719      27.8      29.7  |    7.5x      8.0x
+geomean      0.541       1.570     4.701     5.676  |    3.0x      3.6x
 ```
 
-The C++ geomean against QuickJS went 63x → 8.8x over this work (the es6
-build: 20x → 11.7x). The last cut is the BYTECODE TIER (migrate/BYTECODE.md):
-a compilable function body -- plain params, locals, arithmetic, branches,
-loops, direct calls -- compiles once into a flat opcode stream and runs on
-a slot-indexed stack VM with no per-call EvalContext at all; everything
-else stays on the tree-walker, and the two call each other freely through
-the same dispatch. `loop` went 23x → 10.9x and `fib` 34x → 16.5x on it. `strcat` is the row to stare at: the INTERPRETER now
-concatenates as fast as QuickJS runs the same loop natively, because qjs
-copies the accumulator per `+=` while the slot machinery appends in place.
+(Re-measured on `9e1edf89` / master after #543 with QuickJS 2024-01-13.)
+
+The C++ geomean against QuickJS went 63x → **3.6x** over this work (the es6
+build → **3.0x**). The last big cut is the BYTECODE TIER
+(migrate/BYTECODE.md): a compilable function body -- plain params, locals,
+arithmetic, branches, loops, direct calls -- compiles once into a flat
+opcode stream and runs on a slot-indexed stack VM with no per-call
+EvalContext at all; everything else stays on the tree-walker, and the two
+call each other freely through the same dispatch. `strcat` beats QuickJS
+because the slot machinery appends in place while qjs copies. Octane
+Richards (~16× behind QJS on es6/Rust) is still the object-graph story —
+see `../zoo_octane/RESULTS.md`.
 The `array` row's last big cut came from a CALL-SITE INLINE CACHE: a method
 call that resolved to a registry built-in memoises an opcode on its AST node,
 valid while a dispatch EPOCH stands still. The epoch bumps whenever a

--- a/gallery/game_engine/v2/interp/bench/zoo_octane/RESULTS.md
+++ b/gallery/game_engine/v2/interp/bench/zoo_octane/RESULTS.md
@@ -174,7 +174,7 @@ would narrow if those were added.
 
 ---
 
-## Six-engine matrix (2026-08-07)
+## Six-engine matrix (remeasured 2026-08-08 on `9e1edf89`)
 
 Every engine runs the SAME prepared suite bodies. External engines
 (`node` / `qjs` / `duk`) take the raw zoo files; the Ranger targets
@@ -183,54 +183,96 @@ Every engine runs the SAME prepared suite bodies. External engines
 `python3 bench_matrix.py` (writes `matrix-results.json`) and render with
 `python3 matrix_report.py`.
 
+Host: Intel Xeon cloud agent, Node v22.14, QuickJS 2024-01-13, Duktape 2.7.0,
+`g++ -O3 -march=native`, `rustc -C opt-level=3`. Raw JSON:
+[`matrix-results.json`](./matrix-results.json).
+
 ### Octane score (higher is better)
 
 | Suite | Node (V8) | QuickJS | Duktape | Ranger es6 | Ranger C++ -O3 | Ranger Rust -O3 |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| richards | 36940 | 669 | 281 | 21.7 | 21.7 | 21.7 |
-| deltablue | 61761 | 691 | 328 | 40.6 | 40.6 | 40.6 |
-| splay | 10300 | 1617 | 1172 | 136 | 136† | 136 |
-| regexp | 6994 | 220 | 157 | 27.9 | FAIL | FAIL |
-| crypto | 41046 | 929 | 347 | FAIL | FAIL | FAIL |
-| raytrace | 57719 | 981 | 629 | FAIL | FAIL | FAIL |
-| navier-stokes | 39248 | 1623 | 1373 | FAIL | FAIL | FAIL |
-| earley-boyer | 66591 | 1530 | 684 | FAIL | FAIL | FAIL |
+| richards | 52960 | 920 | 400 | **59** | 0.5† | **59** |
+| deltablue | 125472 | 956 | 483 | **110** | 1† | **110** |
+| splay | 17250 | 2591 | 2188 | **370** | 3† | **370** |
+| regexp | 10728 | 353 | 278 | **75.8** | FAIL | **27.9** |
+| crypto | 60773 | 1361 | 540 | FAIL | FAIL | FAIL |
+| raytrace | 111664 | 1473 | 993 | FAIL | FAIL | FAIL |
+| navier-stokes | 56689 | 2384 | 2172 | FAIL | FAIL | FAIL |
+| earley-boyer | 103765 | 2228 | 1089 | FAIL | FAIL | FAIL |
 
-† C++ splay's score flips between 3 and 136 from run to run on this
-container without any code change — the engine's coarse live clock
-quantizes the harness's timing windows. A fixed-work splay kernel puts
-the C++ target at the same wall time across the phase-5/6 builds, so
-read this row as "runs and verifies", not as a stable throughput.
+† C++ Octane *scores* are quantized by the coarse `liveClock` on this host
+(0.5 / 1 / 3) even though **wall time matches Rust/es6** (richards ~4.3 s vs
+es6 4.2 s / rust 5.5 s). Read C++ throughput from the wall-time table or the
+microbench below, not from these Octane score cells.
 
-Four suites (richards, deltablue, splay, and — on es6 — regexp) produce a
-valid score on the Ranger engine. The other four fail the SAME way on every
-Ranger target, which locates them in the engine's semantics, not a target's
-lowering: crypto returns a wrong digest, raytrace renders the scene
-incorrectly, navier-stokes fails its checksum, and earley-boyer trips the
-engine's TS parser on the Scheme-compiled source (leading-zero numeric keys
-in strict mode). `regexp` is the one target-specific split — see below.
+| Ratio on Richards (reported score) | |
+| --- | ---: |
+| QuickJS / Ranger es6·Rust | **15.6×** |
+| Duktape / Ranger es6·Rust | **6.8×** |
+| Node / Ranger es6·Rust | **897×** |
+| Ranger % of zoo V8 (37102) | **0.16%** |
 
-earley-boyer fails cleanly and fast on every target now — ~0.2 s on es6,
-~3 s on the natives (the parser tokenizes the 210 KB file quickly since the
-O(1) `at` cache, reports the syntax errors, and the script is rejected rather
-than run). Two earlier failure modes are gone: the ~60 s tokenizer hang (the
-O(n²) `at`) and the native ~15 GB allocation blow-up from evaluating the
-malformed post-recovery AST (a syntax-error script now throws instead of
-running — the rule `eval`/`Function` already followed).
+### Wall time of the run (suite driver included)
+
+| Suite | Node (V8) | QuickJS | Duktape | Ranger es6 | Ranger C++ -O3 | Ranger Rust -O3 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| richards | 2.0s | 2.0s | 2.0s | 4.2s | 4.3s | 5.5s |
+| deltablue | 2.0s | 2.0s | 2.0s | 5.6s | 4.4s | 5.4s |
+| splay | 2.1s | 2.5s | 2.4s | 6.2s | 5.7s | 6.3s |
+| regexp | 2.1s | 5.4s | 6.9s | 32.8s | 1.8s‡ | 89.5s |
+
+‡ C++ regexp exits early with checksum FAIL.
+
+### Peak RSS (per-child `ru_maxrss`)
+
+| Suite | Node (V8) | QuickJS | Duktape | Ranger es6 | Ranger C++ -O3 | Ranger Rust -O3 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| richards | 57 MB | 10 MB | 10 MB | 87 MB | **13 MB** | **12 MB** |
+| deltablue | 86 MB | 10 MB | 10 MB | 132 MB | 56 MB | 57 MB |
+| splay | 470 MB | 169 MB | 129 MB | 870 MB | 485 MB | 523 MB |
+| regexp | 86 MB | 10 MB | 10 MB | 224 MB | 29 MB | 32 MB |
+
+Native RSS on Richards is now in the QuickJS class (~12–13 MB). Earlier
+builds retained cycles into multi-GB; that is fixed on this master tip.
+
+### Compatibility
+
+Four suites produce a valid score on Ranger: richards, deltablue, splay, and
+regexp (es6 + Rust; C++ regexp still checksum-fails). crypto (`Unknown type:
+this`), raytrace (incorrect scene), navier-stokes (checksum), and earley-boyer
+(parser rejects Scheme-compiled octal/leading-zero keys) fail the same way on
+every Ranger target — engine semantics, not a lowering bug.
 
 ### Binary size (stripped, this machine)
 
 | | stripped |
 | --- | ---: |
-| Duktape | 511 KB |
-| QuickJS | 1.03 MB |
-| Ranger C++ `octane_runner` (`-O3`) | 1.87 MB |
-| Ranger Rust `octane_runner` (`-O3`) | 2.78 MB |
+| Duktape | **514 KB** |
+| QuickJS | **1.03 MB** |
+| Ranger C++ `octane_runner` (`-O3`) | **1.85 MB** (~1.8× QJS) |
+| Ranger Rust `octane_runner` (`-O3`) | **2.87 MB** |
 
 The Ranger binaries carry the whole engine — the TypeScript lexer/parser, the
-regex engine, `Date`, JSON, the value model — not just an interpreter loop, so
-they land above QuickJS's hand-written C VM. The `-Os` C++ build comes in at
-~1.0 MB, QuickJS's size class, for ~2.7× the run time.
+regex engine, `Date`, JSON, the value model — not just an interpreter loop.
+
+### Microbench vs QuickJS (same tip)
+
+`node …/native/vs_quickjs.cjs` on this build — ms/run, lower is faster:
+
+| case | raw Node | raw QuickJS | eng/ES6 | eng/C++ | ES6/QJS | C++/QJS |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| loop | 0.270 | 0.365 | 2.10 | 1.59 | 5.8× | 4.4× |
+| fib | 0.227 | 0.409 | 3.04 | 4.95 | 7.4× | 12× |
+| strcat | 0.243 | 6.172 | 0.53 | 1.54 | **0.1×** | **0.3×** |
+| array | 0.685 | 1.320 | 4.13 | 4.73 | 3.1× | 3.6× |
+| object | 1.144 | 2.137 | 10.6 | 7.75 | 5.0× | 3.6× |
+| method | 1.127 | 2.430 | 12.2 | 14.3 | 5.0× | 5.9× |
+| regex | 1.028 | 3.719 | 27.8 | 29.7 | 7.5× | 8.0× |
+| **geomean** | 0.541 | 1.570 | 4.70 | 5.68 | **3.0×** | **3.6×** |
+
+C++/QuickJS geomean is now **~3.6×** (was ~12× after #541, ~63× before the E4
+work). `strcat` / in-place append beats qjs; Octane Richards remains the
+object-graph story (~16× behind QJS on the reported es6/Rust score).
 
 ## Bytecode tier, phase 5: unboxed number slots (2026-08-08)
 

--- a/gallery/game_engine/v2/interp/bench/zoo_octane/matrix-results.json
+++ b/gallery/game_engine/v2/interp/bench/zoo_octane/matrix-results.json
@@ -2,82 +2,82 @@
  "node": {
   "richards": {
    "status": "OK",
-   "out": "Richards: 36940\n",
-   "wall_ms": 2200.460767999999,
-   "rss_kb": 57072,
+   "out": "Richards: 52960\n",
+   "wall_ms": 2022.9452589999255,
+   "rss_kb": 58064,
    "scores": {
-    "Richards": 36940.0
+    "Richards": 52960.0
    },
    "errors": {}
   },
   "deltablue": {
    "status": "OK",
-   "out": "DeltaBlue: 61761\n",
-   "wall_ms": 2095.1819960000007,
-   "rss_kb": 87896,
+   "out": "DeltaBlue: 125472\n",
+   "wall_ms": 2021.7518970000583,
+   "rss_kb": 88228,
    "scores": {
-    "DeltaBlue": 61761.0
-   },
-   "errors": {}
-  },
-  "crypto": {
-   "status": "OK",
-   "out": "Crypto: 41046\n",
-   "wall_ms": 4067.7163239999954,
-   "rss_kb": 59632,
-   "scores": {
-    "Crypto": 41046.0
-   },
-   "errors": {}
-  },
-  "raytrace": {
-   "status": "OK",
-   "out": "RayTrace: 57719\n",
-   "wall_ms": 2072.5968240000016,
-   "rss_kb": 73000,
-   "scores": {
-    "RayTrace": 57719.0
-   },
-   "errors": {}
-  },
-  "earley-boyer": {
-   "status": "OK",
-   "out": "EarleyBoyer: 66591\n",
-   "wall_ms": 4055.522746000001,
-   "rss_kb": 90696,
-   "scores": {
-    "EarleyBoyer": 66591.0
+    "DeltaBlue": 125472.0
    },
    "errors": {}
   },
   "regexp": {
    "status": "OK",
-   "out": "RegExp: 6994\n",
-   "wall_ms": 2119.7228620000033,
-   "rss_kb": 74552,
+   "out": "RegExp: 10728\n",
+   "wall_ms": 2060.641965000059,
+   "rss_kb": 88260,
    "scores": {
-    "RegExp": 6994.0
+    "RegExp": 10728.0
    },
    "errors": {}
   },
   "splay": {
    "status": "OK",
-   "out": "Splay: 10300\nSplayLatency: 9128\n",
-   "wall_ms": 2191.677162000005,
-   "rss_kb": 454404,
+   "out": "Splay: 17250\nSplayLatency: 22091\n",
+   "wall_ms": 2099.450670000124,
+   "rss_kb": 481112,
    "scores": {
-    "Splay": 10300.0,
-    "SplayLatency": 9128.0
+    "Splay": 17250.0,
+    "SplayLatency": 22091.0
+   },
+   "errors": {}
+  },
+  "crypto": {
+   "status": "OK",
+   "out": "Crypto: 60773\n",
+   "wall_ms": 4024.4919289998506,
+   "rss_kb": 64128,
+   "scores": {
+    "Crypto": 60773.0
+   },
+   "errors": {}
+  },
+  "raytrace": {
+   "status": "OK",
+   "out": "RayTrace: 111664\n",
+   "wall_ms": 2022.1162729999378,
+   "rss_kb": 74428,
+   "scores": {
+    "RayTrace": 111664.0
    },
    "errors": {}
   },
   "navier-stokes": {
    "status": "OK",
-   "out": "NavierStokes: 39248\n",
-   "wall_ms": 2054.5200339999924,
-   "rss_kb": 60808,
+   "out": "NavierStokes: 56689\n",
+   "wall_ms": 2024.2212869998184,
+   "rss_kb": 61852,
    "scores": {
-    "NavierStokes": 39248.0
+    "NavierStokes": 56689.0
+   },
+   "errors": {}
+  },
+  "earley-boyer": {
+   "status": "OK",
+   "out": "EarleyBoyer: 103765\n",
+   "wall_ms": 4025.8279700001367,
+   "rss_kb": 91472,
+   "scores": {
+    "EarleyBoyer": 103765.0
    },
    "errors": {}
   }
@@ -85,82 +85,82 @@
  "qjs": {
   "richards": {
    "status": "OK",
-   "out": "Richards: 669\n",
-   "wall_ms": 2086.374494999987,
-   "rss_kb": 10692,
+   "out": "Richards: 920\n",
+   "wall_ms": 2005.5315260001407,
+   "rss_kb": 10544,
    "scores": {
-    "Richards": 669.0
+    "Richards": 920.0
    },
    "errors": {}
   },
   "deltablue": {
    "status": "OK",
-   "out": "DeltaBlue: 691\n",
-   "wall_ms": 2014.8605909999874,
-   "rss_kb": 10696,
+   "out": "DeltaBlue: 956\n",
+   "wall_ms": 2005.8319409999967,
+   "rss_kb": 10548,
    "scores": {
-    "DeltaBlue": 691.0
-   },
-   "errors": {}
-  },
-  "crypto": {
-   "status": "OK",
-   "out": "Crypto: 929\n",
-   "wall_ms": 7275.0794070000065,
-   "rss_kb": 10700,
-   "scores": {
-    "Crypto": 929.0
-   },
-   "errors": {}
-  },
-  "raytrace": {
-   "status": "OK",
-   "out": "RayTrace: 981\n",
-   "wall_ms": 4177.873731000005,
-   "rss_kb": 10700,
-   "scores": {
-    "RayTrace": 981.0
-   },
-   "errors": {}
-  },
-  "earley-boyer": {
-   "status": "OK",
-   "out": "EarleyBoyer: 1530\n",
-   "wall_ms": 8296.212738999999,
-   "rss_kb": 18052,
-   "scores": {
-    "EarleyBoyer": 1530.0
+    "DeltaBlue": 956.0
    },
    "errors": {}
   },
   "regexp": {
    "status": "OK",
-   "out": "RegExp: 220\n",
-   "wall_ms": 8662.605667000009,
-   "rss_kb": 10700,
+   "out": "RegExp: 353\n",
+   "wall_ms": 5442.586294000193,
+   "rss_kb": 10548,
    "scores": {
-    "RegExp": 220.0
+    "RegExp": 353.0
    },
    "errors": {}
   },
   "splay": {
    "status": "OK",
-   "out": "Splay: 1617\nSplayLatency: 3806\n",
-   "wall_ms": 3833.2971530000036,
-   "rss_kb": 171920,
+   "out": "Splay: 2591\nSplayLatency: 7555\n",
+   "wall_ms": 2506.8779919999997,
+   "rss_kb": 172612,
    "scores": {
-    "Splay": 1617.0,
-    "SplayLatency": 3806.0
+    "Splay": 2591.0,
+    "SplayLatency": 7555.0
+   },
+   "errors": {}
+  },
+  "crypto": {
+   "status": "OK",
+   "out": "Crypto: 1361\n",
+   "wall_ms": 6079.590887999984,
+   "rss_kb": 11072,
+   "scores": {
+    "Crypto": 1361.0
+   },
+   "errors": {}
+  },
+  "raytrace": {
+   "status": "OK",
+   "out": "RayTrace: 1473\n",
+   "wall_ms": 3017.0427040002323,
+   "rss_kb": 11080,
+   "scores": {
+    "RayTrace": 1473.0
    },
    "errors": {}
   },
   "navier-stokes": {
    "status": "OK",
-   "out": "NavierStokes: 1623\n",
-   "wall_ms": 3050.728050999993,
-   "rss_kb": 10700,
+   "out": "NavierStokes: 2384\n",
+   "wall_ms": 2124.419353000121,
+   "rss_kb": 11080,
    "scores": {
-    "NavierStokes": 1623.0
+    "NavierStokes": 2384.0
+   },
+   "errors": {}
+  },
+  "earley-boyer": {
+   "status": "OK",
+   "out": "EarleyBoyer: 2228\n",
+   "wall_ms": 7323.103124999761,
+   "rss_kb": 18072,
+   "scores": {
+    "EarleyBoyer": 2228.0
    },
    "errors": {}
   }
@@ -168,82 +168,82 @@
  "duk": {
   "richards": {
    "status": "OK",
-   "out": "Richards: 281\n",
-   "wall_ms": 2011.9722470000029,
-   "rss_kb": 10700,
+   "out": "Richards: 400\n",
+   "wall_ms": 2016.6558910000276,
+   "rss_kb": 10548,
    "scores": {
-    "Richards": 281.0
+    "Richards": 400.0
    },
    "errors": {}
   },
   "deltablue": {
    "status": "OK",
-   "out": "DeltaBlue: 328\n",
-   "wall_ms": 2023.025845999996,
-   "rss_kb": 10700,
+   "out": "DeltaBlue: 483\n",
+   "wall_ms": 2005.9192090000124,
+   "rss_kb": 10548,
    "scores": {
-    "DeltaBlue": 328.0
-   },
-   "errors": {}
-  },
-  "crypto": {
-   "status": "OK",
-   "out": "Crypto: 347\n",
-   "wall_ms": 14701.052516000003,
-   "rss_kb": 10700,
-   "scores": {
-    "Crypto": 347.0
-   },
-   "errors": {}
-  },
-  "raytrace": {
-   "status": "OK",
-   "out": "RayTrace: 629\n",
-   "wall_ms": 5284.739231999993,
-   "rss_kb": 10704,
-   "scores": {
-    "RayTrace": 629.0
-   },
-   "errors": {}
-  },
-  "earley-boyer": {
-   "status": "OK",
-   "out": "EarleyBoyer: 684\n",
-   "wall_ms": 15670.193688000012,
-   "rss_kb": 21544,
-   "scores": {
-    "EarleyBoyer": 684.0
+    "DeltaBlue": 483.0
    },
    "errors": {}
   },
   "regexp": {
    "status": "OK",
-   "out": "RegExp: 157\n",
-   "wall_ms": 11082.805791999988,
-   "rss_kb": 10704,
+   "out": "RegExp: 278\n",
+   "wall_ms": 6937.394706000077,
+   "rss_kb": 10548,
    "scores": {
-    "RegExp": 157.0
+    "RegExp": 278.0
    },
    "errors": {}
   },
   "splay": {
    "status": "OK",
-   "out": "Splay: 1172\nSplayLatency: 2226\n",
-   "wall_ms": 3675.7508750000056,
-   "rss_kb": 132264,
+   "out": "Splay: 2188\nSplayLatency: 6151\n",
+   "wall_ms": 2440.7094240000333,
+   "rss_kb": 132356,
    "scores": {
-    "Splay": 1172.0,
-    "SplayLatency": 2226.0
+    "Splay": 2188.0,
+    "SplayLatency": 6151.0
+   },
+   "errors": {}
+  },
+  "crypto": {
+   "status": "OK",
+   "out": "Crypto: 540\n",
+   "wall_ms": 10474.679960999765,
+   "rss_kb": 11080,
+   "scores": {
+    "Crypto": 540.0
+   },
+   "errors": {}
+  },
+  "raytrace": {
+   "status": "OK",
+   "out": "RayTrace: 993\n",
+   "wall_ms": 4170.274310999957,
+   "rss_kb": 11080,
+   "scores": {
+    "RayTrace": 993.0
    },
    "errors": {}
   },
   "navier-stokes": {
    "status": "OK",
-   "out": "NavierStokes: 1373\n",
-   "wall_ms": 3280.7337700000116,
-   "rss_kb": 10704,
+   "out": "NavierStokes: 2172\n",
+   "wall_ms": 3088.9740300003723,
+   "rss_kb": 11084,
    "scores": {
-    "NavierStokes": 1373.0
+    "NavierStokes": 2172.0
+   },
+   "errors": {}
+  },
+  "earley-boyer": {
+   "status": "OK",
+   "out": "EarleyBoyer: 1089\n",
+   "wall_ms": 11648.523667999598,
+   "rss_kb": 21816,
+   "scores": {
+    "EarleyBoyer": 1089.0
    },
    "errors": {}
   }
@@ -251,141 +251,137 @@
  "es6": {
   "richards": {
    "status": "OK",
-   "out": "[tsx] Richards: 21.7\n",
-   "wall_ms": 9309.951192,
-   "rss_kb": 91604,
+   "out": "[tsx] Richards: 59.0\n",
+   "wall_ms": 4155.3769150000335,
+   "rss_kb": 89200,
    "scores": {
-    "Richards": 21.7
+    "Richards": 59.0
    },
    "errors": {}
   },
   "deltablue": {
    "status": "OK",
-   "out": "[tsx] DeltaBlue: 40.6\n",
-   "wall_ms": 13322.162622000007,
-   "rss_kb": 128148,
+   "out": "[tsx] DeltaBlue: 110\n",
+   "wall_ms": 5550.237655999808,
+   "rss_kb": 134948,
    "scores": {
-    "DeltaBlue": 40.6
-   },
-   "errors": {}
-  },
-  "splay": {
-   "status": "OK",
-   "out": "[tsx] Splay: 136\n[tsx] SplayLatency: 1683\n",
-   "wall_ms": 10421.866740000012,
-   "rss_kb": 738196,
-   "scores": {
-    "Splay": 136.0,
-    "SplayLatency": 1683.0
+    "DeltaBlue": 110.0
    },
    "errors": {}
   },
   "regexp": {
    "status": "OK",
-   "out": "[tsx] RegExp: 27.9\n",
-   "wall_ms": 80180.484893,
-   "rss_kb": 126576,
+   "out": "[tsx] RegExp: 75.8\n",
+   "wall_ms": 32783.69465199967,
+   "rss_kb": 229224,
    "scores": {
-    "RegExp": 27.9
-   },
-   "errors": {}
-  },
-  "crypto": {
-   "status": "OK",
-   "out": "Unknown type: this\n[tsx] Crypto: Error: Crypto operation failed\n",
-   "wall_ms": 19993.857502000024,
-   "rss_kb": 118748,
-   "scores": {},
-   "errors": {
-    "Crypto": "Error: Crypto operation failed"
-   }
-  },
-  "raytrace": {
-   "status": "OK",
-   "out": "[tsx] RayTrace: Error: Scene rendered incorrectly\n",
-   "wall_ms": 3164.1826550000474,
-   "rss_kb": 93552,
-   "scores": {},
-   "errors": {
-    "RayTrace": "Error: Scene rendered incorrectly"
-   }
-  },
-  "earley-boyer": {
-   "status": "OK",
-   "out": "Parse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: expected ')' but got '.'\nUnknown type: return\nUnknown type: return\nUnknown type: return\nUnknown type: return\nUnknown type: return\nUnknown type: return\nParse error: expected ')' but got '='\nParse error: expected ']' but got ','\nParse error: expected ')' but got 'null'\nParse error: expected '(' but got 'sc_Pair'\nParse error: expected Identifier but got Punctuator\nParse error: expected ',' but got '('\nParse error: expected ',' but got '.'\nParse error: expected ')' but got ','\nParse error: expected ')' but got '('\nParse error: expected ')' but got '('\nParse error: expected ')' but got '('\nParse error: expected ')' but got '='\nParse error: expected ')' but got '('\nParse error: expected ')' but got '('\nParse error: expected ')' but got '='\nParse error: expected ')' but got 'function'\nParse error: expected ')' but got '.'\n",
-   "wall_ms": 214.60238000145182,
-   "rss_kb": 96920,
-   "scores": {},
-   "errors": {}
-  },
-  "navier-stokes": {
-   "status": "OK",
-   "out": "[tsx] NavierStokes: Error: checksum failed\n",
-   "wall_ms": 113465.87283000002,
-   "rss_kb": 190584,
-   "scores": {},
-   "errors": {
-    "NavierStokes": "Error: checksum failed"
-   }
-  }
- },
- "cpp": {
-  "richards": {
-   "status": "OK",
-   "out": "[tsx] Richards: 21.7\n",
-   "wall_ms": 9045.393262000289,
-   "rss_kb": 12996,
-   "scores": {
-    "Richards": 21.7
-   },
-   "errors": {}
-  },
-  "deltablue": {
-   "status": "OK",
-   "out": "[tsx] DeltaBlue: 40.6\n",
-   "wall_ms": 11867.749344999538,
-   "rss_kb": 50052,
-   "scores": {
-    "DeltaBlue": 40.6
+    "RegExp": 75.8
    },
    "errors": {}
   },
   "splay": {
    "status": "OK",
-   "out": "[tsx] Splay: 3\n[tsx] SplayLatency: 1683\n",
-   "wall_ms": 8120.129243001429,
-   "rss_kb": 497016,
+   "out": "[tsx] Splay: 370\n[tsx] SplayLatency: 1683\n",
+   "wall_ms": 6158.219558999917,
+   "rss_kb": 891328,
    "scores": {
-    "Splay": 3.0,
+    "Splay": 370.0,
     "SplayLatency": 1683.0
+   },
+   "errors": {}
+  },
+  "crypto": {
+   "status": "OK",
+   "out": "Unknown type: this\n",
+   "wall_ms": 92.70953100030965,
+   "rss_kb": 80572,
+   "scores": {},
+   "errors": {}
+  },
+  "raytrace": {
+   "status": "OK",
+   "out": "[tsx] RayTrace: Error: Scene rendered incorrectly\n",
+   "wall_ms": 1448.2162790000075,
+   "rss_kb": 93264,
+   "scores": {},
+   "errors": {
+    "RayTrace": "Error: Scene rendered incorrectly"
+   }
+  },
+  "navier-stokes": {
+   "status": "OK",
+   "out": "[tsx] NavierStokes: Error: checksum failed\n",
+   "wall_ms": 55347.85154800011,
+   "rss_kb": 190732,
+   "scores": {},
+   "errors": {
+    "NavierStokes": "Error: checksum failed"
+   }
+  },
+  "earley-boyer": {
+   "status": "OK",
+   "out": "Parse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: expected ')' but got '.'\nUnknown type: return\nUnknown type: return\nUnknown type: return\nUnknown type: return\nUnknown type: return\nUnknown type: return\nParse error: expected ')' but got '='\nParse error: expected ']' but got ','\nParse error: expected ')' but got 'null'\nParse error: expected '(' but got 'sc_Pair'\nParse error: expected Identifier but got Punctuator\nParse error: expected ',' but got '('\nParse error: expected ',' but got '.'\nParse error: expected ')' but got ','\nParse error: expected ')' but got '('\nParse error: expected ')' but got '('\nParse error: expected ')' but got '('\nParse error: expected ')' but got '='\nParse error: expected ')' but got '('\nParse error: expected ')' but got '('\nParse error: expected ')' but got '='\nParse error: expected ')' but got 'function'\nParse error: expected ')' but got '.'\n",
+   "wall_ms": 123.02642200029368,
+   "rss_kb": 98900,
+   "scores": {},
+   "errors": {}
+  }
+ },
+ "cpp": {
+  "richards": {
+   "status": "OK",
+   "out": "[tsx] Richards: 0.5\n",
+   "wall_ms": 4302.937526999813,
+   "rss_kb": 12868,
+   "scores": {
+    "Richards": 0.5
+   },
+   "errors": {}
+  },
+  "deltablue": {
+   "status": "OK",
+   "out": "[tsx] DeltaBlue: 1\n",
+   "wall_ms": 4441.091839999899,
+   "rss_kb": 57092,
+   "scores": {
+    "DeltaBlue": 1.0
    },
    "errors": {}
   },
   "regexp": {
    "status": "OK",
    "out": "[tsx] RegExp: Error: Wrong checksum.\n",
-   "wall_ms": 22327.704627999992,
-   "rss_kb": 29952,
+   "wall_ms": 1803.9693469995655,
+   "rss_kb": 29652,
    "scores": {},
    "errors": {
     "RegExp": "Error: Wrong checksum."
    }
   },
+  "splay": {
+   "status": "OK",
+   "out": "[tsx] Splay: 3\n[tsx] SplayLatency: 4575\n",
+   "wall_ms": 5711.18490300023,
+   "rss_kb": 496576,
+   "scores": {
+    "Splay": 3.0,
+    "SplayLatency": 4575.0
+   },
+   "errors": {}
+  },
   "crypto": {
    "status": "OK",
-   "out": "Unknown type: this\n[tsx] Crypto: Error: Crypto operation failed\n",
-   "wall_ms": 16078.647529999998,
-   "rss_kb": 26324,
+   "out": "Unknown type: this\n",
+   "wall_ms": 289.982124999824,
+   "rss_kb": 14376,
    "scores": {},
-   "errors": {
-    "Crypto": "Error: Crypto operation failed"
-   }
+   "errors": {}
   },
   "raytrace": {
    "status": "OK",
    "out": "[tsx] RayTrace: Error: Scene rendered incorrectly\n",
-   "wall_ms": 6647.715406000003,
-   "rss_kb": 16084,
+   "wall_ms": 1324.399134000032,
+   "rss_kb": 15612,
    "scores": {},
    "errors": {
     "RayTrace": "Error: Scene rendered incorrectly"
@@ -394,8 +390,8 @@
   "navier-stokes": {
    "status": "OK",
    "out": "[tsx] NavierStokes: Error: checksum failed\n",
-   "wall_ms": 264376.718859,
-   "rss_kb": 20932,
+   "wall_ms": 30009.967202000098,
+   "rss_kb": 20648,
    "scores": {},
    "errors": {
     "NavierStokes": "Error: checksum failed"
@@ -404,8 +400,8 @@
   "earley-boyer": {
    "status": "OK",
    "out": "Parse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: expected ')' but got '.'\nUnknown type: return\nUnknown type: return\nUnknown type: return\nUnknown type: return\nUnknown type: return\nUnknown type: return\nParse error: expected ')' but got '='\nParse error: expected ']' but got ','\nParse error: expected ')' but got 'null'\nParse error: expected '(' but got 'sc_Pair'\nParse error: expected Identifier but got Punctuator\nParse error: expected ',' but got '('\nParse error: expected ',' but got '.'\nParse error: expected ')' but got ','\nParse error: expected ')' but got '('\nParse error: expected ')' but got '('\nParse error: expected ')' but got '('\nParse error: expected ')' but got '='\nParse error: expected ')' but got '('\nParse error: expected ')' but got '('\nParse error: expected ')' but got '='\nParse error: expected ')' but got 'function'\nParse error: expected ')' but got '.'\n",
-   "wall_ms": 2819.533033998596,
-   "rss_kb": 26276,
+   "wall_ms": 2225.1748730000145,
+   "rss_kb": 26008,
    "scores": {},
    "errors": {}
   }
@@ -413,80 +409,78 @@
  "rust": {
   "richards": {
    "status": "OK",
-   "out": "[tsx] Richards: 21.7\n",
-   "wall_ms": 9876.049339998644,
-   "rss_kb": 11744,
+   "out": "[tsx] Richards: 59.0\n",
+   "wall_ms": 5452.263176000088,
+   "rss_kb": 12008,
    "scores": {
-    "Richards": 21.7
+    "Richards": 59.0
    },
    "errors": {}
   },
   "deltablue": {
    "status": "OK",
-   "out": "[tsx] DeltaBlue: 40.6\n",
-   "wall_ms": 12895.936794999216,
-   "rss_kb": 54884,
+   "out": "[tsx] DeltaBlue: 110\n",
+   "wall_ms": 5447.293528000046,
+   "rss_kb": 58864,
    "scores": {
-    "DeltaBlue": 40.6
+    "DeltaBlue": 110.0
+   },
+   "errors": {}
+  },
+  "regexp": {
+   "status": "OK",
+   "out": "[tsx] RegExp: 27.9\n",
+   "wall_ms": 89549.69275899975,
+   "rss_kb": 32812,
+   "scores": {
+    "RegExp": 27.9
+   },
+   "errors": {}
+  },
+  "splay": {
+   "status": "OK",
+   "out": "[tsx] Splay: 370\n[tsx] SplayLatency: 1683\n",
+   "wall_ms": 6296.882747999916,
+   "rss_kb": 535884,
+   "scores": {
+    "Splay": 370.0,
+    "SplayLatency": 1683.0
    },
    "errors": {}
   },
   "crypto": {
    "status": "OK",
-   "out": "Unknown type: this\n[tsx] Crypto: Error: Crypto operation failed\n",
-   "wall_ms": 19863.070477999998,
-   "rss_kb": 26940,
+   "out": "Unknown type: this\n",
+   "wall_ms": 181.41735999961384,
+   "rss_kb": 14240,
    "scores": {},
-   "errors": {
-    "Crypto": "Error: Crypto operation failed"
-   }
+   "errors": {}
   },
   "raytrace": {
    "status": "OK",
    "out": "[tsx] RayTrace: Error: Scene rendered incorrectly\n",
-   "wall_ms": 2614.5440529999746,
-   "rss_kb": 15064,
+   "wall_ms": 1633.6258579999594,
+   "rss_kb": 15136,
    "scores": {},
    "errors": {
     "RayTrace": "Error: Scene rendered incorrectly"
    }
   },
-  "regexp": {
-   "status": "OK",
-   "out": "[tsx] RegExp: Error: Wrong checksum.\n",
-   "wall_ms": 3868.3095299999763,
-   "rss_kb": 30076,
-   "scores": {},
-   "errors": {
-    "RegExp": "Error: Wrong checksum."
-   }
-  },
   "navier-stokes": {
    "status": "OK",
    "out": "[tsx] NavierStokes: Error: checksum failed\n",
-   "wall_ms": 92981.32972899998,
-   "rss_kb": 19040,
+   "wall_ms": 58419.691073999726,
+   "rss_kb": 19312,
    "scores": {},
    "errors": {
     "NavierStokes": "Error: checksum failed"
    }
   },
-  "splay": {
-   "status": "OK",
-   "out": "[tsx] Splay: 136\n[tsx] SplayLatency: 1683\n",
-   "wall_ms": 9365.485296999395,
-   "rss_kb": 535756,
-   "scores": {
-    "Splay": 136.0,
-    "SplayLatency": 1683.0
-   },
-   "errors": {}
-  },
   "earley-boyer": {
    "status": "OK",
    "out": "Parse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: a leading-zero numeric key is not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: octal escape sequences are not allowed in strict mode\nParse error: expected ')' but got '.'\nUnknown type: return\nUnknown type: return\nUnknown type: return\nUnknown type: return\nUnknown type: return\nUnknown type: return\nParse error: expected ')' but got '='\nParse error: expected ']' but got ','\nParse error: expected ')' but got 'null'\nParse error: expected '(' but got 'sc_Pair'\nParse error: expected Identifier but got Punctuator\nParse error: expected ',' but got '('\nParse error: expected ',' but got '.'\nParse error: expected ')' but got ','\nParse error: expected ')' but got '('\nParse error: expected ')' but got '('\nParse error: expected ')' but got '('\nParse error: expected ')' but got '='\nParse error: expected ')' but got '('\nParse error: expected ')' but got '('\nParse error: expected ')' but got '='\nParse error: expected ')' but got 'function'\nParse error: expected ')' but got '.'\n",
-   "wall_ms": 3727.0719509997434,
-   "rss_kb": 27640,
+   "wall_ms": 1531.227485999807,
+   "rss_kb": 27420,
    "scores": {},
    "errors": {}
   }

--- a/gallery/game_engine/v2/interp/bench/zoo_octane/matrix_report.py
+++ b/gallery/game_engine/v2/interp/bench/zoo_octane/matrix_report.py
@@ -27,7 +27,21 @@ def main():
             v = f"{v:g}"
         else:
             errs = r.get("errors") or {}
-            v = "FAIL" if errs else r["status"]
+            out = r.get("out") or ""
+            # Suites that abort without an "Name: …" error line still fail.
+            if errs or any(
+                x in out
+                for x in (
+                    "Unknown type:",
+                    "Parse error:",
+                    "checksum",
+                    "incorrectly",
+                    "Error:",
+                )
+            ):
+                v = "FAIL"
+            else:
+                v = r["status"]
         return (v, f"{r['wall_ms']/1000:.1f}s", rss(r))
 
     def rss(r):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fresh six-engine zoo/Octane matrix on master tip `9e1edf89` (post [#543](https://github.com/terotests/Ranger/pull/543) bytecode-tier work), comparing **Ranger es6 / C++ -O3 / Rust -O3** against **QuickJS 2024-01-13** and **Duktape 2.7.0**.

Reproduce:

```bash
bash scripts/build-engine-module.sh
bash gallery/game_engine/v2/interp/bench/zoo_octane/build-native.sh
PATH=/path/to/qjs-and-duk:$PATH python3 gallery/game_engine/v2/interp/bench/zoo_octane/bench_matrix.py
python3 gallery/game_engine/v2/interp/bench/zoo_octane/matrix_report.py
node gallery/game_engine/v2/interp/bench/native/vs_quickjs.cjs
```

## Richards (higher is better)

| Engine | Score | Peak RSS | Wall |
| --- | ---: | ---: | ---: |
| Node | 52960 | 57 MB | 2.0s |
| QuickJS | **920** | 10 MB | 2.0s |
| Duktape | **400** | 10 MB | 2.0s |
| Ranger es6 | **59** | 87 MB | 4.2s |
| Ranger Rust -O3 | **59** | **12 MB** | 5.5s |
| Ranger C++ -O3 | 0.5† | **13 MB** | 4.3s |

† C++ Octane *score* is liveClock-quantized on this host; wall time matches es6/Rust — read C++ throughput from wall time / microbench.

**QuickJS / Ranger (es6·Rust) ≈ 15.6×** on Richards. Native RSS on Richards is now ~12–13 MB (was multi-GB before the retention fixes).

## Microbench vs QuickJS

C++ geomean **3.6×** behind QuickJS (es6 **3.0×**). `strcat` beats qjs (0.3×). Full table in `native/README.md` / `RESULTS.md`.

## Binary size (stripped)

| | |
| --- | ---: |
| Duktape | 514 KB |
| QuickJS | 1.03 MB |
| Ranger C++ | 1.85 MB |
| Ranger Rust | 2.87 MB |

## Compatibility

Pass with score: richards, deltablue, splay; regexp on es6 (**75.8**) and Rust (**27.9**); C++ regexp still checksum-fails. FAIL on all Ranger targets: crypto, raytrace, navier-stokes, earley-boyer (same semantic/parser gaps as before).

## Files

- Updated `zoo_octane/RESULTS.md` matrix + microbench section
- Fresh `matrix-results.json`
- `matrix_report.py` treats parse/`Unknown type` outs as FAIL
- Synced `native/README.md` QuickJS table to this tip
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba05bb38-0a3c-4072-af79-c9dc89c9e11c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba05bb38-0a3c-4072-af79-c9dc89c9e11c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

