### PR TITLE
Add `is` operator for shape case testing without binding

### DIFF
--- a/PLAN_INLINE_STATICS.md
+++ b/PLAN_INLINE_STATICS.md
@@ -1,9 +1,11 @@
-# PLAN: -inline-statics — trivial static forwarder inlining (WIP handoff)
+# PLAN: -inline-statics — trivial static forwarder inlining
 
-Status: **implemented but unverified**. The compiler rebootstraps cleanly with
-the pass compiled in, the flag is strictly opt-in (`-inline-statics`), and no
-build uses it yet. Nothing about default compilation changes until the flag is
-passed. This document is the handoff for the next session.
+Status: **implemented, verified correct, and NOT worth turning on**. The full
+battery below is green — es6, C++ and Rust all keep their conformance scores
+with the flag — but the measured speedup is within noise on Rust and small and
+mixed on C++. The flag therefore stays strictly opt-in (`-inline-statics`) and
+no build script enables it. Nothing about default compilation changes unless
+the flag is passed. See "Verification results" for the numbers.
 
 ## Why
 
@@ -64,31 +66,77 @@ ComponentEngine.rgr alone has ~1200 EvValueBridge call sites. Per target:
 `bin/output.js` on this branch is the rebootstrapped compiler containing the
 pass (`npm run compile` was clean).
 
-## Verification state — what the next session must do
+## Verification results
 
-1. **Probe test is UNFINISHED.** Scratch probe (a Bridge class + forwarders,
-   compiled with and without the flag, outputs diffed) kept failing to
-   compile in the BASELINE (no flag) — the probe's own Ranger syntax for
-   multi-arg static calls in print/def positions was wrong, not the pass.
-   Write the probe as plain def-position statements
-   (`def s:int (Bridge.add2(x y))` style — mirror engine sources), get the
-   baseline green FIRST, then diff flag-on vs flag-off generated es6 and
-   check the call disappeared (grep for `Bridge.add2` / `isUndefined(`).
-2. `npm test` / compiler feature tests (tests/, feature_tests.rgr) without
-   the flag — prove the default path is untouched (the rebuildWithType
-   extension runs on any `nodes`-lane match, so `defn` tests matter).
-3. Engine es6 build WITH `-inline-statics` added to
-   scripts/build-engine-module.sh (temporarily) → `npm run test:runtime`
-   (1327 must hold). Use `-show-inline-statics` once to eyeball expansions.
-4. Native builds with the flag (add to bench/zoo_octane/build-native.sh
-   RANGER invocation) → conformance-native.cjs on both targets
-   (1297/1303, 0 crashes must hold).
-5. Perf: interleaved fixed-work timing, **Rust** binary before/after the flag
-   (scratchpad fixed/ suite; method/richards rows). C++/es6 expected flat.
-6. If green and Rust wins: leave the flag ON in the two engine build scripts
-   and document in RESULTS.md; otherwise keep opt-in and record numbers.
+All six steps ran. Reproduce the native A/B with the `EXTRA_RANGER_FLAGS` hook
+added to `bench/zoo_octane/build-native.sh`:
+`EXTRA_RANGER_FLAGS=-inline-statics bash .../build-native.sh`.
+
+1. **Probe — green.** A Bridge class of forwarders (`sfn f(b:Box)` →
+   `b.method()`), compiled with and without the flag. Runtime output is
+   byte-identical; the generated es6 shows exactly the intended rewrite:
+   `Bridge.valueOf(b)` → `b.fetchValue()`, `Bridge.plus(b n)` → `b.plus(n)`,
+   `Bridge.isZero(z)` → `z.isZero()`. Cascades fold all the way down
+   (`Bridge.valueOf2(b)` → `b.fetchValue()`, two levels). The deliberately
+   ineligible two-statement forwarder keeps its call. Bridge call sites in
+   the output: 12 → 6.
+2. **`npm test` — no regression.** 1432 passed, 11 failed. The 11 failures are
+   all in `shapes.test.ts` (Rust shape lowering + two writer expectations) and
+   reproduce **identically on the base commit** with the four changed files
+   reverted — pre-existing, unrelated to this pass.
+3. **es6 engine with the flag — green.** 785 expansions
+   (`taggedUndefined` 218, `taggedNull` 111, `taggedString` 64,
+   `isUndefined` 61, `isNull` 51, `taggedNumber`/`taggedArray` 46 each,
+   `taggedObject` 44, `isString` 36, `isNumber` 20, …).
+   `npm run test:runtime`: **1327/1327**, same as baseline.
+4. **Native with the flag — green.** conformance-native.cjs:
+   C++ **1297/1303, 0 crashes**; Rust **1297/1303, 0 crashes**. Both match
+   baseline exactly, same six failures (err 2, for/destr/obj/iter 1 each).
+5. **Perf — flat.** Interleaved fixed-work wall time, 9 reps, min ms,
+   base → flag:
+
+   | script | Rust | C++ |
+   | --- | ---: | ---: |
+   | arith_big | −0.4% | +3.3% |
+   | prop | −2.8% | −5.8% |
+   | call | −1.6% | −3.7% |
+   | method | −1.9% | −3.9% |
+   | typemix | +0.0% | −1.9% |
+   | pool_hit | +1.9% | −0.5% |
+   | pool_miss | +0.9% | −1.9% |
+
+   Rust is noise in both directions. C++ is a consistent but small win outside
+   `arith_big`. Neither justifies turning the flag on by default.
+
+   **Why the Rust win did not materialise.** The generated `octane_runner.rs`
+   loses 313 of 1265 `EvValueBridge::` call sites but only **207 of 7761
+   `.clone()` calls (2.7%)** — because the highest-count forwarders
+   (`taggedUndefined` 218, `taggedNull` 111, `taggedHole` …) take **no
+   arguments**, so they never carried an `Rc` clone to begin with. The
+   handle-taking predicates that do (`isUndefined`, `isNull`, `isString`,
+   `isNumber` — ~200 sites) are the only ones whose clone disappears, and that
+   is too small a slice of the total to show up in wall time.
+6. **Decision: keep opt-in.** No build script enables the flag. The pass is
+   correct and costs nothing when off.
+
+### Known, harmless bail
+
+A forwarder whose body calls a method named exactly `getValue` is never
+expanded — `sfn aaa:int (b:Box) { return (b.getValue()) }` bails, while the
+identical body with the method renamed (`fetchIt`, `readIt`, `getFoo`,
+`getValueX`, `get_value`, …) expands. It is the identifier alone: renaming the
+field, changing the callee's body, or moving the forwarder in the class does
+not matter. `getValue` is a built-in operator form the serializer emits
+(`ng_RangerSerializeClass.rgr` writes `(getValue arr arr_i)`), so the collision
+is almost certainly why eligibility rejects it — but that has not been proven,
+and the effect is only that an optimisation is skipped, never wrong code.
 
 ## NEXT LEVER (user directive): fold shape-case type tests
+
+The step-5 numbers make this lever *more* important, not less: removing the
+static call around a type test bought nothing, because the cost is not the
+call — it is the case machinery underneath it. That is what this section
+removes.
 
 The forwarders bottom out in EvHandle/EvalValue instance methods with this
 shape:
@@ -134,10 +182,9 @@ this is the highest-frequency code in the interpreter.
 
 ## Invariants for whoever continues
 
-- The designated perf branch is `claude/ranger-performance-improvements-uy9a2n`
-  (conformance round pushed as 4a52458). THIS work is parked on its own
-  branch so it can be verified independently — do not merge until the full
-  battery above is green.
+- The perf round this branched from is merged (PR #543, 4a52458). The battery
+  above is green, so this branch is mergeable on correctness grounds — but it
+  buys no measured speed, so merging it only adds an unused flag.
 - Never trust a build ran from the wrong cwd; build scripts must run from
   the repo root; check artifacts, not exit codes.
 - All perf claims: interleaved fixed-work wall time only (RESULTS.md

--- a/PLAN_INLINE_STATICS.md
+++ b/PLAN_INLINE_STATICS.md
@@ -131,12 +131,21 @@ not matter. `getValue` is a built-in operator form the serializer emits
 is almost certainly why eligibility rejects it — but that has not been proven,
 and the effect is only that an optimisation is skipped, never wrong code.
 
-## NEXT LEVER (user directive): fold shape-case type tests
+## NEXT LEVER — DONE, and it won: the `is` operator
 
-The step-5 numbers make this lever *more* important, not less: removing the
-static call around a type test bought nothing, because the cost is not the
-call — it is the case machinery underneath it. That is what this section
-removes.
+**Implemented. See `SHAPES_IS_OPERATOR.md`.** The prediction below held: the
+cost was never the call, it was the case machinery underneath it.
+`is v _:Shape.Case` is the `case` discriminant test with the binding and the
+block removed, so Rust emits `matches!` where it used to emit
+`if let … = v.clone()`.
+
+Measured on the interpreter, interleaved wall time: **Rust 16–20% faster on the
+Octane suites and 10–19% on the fixed-work micros**; C++ and es6 flat — exactly
+the split this document predicted, and the opposite of `-inline-statics`, which
+was flat everywhere. Conformance unchanged (1327/1327 es6, 1297/1303 native,
+0 crashes).
+
+The original reasoning is kept below because it is what pointed at the fix.
 
 The forwarders bottom out in EvHandle/EvalValue instance methods with this
 shape:

--- a/PLAN_INLINE_STATICS.md
+++ b/PLAN_INLINE_STATICS.md
@@ -1,0 +1,144 @@
+# PLAN: -inline-statics — trivial static forwarder inlining (WIP handoff)
+
+Status: **implemented but unverified**. The compiler rebootstraps cleanly with
+the pass compiled in, the flag is strictly opt-in (`-inline-statics`), and no
+build uses it yet. Nothing about default compilation changes until the flag is
+passed. This document is the handoff for the next session.
+
+## Why
+
+The interpreter (gallery/game_engine/v2/interp) funnels almost every value
+question through EvValueBridge static forwarders:
+
+```
+sfn isUndefined:boolean (v:EvHandle) {
+    return (v.isUndefined())
+}
+```
+
+ComponentEngine.rgr alone has ~1200 EvValueBridge call sites. Per target:
+
+- **es6**: V8 inlines these when hot — near-zero cost.
+- **C++**: the writer emits `const rg_ptr<EvHandle>&` parameters and the
+  whole program is one translation unit at -O3 — g++ inlines them. Near-zero.
+- **Rust**: the writer emits OWNED `Rc<RefCell<EvHandle>>` parameters, so every
+  call site pays `v.clone()` — a refcount up/down pair per call that LLVM does
+  not reliably cancel. **This is the target where the win lives.** Inlining
+  `EvValueBridge::isUndefined(v.clone())` into `v.borrow().isUndefined()`
+  removes the clone entirely.
+
+## What is implemented (3 edits, all committed on this branch)
+
+1. **compiler/ng_RangerFlowParser.rgr** — `tryInlineTrivialStatic` +
+   `inlineStaticEligible` (placed right before `TransformOpFn`), hooked into
+   `cmdLocalCall`'s ns>1 branch right after `findFunctionDesc` resolves,
+   gated on `ctx.hasCompilerFlag("inline-statics")`.
+
+   Eligibility (deliberately conservative — anything else keeps the call):
+   - callee is `sfn` (`m.is_static`), on a non-template class, resolved via
+     the plain `Class.name` two-segment shape;
+   - body is EXACTLY one `return (expr)` (expression body only);
+   - no optional return, no optional/keyword/default params;
+   - every name in the body is a parameter, a class-qualified reference, or
+     a language operator (bare names from the callee scope ⇒ bail; direct
+     recursion ⇒ bail); depth cap 6 for cascades;
+   - every CALL argument is a plain bare name (no expressions, no literals,
+     no dotted refs) so evaluation order/count cannot change.
+
+   Transform: build a `RangerArgMatch` with param→argNode in the `nodes`
+   lane, `retExpr.rebuildWithType(am true)`, `node.getChildrenFrom(newExpr)`,
+   `flow_done = false`, re-`WalkNode` in the CALLER's context (types, param
+   descs, ref counts recomputed as if the body were written at the site).
+   Debug flag: `-show-inline-statics` prints each expansion.
+
+2. **compiler/ng_CodeNodeCompilerExtensions.rgr** — `rebuildWithType` gains
+   ns-root substitution: a qualified reference whose ROOT segment matches a
+   `match.nodes` binding (`v.isUndefined` with `v` bound) is rebuilt with
+   ns[0] replaced and `vref` rejoined — only when the bound node is a bare
+   name. Without this the dominant forwarder shape cannot substitute at all
+   (`defn` bodies share this limitation today; this extension fixes both).
+
+3. **compiler/VirtualCompiler.rgr** — flag registered in the help list.
+   (CLI `-flags` auto-populate `ctx.compilerFlags`; no other plumbing.)
+
+`bin/output.js` on this branch is the rebootstrapped compiler containing the
+pass (`npm run compile` was clean).
+
+## Verification state — what the next session must do
+
+1. **Probe test is UNFINISHED.** Scratch probe (a Bridge class + forwarders,
+   compiled with and without the flag, outputs diffed) kept failing to
+   compile in the BASELINE (no flag) — the probe's own Ranger syntax for
+   multi-arg static calls in print/def positions was wrong, not the pass.
+   Write the probe as plain def-position statements
+   (`def s:int (Bridge.add2(x y))` style — mirror engine sources), get the
+   baseline green FIRST, then diff flag-on vs flag-off generated es6 and
+   check the call disappeared (grep for `Bridge.add2` / `isUndefined(`).
+2. `npm test` / compiler feature tests (tests/, feature_tests.rgr) without
+   the flag — prove the default path is untouched (the rebuildWithType
+   extension runs on any `nodes`-lane match, so `defn` tests matter).
+3. Engine es6 build WITH `-inline-statics` added to
+   scripts/build-engine-module.sh (temporarily) → `npm run test:runtime`
+   (1327 must hold). Use `-show-inline-statics` once to eyeball expansions.
+4. Native builds with the flag (add to bench/zoo_octane/build-native.sh
+   RANGER invocation) → conformance-native.cjs on both targets
+   (1297/1303, 0 crashes must hold).
+5. Perf: interleaved fixed-work timing, **Rust** binary before/after the flag
+   (scratchpad fixed/ suite; method/richards rows). C++/es6 expected flat.
+6. If green and Rust wins: leave the flag ON in the two engine build scripts
+   and document in RESULTS.md; otherwise keep opt-in and record numbers.
+
+## NEXT LEVER (user directive): fold shape-case type tests
+
+The forwarders bottom out in EvHandle/EvalValue instance methods with this
+shape:
+
+```
+fn isNumber:boolean () {
+    case self n:EvalValue.Number {
+        return true
+    }
+    return false
+}
+```
+
+That is a TYPE TEST expressed as a case narrowing: bind-and-return-true,
+fall-through-return-false. Today it compiles (per target) into the generic
+case machinery — on Rust a match with a binding, on C++ a variant
+kind check through the case scaffolding — plus a method call to reach it.
+
+The optimization to implement next: **detect this exact body shape**
+(single `case self x:Shape.Case { return true }` followed by `return false`,
+no other statements, no use of the binding) **and compile it to a direct
+discriminant check** with no binding and no call:
+
+- Rust: `matches!(&*self_.borrow().body, union_EvalValue::Number(..))`-shaped
+  emission (or whatever the writer's existing kind-test primitive is);
+- C++: the variant kind/tag compare the case header already lowers to,
+  minus the binding;
+- es6: the existing kind-tag field compare.
+
+Recognition can live in the flow (mark the method desc as a pure kind test:
+`m.is_kind_test = true`, kind recorded) with each writer emitting its native
+tag compare for calls to marked methods — OR as a writer-level peephole on
+the method body. Flow-level marking composes with -inline-statics: the
+static forwarder inlines to `v.isNumber()`, and the marked instance method
+emits as a tag compare — the full chain
+`EvValueBridge.isNumber(v)` → `v.isNumber()` → one discriminant load+compare
+per test, no calls, no Rc clone.
+
+Search for candidates: `grep -n "case self\|case body" gallery/game_engine/v2/interp/migrate/src/EvalValue.rgr EvHandle.rgr`
+(EvalValue.isNumber/isString/isArrayValue/isSet/isMap..., EvHandle wrappers
+around body). These sit under EVERY dynamic type dispatch in the engine —
+this is the highest-frequency code in the interpreter.
+
+## Invariants for whoever continues
+
+- The designated perf branch is `claude/ranger-performance-improvements-uy9a2n`
+  (conformance round pushed as 4a52458). THIS work is parked on its own
+  branch so it can be verified independently — do not merge until the full
+  battery above is green.
+- Never trust a build ran from the wrong cwd; build scripts must run from
+  the repo root; check artifacts, not exit codes.
+- All perf claims: interleaved fixed-work wall time only (RESULTS.md
+  discipline).

--- a/PLAN_SHAPES.md
+++ b/PLAN_SHAPES.md
@@ -120,6 +120,7 @@ are just written in the language of a fat class instead of declared to the compi
 |---|---|---|---|
 | `union Name (A B C)` | `ng_RangerFlowParser.rgr:4718`; `RangerAppClassDesc.is_union` / `.is_union_of` (`:35` / `:66`) | A nominal set of existing classes usable as a type | No payload, no closedness guarantee, no exhaustiveness, no declared semantics |
 | `case v x:T { … }` | `lib/stdlib.rgr:149` (operator with a template per target) | Runtime narrowing to one member | Not a statement the compiler reasons about — no arm coverage analysis |
+| `is v _:Shape.Case` | `lib/stdlib.rgr`, right after `case` (see `SHAPES_IS_OPERATOR.md`) | The discriminant test alone, as an expression — no binding, no block | No narrowing: when the arm reads the payload, `case` is still the operator |
 | `record` | `ng_RangerFlowParser.rgr:3935`, `:3985`, `:4861` | A class with a synthesized keyword constructor | A reference type on every target — no inline payload |
 | `Enum N:int (…)` | `ng_RangerAppEnums.rgr` | A plain integer enum | No payload |
 | `systemunion` | `ng_RangerFlowParser.rgr:3909` | Unions over system classes | Same limits |

--- a/SHAPES_IS_OPERATOR.md
+++ b/SHAPES_IS_OPERATOR.md
@@ -133,11 +133,67 @@ ValueMain.isNumNew = function(v) {
 
 No target evaluates the value operand more than once.
 
-## Equivalence
+## Cross-target verification
 
-The probe compiles both forms side by side and prints them together. ES6,
-Python, Rust, C++ and Go all answer `TT / FF / FF` — `is` agrees with `case` on
-a matching case, a different case, and a payload-free case.
+A probe declares a four-case shape (payload-free, scalar-payload, and two
+reference cases in a group) and answers every question **twice** — once through
+`case`, once through `is` — plus `is` composed with `||`, negated with
+`false ==`, used as an `if` condition, and followed by a `case` that reads the
+payload. Any target where the two lowerings disagree prints a mismatched row.
+
+| target | compiles | runs here | result |
+| --- | --- | --- | --- |
+| es6 | ✅ | ✅ | reference output |
+| python | ✅ | ✅ | **matches es6** |
+| go | ✅ | ✅ | **matches es6** |
+| rust | ✅ | ✅ | **matches es6** |
+| cpp | ✅ | ✅ | **matches es6** |
+| java7 | ✅ | ✅ | **matches es6** |
+| php | ✅ | ✗ | `is` lowering correct; program fails on an unrelated writer bug (below) |
+| swift6 / swift3 | ✅ | — | no toolchain here; emission inspected |
+| kotlin | ✅ | — | no toolchain here; emission inspected |
+| dart | ✅ | — | no toolchain here; emission inspected |
+| csharp | ✅ | — | no toolchain here; emission inspected |
+| scala | ✅ | — | no toolchain here; emission inspected |
+
+Reference output, identical on all six runnable targets:
+
+```
+nul case=TFFF is=TFFF or=F not=T d=nul
+num case=FTFF is=FTFF or=T not=F d=num:42
+txt case=FFTF is=FFTF or=T not=T d=txt:hi
+lst case=FFFT is=FFFT or=F not=T d=lst
+```
+
+**PHP** compiles and the operator itself lowers correctly —
+`return (is_object($v) && get_class($v) == "Val_Nul");` — but the program
+cannot run, because the PHP writer emits a static call from `main` as
+`$Probe->row(...)` on an undefined variable. This is unrelated to shapes: a
+seven-line class with one `sfn` and no shape at all reproduces it
+(`$T->hello("there")`).
+
+**Not executed:** swift, kotlin, dart, csharp and scala have no toolchain in
+this container, so only their emitted expressions were checked
+(`({ () -> Bool in if case .Val_Nul = v { … } })()`, `(v is Val_Nul)`,
+`(v is Val_Nul)`, `(v is Val_Nul)`, `(v.isInstanceOf[Val_Nul])`).
+
+## Limitation: group views do not work — and neither does `case`
+
+`is v _:Shape.Group` (a group rather than a case) is **broken**, but it is
+broken in exactly the way `case v x:Shape.Group` is already broken, because
+both ask the writer for a discriminant named after the group:
+
+- **rust** — both emit `union_Val::union_Val_Prim`; the enum has no such
+  variant, so the file fails to compile with two identical `E0599` errors, one
+  from `case` and one from `is`.
+- **go** — both emit `union_Val_tag_union_Val_Prim`; undefined, same story.
+- **es6 / python** — both compare against `"union_Val_Prim"`, a tag no case
+  ever carries, so both silently answer `false` for every value.
+
+So `is` is faithful to `case` here too: it neither fixes nor worsens group
+narrowing. This is the same gap as the known-failing
+`shapes.test.ts > lowering > makes a group a type of its own`. Test against a
+**case**, not a group, until that is fixed.
 
 ## Measured effect on the interpreter
 

--- a/SHAPES_IS_OPERATOR.md
+++ b/SHAPES_IS_OPERATOR.md
@@ -1,0 +1,238 @@
+# `is` — the kind test for closed shape families
+
+`is v _:Shape.Case` answers **"does this value currently hold that case?"** and
+nothing else. It is an expression, so it composes into `return`, `if`, `&&` and
+anywhere else a boolean fits.
+
+```ranger
+fn isNumber:boolean () {
+    return (is self _:EvalValue.Number)
+}
+```
+
+Declared in `compiler/stdlib.rgr` (mirrored in `lib/stdlib.rgr`), immediately
+after the `case` operator it is derived from.
+
+## Why it exists
+
+`case v x:Shape.Case { … }` already tests the discriminant — but it also
+**binds** `x` and opens a block. An arm that only wants the answer pays for a
+binding it never reads:
+
+| target | what the binding costs in `case` |
+| --- | --- |
+| **Rust** | `.clone()` of the scrutinee — a refcount up/down pair for every reference case |
+| **Go** | a declared local plus `_ = x` to satisfy the unused-variable rule |
+| **ES6 / Python / PHP** | a dead assignment (`var x = v;`) |
+| **C++** | `mpark::get<T>(v)` on top of the `holds_alternative` test |
+
+The Rust row is the expensive one. `union_EvalValue` carries
+`Rc<RefCell<…>>` in eight of its twelve variants, and the `case` template is
+
+```
+"if let " (typeof 1) "::" (typeof 2) "(" (e 2) ") = " (e 1) ".clone() { … }"
+```
+
+so **every** narrowing clones, whether or not the arm reads the binding. In the
+generated interpreter that was 216 of 216 case sites.
+
+`is` is the same discriminant test with the binding and the block removed. It
+invents nothing per target — each template is the test the `case` operator on
+that target already lowers to.
+
+## Spelling
+
+```
+(is <value> _:<Shape>.<Case>)
+```
+
+The `_` is the binding you are *not* taking. It is a real annotated argument,
+not a wildcard token: the compiler's argument matcher types an operator
+argument from its `:Type` annotation, so the case has to arrive attached to a
+name. Nothing is defined — the parameter is `@(noeval)`, so `_` never becomes a
+variable and the same spelling may appear twice in one scope. Any name works;
+`_` is the convention because it reads as "no binding".
+
+## What each target emits
+
+Source:
+
+```ranger
+shape Value {
+    case Num { def n:double 0.0 }
+    case Text { def s:string "" }
+    case Nothing { }
+}
+
+sfn isNumNew:boolean (v:Value) {
+    return (is v _:Value.Num)
+}
+```
+
+Compiled (`node bin/output.js -l=<target> is_probe.rgr`):
+
+| target | emitted body |
+| --- | --- |
+| **rust** | `matches!(v, union_Value::Value_Num(..))` |
+| **cpp** | `mpark::holds_alternative<Value_Num>(v)` |
+| **go** | `(v.tag == union_Value_tag_Value_Num)` |
+| **es6** | `(v != null && v.__rg_kind === "Value_Num")` |
+| **python** | `(v is not None and getattr(v, "_rg_kind", None) == "Value_Num")` |
+| **kotlin** | `(v is Value_Num)` |
+| **dart** | `(v is Value_Num)` |
+| **csharp** | `(v is Value_Num)` |
+| **java7** | `(v instanceof Value_Num)` |
+| **scala** | `(v.isInstanceOf[Value_Num])` |
+| **php** | `(is_object(v) && get_class(v) == "Value_Num")` |
+| **swift6/3** | `({ () -> Bool in if case .Value_Num = v { return true }; return false })()` |
+
+Side by side on Rust — the `case` form above, the `is` form below:
+
+```rust
+pub fn isNumOld(v : &union_Value) -> bool {
+  if let union_Value::Value_Num(x) = v.clone() { /* union case */
+    return true;
+  };
+  false
+}
+pub fn isNumNew(v : &union_Value) -> bool {
+  matches!(v, union_Value::Value_Num(..))
+}
+```
+
+and on ES6:
+
+```js
+ValueMain.isNumOld = function(v) {
+  if( v != null && v.__rg_kind === "Value_Num" ) /* union case */ {
+    var x = v;
+    return true;
+  };
+  return false;
+};
+ValueMain.isNumNew = function(v) {
+  return (v != null && v.__rg_kind === "Value_Num");
+};
+```
+
+### Notes per target
+
+- **Rust** — `matches!` reads the discriminant through the reference. No clone,
+  no borrow of the payload, no drop at the end of the expression.
+- **C++** — `holds_alternative` was already the bare index compare; the `case`
+  template only added `mpark::get` on top. The template carries the same
+  `variant.hpp` makefile dependency the `case` operator declares.
+- **Swift** — `if case` is a statement, not an expression. An immediately
+  applied closure is the only way to spell the test inline. `(e 1)` is named
+  once, so the value is still evaluated exactly once.
+- **Go** — the tag compare alone; no variant pointer is bound, so there is no
+  `_ = x` discard to emit.
+- **llvm** — no template, matching the `case` operator. The llvm target does not
+  compile shape families at all today (`case` itself fails to match there), so
+  this adds no new gap.
+
+No target evaluates the value operand more than once.
+
+## Equivalence
+
+The probe compiles both forms side by side and prints them together. ES6,
+Python, Rust, C++ and Go all answer `TT / FF / FF` — `is` agrees with `case` on
+a matching case, a different case, and a payload-free case.
+
+## Measured effect on the interpreter
+
+`gallery/game_engine/v2/interp` was refactored onto the operator (see
+"Engine refactor" below). Generated Rust for the Octane runner:
+
+| | before | after |
+| --- | ---: | ---: |
+| `if let union_…` narrowings | 216 | 197 |
+| `matches!` kind tests | 0 | 19 |
+| `.clone()` calls | 7761 | 7499 |
+| `EvValueBridge::` calls | 1265 | 1022 |
+
+Interleaved wall time, same host, baseline binaries kept and re-run against the
+refactored ones. **Octane suites** (the harness from
+`zoo_octane/bench_matrix.py`, 5 reps, min ms — the score is liveClock-quantized
+on C++, so wall time is the honest read):
+
+| suite | Rust | C++ | es6 |
+| --- | ---: | ---: | ---: |
+| richards | **−16.4%** | −1.1% | +2.3% |
+| deltablue | **−17.2%** | +0.4% | −0.7% |
+| splay | **−20.5%** | −2.9% | +10.7% |
+
+**Fixed-work microbenchmarks** (`zoo_octane/micro`, 13 reps, min ms):
+
+| script | Rust | C++ | es6 |
+| --- | ---: | ---: | ---: |
+| arith_big | −12.8% | +6.6% | −3.4% |
+| prop | −10.8% | −4.8% | +1.2% |
+| call | −10.2% | −0.2% | +1.1% |
+| method | −18.3% | −2.9% | +1.7% |
+| typemix | −18.5% | −0.7% | +0.8% |
+| pool_hit | −18.8% | +4.6% | +1.6% |
+| pool_miss | −14.2% | +3.5% | +0.1% |
+
+Read the three targets separately, because the reason each moves is different:
+
+- **Rust — 10–20% faster, consistently.** This is the target the operator was
+  written for. Every `case` cloned the scrutinee; the predicates under every
+  dynamic type dispatch now read the discriminant in place.
+- **C++ — flat, as predicted.** `holds_alternative` was already the bare index
+  compare, and `mpark::get` on a variant with inline scalar cases is close to
+  free. Nothing was there to remove. (es6 `splay` and C++ `arith_big` swing
+  either way run to run; those rows are noise, not signal.)
+- **es6 — flat.** V8 already folds the string tag compare and eliminates the
+  dead `var x = v`, so the operator gives its JIT nothing new.
+
+Absolute standing on this host after the refactor (Octane richards, from
+`bench_matrix.py`) — for orientation against PR #544's six-engine matrix, which
+was measured on a different machine:
+
+| engine | richards score | wall | peak RSS |
+| --- | ---: | ---: | ---: |
+| Node (V8) | 22530 | 2.07s | 57 MB |
+| Ranger C++ -O3 | 0.5† | **5.26s** | **12.6 MB** |
+| Ranger Rust -O3 | 59.0 | 6.49s | **12.0 MB** |
+| Ranger es6 | 21.7 | 7.96s | 94 MB |
+
+† liveClock-quantized on this host — read C++ throughput from wall time.
+The Ranger scores land in quantized buckets (21.7 / 40.6 / 59.0 / 136) at this
+speed, which is why every claim above is wall time.
+
+## Engine refactor
+
+What changed in `gallery/game_engine/v2/interp/migrate/src`:
+
+- **`EvalValue.rgr`** — 12 single-case predicates (`isNull`, `isNumber`,
+  `isString`, `isHole`, `isUndefined`, `isBoolean`, `isElement`,
+  `isArrayValue`, `isObject`, `isFunction`, `isMap`, `isSet`) became one-line
+  `is` expressions; `isNullOrUndefined` became `(is …) || (is …)`; two
+  `EvPropertySlot.Accessor` tests on a local scrutinee likewise.
+- **`EvHandle.rgr`** — the three payload-free arms of `fromBody`
+  (`Hole`/`Null`/`Undefined`) became `if (is ev _:…)`, since they bound a
+  value they never read.
+- **`ComponentEngine.rgr`** — 243 `EvValueBridge.isX(v)` static forwarder
+  calls became direct `v.isX()`. Only call sites whose argument is a bare name
+  were rewritten; the 18 that pass an expression keep the call, because moving
+  an expression into receiver position would change how it parses.
+
+The `EvValueBridge` forwarders themselves are unchanged and still exported —
+only the engine's internal call sites stopped going through them.
+
+Conformance held at every step: `test:runtime` **1327/1327** on es6, and
+`conformance-native.cjs` **1297/1303 with 0 crashes** on both C++ and Rust,
+identical to baseline.
+
+## When to keep using `case`
+
+`is` replaces only the pure test. When the arm reads the payload, `case` is
+still the operator you want — it binds the narrowed value, which is the thing
+`is` deliberately gives up:
+
+```ranger
+case body a:EvalValue.Array {
+    return (array_length a.items)
+}
+```

--- a/SHAPES_IS_OPERATOR.md
+++ b/SHAPES_IS_OPERATOR.md
@@ -141,7 +141,7 @@ reference cases in a group) and answers every question **twice** — once throug
 `false ==`, used as an `if` condition, and followed by a `case` that reads the
 payload. Any target where the two lowerings disagree prints a mismatched row.
 
-| target | compiles | runs here | result |
+| target | compiles | executed | result |
 | --- | --- | --- | --- |
 | es6 | ✅ | ✅ | reference output |
 | python | ✅ | ✅ | **matches es6** |
@@ -149,14 +149,14 @@ payload. Any target where the two lowerings disagree prints a mismatched row.
 | rust | ✅ | ✅ | **matches es6** |
 | cpp | ✅ | ✅ | **matches es6** |
 | java7 | ✅ | ✅ | **matches es6** |
-| php | ✅ | ✗ | `is` lowering correct; program fails on an unrelated writer bug (below) |
-| swift6 / swift3 | ✅ | — | no toolchain here; emission inspected |
-| kotlin | ✅ | — | no toolchain here; emission inspected |
+| kotlin | ✅ | ✅ | **matches es6** |
+| php | ✅ | ✅ | **matches es6** (needed a writer fix — see below) |
+| swift6 / swift3 | ✅ | ✗ | toolchain unreachable; emission asserted by test |
 | dart | ✅ | — | no toolchain here; emission inspected |
 | csharp | ✅ | — | no toolchain here; emission inspected |
 | scala | ✅ | — | no toolchain here; emission inspected |
 
-Reference output, identical on all six runnable targets:
+Reference output, identical on all eight executed targets:
 
 ```
 nul case=TFFF is=TFFF or=F not=T d=nul
@@ -165,35 +165,59 @@ txt case=FFTF is=FFTF or=T not=T d=txt:hi
 lst case=FFFT is=FFFT or=F not=T d=lst
 ```
 
-**PHP** compiles and the operator itself lowers correctly —
-`return (is_object($v) && get_class($v) == "Val_Nul");` — but the program
-cannot run, because the PHP writer emits a static call from `main` as
-`$Probe->row(...)` on an undefined variable. This is unrelated to shapes: a
-seven-line class with one `sfn` and no shape at all reproduces it
-(`$T->hello("there")`).
+`tests/is-operator.test.ts` runs `tests/fixtures/is_operator.rgr` on ES6,
+Python, Go, Rust and Kotlin (each skipped when its toolchain is absent) and
+asserts the emitted expression for Rust, C++, Kotlin and Swift — so Swift, whose
+toolchain cannot be fetched in a sandbox, is still regression-locked.
 
-**Not executed:** swift, kotlin, dart, csharp and scala have no toolchain in
-this container, so only their emitted expressions were checked
-(`({ () -> Bool in if case .Val_Nul = v { … } })()`, `(v is Val_Nul)`,
-`(v is Val_Nul)`, `(v is Val_Nul)`, `(v.isInstanceOf[Val_Nul])`).
+**Swift is the one target never executed.** Its only distribution host,
+`download.swift.org`, is refused by the network policy here (the proxy answers
+403 to CONNECT), so the claim for Swift rests on reading the emitted code and on
+the codegen assertions in the test, not on a run.
 
-## Limitation: group views do not work — and neither does `case`
+**PHP needed a writer fix to be testable at all.** It emitted a static call from
+`main` as `$Probe->row(...)` — a member call on an undefined variable. The
+param-desc branch of `writeVRef` was missing the leading-class check the plain-ns
+branch already had, so it always wrote `$name->`. Fixed in
+`ng_RangerPHPClassWriter.rgr`; PHP now emits `T::hello(...)` and runs both
+probes correctly. Nothing to do with shapes — a seven-line class with one `sfn`
+reproduced it.
 
-`is v _:Shape.Group` (a group rather than a case) is **broken**, but it is
-broken in exactly the way `case v x:Shape.Group` is already broken, because
-both ask the writer for a discriminant named after the group:
+## Groups: expanded into their member cases
 
-- **rust** — both emit `union_Val::union_Val_Prim`; the enum has no such
-  variant, so the file fails to compile with two identical `E0599` errors, one
-  from `case` and one from `is`.
-- **go** — both emit `union_Val_tag_union_Val_Prim`; undefined, same story.
-- **es6 / python** — both compare against `"union_Val_Prim"`, a tag no case
-  ever carries, so both silently answer `false` for every value.
+A group is **not** a discriminant any target can test. The generated union
+carries one tag per *case*, so asking a writer for a group tag produces a name
+that does not exist:
 
-So `is` is faithful to `case` here too: it neither fixes nor worsens group
-narrowing. This is the same gap as the known-failing
-`shapes.test.ts > lowering > makes a group a type of its own`. Test against a
-**case**, not a group, until that is fixed.
+- **rust** — `union_Val::union_Val_Prim` names no variant (`E0599`)
+- **go** — `union_Val_tag_union_Val_Prim` is undefined
+- **es6 / python** — a comparison against a tag no case ever carries, silently
+  false for every value
+- **swift** — a group lowers to its *own separate enum*, so a group tag is a
+  comparison against a different type entirely
+
+So `is v _:Shape.Group` is expanded at desugar time into a disjunction over the
+group's member cases — the same move `match` already makes for a group arm —
+and every target then sees only per-case tests it already knows how to lower:
+
+```rust
+pub fn isPrim(v : &union_Val) -> bool {
+  (matches!(v, union_Val::Val_Nul(..))) || (matches!(v, union_Val::Val_Num(..)))
+}
+```
+
+Verified running on ES6, Python, Go, Rust, C++, Kotlin, Java and PHP.
+
+On the interface-lowering targets (Kotlin, Java, C#, Dart, Scala) a group *is* a
+real type — Kotlin emits `sealed interface union_Val_Prim` and each case
+implements it — so the disjunction is redundant there, but still correct. The
+expansion is deliberately target-independent: putting "does this target make
+groups real types?" into the flow would push writer knowledge up a layer.
+
+**`case v x:Shape.Group` is still broken** — it needs a narrowed *binding*, not
+just an answer, so the same expansion does not apply to it. That remains the
+known-failing `shapes.test.ts > lowering > makes a group a type of its own`. Use
+`is` for a group test; use `case` on a concrete case when you need the payload.
 
 ## Measured effect on the interpreter
 

--- a/bin/output.js
+++ b/bin/output.js
@@ -2683,6 +2683,26 @@ class CodeNode  {
       match.builtNodes[this.vref] = newNode_2;
       return newNode_2;
     }
+    if ( (this.ns.length) > 1 ) {
+      if ( ( typeof(match.nodes[(this.ns[0])] ) != "undefined" && Object.prototype.hasOwnProperty.call(match.nodes, (this.ns[0])) ) ) {
+        const rootAst = (( Object.prototype.hasOwnProperty.call(match.nodes, (this.ns[0])) ? match.nodes[(this.ns[0])] : undefined ));
+        if ( ((((rootAst.children.length) == 0) && ((rootAst.ns.length) < 2)) && ((rootAst.vref.length) > 0)) && (rootAst.expression == false) ) {
+          const nsNode = new CodeNode(this.code, this.sp, this.ep);
+          nsNode.value_type = this.value_type;
+          nsNode.expression = this.expression;
+          for ( let i = 0; i < this.ns.length; i++) {
+            var n = this.ns[i];
+            if ( i == 0 ) {
+              nsNode.ns.push(rootAst.vref);
+            } else {
+              nsNode.ns.push(n);
+            }
+          };
+          nsNode.vref = nsNode.ns.join(".");
+          return nsNode;
+        }
+      }
+    }
     newNode.has_operator = this.has_operator;
     newNode.op_index = this.op_index;
     newNode.mutable_def = this.mutable_def;
@@ -2713,14 +2733,14 @@ class CodeNode  {
       const t_ann = this.type_annotation;
       newNode.type_annotation = t_ann.rebuildWithType(match, true);
     }
-    for ( let i = 0; i < this.ns.length; i++) {
-      var n = this.ns[i];
+    for ( let i_1 = 0; i_1 < this.ns.length; i_1++) {
+      var n_1 = this.ns[i_1];
       if ( changeVref ) {
-        const new_ns = match.getTypeName(n);
+        const new_ns = match.getTypeName(n_1);
         newNode.ns.push(new_ns);
       } else {
         newNode.vref = this.vref;
-        newNode.ns.push(n);
+        newNode.ns.push(n_1);
       }
     };
     newNode.string_value = this.string_value;
@@ -2743,21 +2763,21 @@ class CodeNode  {
         }
         break;
     };
-    for ( let i_1 = 0; i_1 < this.prop_keys.length; i_1++) {
-      var key = this.prop_keys[i_1];
+    for ( let i_2 = 0; i_2 < this.prop_keys.length; i_2++) {
+      var key = this.prop_keys[i_2];
       newNode.prop_keys.push(key);
       const oldp = ( Object.prototype.hasOwnProperty.call(this.props, key) ? this.props[key] : undefined );
       const np = oldp.rebuildWithType(match, changeVref);
       newNode.props[key] = np;
     };
-    for ( let i_2 = 0; i_2 < this.children.length; i_2++) {
-      var ch = this.children[i_2];
+    for ( let i_3 = 0; i_3 < this.children.length; i_3++) {
+      var ch = this.children[i_3];
       const newCh = ch.rebuildWithType(match, changeVref);
       newCh.parent = newNode;
       newNode.children.push(newCh);
     };
-    for ( let i_3 = 0; i_3 < this.attrs.length; i_3++) {
-      var ch_1 = this.attrs[i_3];
+    for ( let i_4 = 0; i_4 < this.attrs.length; i_4++) {
+      var ch_1 = this.attrs[i_4];
       const newCh_1 = ch_1.rebuildWithType(match, changeVref);
       newNode.attrs.push(newCh_1);
     };
@@ -9558,6 +9578,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       this.isDefinedArgSignature = {};
       this.extendedClasses = {};
       this.allNewRNodes = [];     /** note: unused */
+      this.inline_static_depth = 0;
       this.infinite_recursion = false;
       this.match_types = {};
     }
@@ -11231,6 +11252,11 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         this.checkInitializedObjectReceiver(rootName, node, ctx);
         const vFnDef = this.findFunctionDesc(fnNode, ctx, wr);
         if ( (typeof(vFnDef) !== "undefined" && vFnDef != null )  ) {
+          if ( ctx.hasCompilerFlag("inline-statics") ) {
+            if ( await this.tryInlineTrivialStatic(node, fnNode, (vFnDef), ctx, wr) ) {
+              return true;
+            }
+          }
           if ( vFnDef.nameNode.hasFlag("throws") ) {
             if ( false == ctx.isTryBlock() ) {
               ctx.addError(node, ("The method " + vFnDef.name) + " potentially throws an exception, try { } block is required");
@@ -12129,6 +12155,137 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
         await this.WalkNode(node, ctx, wr);
       }
       return am.builtNodes;
+    };
+    async inlineStaticEligible (m, fnNode, ctx) {
+      if ( typeof(m.fnBody) === "undefined" ) {
+        return false;
+      }
+      const body = m.fnBody;
+      if ( (body.children.length) != 1 ) {
+        return false;
+      }
+      const ret = body.children[0];
+      if ( false == ret.isFirstVref("return") ) {
+        return false;
+      }
+      if ( (ret.children.length) != 2 ) {
+        return false;
+      }
+      if ( m.nameNode.hasFlag("optional") ) {
+        return false;
+      }
+      const retExpr = ret.children[1];
+      if ( retExpr.expression == false ) {
+        return false;
+      }
+      let paramNames = {};
+      let b_ok = true;
+      for ( let i = 0; i < m.params.length; i++) {
+        var p = m.params[i];
+        if ( p.nameNode.hasFlag("optional") ) {
+          b_ok = false;
+        }
+        if ( p.nameNode.hasFlag("keyword") ) {
+          b_ok = false;
+        }
+        if ( p.nameNode.hasFlag("default") ) {
+          b_ok = false;
+        }
+        paramNames[p.name] = true;
+      };
+      if ( b_ok == false ) {
+        return false;
+      }
+      const fullName = fnNode.vref;
+      await retExpr.forTree((async (item, i) => { 
+        if ( (item.vref.length) > 0 ) {
+          let rootName = item.vref;
+          if ( (item.ns.length) > 0 ) {
+            rootName = item.ns[0];
+          }
+          if ( ( typeof(paramNames[rootName] ) != "undefined" && Object.prototype.hasOwnProperty.call(paramNames, rootName) ) ) {
+          } else {
+            if ( item.vref == fullName ) {
+              b_ok = false;
+            } else {
+              if ( ctx.isDefinedClass(rootName) ) {
+              } else {
+                const ops = await ctx.getOperators(item.vref);
+                if ( (ops.length) > 0 ) {
+                } else {
+                  b_ok = false;
+                }
+              }
+            }
+          }
+        }
+      }));
+      return b_ok;
+    };
+    async tryInlineTrivialStatic (node, fnNode, m, ctx, wr) {
+      if ( this.inline_static_depth > 6 ) {
+        return false;
+      }
+      if ( m.is_static == false ) {
+        return false;
+      }
+      if ( (fnNode.ns.length) != 2 ) {
+        return false;
+      }
+      const clName = fnNode.ns[0];
+      if ( false == ctx.isDefinedClass(clName) ) {
+        return false;
+      }
+      const cl = ctx.findClass(clName);
+      if ( cl.is_template ) {
+        return false;
+      }
+      if ( false == cl.hasStaticMethod((fnNode.ns[((fnNode.ns.length) - 1)])) ) {
+        return false;
+      }
+      if ( (node.children.length) != 2 ) {
+        return false;
+      }
+      const callArgs = node.getSecond();
+      if ( callArgs.expression == false ) {
+        return false;
+      }
+      if ( (callArgs.children.length) != (m.params.length) ) {
+        return false;
+      }
+      let b_atoms = true;
+      for ( let i = 0; i < callArgs.children.length; i++) {
+        var a = callArgs.children[i];
+        if ( ((a.expression || ((a.children.length) > 0)) || ((a.ns.length) > 1)) || ((a.vref.length) == 0) ) {
+          b_atoms = false;
+        }
+      };
+      if ( b_atoms == false ) {
+        return false;
+      }
+      if ( false == await this.inlineStaticEligible(m, fnNode, ctx) ) {
+        return false;
+      }
+      const am = new RangerArgMatch();
+      for ( let i_1 = 0; i_1 < callArgs.children.length; i_1++) {
+        var a_1 = callArgs.children[i_1];
+        const p = m.params[i_1];
+        am.addNode(p.name, a_1);
+      };
+      const body = m.fnBody;
+      const ret = body.children[0];
+      const retExpr = ret.children[1];
+      const newExpr = retExpr.rebuildWithType(am, true);
+      if ( ctx.hasCompilerFlag("show-inline-statics") ) {
+        console.log((("inline-statics: " + fnNode.vref) + " -> ") + newExpr.getCode());
+      }
+      node.getChildrenFrom(newExpr);
+      node.flow_done = false;
+      node.hasFnCall = false;
+      this.inline_static_depth = this.inline_static_depth + 1;
+      await this.WalkNode(node, ctx, wr);
+      this.inline_static_depth = this.inline_static_depth - 1;
+      return true;
     };
     async TransformOpFn (opFnList, origNode, ctx, wr) {
       if ( this.infinite_recursion ) {
@@ -52492,7 +52649,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
                                                         let the_file = "";
                                                         let plugins_only = false;
                                                         const valid_options = ["l", "Selected language, one of " + (allowed_languages.join(", ")), "d", "output directory, default directory is \"bin/\"", "o", "output file, default is \"output.<language>\"", "classdoc", "write class documentation .md file", "operatordoc", "write operator documention into .md file"];
-                                                        const valid_flags = ["no-color", "Disable colored output", "deadcode", "Eliminate functions which are not called by any other functions", "dead4main", "Eliminate functions and classes which are unreachable from the main function", "forever", "Leave the main program into eternal loop (Go, Swift)", "allowti", "Allow type inference at target lang (creates slightly smaller code)", "plugins-only", "ignore built-in language output and use only plugins", "plugins", "(node compiler only) run specified npm plugins -plugins=\"plugin1,plugin2\"", "strict", "Strict mode. Do not allow automatic unwrapping of optionals outside of try blocks.", "strict-ownership", "Print the inferred ownership of each function parameter (borrowed, moved, shared, owned, unknown)", "rust-shared-classes", "Emit Rc<RefCell<T>> for classes the sharing analysis marks as shared (Rust target; the default since the conformance gate closed — kept for compatibility)", "rust-value-classes", "Every class is a plain value struct on Rust (the pre-ownership object model); disables the shared-class Rc<RefCell<T>> emission", "native-fast-alloc", "Rust/C++ targets: emit a thread-local size-class freelist allocator (never returns memory to the OS; single-process benchmark/tool builds)", "cpp-single-thread", "C++ target: reference-count objects WITHOUT atomics (rg_ptr). Same aliasing as std::shared_ptr and no lock-prefixed increment per copy; a pointer copied across threads corrupts the count, so single-threaded builds only", "typescript", "Writes JavaScript code with TypeScript annotations", "esm", "Writes JavaScript code with ESM module syntax", "npm", "Write the package.json to the output directory", "pubspec", "Write pubspec.yaml for a Dart / Flutter package (requires -name= -version= -description=)", "flutter", "When used with -pubspec, emit a Flutter-oriented pubspec.yaml", "nodecli", "Insert node.js command line header #!/usr/bin/env node to the beginning of the JavaScript file", "nodemodule", "Export the classes as Node.js CommonJS modules", "client", "the code is ment to be run in the client environment", "scalafiddle", "scalafiddle.io compatible output", "compiler", "recompile the compiler", "copysrc", "copy all the source codes into the target directory"];
+                                                        const valid_flags = ["no-color", "Disable colored output", "deadcode", "Eliminate functions which are not called by any other functions", "dead4main", "Eliminate functions and classes which are unreachable from the main function", "forever", "Leave the main program into eternal loop (Go, Swift)", "allowti", "Allow type inference at target lang (creates slightly smaller code)", "plugins-only", "ignore built-in language output and use only plugins", "plugins", "(node compiler only) run specified npm plugins -plugins=\"plugin1,plugin2\"", "strict", "Strict mode. Do not allow automatic unwrapping of optionals outside of try blocks.", "strict-ownership", "Print the inferred ownership of each function parameter (borrowed, moved, shared, owned, unknown)", "rust-shared-classes", "Emit Rc<RefCell<T>> for classes the sharing analysis marks as shared (Rust target; the default since the conformance gate closed — kept for compatibility)", "rust-value-classes", "Every class is a plain value struct on Rust (the pre-ownership object model); disables the shared-class Rc<RefCell<T>> emission", "inline-statics", "Expand trivial static forwarders (a single return of an expression over the parameters) at their call sites instead of emitting a call", "native-fast-alloc", "Rust/C++ targets: emit a thread-local size-class freelist allocator (never returns memory to the OS; single-process benchmark/tool builds)", "cpp-single-thread", "C++ target: reference-count objects WITHOUT atomics (rg_ptr). Same aliasing as std::shared_ptr and no lock-prefixed increment per copy; a pointer copied across threads corrupts the count, so single-threaded builds only", "typescript", "Writes JavaScript code with TypeScript annotations", "esm", "Writes JavaScript code with ESM module syntax", "npm", "Write the package.json to the output directory", "pubspec", "Write pubspec.yaml for a Dart / Flutter package (requires -name= -version= -description=)", "flutter", "When used with -pubspec, emit a Flutter-oriented pubspec.yaml", "nodecli", "Insert node.js command line header #!/usr/bin/env node to the beginning of the JavaScript file", "nodemodule", "Export the classes as Node.js CommonJS modules", "client", "the code is ment to be run in the client environment", "scalafiddle", "scalafiddle.io compatible output", "compiler", "recompile the compiler", "copysrc", "copy all the source codes into the target directory"];
                                                         const parser_pragmas = ["@noinfix(true)", "disable operator infix parsing and automatic type definition checking "];
                                                         if ( ( typeof(params.flags["compiler"] ) != "undefined" && Object.prototype.hasOwnProperty.call(params.flags, "compiler") ) ) {
                                                           cli.printHeader();

--- a/bin/output.js
+++ b/bin/output.js
@@ -13200,6 +13200,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
       if ( ((Object.keys(renames)).length) > 0 ) {
         this.rewriteShapeRefs(node, renames);
         this.expandMatchesIn(node, ctx, wr);
+        this.expandGroupKindTests(node, ctx, wr);
       }
     };
     isShapeDeclaration (node) {
@@ -14655,6 +14656,53 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
           this.expandMatchesInFn(ch, nextFn, ctx, wr);
         }
       };
+    };
+    expandGroupKindTests (node, ctx, wr) {
+      for ( let i = 0; i < node.children.length; i++) {
+        var ch = node.children[i];
+        this.expandGroupKindTests(ch, ctx, wr);
+      };
+      if ( (node.children.length) != 3 ) {
+        return;
+      }
+      const head = node.children[0];
+      if ( head.vref != "is" ) {
+        return;
+      }
+      const typeNode = node.children[2];
+      if ( (typeNode.type_name.length) == 0 ) {
+        return;
+      }
+      if ( (( typeof(this.shapeGroupCases[typeNode.type_name] ) != "undefined" && Object.prototype.hasOwnProperty.call(this.shapeGroupCases, typeNode.type_name) )) == false ) {
+        return;
+      }
+      const members = (( Object.prototype.hasOwnProperty.call(this.shapeGroupCases, typeNode.type_name) ? this.shapeGroupCases[typeNode.type_name] : undefined ));
+      if ( (members.length) == 0 ) {
+        ctx.addError(node, ("group " + typeNode.type_name) + " has no cases to test");
+        return;
+      }
+      const scrutinee = node.children[1];
+      let acc = this.buildCaseKindTest(node, scrutinee, (members[0]));
+      for ( let mi = 0; mi < members.length; mi++) {
+        var m = members[mi];
+        if ( mi > 0 ) {
+          const orNode = node.newExpressionNode();
+          orNode.children.push(node.newVRefNode("||"));
+          orNode.children.push(acc);
+          orNode.children.push(this.buildCaseKindTest(node, scrutinee, m));
+          acc = orNode;
+        }
+      };
+      node.getChildrenFrom(acc);
+    };
+    buildCaseKindTest (proto, scrutinee, cls) {
+      const e = proto.newExpressionNode();
+      e.children.push(proto.newVRefNode("is"));
+      e.children.push(scrutinee.copy());
+      const typeNode = proto.newVRefNode("_");
+      typeNode.type_name = cls;
+      e.children.push(typeNode);
+      return e;
     };
     declaredTypeOf (fnNode, name) {
       if ( (fnNode.children.length) > 2 ) {
@@ -34605,6 +34653,7 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
                           }
                         }
                         if ( (node.nsp.length) > 0 ) {
+                          let nsp_was_static = false;
                           for ( let i = 0; i < node.nsp.length; i++) {
                             var p = node.nsp[i];
                             if ( i == 0 ) {
@@ -34615,10 +34664,19 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
                               }
                             }
                             if ( i > 0 ) {
-                              wr.out("->", false);
+                              if ( (i == 1) && nsp_was_static ) {
+                                wr.out("::", false);
+                              } else {
+                                wr.out("->", false);
+                              }
                             }
                             if ( i == 0 ) {
-                              wr.out("$", false);
+                              const part0 = node.ns[0];
+                              if ( ctx.hasClass(part0) ) {
+                                nsp_was_static = true;
+                              } else {
+                                wr.out("$", false);
+                              }
                               if ( p.nameNode.hasFlag("optional") ) {
                               }
                               const part_1 = node.ns[0];

--- a/compiler/VirtualCompiler.rgr
+++ b/compiler/VirtualCompiler.rgr
@@ -209,6 +209,7 @@ class tester {
       'strict-ownership' 'Print the inferred ownership of each function parameter (borrowed, moved, shared, owned, unknown)'
       'rust-shared-classes' 'Emit Rc<RefCell<T>> for classes the sharing analysis marks as shared (Rust target; the default since the conformance gate closed — kept for compatibility)'
       'rust-value-classes' 'Every class is a plain value struct on Rust (the pre-ownership object model); disables the shared-class Rc<RefCell<T>> emission'
+      'inline-statics' 'Expand trivial static forwarders (a single return of an expression over the parameters) at their call sites instead of emitting a call'
       'native-fast-alloc' 'Rust/C++ targets: emit a thread-local size-class freelist allocator (never returns memory to the OS; single-process benchmark/tool builds)'
       'cpp-single-thread' 'C++ target: reference-count objects WITHOUT atomics (rg_ptr). Same aliasing as std::shared_ptr and no lock-prefixed increment per copy; a pointer copied across threads corrupts the count, so single-threaded builds only'
       'typescript' 'Writes JavaScript code with TypeScript annotations'

--- a/compiler/ng_CodeNodeCompilerExtensions.rgr
+++ b/compiler/ng_CodeNodeCompilerExtensions.rgr
@@ -497,6 +497,31 @@ extension CodeNode {
       set match.builtNodes vref newNode
       return newNode
     }
+    ; a QUALIFIED reference whose ROOT segment is a substituted node --
+    ; `v.isUndefined` with v bound to a call argument (the static-forwarder
+    ; inliner and defn bodies that touch a member of a parameter). Only a
+    ; plain bare name can stand in as the root of a member chain, so an
+    ; expression or literal binding leaves the node untouched here -- the
+    ; inliner refuses such arguments before building the match.
+    if( (array_length ns) > 1 ) {
+      if( has match.nodes (first ns) ) {
+        def rootAst (unwrap (get match.nodes (first ns)))
+        if( ( (array_length rootAst.children) == 0 ) && ( (array_length rootAst.ns) < 2 ) && ( (strlen rootAst.vref) > 0 ) && (rootAst.expression == false) ) {
+          def nsNode@(lives):CodeNode (new CodeNode ( (unwrap code) sp ep))
+          nsNode.value_type = value_type
+          nsNode.expression = expression
+          for ns n:string i {
+            if( i == 0 ) {
+              push nsNode.ns rootAst.vref
+            } {
+              push nsNode.ns n
+            }
+          }
+          nsNode.vref = (join nsNode.ns ".")
+          return nsNode
+        }
+      }
+    }
     newNode.has_operator = has_operator
     newNode.op_index = op_index
     newNode.mutable_def = mutable_def

--- a/compiler/ng_RangerFlowParser.rgr
+++ b/compiler/ng_RangerFlowParser.rgr
@@ -2124,6 +2124,14 @@ class RangerFlowParser {
 
       if (!null? vFnDef) {
 
+        ; -inline-statics: a trivial static forwarder expands into its body
+        ; here instead of becoming a call
+        if( ctx.hasCompilerFlag("inline-statics") ) {
+          if( this.tryInlineTrivialStatic( node fnNode (unwrap vFnDef) ctx wr ) ) {
+            return true
+          }
+        }
+
         if(vFnDef.nameNode.hasFlag("throws")) {
           if(false == (ctx.isTryBlock()) ) {
             ctx.addError(node ('The method ' + vFnDef.name + " potentially throws an exception, try { } block is required"))
@@ -3151,11 +3159,168 @@ class RangerFlowParser {
     return am.builtNodes
   }
 
+  ; ---- -inline-statics ------------------------------------------------------
+  ; A TRIVIAL static forwarder -- `sfn isUndefined:boolean (v:EvHandle) {
+  ; return (v.isUndefined()) }` -- expands into its body at the call site
+  ; instead of paying a function call (and, on the Rust target, an Rc clone
+  ; per handle argument). Deliberately conservative: the body must be exactly
+  ; one `return (expr)`, every name in it must be a parameter, a
+  ; class-qualified reference or a language operator, and every call
+  ; argument must be a plain bare name, so nothing can double-evaluate or
+  ; change evaluation order. Anything else keeps the ordinary call.
+  def inline_static_depth:int 0
+
+  fn inlineStaticEligible:boolean (m:RangerAppFunctionDesc fnNode:CodeNode ctx:RangerAppWriterContext) {
+    if( null? m.fnBody ) {
+      return false
+    }
+    def body:CodeNode (unwrap m.fnBody)
+    if( (array_length body.children) != 1 ) {
+      return false
+    }
+    def ret (first body.children)
+    if( false == (ret.isFirstVref("return")) ) {
+      return false
+    }
+    if( (array_length ret.children) != 2 ) {
+      return false
+    }
+    if( m.nameNode.hasFlag("optional") ) {
+      return false
+    }
+    def retExpr (at ret.children 1)
+    ; a bare-atom body (`return v`) is possible but rare -- only expression
+    ; bodies are expanded, so the call node keeps its expression shape
+    if( retExpr.expression == false ) {
+      return false
+    }
+    def paramNames:[string:boolean]
+    def b_ok true
+    for m.params p:RangerAppParamDesc i {
+      if( p.nameNode.hasFlag("optional") ) {
+        b_ok = false
+      }
+      if( p.nameNode.hasFlag("keyword") ) {
+        b_ok = false
+      }
+      if( p.nameNode.hasFlag("default") ) {
+        b_ok = false
+      }
+      set paramNames p.name true
+    }
+    if( b_ok == false ) {
+      return false
+    }
+    def fullName:string fnNode.vref
+    retExpr.forTree({
+      if( (strlen item.vref) > 0 ) {
+        def rootName:string item.vref
+        if( (array_length item.ns) > 0 ) {
+          rootName = (first item.ns)
+        }
+        if( has paramNames rootName ) {
+          ; a parameter use
+        } {
+          if( item.vref == fullName ) {
+            ; direct recursion can never terminate the expansion
+            b_ok = false
+          } {
+            if( ctx.isDefinedClass(rootName) ) {
+              ; a class-qualified reference resolves the same anywhere
+            } {
+              def ops (ctx.getOperators(item.vref))
+              if( (array_length ops) > 0 ) {
+                ; a language operator
+              } {
+                ; a bare name from the callee's scope -- substituting it
+                ; into the caller would capture the wrong binding
+                b_ok = false
+              }
+            }
+          }
+        }
+      }
+    })
+    return b_ok
+  }
+
+  fn tryInlineTrivialStatic:boolean (node:CodeNode fnNode:CodeNode m:RangerAppFunctionDesc ctx:RangerAppWriterContext wr:CodeWriter) {
+    if( inline_static_depth > 6 ) {
+      return false
+    }
+    if( m.is_static == false ) {
+      return false
+    }
+    ; only the plain `Class.name args` shape -- a variable-rooted or deeper
+    ; chain is an instance call or a namespace walk
+    if( (array_length fnNode.ns) != 2 ) {
+      return false
+    }
+    def clName:string (first fnNode.ns)
+    if( false == (ctx.isDefinedClass(clName)) ) {
+      return false
+    }
+    def cl (ctx.findClass(clName))
+    if( cl.is_template ) {
+      return false
+    }
+    if( false == (cl.hasStaticMethod( (last fnNode.ns) )) ) {
+      return false
+    }
+    if( (array_length node.children) != 2 ) {
+      return false
+    }
+    def callArgs (node.getSecond())
+    if( callArgs.expression == false ) {
+      return false
+    }
+    if( (array_length callArgs.children) != (array_length m.params) ) {
+      return false
+    }
+    ; every argument must be a plain bare name: an expression argument moved
+    ; into the body's position could evaluate in a different order (or, if a
+    ; parameter repeats, twice), and a literal cannot root a member chain
+    def b_atoms true
+    for callArgs.children a:CodeNode i {
+      if( a.expression || ( (array_length a.children) > 0 ) || ( (array_length a.ns) > 1 ) || ( (strlen a.vref) == 0 ) ) {
+        b_atoms = false
+      }
+    }
+    if( b_atoms == false ) {
+      return false
+    }
+    if( false == (this.inlineStaticEligible(m fnNode ctx)) ) {
+      return false
+    }
+    def am@(lives) (new RangerArgMatch)
+    for callArgs.children a:CodeNode i {
+      def p:RangerAppParamDesc (at m.params i)
+      am.addNode( p.name a )
+    }
+    def body:CodeNode (unwrap m.fnBody)
+    def ret (first body.children)
+    def retExpr (at ret.children 1)
+    def newExpr (retExpr.rebuildWithType(am true))
+    if(ctx.hasCompilerFlag("show-inline-statics")) {
+      print "inline-statics: " + fnNode.vref + " -> " + (newExpr.getCode())
+    }
+    ; splice the rebuilt body into the call node and re-flow it in the
+    ; CALLER's context -- types, param descriptors and ref counts are all
+    ; computed for the new expression exactly as if it had been written here
+    node.getChildrenFrom(newExpr)
+    node.flow_done = false
+    node.hasFnCall = false
+    inline_static_depth = inline_static_depth + 1
+    this.WalkNode(node ctx wr)
+    inline_static_depth = inline_static_depth - 1
+    return true
+  }
+
   ; transforms a node
   ; origNode has the syntax (opname x y z)
   ; against given operator definition nodes in opFnList in format
   ;   defn someOp (x) (x + 1)
-  ; 
+  ;
   def infinite_recursion false
   def match_types:[string:string]
 

--- a/compiler/ng_RangerFlowParser.rgr
+++ b/compiler/ng_RangerFlowParser.rgr
@@ -4450,6 +4450,9 @@ class RangerFlowParser {
       this.rewriteShapeRefs(node renames)
       ; after the rename, an arm written as `Value.Num` reads as `Value_Num`
       this.expandMatchesIn(node ctx wr)
+      ; …and `is v _:Value.Prim` reads as `Value_Prim`, which is a group, not a
+      ; tag any target can compare — expand it into its member cases
+      this.expandGroupKindTests(node ctx wr)
     }
   }
 
@@ -5992,6 +5995,65 @@ class RangerFlowParser {
         this.expandMatchesInFn(ch nextFn ctx wr)
       }
     }
+  }
+
+  ; `is v _:Shape.Group` — a group is not a discriminant any target can test.
+  ; The generated union carries one tag per CASE, so asking a writer for a
+  ; group tag produces a name that does not exist (`union_Val::union_Val_Prim`
+  ; on Rust, `union_Val_tag_union_Val_Prim` on Go) or, on the tag-string
+  ; targets, a comparison that is simply never true. So a group test expands
+  ; here into a disjunction over the group's member cases — the same move
+  ; `match` makes for a group arm — and every target then sees only per-case
+  ; tests it already knows how to lower.
+  ;
+  ; Runs on the renamed tree, so the annotation already reads as the generated
+  ; group class name.
+  fn expandGroupKindTests:void (node@(lives):CodeNode ctx:RangerAppWriterContext wr:CodeWriter) {
+    for node.children ch:CodeNode i {
+      this.expandGroupKindTests(ch ctx wr)
+    }
+    if ((array_length node.children) != 3) {
+      return
+    }
+    def head:CodeNode (first node.children)
+    if (head.vref != "is") {
+      return
+    }
+    def typeNode:CodeNode (itemAt node.children 2)
+    if ((strlen typeNode.type_name) == 0) {
+      return
+    }
+    if ((has shapeGroupCases typeNode.type_name) == false) {
+      return
+    }
+    def members:[string] (unwrap (get shapeGroupCases typeNode.type_name))
+    if ((array_length members) == 0) {
+      ctx.addError(node (("group " + typeNode.type_name) + " has no cases to test"))
+      return
+    }
+    def scrutinee:CodeNode (itemAt node.children 1)
+    def acc:CodeNode (this.buildCaseKindTest(node scrutinee (first members)))
+    for members m:string mi {
+      if (mi > 0) {
+        def orNode:CodeNode (node.newExpressionNode())
+        push orNode.children (node.newVRefNode("||"))
+        push orNode.children acc
+        push orNode.children (this.buildCaseKindTest(node scrutinee m))
+        acc = orNode
+      }
+    }
+    node.getChildrenFrom(acc)
+  }
+
+  ; One `is v _:Case` node, built the way expandMatch builds its narrowings.
+  fn buildCaseKindTest:CodeNode (proto:CodeNode scrutinee:CodeNode cls:string) {
+    def e:CodeNode (proto.newExpressionNode())
+    push e.children (proto.newVRefNode("is"))
+    push e.children (scrutinee.copy())
+    def typeNode:CodeNode (proto.newVRefNode("_"))
+    typeNode.type_name = cls
+    push e.children typeNode
+    return e
   }
 
   ; The declared type of `name` inside this function: a parameter first, then a

--- a/compiler/ng_RangerPHPClassWriter.rgr
+++ b/compiler/ng_RangerPHPClassWriter.rgr
@@ -93,6 +93,12 @@ fn EncodeString:string (node:CodeNode ctx:RangerAppWriterContext wr:CodeWriter) 
       }
     }
     if ((array_length node.nsp) > 0) {
+      ; A leading class name is a static reference, not a variable: PHP spells
+      ; it `Cls::member`, and emitting `$Cls->member` reads a variable that was
+      ; never assigned. The plain-ns branch below already handles this; the
+      ; param-desc branch has to as well, or a static call from `main` dies at
+      ; runtime.
+      def nsp_was_static:boolean false
       for node.nsp p:RangerAppParamDesc i {
 
         if (i == 0) {
@@ -100,14 +106,23 @@ fn EncodeString:string (node:CodeNode ctx:RangerAppWriterContext wr:CodeWriter) 
           if(part == "this") {
             wr.out("$this" false)
             continue
-          } 
-        }        
+          }
+        }
 
         if (i > 0) {
-          wr.out("->" false)
+          if ((i == 1) && nsp_was_static) {
+            wr.out("::" false)
+          } {
+            wr.out("->" false)
+          }
         }
         if (i == 0) {
-          wr.out("$" false)
+          def part0:string (itemAt node.ns 0)
+          if (ctx.hasClass(part0)) {
+            nsp_was_static = true
+          } {
+            wr.out("$" false)
+          }
           if (p.nameNode.hasFlag("optional")) {
           }
           def part:string (itemAt node.ns 0)

--- a/compiler/stdlib.rgr
+++ b/compiler/stdlib.rgr
@@ -241,10 +241,51 @@ operators {
                 (forkctx _ ) (def 2) "if let " (typeof 1) "::" (typeof 2) "(" (e 2) ") = " (e 1) ".clone() { /* union case */" nl I
                         (block 3)
                         nl i "}"
-            ) 
-            
+            )
+
         }
-    }    
+    }
+    ; `is v Shape.Case` — the kind test of `case` with the binding and the
+    ; block taken away. `case v x:Shape.Case { … }` answers "is it this case?"
+    ; and then hands the arm a narrowed `x`; an arm that only wants the answer
+    ; pays for a binding it never reads. On Rust that binding costs a
+    ; `.clone()` of the scrutinee (a refcount pair for every reference case),
+    ; on Go a declared-and-discarded local, on ES6/Python a dead assignment.
+    ; This is an expression, so it composes: `return (is self EvalValue.Number)`
+    ; replaces the whole `case self n:… { return true } return false` shape.
+    ; Every template below is the same discriminant test the `case` operator
+    ; above already lowers to on that target — nothing new is invented, and no
+    ; target evaluates (e 1) more than once.
+    is _:boolean ( arg@(union):T item@(noeval):T ) {
+        templates {
+            ranger ( "(is " (e 1) " " (typeof 2) ")" )
+            ; S5 FlatTaggedObject: the stable kind tag, no `var x = …` after it
+            es6    ( "(" (e 1) " != null && " (e 1) ".__rg_kind === \"" (typeof 2) "\")" )
+            ; single underscore — __rg_kind would be Python-mangled on the instance
+            python ( "(" (e 1) " is not None and getattr(" (e 1) ", \"_rg_kind\", None) == \"" (typeof 2) "\")" )
+            ; S5 tagged struct: the tag compare alone, no variant pointer bound
+            go     ( "(" (e 1) ".tag == " (typeof 1) "_tag_" (rawtype 2) ")" )
+            ; matches! reads the discriminant in place — no clone of the
+            ; scrutinee, which is the whole point of this operator on Rust
+            rust   ( "matches!(" (e 1) ", " (typeof 1) "::" (typeof 2) "(..))" )
+            ; holds_alternative is already the bare index compare; the `case`
+            ; template only added mpark::get on top of it
+            cpp    ( "mpark::holds_alternative<" (typeof 2) ">(" (e 1) ")"
+                (plugin 'makefile' ((dep 'variant.hpp' 'https://github.com/mpark/variant/releases/download/v1.2.2/variant.hpp')))
+            )
+            csharp ( "(" (e 1) " is " (typeof 2) ")" )
+            kotlin ( "(" (e 1) " is " (typeof 2) ")" )
+            dart   ( "(" (e 1) " is " (typeof 2) ")" )
+            java7  ( "(" (e 1) " instanceof " (typeof 2) ")" )
+            php    ( "(is_object(" (e 1) ") && get_class(" (e 1) ") == \"" (typeof 2) "\")" )
+            scala  ( "(" (e 1) ".isInstanceOf[" (typeof 2) "])" )
+            ; Swift's enum test is `if case`, a statement — an immediately
+            ; applied closure is the only way to spell it as an expression.
+            ; (e 1) is still named once, so it is still evaluated once.
+            swift3 ( "({ () -> Bool in if case ." (rawtype 2) " = " (e 1) " { return true }; return false })()" )
+            swift6 ( "({ () -> Bool in if case ." (rawtype 2) " = " (e 1) " { return true }; return false })()" )
+        }
+    }
     ; Reference identity: are these two names the same object? `==` means
     ; something different on every target — structural on Kotlin, a trait bound
     ; on Rust, pointer on C++ — so identity gets its own operator rather than a

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -88,6 +88,7 @@ export default defineConfig({
           items: [
             { label: "Program structure", slug: "language/structure" },
             { label: "Types", slug: "language/types" },
+            { label: "Shapes", slug: "language/shapes" },
             { label: "Strings", slug: "language/strings" },
             { label: "Optional values", slug: "language/optionals" },
             { label: "Ownership and lifetime", slug: "language/ownership" },

--- a/docs/site/src/content/docs/language/shapes.md
+++ b/docs/site/src/content/docs/language/shapes.md
@@ -1,0 +1,139 @@
+---
+title: Shapes
+description: A shape is a closed set of cases with a payload. The page states the declaration, the narrowing operators and the output of each target language.
+---
+
+A shape is a closed set of cases. Each case has a name and its own fields. A
+value of the shape type holds one case at a time. The compiler knows every
+case, so it can report a case that a `match` statement does not cover.
+
+```lisp
+shape Value {
+    case Nothing
+    case Num {
+        def n:double 0.0
+    }
+    case Text {
+        def s:string ""
+    }
+}
+```
+
+The declaration writes one class for each case and one union over the classes.
+No target language knows the word `shape`. A target carries a shape as well as
+it carries a union.
+
+## The construction of a value
+
+The constructor of a case takes the fields of the case in order.
+
+```lisp
+def a:Value (new Value.Nothing())
+def b:Value (new Value.Num(42.0))
+def c:Value (new Value.Text("hello"))
+```
+
+## The narrowing of a value
+
+The operator `case` tests the value and binds the narrowed value to a name. The
+block reads the fields of the case.
+
+```lisp
+case v x:Value.Num {
+    print (to_string x.n)
+}
+```
+
+## The kind test
+
+The operator `is` answers the question "does the value hold this case?". It
+gives a boolean, and it binds nothing.
+
+```lisp
+fn isNumber:boolean (v:Value) {
+    return (is v _:Value.Num)
+}
+```
+
+The name `_` is the binding that the operator does not take. The compiler reads
+the case from the type after the colon, so the case needs a name in front of
+it. The operator defines no variable, and the same form can appear two times in
+one block.
+
+`is` is an expression. It goes into a `return`, into an `if` condition, and
+into a boolean operator.
+
+```lisp
+if (is v _:Value.Nothing) {
+    return "nothing"
+}
+return ((is v _:Value.Num) || (is v _:Value.Text))
+```
+
+Use `case` when the block reads the payload of the case. Use `is` when the
+program needs the answer only. The binding of `case` has a cost: on the Rust
+target it writes a clone of the value.
+
+## Groups
+
+A group is a name for a set of cases. A case joins a group with `does`. A group
+declares fields that each case of the group receives.
+
+```lisp
+shape Value {
+    group Prim @(value)
+    group Ref @(reference) {
+        def identityId:int 0
+    }
+
+    case Nothing does Prim
+    case Num does Prim {
+        def n:double 0.0
+    }
+    case Text does Ref {
+        def s:string ""
+    }
+}
+```
+
+The operator `is` accepts a group. The compiler writes one test for each case
+of the group and joins the tests with `||`.
+
+```lisp
+def b:boolean (is v _:Value.Prim)
+```
+
+## The output of each target language
+
+The operator `is` writes the test that the target language already uses for
+`case`. It adds no new form.
+
+| Target | The output of `is v _:Value.Num` |
+| --- | --- |
+| JavaScript | `(v != null && v.__rg_kind === "Value_Num")` |
+| Python | `(v is not None and getattr(v, "_rg_kind", None) == "Value_Num")` |
+| Go | `(v.tag == union_Value_tag_Value_Num)` |
+| Rust | `matches!(v, union_Value::Value_Num(..))` |
+| C++ | `mpark::holds_alternative<Value_Num>(v)` |
+| Kotlin, Dart, C# | `(v is Value_Num)` |
+| Java | `(v instanceof Value_Num)` |
+| Scala | `(v.isInstanceOf[Value_Num])` |
+| Swift | `({ () -> Bool in if case .Value_Num = v { return true }; return false })()` |
+| PHP | `(is_object($v) && get_class($v) == "Value_Num")` |
+
+Swift has no expression form of `if case`. The compiler writes a closure and
+calls it. The value operand has one name in the output, so the program reads it
+one time.
+
+## The state of each target language
+
+The test `tests/is-operator.test.ts` runs one program on JavaScript, Python,
+Go, Rust and Kotlin. It compares the answer of `case` against the answer of
+`is` for each case and for each group. The same program also runs on C++, Java
+and PHP.
+
+The Swift toolchain is not available in the test container. The test reads the
+output of the Swift writer instead of a run of the program.
+
+The page [Target languages](/Ranger/docs/targets/overview/) states the limits
+of a shape on each target language.

--- a/docs/site/src/content/docs/targets/overview.md
+++ b/docs/site/src/content/docs/targets/overview.md
@@ -56,6 +56,52 @@ command-line target in the support row, including Dart. A mark ✔ is an own
 template; ✱ is the default `*` template; ✕ means the operator has no template
 for that target.
 
+## The state of a shape on each target language
+
+A [shape](/Ranger/docs/language/shapes/) is a closed set of cases. The
+declaration writes one class for each case and one union over the classes. The
+table states the result of one program that tests each case and each group. The
+program compares the answer of the operator `case` against the answer of the
+operator `is`.
+
+| Target | The program runs | The known limit |
+| --- | --- | --- |
+| JavaScript | yes | none |
+| Python | yes | none |
+| Go | yes | none |
+| Kotlin | yes | none |
+| Java | yes | none |
+| C++ | yes | The variant holds a scalar case behind a pointer. The test asks for the case by value. |
+| Rust | yes | A case value is not wrapped into the union. See the note below. |
+| PHP | yes | none for a shape |
+| Swift | not tested | The toolchain is not available in the test container. The test reads the output of the writer. |
+| Dart, C#, Scala | not tested | No toolchain in the test container. |
+| llvm | no | The writer has no template for `case`, so it compiles no shape. |
+
+**The limit of the Rust target.** A value of a case type does not become a
+value of the union type at an argument. The program below does not compile,
+because `add` takes the union and `n` has the type of the case:
+
+```lisp
+def n:Value (new Value.Num(2.0))
+p.add(n)          ; expected &union_Value, found &Value_Num
+```
+
+Give the value a name of the union type first. The writer then wraps the value:
+
+```lisp
+def n:Value (new Value.Num(2.0))
+def v:Value n
+p.add(v)
+```
+
+This limit is the reason for 8 of the 11 shape tests that fail today.
+
+**A group.** The operator `is` accepts a group on each target language. The
+compiler writes one test for each case of the group. The operator `case` does
+not accept a group, because it must bind a narrowed value, and no target has a
+type for the group on every writer. Use `is` for the test of a group.
+
 ## Other targets in the language file
 
 The file `compiler/Lang.rgr` declares more targets than the command line lists:

--- a/gallery/game_engine/v2/interp/bench/zoo_octane/build-native.sh
+++ b/gallery/game_engine/v2/interp/bench/zoo_octane/build-native.sh
@@ -29,7 +29,7 @@ for T in $TARGETS; do
   # single-threaded (cpp-only flag, ignored elsewhere). See bench/native.
   RANGER_LIB=./compiler/Lang.rgr:./lib/stdops.rgr node bin/output.js -l="$T" \
     "$SRC" -d="$OUT_DIR" -o=octane_runner."$EXT" -nodecli -native-fast-alloc \
-    -cpp-single-thread $TARGET_FLAG
+    -cpp-single-thread $TARGET_FLAG $EXTRA_RANGER_FLAGS
   case "$T" in
     cpp)
       # Shape case classes are emitted after ordinary classes; move the

--- a/gallery/game_engine/v2/interp/migrate/src/ComponentEngine.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/ComponentEngine.rgr
@@ -1502,14 +1502,14 @@ class ComponentEngine {
             def exportName:string (itemAt exportNames k)
             def localName:string (itemAt localNames k)
             def existing:EvHandle (moduleScope.lookup(exportName))
-            if (EvValueBridge.isFunction(existing)) {
+            if (existing.isFunction()) {
                 if (existing.hasFunctionNode()) {
                     def fnNode:TSNode (existing.functionNodeOf())
                     def emptyHelpers:[TSNode]
                     this.bindImportedFunction(exportName localName fnNode emptyHelpers "")
                 }
             } {
-                if (false == (EvValueBridge.isNull(existing))) {
+                if (false == (existing.isNull())) {
                     this.defineModuleBinding(localName existing)
                 }
             }
@@ -1875,7 +1875,7 @@ class ComponentEngine {
                 if argNode.left {
                     sv = (this.evaluateExpr((unwrap argNode.left)))
                 }
-                if (EvValueBridge.isArrayValue(sv)) {
+                if (sv.isArray()) {
                     def k:int 0
                     while (k < (sv.denseLen())) {
                         push args (sv.arrayItemAt(k))
@@ -1898,7 +1898,7 @@ class ComponentEngine {
     ; Convenience: read back a registered / script-defined global by name.
     fn getGlobal:EvHandle (name:string) {
         def v:EvHandle (context.lookup(name))
-        if (false == (EvValueBridge.isNull(v))) {
+        if (false == (v.isNull())) {
             return v
         }
         return (hostScope.lookup(name))
@@ -2069,7 +2069,7 @@ class ComponentEngine {
         def n:int (array_length argNodes)
         if (n == 1) {
             def only:EvHandle (this.evaluateExpr((itemAt argNodes 0)))
-            if (EvValueBridge.isNumber(only)) {
+            if (only.isNumber()) {
                 ; D-ARRAYLEN: `Array(len)` accepts only a uint32. A negative or
                 ; fractional length is a RangeError, and an enormous one used to
                 ; be a host crash ("Invalid array length") rather than a guest
@@ -2234,7 +2234,7 @@ class ComponentEngine {
         }
         def evSrc:EvHandle (itemAt args 0)
         ; eval of a non-string returns the argument untouched.
-        if (false == (EvValueBridge.isString(evSrc))) {
+        if (false == (evSrc.isString())) {
             return evSrc
         }
         def savedEvalCtx:EvalContext context
@@ -2530,14 +2530,14 @@ class ComponentEngine {
     ; non-function names return null.
     fn callFunction:EvHandle (name:string props:EvHandle) {
         def fnValue:EvHandle (context.lookup(name))
-        if (false == (EvValueBridge.isFunction(fnValue))) {
+        if (false == (fnValue.isFunction())) {
             ; Host lifecycle door: a name not in the entry scope may be a loaded
             ; virtual module's top-level function (e.g. the ranger:core
             ; __rgGameInit / __rgGameUpdate entry points — module scopes are
             ; isolated, so they are NOT entry bindings). Module functions carry
             ; their closure, so the call roots in their own module scope.
             def mv:EvHandle (this.lookupModuleExport(name))
-            if (EvValueBridge.isFunction(mv)) {
+            if (mv.isFunction()) {
                 if (mv.hasFunctionNode()) {
                     def margs:[EvHandle]
                     push margs props
@@ -2570,7 +2570,7 @@ class ComponentEngine {
     ; element tree (for screen render functions).
     fn callRender:EVGElement (name:string props:EvHandle) {
         def fnValue:EvHandle (context.lookup(name))
-        if (false == (EvValueBridge.isFunction(fnValue))) {
+        if (false == (fnValue.isFunction())) {
             def empty (new EVGElement())
             return empty
         }
@@ -3450,7 +3450,7 @@ class ComponentEngine {
         }
         if (pattern.nodeType == "AssignmentPattern") {
             def v:EvHandle value
-            if ((EvValueBridge.isNull(v)) || (EvValueBridge.isUndefined(v))) {
+            if ((v.isNull()) || (v.isUndefined())) {
                 if pattern.right {
                     v = (this.evaluateExpr((unwrap pattern.right)))
                 }
@@ -3480,7 +3480,7 @@ class ComponentEngine {
             } {
                 if (el.nodeType == "RestElement") {
                     def items:[EvHandle]
-                    if (EvValueBridge.isArrayValue(value)) {
+                    if (value.isArray()) {
                         def k:int idx
                         while (k < (value.denseLen())) {
                             push items (value.arrayItemAt(k))
@@ -3499,7 +3499,7 @@ class ComponentEngine {
                     }
                 } {
                     def elemVal:EvHandle (EvValueBridge.taggedUndefined())
-                    if (EvValueBridge.isArrayValue(value)) {
+                    if (value.isArray()) {
                         if (idx < (value.denseLen())) {
                             elemVal = (value.arrayItemAt(idx))
                         }
@@ -3522,7 +3522,7 @@ class ComponentEngine {
             if (prop.nodeType == "RestElement") {
                 def rkeys:[string]
                 def rvals:[EvHandle]
-                if (EvValueBridge.isObject(value)) {
+                if (value.isObject()) {
                     def ks:[string] (value.ownDataKeys())
                     def ki:int 0
                     while (ki < (array_length ks)) {
@@ -3539,7 +3539,7 @@ class ComponentEngine {
                 def srcKey:string prop.name
                 push usedKeys srcKey
                 def v:EvHandle (value.getMember(srcKey))
-                if ((EvValueBridge.isNull(v)) || (EvValueBridge.isUndefined(v))) {
+                if ((v.isNull()) || (v.isUndefined())) {
                     if prop.init {
                         v = (this.evaluateExpr((unwrap prop.init)))
                     }
@@ -3676,7 +3676,7 @@ class ComponentEngine {
 
                 ; a missing prop now reads as undefined (rule 6); treat null OR
                 ; undefined as absent so the default still fires.
-                if ((EvValueBridge.isNull(propValue)) || (EvValueBridge.isUndefined(propValue))) {
+                if ((propValue.isNull()) || (propValue.isUndefined())) {
                     ; Use default value if provided
                     if prop.init {
                         def initNode:TSNode (unwrap prop.init)
@@ -4768,7 +4768,7 @@ class ComponentEngine {
             if (walk.hasOwnSetter(key)) { return true }
             if (this.objHasKey(walk key)) { return true }
             def nxt:EvHandle (this.protoOfValue(walk))
-            if (EvValueBridge.isNull(nxt)) {
+            if (nxt.isNull()) {
                 return false
             }
             walk = nxt
@@ -5351,7 +5351,7 @@ class ComponentEngine {
         if (stmt.nodeType == "WithStatement") {
             if stmt.left {
                 def wRaw:EvHandle (this.evaluateExpr((unwrap stmt.left)))
-                if ((EvValueBridge.isNull(wRaw)) || (EvValueBridge.isUndefined(wRaw))) {
+                if ((wRaw.isNull()) || (wRaw.isUndefined())) {
                     def _w:EvHandle (this.throwSpecError("TypeError" "with(...) requires an object"))
                     return
                 }
@@ -5813,7 +5813,7 @@ class ComponentEngine {
                         def objValue:EvHandle (context.lookup(objName))
                         
                         ; Array.push()
-                        if ((methodName == "push") && (EvValueBridge.isArrayValue(objValue))) {
+                        if ((methodName == "push") && (objValue.isArray())) {
                             ; Get arguments from node.children
                             if ((array_length node.children) > 0) {
                                 def argNode:TSNode (itemAt node.children 0)
@@ -5927,7 +5927,7 @@ class ComponentEngine {
             def rightNode:TSNode (unwrap node.right)
             def arrayValue:EvHandle (this.evaluateExpr(rightNode))
             
-            if (EvValueBridge.isArrayValue(arrayValue)) {
+            if (arrayValue.isArray()) {
                 def i:int 0
                 while (i < (arrayValue.denseLen())) {
                     def item:EvHandle (arrayValue.arrayItemAt(i))
@@ -6314,7 +6314,7 @@ class ComponentEngine {
             ; `x = new String("1"); x += 1` gave 2 instead of "11".
             def lp:EvHandle (this.toPrimitiveDefault(current))
             def rp:EvHandle (this.toPrimitiveDefault(rightValue))
-            if ((EvValueBridge.isString(lp)) || (EvValueBridge.isString(rp))) {
+            if ((lp.isString()) || (rp.isString())) {
                 return (EvValueBridge.taggedString((this.toStringOf(lp)) + (this.toStringOf(rp))))
             }
             return (EvValueBridge.taggedNumber((this.toNumberOf(lp)) + (this.toNumberOf(rp))))
@@ -6383,7 +6383,7 @@ class ComponentEngine {
         if (opK == 16) {
             ; nullish: assign when the current value is null OR undefined
             ; (a missing member now reads as undefined — D-IDENTITY rule 6).
-            if ((EvValueBridge.isNull(current)) || (EvValueBridge.isUndefined(current))) {
+            if ((current.isNull()) || (current.isUndefined())) {
                 return rightValue
             }
             return current
@@ -6418,9 +6418,9 @@ class ComponentEngine {
         ; mode. It was silently dropped, so a test that expected the throw saw
         ; nothing happen at all.
         if strictReferences {
-            if ((EvValueBridge.isNull(obj)) || (EvValueBridge.isUndefined(obj))) {
+            if ((obj.isNull()) || (obj.isUndefined())) {
                 def baseDesc:string "undefined"
-                if (EvValueBridge.isNull(obj)) { baseDesc = "null" }
+                if (obj.isNull()) { baseDesc = "null" }
                 def wname:string leftNode.name
                 if ((strlen wname) == 0) { wname = "property" }
                 return (this.throwSpecError("TypeError" ("Cannot set properties of " + (baseDesc + (" (setting '" + (wname + "')"))))))
@@ -6794,7 +6794,7 @@ class ComponentEngine {
         if leftNode.computed {
             if leftNode.right {
                 def indexVal:EvHandle (this.evaluateExpr((unwrap leftNode.right)))
-                if (EvValueBridge.isNumber(indexVal)) {
+                if (indexVal.isNumber()) {
                     return (obj.getIndex((to_int (indexVal.toNumber()))))
                 }
                 return (obj.getMember((indexVal.toString())))
@@ -7729,7 +7729,7 @@ class ComponentEngine {
             return ""
         }
         def nmV:EvHandle (namesV.arrayItemAt(idx))
-        if (false == (EvValueBridge.isString(nmV))) {
+        if (false == (nmV.isString())) {
             return ""
         }
         return (nmV.stringOf())
@@ -7860,7 +7860,7 @@ class ComponentEngine {
                 ; `function ({a = 5} = {})`. The default was only applied to
                 ; plain identifier parameters, so calling with no argument
                 ; destructured `undefined` and bound nothing.
-                if (EvValueBridge.isUndefined(pv)) {
+                if (pv.isUndefined()) {
                     if param.init {
                         pv = (this.evaluateExpr((unwrap param.init)))
                     }
@@ -7871,7 +7871,7 @@ class ComponentEngine {
                 if (pi < na) {
                     v = (itemAt argVals pi)
                 }
-                if (EvValueBridge.isUndefined(v)) {
+                if (v.isUndefined()) {
                     if param.init {
                         v = (this.evaluateExpr((unwrap param.init)))
                     }
@@ -7923,7 +7923,7 @@ class ComponentEngine {
             return argNode
         }
         def v:EvHandle (this.evaluateExpr(argNode))
-        if (EvValueBridge.isFunction(v)) {
+        if (v.isFunction()) {
             if (v.hasFunctionNode()) {
                 return (v.functionNodeOf())
             }
@@ -8028,7 +8028,7 @@ class ComponentEngine {
             def emsg:string ""
             if ((array_length args) > 0) {
                 def ev:EvHandle (itemAt args 0)
-                if (false == (EvValueBridge.isUndefined(ev))) {
+                if (false == (ev.isUndefined())) {
                     emsg = (this.toStringOf(ev))
                     if scriptThrew {
                         return (EvValueBridge.taggedUndefined())
@@ -8073,19 +8073,19 @@ class ComponentEngine {
             }
             ; Called as a FUNCTION a wrapper coerces rather than boxes.
             if (name == "String") {
-                if (EvValueBridge.isNull(prim)) {
+                if (prim.isNull()) {
                     return (EvValueBridge.taggedString(""))
                 }
                 return (EvValueBridge.taggedString((this.toStringOf(prim))))
             }
             if (name == "Number") {
-                if (EvValueBridge.isNull(prim)) {
+                if (prim.isNull()) {
                     return (EvValueBridge.taggedNumber(0.0))
                 }
                 return (EvValueBridge.taggedNumber((this.toNumberOf(prim))))
             }
             if (name == "Boolean") {
-                if (EvValueBridge.isNull(prim)) {
+                if (prim.isNull()) {
                     return (EvValueBridge.taggedBoolean(false))
                 }
                 return (EvValueBridge.taggedBoolean((prim.toBool())))
@@ -8100,7 +8100,7 @@ class ComponentEngine {
         def n:int (array_length args)
         if (n == 1) {
             def only:EvHandle (itemAt args 0)
-            if (EvValueBridge.isNumber(only)) {
+            if (only.isNumber()) {
                 def rawLen:double (only.toNumber())
                 if ((rawLen < 0.0) || (rawLen > 4294967295.0)) {
                     return (this.throwSpecError("RangeError" "Invalid array length"))
@@ -9755,9 +9755,9 @@ class ComponentEngine {
         ; Reading a property of null/undefined is a TypeError, same message
         ; as the walker's member read. The gate keeps `?.` on the walker, so
         ; reaching here with a nullish base always means a plain `.` / `[]`.
-        if ((EvValueBridge.isNull(obj)) || (EvValueBridge.isUndefined(obj))) {
+        if ((obj.isNull()) || (obj.isUndefined())) {
             def rDesc:string "undefined"
-            if (EvValueBridge.isNull(obj)) {
+            if (obj.isNull()) {
                 rDesc = "null"
             }
             return (this.throwSpecError("TypeError" ("Cannot read properties of " + (rDesc + (" (reading '" + (name + "')"))))))
@@ -9848,9 +9848,9 @@ class ComponentEngine {
         ; Writing a property of null/undefined is a TypeError, under the
         ; same realm flag the walker's assignment path uses.
         if strictReferences {
-            if ((EvValueBridge.isNull(obj)) || (EvValueBridge.isUndefined(obj))) {
+            if ((obj.isNull()) || (obj.isUndefined())) {
                 def wDesc:string "undefined"
-                if (EvValueBridge.isNull(obj)) {
+                if (obj.isNull()) {
                     wDesc = "null"
                 }
                 def _wt:EvHandle (this.throwSpecError("TypeError" ("Cannot set properties of " + (wDesc + (" (setting '" + (name + "')"))))))
@@ -9992,9 +9992,9 @@ class ComponentEngine {
     ; walker chain: own/proto members first (guest wins), then the class
     ; table for instances, then the registry, then primitive borrows.
     fn bcCallMethod:EvHandle (obj:EvHandle methodName:string argVals:[EvHandle]) {
-        if ((EvValueBridge.isNull(obj)) || (EvValueBridge.isUndefined(obj))) {
+        if ((obj.isNull()) || (obj.isUndefined())) {
             def nDesc:string "undefined"
-            if (EvValueBridge.isNull(obj)) {
+            if (obj.isNull()) {
                 nDesc = "null"
             }
             return (this.throwSpecError("TypeError" ("Cannot read properties of " + (nDesc + (" (reading '" + (methodName + "')"))))))
@@ -11425,7 +11425,7 @@ class ComponentEngine {
         def bcThisF:EvHandle (EvValueBridge.taggedUndefined())
         if (fnv.hasBoundThis()) {
             bcThisF = (fnv.boundThisOf())
-            if ((EvValueBridge.isNull(bcThisF)) || (EvValueBridge.isUndefined(bcThisF))) {
+            if ((bcThisF.isNull()) || (bcThisF.isUndefined())) {
                 bcThisF = (this.theGlobalObject())
             } {
                 if (bcThisF.isString()) { bcThisF = (this.toObjectValue(bcThisF)) }
@@ -11704,7 +11704,7 @@ class ComponentEngine {
                 si2 = (si2 + 1)
             }
             def nextIn:EvHandle (this.protoOfValue(walkIn))
-            if (EvValueBridge.isNull(nextIn)) {
+            if (nextIn.isNull()) {
                 inSteps = 16
             } {
                 walkIn = nextIn
@@ -11719,13 +11719,13 @@ class ComponentEngine {
     ; the walker and the bytecode tier.
     fn forOfItemList:[EvHandle] (src:EvHandle) {
         def items:[EvHandle]
-        if (EvValueBridge.isArrayValue(src)) {
+        if (src.isArray()) {
             items = (src.itemsOf())
         } {
-            if (EvValueBridge.isSet(src)) {
+            if (src.isSet()) {
                 items = (src.itemsOf())
             } {
-                if (EvValueBridge.isMap(src)) {
+                if (src.isMap()) {
                     def k:int 0
                     while (k < (src.denseLen())) {
                         def pair:[EvHandle]
@@ -11735,7 +11735,7 @@ class ComponentEngine {
                         k = (k + 1)
                     }
                 } {
-                    if (EvValueBridge.isString(src)) {
+                    if (src.isString()) {
                         def si:int 0
                         while (si < (strlen (src.stringOf()))) {
                             push items (EvValueBridge.taggedString((substring (src.stringOf()) si (si + 1))))
@@ -12014,7 +12014,7 @@ class ComponentEngine {
                 mvj = (mvj + 1)
             }
             def cOut:EvHandle (this.callBuiltinCtorValues(ctorNameV mergedV false))
-            if (false == (EvValueBridge.isNull(cOut))) {
+            if (false == (cOut.isNull())) {
                 return cOut
             }
             if scriptThrew {
@@ -12092,7 +12092,7 @@ class ComponentEngine {
                     def bcThis:EvHandle (EvValueBridge.taggedUndefined())
                     if (fnValue.hasBoundThis()) {
                         bcThis = (fnValue.boundThisOf())
-                        if ((EvValueBridge.isNull(bcThis)) || (EvValueBridge.isUndefined(bcThis))) {
+                        if ((bcThis.isNull()) || (bcThis.isUndefined())) {
                             bcThis = (this.theGlobalObject())
                         } {
                             if (bcThis.isString()) { bcThis = (this.toObjectValue(bcThis)) }
@@ -12154,7 +12154,7 @@ class ComponentEngine {
                 calleeStrict = true
             }
             if (false == calleeStrict) {
-                if ((EvValueBridge.isNull(rawThis)) || (EvValueBridge.isUndefined(rawThis))) {
+                if ((rawThis.isNull()) || (rawThis.isUndefined())) {
                     rawThis = (this.theGlobalObject())
                 } {
                     if (rawThis.isString()) { rawThis = (this.toObjectValue(rawThis)) }
@@ -12299,7 +12299,7 @@ class ComponentEngine {
         ; Fallback: any other expression (e.g. a helper call that returns JSX,
         ; like hud() -> playHud(...)). Evaluate it and unwrap the element result.
         def val:EvHandle (this.evaluateExpr(node))
-        if (EvValueBridge.isElement(val)) {
+        if (val.isElement()) {
             if (val.hasElement()) {
                 return (val.elementOf())
             }
@@ -12514,15 +12514,15 @@ class ComponentEngine {
                     def exprNode:TSNode (unwrap child.left)
                     def exprValue:EvHandle (this.evaluateExpr(exprNode))
                     
-                    if (EvValueBridge.isElement(exprValue)) {
+                    if (exprValue.isElement()) {
                         push results exprValue
                     }
-                    if (EvValueBridge.isArrayValue(exprValue)) {
+                    if (exprValue.isArray()) {
                         ; Flatten array elements into children
                         def ai:int 0
                         while (ai < (exprValue.denseLen())) {
                             def arrItem:EvHandle (exprValue.arrayItemAt(ai))
-                            if (EvValueBridge.isElement(arrItem)) {
+                            if (arrItem.isElement()) {
                                 push results arrItem
                             }
                             ai = ai + 1
@@ -12716,11 +12716,11 @@ class ComponentEngine {
                 def callResult:EvHandle (this.evaluateExpr(exprNode))
                 
                 ; Handle array result (array of elements from function)
-                if (EvValueBridge.isArrayValue(callResult)) {
+                if (callResult.isArray()) {
                     def ai:int 0
                     while (ai < (callResult.denseLen())) {
                         def arrItem:EvHandle (callResult.arrayItemAt(ai))
-                        if (EvValueBridge.isElement(arrItem)) {
+                        if (arrItem.isElement()) {
                             if (arrItem.hasElement()) {
                                 def arrChildEl:EVGElement (arrItem.elementOf())
                                 if ((strlen arrChildEl.tagName) > 0) {
@@ -12734,7 +12734,7 @@ class ComponentEngine {
                 }
                 
                 ; Handle single element result
-                if (EvValueBridge.isElement(callResult)) {
+                if (callResult.isElement()) {
                     if (callResult.hasElement()) {
                         def childEl:EVGElement (callResult.elementOf())
                         if ((strlen childEl.tagName) > 0) {
@@ -12745,8 +12745,8 @@ class ComponentEngine {
                 }
                 
                 ; Handle string/number result as text
-                def isStr:boolean (EvValueBridge.isString(callResult))
-                def isNum:boolean (EvValueBridge.isNumber(callResult))
+                def isStr:boolean (callResult.isString())
+                def isNum:boolean (callResult.isNumber())
                 if (isStr || isNum) {
                     def textEl (new EVGElement())
                     textEl.tagName = "text"
@@ -12774,7 +12774,7 @@ class ComponentEngine {
             def value:EvHandle (this.evaluateExpr(exprNode))
             
             ; Handle EVGElement values (e.g., {children} prop containing JSX)
-            if (EvValueBridge.isElement(value)) {
+            if (value.isElement()) {
                 if (value.hasElement()) {
                     def childEl:EVGElement (value.elementOf())
                     if ((strlen childEl.tagName) > 0) {
@@ -12785,11 +12785,11 @@ class ComponentEngine {
             }
             
             ; Handle arrays of EVGElements (e.g., {children} containing multiple elements)
-            if (EvValueBridge.isArrayValue(value)) {
+            if (value.isArray()) {
                 def ai:int 0
                 while (ai < (value.denseLen())) {
                     def arrItem:EvHandle (value.arrayItemAt(ai))
-                    if (EvValueBridge.isElement(arrItem)) {
+                    if (arrItem.isElement()) {
                         if (arrItem.hasElement()) {
                             def arrChildEl:EVGElement (arrItem.elementOf())
                             if ((strlen arrChildEl.tagName) > 0) {
@@ -12802,8 +12802,8 @@ class ComponentEngine {
                 return
             }
             
-            def isStr:boolean (EvValueBridge.isString(value))
-            def isNum:boolean (EvValueBridge.isNumber(value))
+            def isStr:boolean (value.isString())
+            def isNum:boolean (value.isNumber())
             if (isStr || isNum) {
                 def textEl (new EVGElement())
                 textEl.tagName = "text"
@@ -12825,7 +12825,7 @@ class ComponentEngine {
                         def arrayExpr:TSNode (unwrap calleeNode.left)
                         def arrayValue:EvHandle (this.evaluateExpr(arrayExpr))
                         
-                        if (EvValueBridge.isArrayValue(arrayValue)) {
+                        if (arrayValue.isArray()) {
                             ; Get the callback function
                             if ((array_length callNode.children) > 0) {
                                 def callback:TSNode (itemAt callNode.children 0)
@@ -12891,7 +12891,7 @@ class ComponentEngine {
                 ; generic expression body — e.g. (e, i) => buildTile(e, i) — is
                 ; evaluated like any expression; an element result is the child.
                 def v:EvHandle (this.evaluateExpr(body))
-                if (EvValueBridge.isElement(v)) {
+                if (v.isElement()) {
                     if (v.hasElement()) {
                         return (v.elementOf())
                     }
@@ -13387,9 +13387,9 @@ class ComponentEngine {
                 ; the same as reading one. The read path already said so; the
                 ; CALL path fell through and answered nothing.
                 if strictReferences {
-                    if ((EvValueBridge.isNull(obj)) || (EvValueBridge.isUndefined(obj))) {
+                    if ((obj.isNull()) || (obj.isUndefined())) {
                         def nullDesc:string "undefined"
-                        if (EvValueBridge.isNull(obj)) { nullDesc = "null" }
+                        if (obj.isNull()) { nullDesc = "null" }
                         return (this.throwSpecError("TypeError" ("Cannot read properties of " + (nullDesc + (" (reading '" + (methodName + "')"))))))
                     }
                 }
@@ -13616,14 +13616,14 @@ class ComponentEngine {
                         def frItems:[EvHandle]
                         if ((array_length node.children) > 0) {
                             def srcV:EvHandle (this.evaluateExpr((itemAt node.children 0)))
-                            if (EvValueBridge.isArrayValue(srcV)) {
+                            if (srcV.isArray()) {
                                 def fi:int 0
                                 while (fi < (srcV.denseLen())) {
                                     push frItems (srcV.arrayItemAt(fi))
                                     fi = (fi + 1)
                                 }
                             }
-                            if (EvValueBridge.isString(srcV)) {
+                            if (srcV.isString()) {
                                 def sIdx:int 0
                                 while (sIdx < (strlen (srcV.stringOf()))) {
                                     def sEnd:int (sIdx + 1)
@@ -13631,7 +13631,7 @@ class ComponentEngine {
                                     sIdx = (sIdx + 1)
                                 }
                             }
-                            if (EvValueBridge.isSet(srcV)) {
+                            if (srcV.isSet()) {
                                 def stI:int 0
                                 while (stI < (srcV.denseLen())) {
                                     push frItems (srcV.arrayItemAt(stI))
@@ -13646,7 +13646,7 @@ class ComponentEngine {
                         if ((array_length node.children) > 0) {
                             tv = (this.evaluateExpr((itemAt node.children 0)))
                         }
-                        return (EvValueBridge.taggedBoolean((EvValueBridge.isArrayValue(tv))))
+                        return (EvValueBridge.taggedBoolean((tv.isArray())))
                     }
                 }
                 if (arrStaticName == "Number") {
@@ -13655,7 +13655,7 @@ class ComponentEngine {
                         nv = (this.evaluateExpr((itemAt node.children 0)))
                     }
                     if (methodName == "isInteger") {
-                        if (EvValueBridge.isNumber(nv)) {
+                        if (nv.isNumber()) {
                             def d:double (nv.toNumber())
                             if (d != d) {
                                 return (EvValueBridge.taggedBoolean(false))
@@ -13668,14 +13668,14 @@ class ComponentEngine {
                         return (EvValueBridge.taggedBoolean(false))
                     }
                     if (methodName == "isNaN") {
-                        if (EvValueBridge.isNumber(nv)) {
+                        if (nv.isNumber()) {
                             def d2:double (nv.toNumber())
                             return (EvValueBridge.taggedBoolean((d2 != d2)))
                         }
                         return (EvValueBridge.taggedBoolean(false))
                     }
                     if (methodName == "isFinite") {
-                        if (EvValueBridge.isNumber(nv)) {
+                        if (nv.isNumber()) {
                             def d3:double (nv.toNumber())
                             return (EvValueBridge.taggedBoolean((d3 == d3)))
                         }
@@ -13694,7 +13694,7 @@ class ComponentEngine {
                     ; continued, and the assertion that followed measured
                     ; whatever the no-op left behind.
                     if (this.objectStaticCoerces(methodName)) {
-                        if ((EvValueBridge.isNull(src)) || (EvValueBridge.isUndefined(src))) {
+                        if ((src.isNull()) || (src.isUndefined())) {
                             return (this.throwSpecError("TypeError" ("Object." + methodName + " called on null or undefined")))
                         }
                     }
@@ -13711,7 +13711,7 @@ class ComponentEngine {
                             ; way to make a prototype-less object, so null is
                             ; allowed for create alone.
                             if (methodName == "create") {
-                                if (EvValueBridge.isNull(src)) {
+                                if (src.isNull()) {
                                     okKind = true
                                 }
                             }
@@ -13794,7 +13794,7 @@ class ComponentEngine {
                     if (methodName == "is") {
                         if ((array_length node.children) > 1) {
                             def isB:EvHandle (this.evaluateExpr((itemAt node.children 1)))
-                            if ((EvValueBridge.isNumber(src)) && (EvValueBridge.isNumber(isB))) {
+                            if ((src.isNumber()) && (isB.isNumber())) {
                                 def an:double (src.toNumber())
                                 def bn:double (isB.toNumber())
                                 if (an != an) {
@@ -13902,7 +13902,7 @@ class ComponentEngine {
                             }
                             ; An explicit `undefined` second argument means "no
                             ; properties"; anything else must be an object.
-                            if (false == (EvValueBridge.isUndefined(cDescs))) {
+                            if (false == (cDescs.isUndefined())) {
                                 def cErr:string (this.applyDescriptorMap(created cDescs))
                                 if scriptThrew {
                                     return (EvValueBridge.taggedUndefined())
@@ -13966,7 +13966,7 @@ class ComponentEngine {
                             ; stringValue rather than objectMap, so the
                             ; descriptor came back undefined for a property that
                             ; plainly exists. `length` likewise.
-                            if (EvValueBridge.isArrayValue(src)) {
+                            if (src.isArray()) {
                                 if (dk == "length") {
                                     def keysL:[string]
                                     def valsL:[EvHandle]
@@ -14006,7 +14006,7 @@ class ComponentEngine {
                                     }
                                 }
                             }
-                            if (EvValueBridge.isString(src)) {
+                            if (src.isString()) {
                                 if (dk == "length") {
                                     def keysS:[string]
                                     def valsS:[EvHandle]
@@ -14223,7 +14223,7 @@ class ComponentEngine {
                             }
                             if ((array_length node.children) > 1) {
                                 def arr:EvHandle (this.evaluateExpr((itemAt node.children 1)))
-                                if (EvValueBridge.isArrayValue(arr)) {
+                                if (arr.isArray()) {
                                     def aai:int 0
                                     while (aai < (arr.denseLen())) {
                                         push applyArgs (arr.arrayItemAt(aai))
@@ -14315,7 +14315,7 @@ class ComponentEngine {
                         def steps:int 0
                         while (steps < 16) {
                             def nxt:EvHandle (this.protoOfValue(walk))
-                            if (EvValueBridge.isNull(nxt)) {
+                            if (nxt.isNull()) {
                                 steps = 16
                             } {
                                 if (nxt.equals(obj)) {
@@ -14461,7 +14461,7 @@ class ComponentEngine {
                     def sDesc:string ""
                     if ((array_length node.children) > 0) {
                         def sdv:EvHandle (this.evaluateExpr((itemAt node.children 0)))
-                        if (false == (EvValueBridge.isUndefined(sdv))) {
+                        if (false == (sdv.isUndefined())) {
                             sDesc = (sdv.toString())
                         }
                     }
@@ -14483,7 +14483,7 @@ class ComponentEngine {
                     }
                     def evSrcV:EvHandle (this.evaluateExpr((itemAt node.children 0)))
                     ; eval of a non-string returns the argument untouched.
-                    if (false == (EvValueBridge.isString(evSrcV))) {
+                    if (false == (evSrcV.isString())) {
                         return evSrcV
                     }
                     return (this.runEvalSource((evSrcV.stringOf())))
@@ -14529,7 +14529,7 @@ class ComponentEngine {
                         if scriptThrew {
                             return (EvValueBridge.taggedUndefined())
                         }
-                        if (false == (EvValueBridge.isUndefined(emv))) {
+                        if (false == (emv.isUndefined())) {
                             emsg = (this.toStringOf(emv))
                             if scriptThrew {
                                 return (EvValueBridge.taggedUndefined())
@@ -14645,7 +14645,7 @@ class ComponentEngine {
                 ; Look up the function in context
                 def fnValue:EvHandle (context.lookup(fnName))
                 if (false == quiet) {
-                    this.trace("Lookup function '" + fnName + "' -> type=" + (fnValue.kindName()) + " isFunction=" + (to_string (EvValueBridge.isFunction(fnValue))))
+                    this.trace("Lookup function '" + fnName + "' -> type=" + (fnValue.kindName()) + " isFunction=" + (to_string (fnValue.isFunction())))
                 }
                 ; D-REGISTRY: a built-in held in a variable is callable like any
                 ; other function value. It has no functionNode, so the paths
@@ -14661,7 +14661,7 @@ class ComponentEngine {
                     }
                     return (this.runIndirectEval(ieArgs0))
                 }
-                if (EvValueBridge.isFunction(fnValue)) {
+                if (fnValue.isFunction()) {
                     if (fnValue.hasFunctionNode()) {
                         ; Args (with ...spread) bound centrally; the call scope is
                         ; parented on the function's captured closure when it has
@@ -14712,7 +14712,7 @@ class ComponentEngine {
                 }
                 return (this.runIndirectEval(ieArgs1))
             }
-            if (EvValueBridge.isFunction(calleeFn)) {
+            if (calleeFn.isFunction()) {
                 if (calleeFn.hasFunctionNode()) {
                     def calleeArgs:[EvHandle] (this.collectCallArgs(node))
                     return (this.callFnValueWithValues(calleeFn calleeArgs))
@@ -14891,7 +14891,7 @@ class ComponentEngine {
                 def left:EvHandle (this.evaluateExpr(leftExpr))
                 ; nullish: fall through to the right only when left is null OR
                 ; undefined (a missing member now reads as undefined — rule 6).
-                if (false == ((EvValueBridge.isNull(left)) || (EvValueBridge.isUndefined(left)))) {
+                if (false == ((left.isNull()) || (left.isUndefined()))) {
                     return left
                 }
                 if node.right {
@@ -14980,12 +14980,12 @@ class ComponentEngine {
                 ; A FUNCTION left-operand is object-like too, and its
                 ; prototype-chain answer (including the TypeError for a
                 ; non-object F.prototype) has to be reached the same way.
-                def lvObjectLike:boolean (EvValueBridge.isObject(lv))
+                def lvObjectLike:boolean (lv.isObject())
                 if (lv.isFunction()) { lvObjectLike = true }
                 if (lv.isArray()) { lvObjectLike = true }
                 if lvObjectLike {
                     def tag:EvHandle (lv.getMember("__class__"))
-                    if (EvValueBridge.isString(tag)) {
+                    if (tag.isString()) {
                         return (EvValueBridge.taggedBoolean(((tag.stringOf()) == cname)))
                     }
                     ; D-ERRORS: every native error inherits from Error, so
@@ -15183,7 +15183,7 @@ class ComponentEngine {
             ; returning a number must add, not concatenate.
             def lp:EvHandle (this.toPrimitiveDefault(left))
             def rp:EvHandle (this.toPrimitiveDefault(right))
-            if ((EvValueBridge.isString(lp)) || (EvValueBridge.isString(rp))) {
+            if ((lp.isString()) || (rp.isString())) {
                 return (EvValueBridge.taggedString((this.toStringOf(lp)) + (this.toStringOf(rp))))
             }
             return (EvValueBridge.taggedNumber((this.toNumberOf(lp)) + (this.toNumberOf(rp))))
@@ -15283,7 +15283,7 @@ class ComponentEngine {
         if ((opK == 26) || (opK == 27) || (opK == 28) || (opK == 29)) {
             def lr:EvHandle (this.toPrimitive(left false))
             def rr:EvHandle (this.toPrimitive(right false))
-            if ((EvValueBridge.isString(lr)) && (EvValueBridge.isString(rr))) {
+            if ((lr.isString()) && (rr.isString())) {
                 def ls:string (lr.stringOf())
                 def rs:string (rr.stringOf())
                 def cmp:int (this.compareStrings(ls rs))
@@ -15334,8 +15334,8 @@ class ComponentEngine {
     ; null/undefined special case, so `1 == '1'`, `true == 1` and
     ; `[1] == 1` were all false -- the comparisons `==` exists to make.
     fn looseEquals:boolean (left:EvHandle right:EvHandle) {
-        def ln:boolean ((EvValueBridge.isNull(left)) || (EvValueBridge.isUndefined(left)))
-        def rn:boolean ((EvValueBridge.isNull(right)) || (EvValueBridge.isUndefined(right)))
+        def ln:boolean ((left.isNull()) || (left.isUndefined()))
+        def rn:boolean ((right.isNull()) || (right.isUndefined()))
         ; null and undefined equal each other and nothing else.
         if (ln || rn) {
             return (ln && rn)
@@ -15359,13 +15359,13 @@ class ComponentEngine {
             return (this.looseEquals(left rp))
         }
         ; Same primitive type: strict comparison.
-        if ((EvValueBridge.isString(left)) && (EvValueBridge.isString(right))) {
+        if ((left.isString()) && (right.isString())) {
             return (left.equals(right))
         }
-        if ((EvValueBridge.isNumber(left)) && (EvValueBridge.isNumber(right))) {
+        if ((left.isNumber()) && (right.isNumber())) {
             return (left.equals(right))
         }
-        if ((EvValueBridge.isBoolean(left)) && (EvValueBridge.isBoolean(right))) {
+        if ((left.isBoolean()) && (right.isBoolean())) {
             return (left.equals(right))
         }
         ; Mixed primitives compare numerically, which is what makes
@@ -15437,7 +15437,7 @@ class ComponentEngine {
     ; constructors answer 0 for their own primitive: `'a' instanceof String` is
     ; false while `new String('a') instanceof String` is true.
     fn builtinInstanceOf:int (v:EvHandle cname:string) {
-        if ((v.isNull()) || (EvValueBridge.isUndefined(v))) {
+        if ((v.isNull()) || (v.isUndefined())) {
             return 0
         }
         def isObjectLike:boolean false
@@ -15726,20 +15726,20 @@ class ComponentEngine {
             if (name == "isNaN") {
                 if ((array_length args) == 0) { return (EvValueBridge.taggedBoolean(false)) }
                 def nv:EvHandle (itemAt args 0)
-                if (false == (EvValueBridge.isNumber(nv))) { return (EvValueBridge.taggedBoolean(false)) }
+                if (false == (nv.isNumber())) { return (EvValueBridge.taggedBoolean(false)) }
                 def nn:double nv.numberValue
                 return (EvValueBridge.taggedBoolean((nn != nn)))
             }
             if (name == "isFinite") {
                 if ((array_length args) == 0) { return (EvValueBridge.taggedBoolean(false)) }
                 def fv:EvHandle (itemAt args 0)
-                if (false == (EvValueBridge.isNumber(fv))) { return (EvValueBridge.taggedBoolean(false)) }
+                if (false == (fv.isNumber())) { return (EvValueBridge.taggedBoolean(false)) }
                 return (EvValueBridge.taggedBoolean((this.isFiniteNum(fv.numberValue))))
             }
             if (name == "isInteger") {
                 if ((array_length args) == 0) { return (EvValueBridge.taggedBoolean(false)) }
                 def iv:EvHandle (itemAt args 0)
-                if (false == (EvValueBridge.isNumber(iv))) { return (EvValueBridge.taggedBoolean(false)) }
+                if (false == (iv.isNumber())) { return (EvValueBridge.taggedBoolean(false)) }
                 def dn:double iv.numberValue
                 if (false == (this.isFiniteNum(dn))) { return (EvValueBridge.taggedBoolean(false)) }
                 return (EvValueBridge.taggedBoolean(((this.floorNum(dn)) == dn)))
@@ -15773,7 +15773,7 @@ class ComponentEngine {
             ; They have to be repeated here rather than assumed, since this is a
             ; second door into the same statics.
             if (this.objectStaticCoerces(name)) {
-                if ((EvValueBridge.isNull(a0)) || (EvValueBridge.isUndefined(a0))) {
+                if ((a0.isNull()) || (a0.isUndefined())) {
                     return (this.throwSpecError("TypeError" ("Object." + name + " called on null or undefined")))
                 }
             }
@@ -17051,7 +17051,7 @@ class ComponentEngine {
         def filler:string " "
         if ((array_length args) > 1) {
             def fv:EvHandle (itemAt args 1)
-            if (false == (EvValueBridge.isUndefined(fv))) {
+            if (false == (fv.isUndefined())) {
                 filler = (fv.toString())
             }
         }
@@ -17076,12 +17076,12 @@ class ComponentEngine {
     ; ToString for a value used as an ARRAY ELEMENT during join/toString: null
     ; and undefined render as empty, everything else by its own rules.
     fn elementToString:string (v:EvHandle) {
-        if (EvValueBridge.isNull(v)) { return "" }
-        if (EvValueBridge.isUndefined(v)) { return "" }
+        if (v.isNull()) { return "" }
+        if (v.isUndefined()) { return "" }
         ; Hole used to share valueType 8 with Undefined; now it is its own
         ; kind, so join/toString must skip it explicitly (spec: empty string).
-        if (EvValueBridge.isHole(v)) { return "" }
-        if (EvValueBridge.isArrayValue(v)) {
+        if (v.isHole()) { return "" }
+        if (v.isArray()) {
             return (this.arrayJoinString(v ","))
         }
         return (v.toString())
@@ -17638,7 +17638,7 @@ class ComponentEngine {
         if coercesReceiver {
             ; ToObject on the receiver: null and undefined are a TypeError, which
             ; is what `Object.prototype.hasOwnProperty.call(null, "x")` asserts.
-            if ((EvValueBridge.isNull(recv)) || (EvValueBridge.isUndefined(recv))) {
+            if ((recv.isNull()) || (recv.isUndefined())) {
                 return (this.throwSpecError("TypeError" ("Object.prototype." + name + " called on null or undefined")))
             }
         }
@@ -17691,7 +17691,7 @@ class ComponentEngine {
             def steps0:int 0
             while (steps0 < 16) {
                 def nxt0:EvHandle (this.protoOfValue(walk0))
-                if (EvValueBridge.isNull(nxt0)) {
+                if (nxt0.isNull()) {
                     return (EvValueBridge.taggedBoolean(false))
                 }
                 if (nxt0.equals(recv)) {
@@ -17725,7 +17725,7 @@ class ComponentEngine {
             if (kind == "number") {
                 if ((array_length args) > 0) {
                     def rv:EvHandle (itemAt args 0)
-                    if (false == (EvValueBridge.isUndefined(rv))) {
+                    if (false == (rv.isUndefined())) {
                         def radix:int (to_int (rv.toNumber()))
                         if ((radix < 2) || (radix > 36)) {
                             return (this.throwSpecError("RangeError" "toString() radix must be between 2 and 36"))
@@ -17823,7 +17823,7 @@ class ComponentEngine {
             ; f(1)` — arrives with no receiver. Per spec that is a TypeError,
             ; not an operation on the empty string, which is what reading
             ; stringValue off undefined would have silently produced.
-            if ((EvValueBridge.isNull(recv)) || (EvValueBridge.isUndefined(recv))) {
+            if ((recv.isNull()) || (recv.isUndefined())) {
                 return (this.throwSpecError("TypeError" ("String.prototype." + name + " called on null or undefined")))
             }
             ; D-REGISTRY: String.prototype methods coerce `this` via ToString.
@@ -17963,7 +17963,7 @@ class ComponentEngine {
                         }
                         if ((array_length args) > 1) {
                             def lenArg:EvHandle (itemAt args 1)
-                            if (false == (EvValueBridge.isUndefined(lenArg))) {
+                            if (false == (lenArg.isUndefined())) {
                                 sbLen = (to_int (lenArg.toNumber()))
                             }
                         }
@@ -18040,7 +18040,7 @@ class ComponentEngine {
                             ; An UNDEFINED end means "to the end of the string",
                             ; not 0 -- `s.slice(-4, undefined)` keeps the tail.
                             def eV:EvHandle (itemAt args 1)
-                            if (false == (EvValueBridge.isUndefined(eV))) {
+                            if (false == (eV.isUndefined())) {
                                 b = (this.toIntegerOf(eV))
                             }
                         }
@@ -18088,7 +18088,7 @@ class ComponentEngine {
                         def limitN:int 0
                         if ((array_length args) > 1) {
                             def limV:EvHandle (itemAt args 1)
-                            if (false == (EvValueBridge.isUndefined(limV))) {
+                            if (false == (limV.isUndefined())) {
                                 hasLimit = true
                                 ; The limit is ToUINT32, not a clamped integer:
                                 ; -(2^32)+1 wraps to 1, so the result keeps one
@@ -18107,7 +18107,7 @@ class ComponentEngine {
                         def sepRe:EvHandle (EvValueBridge.taggedNull())
                         if ((array_length args) > 0) {
                             def sepV:EvHandle (itemAt args 0)
-                            if (false == (EvValueBridge.isUndefined(sepV))) {
+                            if (false == (sepV.isUndefined())) {
                                 haveSep = true
                                 ; D-REGEX: a RegExp separator splits on every
                                 ; match and interleaves its captures into the
@@ -18461,7 +18461,7 @@ class ComponentEngine {
                 }
                 if ((array_length args) > 1) {
                     def av1:EvHandle (itemAt args 1)
-                    if (false == (EvValueBridge.isUndefined(av1))) {
+                    if (false == (av1.isUndefined())) {
                         a1 = (this.toIntegerOf(av1))
                     }
                 }
@@ -18618,7 +18618,7 @@ class ComponentEngine {
             ; D-REGISTRY: same as for strings — an unbound extraction invoked
             ; with no receiver is a TypeError, not an operation on an empty
             ; array, which is what reading arrayValue off undefined would give.
-            if ((EvValueBridge.isNull(recv)) || (EvValueBridge.isUndefined(recv))) {
+            if ((recv.isNull()) || (recv.isUndefined())) {
                 return (this.throwSpecError("TypeError" ("Array.prototype." + name + " called on null or undefined")))
             }
             ; D-CBCHECK: the higher-order methods require a callable. Given a
@@ -18670,7 +18670,7 @@ class ComponentEngine {
             if (name == "fill") { isArrayMutator = true }
             def elems:[EvHandle]
             if (false == isArrayMutator) {
-                if (EvValueBridge.isArrayValue(recv)) {
+                if (recv.isArray()) {
                     elems = (recv.itemsOf())
                 } {
                     elems = (this.arrayLikeElements(recv))
@@ -18697,8 +18697,8 @@ class ComponentEngine {
                     }
                     def tlsEl:EvHandle (this.arrayElemAt(recv tlsI))
                     def skipEl:boolean false
-                    if (EvValueBridge.isNull(tlsEl)) { skipEl = true }
-                    if (EvValueBridge.isUndefined(tlsEl)) { skipEl = true }
+                    if (tlsEl.isNull()) { skipEl = true }
+                    if (tlsEl.isUndefined()) { skipEl = true }
                     if (false == skipEl) {
                         def tlsArgs:[EvHandle]
                         def tlsV:EvHandle (this.callMethodOnValue(tlsEl "toLocaleString" tlsArgs))
@@ -18764,9 +18764,9 @@ class ComponentEngine {
                             ; disagreed about the same array.
                             def jv:EvHandle (this.arrayElemAt(recv ii))
                             def jSkip:boolean false
-                            if (EvValueBridge.isHole(jv)) { jSkip = true }
-                            if (EvValueBridge.isNull(jv)) { jSkip = true }
-                            if (EvValueBridge.isUndefined(jv)) { jSkip = true }
+                            if (jv.isHole()) { jSkip = true }
+                            if (jv.isNull()) { jSkip = true }
+                            if (jv.isUndefined()) { jSkip = true }
                             if (false == jSkip) {
                                 out = (out + (this.toStringOf(jv)))
                                 if scriptThrew {
@@ -18856,7 +18856,7 @@ class ComponentEngine {
                             while (ii < alen) {
                                 def el:EvHandle (this.arrayElemAt(recv ii))
                                 ; D-HOLES: an ABSENT element is not visited.
-                                if (EvValueBridge.isHole(el)) {
+                                if (el.isHole()) {
                                     ii = (ii + 1)
                                 } {
                                     def cargs:[EvHandle]
@@ -19208,7 +19208,7 @@ class ComponentEngine {
                         ; element, whatever `length` it happens to inherit. The
                         ; receiver was spread unconditionally, so a plain object
                         ; came out as its indices instead of as itself.
-                        if (EvValueBridge.isArrayValue(recv)) {
+                        if (recv.isArray()) {
                             def q:int 0
                             while (q < alen) {
                                 push items (this.arrayElemAt(recv q))
@@ -19220,7 +19220,7 @@ class ComponentEngine {
                         def ai:int 0
                         while (ai < (array_length args)) {
                             def av:EvHandle (itemAt args ai)
-                            if (EvValueBridge.isArrayValue(av)) {
+                            if (av.isArray()) {
                                 ; D-HOLES: an element the argument does not have
                                 ; is not copied, but one INHERITED from its
                                 ; prototype is -- concat asks HasProperty, which
@@ -19244,7 +19244,7 @@ class ComponentEngine {
                         def q:int 0
                         while (q < (array_length elems)) {
                             def el:EvHandle (this.arrayElemAt(recv q))
-                            if (EvValueBridge.isArrayValue(el)) {
+                            if (el.isArray()) {
                                 def r:int 0
                                 while (r < (el.denseLen())) {
                                     push items (el.arrayItemAt(r))
@@ -19308,7 +19308,7 @@ class ComponentEngine {
                 if scriptThrew {
                     return (EvValueBridge.taggedUndefined())
                 }
-                return (EvValueBridge.taggedBoolean((EvValueBridge.isArrayValue(hit))))
+                return (EvValueBridge.taggedBoolean((hit.isArray())))
             }
         }
         ; ---- Number.prototype ----------------------------------------------
@@ -19323,7 +19323,7 @@ class ComponentEngine {
                 def digits:int 0
                 if ((array_length args) > 0) {
                     def dv:EvHandle (itemAt args 0)
-                    if (false == (EvValueBridge.isUndefined(dv))) {
+                    if (false == (dv.isUndefined())) {
                         digits = (this.toIntegerOf(dv))
                     }
                 }
@@ -19339,7 +19339,7 @@ class ComponentEngine {
                 def eauto:boolean true
                 if ((array_length args) > 0) {
                     def ev:EvHandle (itemAt args 0)
-                    if (false == (EvValueBridge.isUndefined(ev))) {
+                    if (false == (ev.isUndefined())) {
                         edigits = (this.toIntegerOf(ev))
                         eauto = false
                     }
@@ -19356,7 +19356,7 @@ class ComponentEngine {
                     return (EvValueBridge.taggedString((this.toStringOf(fprim))))
                 }
                 def pv:EvHandle (itemAt args 0)
-                if (EvValueBridge.isUndefined(pv)) {
+                if (pv.isUndefined()) {
                     return (EvValueBridge.taggedString((this.toStringOf(fprim))))
                 }
                 def prec:int (this.toIntegerOf(pv))
@@ -19400,7 +19400,7 @@ class ComponentEngine {
                     ; which is what lets `f.apply(null, arguments)` forward a
                     ; call. A primitive that is not null/undefined is a
                     ; TypeError rather than an empty argument list.
-                    if (false == ((EvValueBridge.isNull(arr)) || (EvValueBridge.isUndefined(arr)))) {
+                    if (false == ((arr.isNull()) || (arr.isUndefined()))) {
                         def okArgs:boolean false
                         if (arr.isArray()) { okArgs = true }
                         if (arr.isObject()) { okArgs = true }
@@ -19492,7 +19492,7 @@ class ComponentEngine {
         if (v.isString()) { return (this.makeWrapper("String" v)) }
         if (v.isNumber()) { return (this.makeWrapper("Number" v)) }
         if (v.isBoolean()) { return (this.makeWrapper("Boolean" v)) }
-        if ((v.isNull()) || (EvValueBridge.isUndefined(v))) {
+        if ((v.isNull()) || (v.isUndefined())) {
             def keysO:[string]
             def valsO:[EvHandle]
             def o:EvHandle (EvValueBridge.taggedObject(keysO valsO))
@@ -19564,7 +19564,7 @@ class ComponentEngine {
     ; than the value type.
     ; --------------------------------------------------------------------------
     fn objectClassOf:string (v:EvHandle) {
-        if (EvValueBridge.isUndefined(v)) { return "Undefined" }
+        if (v.isUndefined()) { return "Undefined" }
         if (v.isNull()) { return "Null" }
         if (v.isArray()) { return "Array" }
         if (v.isFunction()) { return "Function" }
@@ -19679,7 +19679,7 @@ class ComponentEngine {
             return true
         }
         ; Present but not a function: not the default, and not usable either.
-        if (false == (EvValueBridge.isUndefined(m))) {
+        if (false == (m.isUndefined())) {
             return false
         }
         return true
@@ -20174,13 +20174,13 @@ class ComponentEngine {
             return v.numberValue
         }
         def p:EvHandle (this.toPrimitive(v false))
-        if (EvValueBridge.isString(p)) {
+        if (p.isString()) {
             return (this.stringToNumber((p.stringOf())))
         }
-        if (EvValueBridge.isUndefined(p)) {
+        if (p.isUndefined()) {
             return (0.0 / 0.0)
         }
-        if (EvValueBridge.isNull(p)) {
+        if (p.isNull()) {
             return 0.0
         }
         return (p.toNumber())
@@ -20215,7 +20215,7 @@ class ComponentEngine {
             if hasGet {
                 def g:EvHandle (this.descGet(d "get"))
                 if (false == (g.isFunction())) {
-                    if (false == (EvValueBridge.isUndefined(g))) {
+                    if (false == (g.isUndefined())) {
                         return "getter must be a function"
                     }
                 }
@@ -20223,7 +20223,7 @@ class ComponentEngine {
             if hasSet {
                 def st:EvHandle (this.descGet(d "set"))
                 if (false == (st.isFunction())) {
-                    if (false == (EvValueBridge.isUndefined(st))) {
+                    if (false == (st.isUndefined())) {
                         return "setter must be a function"
                     }
                 }
@@ -20271,7 +20271,7 @@ class ComponentEngine {
                 pattern = (this.regexSourceOf(pv))
                 flags = (this.regexFlagsOf(pv))
             } {
-                if (false == (EvValueBridge.isUndefined(pv))) {
+                if (false == (pv.isUndefined())) {
                     pattern = (this.toStringOf(pv))
                     if scriptThrew {
                         return (EvValueBridge.taggedUndefined())
@@ -20284,7 +20284,7 @@ class ComponentEngine {
             if scriptThrew {
                 return (EvValueBridge.taggedUndefined())
             }
-            if (false == (EvValueBridge.isUndefined(fv))) {
+            if (false == (fv.isUndefined())) {
                 flags = (this.toStringOf(fv))
                 if scriptThrew {
                     return (EvValueBridge.taggedUndefined())
@@ -20330,7 +20330,7 @@ class ComponentEngine {
                 pattern = (this.regexSourceOf(pv))
                 flags = (this.regexFlagsOf(pv))
             } {
-                if (false == (EvValueBridge.isUndefined(pv))) {
+                if (false == (pv.isUndefined())) {
                     pattern = (this.toStringOf(pv))
                     if scriptThrew {
                         return (EvValueBridge.taggedUndefined())
@@ -20340,7 +20340,7 @@ class ComponentEngine {
         }
         if ((array_length args) > 1) {
             def fv:EvHandle (itemAt args 1)
-            if (false == (EvValueBridge.isUndefined(fv))) {
+            if (false == (fv.isUndefined())) {
                 flags = (this.toStringOf(fv))
                 if scriptThrew {
                     return (EvValueBridge.taggedUndefined())
@@ -20434,10 +20434,10 @@ class ComponentEngine {
     fn errorToString:string (e:EvHandle) {
         def nm:string "Error"
         def nv:EvHandle (e.getMember("name"))
-        if (EvValueBridge.isString(nv)) { nm = (nv.stringOf()) }
+        if (nv.isString()) { nm = (nv.stringOf()) }
         def msg:string ""
         def mv:EvHandle (e.getMember("message"))
-        if (EvValueBridge.isString(mv)) { msg = (mv.stringOf()) }
+        if (mv.isString()) { msg = (mv.stringOf()) }
         if ((strlen msg) == 0) {
             return nm
         }
@@ -20456,7 +20456,7 @@ class ComponentEngine {
 
     fn regexFlagsOf:string (v:EvHandle) {
         def f:EvHandle (v.getMember("flags"))
-        if (EvValueBridge.isString(f)) {
+        if (f.isString()) {
             return (f.stringOf())
         }
         return ""
@@ -20464,7 +20464,7 @@ class ComponentEngine {
 
     fn regexSourceOf:string (v:EvHandle) {
         def sv:EvHandle (v.getMember("source"))
-        if (EvValueBridge.isString(sv)) {
+        if (sv.isString()) {
             return (sv.stringOf())
         }
         return ""
@@ -20583,7 +20583,7 @@ class ComponentEngine {
         if (this.isRegexValue(v)) {
             return v
         }
-        if (EvValueBridge.isUndefined(v)) {
+        if (v.isUndefined()) {
             return (this.makeRegexValue("" ""))
         }
         ; null is NOT the empty pattern: `'gnulluna'.match(null)` looks for the
@@ -20711,10 +20711,10 @@ class ComponentEngine {
     ; through .call().
     fn arrayLikeElements:[EvHandle] (v:EvHandle) {
         def out:[EvHandle]
-        if (EvValueBridge.isArrayValue(v)) {
+        if (v.isArray()) {
             return (v.itemsOf())
         }
-        if (EvValueBridge.isString(v)) {
+        if (v.isString()) {
             def si:int 0
             while (si < (strlen (v.stringOf()))) {
                 push out (EvValueBridge.taggedString((substring (v.stringOf()) si (si + 1))))
@@ -20730,7 +20730,7 @@ class ComponentEngine {
         if scriptThrew {
             return out
         }
-        if (EvValueBridge.isUndefined(lenV)) {
+        if (lenV.isUndefined()) {
             return out
         }
         ; D-STRNUM: ToUint32 goes through the engine's ToNumber, which follows
@@ -20777,7 +20777,7 @@ class ComponentEngine {
     ; answers the HOLE sentinel, which is exactly what the skip tests already
     ; look for, so no call site has to learn a new shape.
     fn arrayElemAt:EvHandle (recv:EvHandle idx:int) {
-        if (EvValueBridge.isArrayValue(recv)) {
+        if (recv.isArray()) {
             ; D-ACCESSORS: an index redefined as an ACCESSOR --
             ; `Object.defineProperty(arr, "0", {get: …})` -- is a real property
             ; of the array and its getter runs. Reading the dense slot first
@@ -20790,7 +20790,7 @@ class ComponentEngine {
             }
             if (idx < (recv.denseLen())) {
                 def slot:EvHandle (recv.arrayItemAt(idx))
-                if (false == (EvValueBridge.isHole(slot))) {
+                if (false == (slot.isHole())) {
                     return slot
                 }
             }
@@ -20804,7 +20804,7 @@ class ComponentEngine {
             }
             return (EvValueBridge.taggedHole())
         }
-        if (EvValueBridge.isString(recv)) {
+        if (recv.isString()) {
             if (idx < (strlen (recv.stringOf()))) {
                 return (EvValueBridge.taggedString((substring (recv.stringOf()) idx (idx + 1))))
             }
@@ -20843,7 +20843,7 @@ class ComponentEngine {
     ; and everything else through ToString so an object runs its own.
     fn arrayJoinLive:EvHandle (recv:EvHandle sep:string) {
         def n:int (recv.arrayLength())
-        if (false == (EvValueBridge.isArrayValue(recv))) {
+        if (false == (recv.isArray())) {
             def lv:EvHandle (this.getPropertyValue(recv "length"))
             if scriptThrew {
                 return (EvValueBridge.taggedUndefined())
@@ -20866,9 +20866,9 @@ class ComponentEngine {
                 return (EvValueBridge.taggedUndefined())
             }
             def skip:boolean false
-            if (EvValueBridge.isHole(v)) { skip = true }
-            if (EvValueBridge.isNull(v)) { skip = true }
-            if (EvValueBridge.isUndefined(v)) { skip = true }
+            if (v.isHole()) { skip = true }
+            if (v.isNull()) { skip = true }
+            if (v.isUndefined()) { skip = true }
             if (false == skip) {
                 out = (out + (this.toStringOf(v)))
                 if scriptThrew {
@@ -20910,7 +20910,7 @@ class ComponentEngine {
             }
         }
         def direct:EvHandle (obj.getMember(key))
-        if (false == (EvValueBridge.isUndefined(direct))) {
+        if (false == (direct.isUndefined())) {
             return direct
         }
         ; D-PROTO: an ARRAY carries no prototype link of its own, so the value
@@ -20927,7 +20927,7 @@ class ComponentEngine {
     ; ToString: an object runs its own toString/valueOf, everything else answers
     ; for itself.
     fn toStringOf:string (v:EvHandle) {
-        if (EvValueBridge.isString(v)) {
+        if (v.isString()) {
             return (v.stringOf())
         }
         def p:EvHandle v
@@ -20936,7 +20936,7 @@ class ComponentEngine {
         if (v.isObject()) { p = (this.toPrimitive(v true)) }
         if (v.isArray()) { p = (this.toPrimitive(v true)) }
         if (v.isFunction()) { p = (this.toPrimitive(v true)) }
-        if (EvValueBridge.isString(p)) {
+        if (p.isString()) {
             ; Bind before returning. `p` here is a value this scope OWNS --
             ; toPrimitive handed back a fresh one -- so returning its stringValue
             ; directly gave the caller a pointer into a value that scope exit
@@ -21008,7 +21008,7 @@ class ComponentEngine {
         def walk:EvHandle (this.protoOfValue(obj))
         def steps:int 0
         while (steps < 16) {
-            if (EvValueBridge.isNull(walk)) {
+            if (walk.isNull()) {
                 return (EvValueBridge.taggedNull())
             }
             if (walk.hasOwnData(key)) {
@@ -21021,7 +21021,7 @@ class ComponentEngine {
                 if (wi >= 0) {
                     if (wi < (walk.denseLen())) {
                         def wslot:EvHandle (walk.arrayItemAt(wi))
-                        if (false == (EvValueBridge.isHole(wslot))) {
+                        if (false == (wslot.isHole())) {
                             return wslot
                         }
                     }
@@ -21149,14 +21149,14 @@ class ComponentEngine {
     }
 
     fn toPropertyKey:string (v:EvHandle) {
-        if (EvValueBridge.isString(v)) {
+        if (v.isString()) {
             return (v.stringOf())
         }
         def p:EvHandle v
         if (v.isObject()) { p = (this.toPrimitive(v true)) }
         if (v.isArray()) { p = (this.toPrimitive(v true)) }
         if (v.isFunction()) { p = (this.toPrimitive(v true)) }
-        if (EvValueBridge.isString(p)) {
+        if (p.isString()) {
             ; Bind before returning. `p` here is a value this scope OWNS --
             ; toPrimitive handed back a fresh one -- so returning its stringValue
             ; directly gave the caller a pointer into a value that scope exit
@@ -21184,7 +21184,7 @@ class ComponentEngine {
         ; `Object.defineProperties(o, false)` boxes the boolean, finds no own
         ; enumerable property on it, and quietly returns o. Only null and
         ; undefined are a TypeError, and ToObject raises that itself.
-        if ((EvValueBridge.isNull(rawDescs)) || (EvValueBridge.isUndefined(rawDescs))) {
+        if ((rawDescs.isNull()) || (rawDescs.isUndefined())) {
             return "Properties must be an object"
         }
         def descs:EvHandle (this.toObjectValue(rawDescs))
@@ -21260,7 +21260,7 @@ class ComponentEngine {
             if (walk.hasOwnGetter(key)) { return true }
             if (walk.hasOwnSetter(key)) { return true }
             def nxt:EvHandle (this.protoOfValue(walk))
-            if (EvValueBridge.isNull(nxt)) {
+            if (nxt.isNull()) {
                 return false
             }
             walk = nxt
@@ -21293,7 +21293,7 @@ class ComponentEngine {
                 return (walk.getOwnData(key))
             }
             def nxt:EvHandle (this.protoOfValue(walk))
-            if (EvValueBridge.isNull(nxt)) {
+            if (nxt.isNull()) {
                 return (EvValueBridge.taggedUndefined())
             }
             walk = nxt
@@ -22212,28 +22212,28 @@ class ComponentEngine {
     }
 
     fn typeofTag:string (val:EvHandle) {
-        if (EvValueBridge.isUndefined(val)) {
+        if (val.isUndefined()) {
             return "undefined"
         }
-        if (EvValueBridge.isNull(val)) {
+        if (val.isNull()) {
             return "object"
         }
-        if (EvValueBridge.isNumber(val)) {
+        if (val.isNumber()) {
             return "number"
         }
-        if (EvValueBridge.isString(val)) {
+        if (val.isString()) {
             return "string"
         }
-        if (EvValueBridge.isBoolean(val)) {
+        if (val.isBoolean()) {
             return "boolean"
         }
-        if (EvValueBridge.isFunction(val)) {
+        if (val.isFunction()) {
             return "function"
         }
-        if (EvValueBridge.isArrayValue(val)) {
+        if (val.isArray()) {
             return "object"
         }
-        if (EvValueBridge.isObject(val)) {
+        if (val.isObject()) {
             ; D-SYMBOL: symbols are modelled as objects internally, but `typeof`
             ; must answer "symbol" — that is how guest code tells them apart, and
             ; answering "object" would make every symbol type-check wrong.
@@ -22243,13 +22243,13 @@ class ComponentEngine {
             }
             return "object"
         }
-        if (EvValueBridge.isMap(val)) {
+        if (val.isMap()) {
             return "object"
         }
-        if (EvValueBridge.isSet(val)) {
+        if (val.isSet()) {
             return "object"
         }
-        if (EvValueBridge.isElement(val)) {
+        if (val.isElement()) {
             return "object"
         }
         return "undefined"
@@ -22980,7 +22980,7 @@ class ComponentEngine {
                 if an.left {
                     sv = (this.evaluateExpr((unwrap an.left)))
                 }
-                if (EvValueBridge.isArrayValue(sv)) {
+                if (sv.isArray()) {
                     def k:int 0
                     while (k < (sv.denseLen())) {
                         push argVals (sv.arrayItemAt(k))
@@ -23106,11 +23106,11 @@ class ComponentEngine {
             def m:EvHandle (EvValueBridge.taggedMapEmpty())
             if ((array_length node.children) > 0) {
                 def init:EvHandle (this.evaluateExpr((itemAt node.children 0)))
-                if (EvValueBridge.isArrayValue(init)) {
+                if (init.isArray()) {
                     def i:int 0
                     while (i < (init.denseLen())) {
                         def pair:EvHandle (init.arrayItemAt(i))
-                        if (EvValueBridge.isArrayValue(pair)) {
+                        if (pair.isArray()) {
                             m.mapSet((pair.getIndex(0)) (pair.getIndex(1)))
                         }
                         i = (i + 1)
@@ -23123,7 +23123,7 @@ class ComponentEngine {
             def st:EvHandle (EvValueBridge.taggedSetEmpty())
             if ((array_length node.children) > 0) {
                 def init:EvHandle (this.evaluateExpr((itemAt node.children 0)))
-                if (EvValueBridge.isArrayValue(init)) {
+                if (init.isArray()) {
                     def i:int 0
                     while (i < (init.denseLen())) {
                         st.setAdd((init.arrayItemAt(i)))
@@ -23147,7 +23147,7 @@ class ComponentEngine {
                         if scriptThrew {
                             return (EvValueBridge.taggedUndefined())
                         }
-                        if (false == (EvValueBridge.isUndefined(mv))) {
+                        if (false == (mv.isUndefined())) {
                             msg = (this.toStringOf(mv))
                             if scriptThrew {
                                 return (EvValueBridge.taggedUndefined())
@@ -23327,13 +23327,13 @@ class ComponentEngine {
                         ; does not -- so the value's own function name is the
                         ; fallback. Without it `var F = RegExp.prototype.constructor;
                         ; new F` built a plain object.
-                        if (false == (EvValueBridge.isString(aliasName))) {
+                        if (false == (aliasName.isString())) {
                             def aliasCtor:string (this.builtinCtorNameOf(aliasV))
                             if ((strlen aliasCtor) > 0) {
                                 aliasName = (EvValueBridge.taggedString(aliasCtor))
                             }
                         }
-                        if (EvValueBridge.isString(aliasName)) {
+                        if (aliasName.isString()) {
                             def an:string (aliasName.stringOf())
                             if (this.isBuiltinCtorName(an)) {
                                 if (this.isWrapperCtorName(an)) {
@@ -23601,9 +23601,9 @@ class ComponentEngine {
             ; before this point and must not throw.
             if strictReferences {
                 if (node.optional == false) {
-                    if ((EvValueBridge.isNull(obj)) || (EvValueBridge.isUndefined(obj))) {
+                    if ((obj.isNull()) || (obj.isUndefined())) {
                         def tgtDesc:string "undefined"
-                        if (EvValueBridge.isNull(obj)) {
+                        if (obj.isNull()) {
                             tgtDesc = "null"
                         }
                         def pn:string propName
@@ -23775,7 +23775,7 @@ class ComponentEngine {
 
             ; Map/Set .size property (element count).
             if (propName == "size") {
-                if ((EvValueBridge.isMap(obj)) || (EvValueBridge.isSet(obj))) {
+                if ((obj.isMap()) || (obj.isSet())) {
                     return (EvHandle.fromInt((obj.denseLen())))
                 }
             }
@@ -23796,8 +23796,8 @@ class ComponentEngine {
                     ; runs. Only the written form was checked, above, so the
                     ; getter was skipped and the read answered undefined.
                     def ckey:string ""
-                    if (EvValueBridge.isString(indexVal)) { ckey = (indexVal.stringOf()) }
-                    if (EvValueBridge.isNumber(indexVal)) { ckey = (this.toPropertyKey(indexVal)) }
+                    if (indexVal.isString()) { ckey = (indexVal.stringOf()) }
+                    if (indexVal.isNumber()) { ckey = (this.toPropertyKey(indexVal)) }
                     ; D-ARGMAP: `arguments[0]` and the first named parameter are
                     ; ONE binding in sloppy mode, so a reassignment of either is
                     ; visible through the other. The object held a snapshot taken
@@ -23864,14 +23864,14 @@ class ComponentEngine {
                         }
                         return viaFar
                     }
-                    if (EvValueBridge.isNumber(indexVal)) {
+                    if (indexVal.isNumber()) {
                         def idx:int (to_int (indexVal.toNumber()))
                         if (false == quiet) {
                             this.trace("  Getting index " + (to_string idx) + " from array of length " + (to_string (obj.denseLen())))
                         }
                         return (obj.getIndex(idx))
                     }
-                    if (EvValueBridge.isString(indexVal)) {
+                    if (indexVal.isString()) {
                         ; A string key that names an index reaches the character,
                         ; and a key that names nothing reads as undefined --
                         ; `'abc'['foo']` is undefined, not null.
@@ -23945,7 +23945,7 @@ class ComponentEngine {
                 if elem.left {
                     sv = (this.evaluateExpr((unwrap elem.left)))
                 }
-                if (EvValueBridge.isArrayValue(sv)) {
+                if (sv.isArray()) {
                     def k:int 0
                     while (k < (sv.denseLen())) {
                         push items (sv.arrayItemAt(k))
@@ -24134,7 +24134,7 @@ class ComponentEngine {
             }
             return out
         }
-        if (EvValueBridge.isObject(v)) {
+        if (v.isObject()) {
             out = (v.ownDataKeys())
             ; D-ACCESSORS: an accessor property lives in getterMap/setterMap
             ; rather than objectMap, so listing only objectMap left every
@@ -24164,7 +24164,7 @@ class ComponentEngine {
         }
         ; A string coerces to an object whose own keys are its character
         ; indices, which is what Object.keys('abc') returns.
-        if (EvValueBridge.isString(v)) {
+        if (v.isString()) {
             def si:int 0
             while (si < (strlen (v.stringOf()))) {
                 push out (to_string si)
@@ -24175,7 +24175,7 @@ class ComponentEngine {
         ; D-ARRAYKEYS: an array's own keys are its INDICES, as strings. Elements
         ; live in arrayValue rather than objectMap, so Object.keys([1,2]) used to
         ; answer nothing at all instead of ["0","1"].
-        if (EvValueBridge.isArrayValue(v)) {
+        if (v.isArray()) {
             def i:int 0
             while (i < (v.denseLen())) {
                 ; D-HOLES: an ABSENT element has no key, so Object.keys and
@@ -24227,7 +24227,7 @@ class ComponentEngine {
 
     fn objectEnumerableKeysRaw:[string] (v:EvHandle) {
         def out:[string]
-        if (EvValueBridge.isArrayValue(v)) {
+        if (v.isArray()) {
             ; An index is enumerable UNLESS defineProperty recorded otherwise --
             ; `Object.defineProperties(a, {"0": {value: 1}})` creates a
             ; non-enumerable element, and for-in must skip it.
@@ -24242,10 +24242,10 @@ class ComponentEngine {
             }
             return out
         }
-        if (EvValueBridge.isString(v)) {
+        if (v.isString()) {
             return (this.objectKeys(v))
         }
-        def holdsProps:boolean (EvValueBridge.isObject(v))
+        def holdsProps:boolean (v.isObject())
         if (v.isFunction()) { holdsProps = true }
         if holdsProps {
             def all:[string] (this.objectKeys(v))
@@ -24264,7 +24264,7 @@ class ComponentEngine {
     ; True if an object value owns `key` (distinguishes a present-but-null value
     ; from an absent key, which getMember cannot). Used by the `in` operator.
     fn objHasKey:boolean (v:EvHandle key:string) {
-        if (EvValueBridge.isObject(v)) {
+        if (v.isObject()) {
             return (v.hasOwnData(key))
         }
         ; D-FNPROPS: length, name and prototype are OWN properties of every
@@ -24346,15 +24346,15 @@ class ComponentEngine {
     ; Serialise a value to JSON. undefined/functions become null (JSON has no such
     ; types); the internal __class__ tag on class instances is omitted.
     fn jsonStringify:string (v:EvHandle) {
-        if (EvValueBridge.isNull(v)) {
+        if (v.isNull()) {
             return "null"
         }
-        if (EvValueBridge.isUndefined(v)) {
+        if (v.isUndefined()) {
             return "null"
         }
         ; D-IEEE: JSON has no NaN or Infinity; both serialise as null. Emitting
         ; the literal text "NaN" produces JSON that will not parse back.
-        if (EvValueBridge.isNumber(v)) {
+        if (v.isNumber()) {
             def nv:double (v.toNumber())
             if (nv != nv) {
                 return "null"
@@ -24367,19 +24367,19 @@ class ComponentEngine {
                 return "null"
             }
         }
-        if (EvValueBridge.isBoolean(v)) {
+        if (v.isBoolean()) {
             if (v.toBool()) {
                 return "true"
             }
             return "false"
         }
-        if (EvValueBridge.isNumber(v)) {
+        if (v.isNumber()) {
             return (v.toString())
         }
-        if (EvValueBridge.isString(v)) {
+        if (v.isString()) {
             return (this.jsonQuote((v.stringOf())))
         }
-        if (EvValueBridge.isArrayValue(v)) {
+        if (v.isArray()) {
             def out:string "["
             def i:int 0
             while (i < (v.denseLen())) {
@@ -24391,7 +24391,7 @@ class ComponentEngine {
             }
             return (out + "]")
         }
-        if (EvValueBridge.isObject(v)) {
+        if (v.isObject()) {
             def out:string "{"
             def ks:[string] (this.objectKeys(v))
             def i:int 0
@@ -24824,7 +24824,7 @@ class ComponentEngine {
                 if prop.left {
                     sv = (this.evaluateExpr((unwrap prop.left)))
                 }
-                if (EvValueBridge.isObject(sv)) {
+                if (sv.isObject()) {
                     def sks:[string] (this.objectKeys(sv))
                     def si:int 0
                     while (si < (array_length sks)) {

--- a/gallery/game_engine/v2/interp/migrate/src/EvHandle.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/EvHandle.rgr
@@ -524,13 +524,13 @@ class EvHandle {
     }
 
     sfn fromBody:EvHandle (ev:EvalValue) {
-        case ev h:EvalValue.Hole {
+        if (is ev _:EvalValue.Hole) {
             return (EvHandle.hole())
         }
-        case ev n:EvalValue.Null {
+        if (is ev _:EvalValue.Null) {
             return (EvHandle.null())
         }
-        case ev u:EvalValue.Undefined {
+        if (is ev _:EvalValue.Undefined) {
             return (EvHandle.undefined())
         }
         case ev num:EvalValue.Number {

--- a/gallery/game_engine/v2/interp/migrate/src/EvalValue.rgr
+++ b/gallery/game_engine/v2/interp/migrate/src/EvalValue.rgr
@@ -177,86 +177,44 @@ shape EvalValue {
     }
 
     fn isNull:boolean () {
-        case self n:EvalValue.Null {
-            return true
-        }
-        return false
+        return (is self _:EvalValue.Null)
     }
     fn isNumber:boolean () {
-        case self n:EvalValue.Number {
-            return true
-        }
-        return false
+        return (is self _:EvalValue.Number)
     }
     fn isString:boolean () {
-        case self n:EvalValue.String {
-            return true
-        }
-        return false
+        return (is self _:EvalValue.String)
     }
     fn isHole:boolean () {
-        case self n:EvalValue.Hole {
-            return true
-        }
-        return false
+        return (is self _:EvalValue.Hole)
     }
     fn isUndefined:boolean () {
-        case self n:EvalValue.Undefined {
-            return true
-        }
-        return false
+        return (is self _:EvalValue.Undefined)
     }
     fn isBoolean:boolean () {
-        case self n:EvalValue.Boolean {
-            return true
-        }
-        return false
+        return (is self _:EvalValue.Boolean)
     }
     fn isNullOrUndefined:boolean () {
-        case self n:EvalValue.Null {
-            return true
-        }
-        case self u:EvalValue.Undefined {
-            return true
-        }
-        return false
+        return ((is self _:EvalValue.Null) || (is self _:EvalValue.Undefined))
     }
     fn isElement:boolean () {
-        case self n:EvalValue.Element {
-            return true
-        }
-        return false
+        return (is self _:EvalValue.Element)
     }
     ; Named isArrayValue — a global `isArray` operator blocks methods named isArray.
     fn isArrayValue:boolean () {
-        case self n:EvalValue.Array {
-            return true
-        }
-        return false
+        return (is self _:EvalValue.Array)
     }
     fn isObject:boolean () {
-        case self n:EvalValue.Object {
-            return true
-        }
-        return false
+        return (is self _:EvalValue.Object)
     }
     fn isFunction:boolean () {
-        case self n:EvalValue.Function {
-            return true
-        }
-        return false
+        return (is self _:EvalValue.Function)
     }
     fn isMap:boolean () {
-        case self n:EvalValue.Map {
-            return true
-        }
-        return false
+        return (is self _:EvalValue.Map)
     }
     fn isSet:boolean () {
-        case self n:EvalValue.Set {
-            return true
-        }
-        return false
+        return (is self _:EvalValue.Set)
     }
 }
 
@@ -463,10 +421,7 @@ class EvPropertyBag {
             return false
         }
         def slot:EvPropertySlot (unwrap (get slots key))
-        case slot a:EvPropertySlot.Accessor {
-            return true
-        }
-        return false
+        return (is slot _:EvPropertySlot.Accessor)
     }
     fn getGetter:EvalValue (key:string) {
         def slot:EvPropertySlot (unwrap (get slots key))
@@ -569,7 +524,7 @@ class EvPropertyBag {
             return
         }
         def slot:EvPropertySlot (unwrap (get slots key))
-        case slot a:EvPropertySlot.Accessor {
+        if (is slot _:EvPropertySlot.Accessor) {
             this.removeData(key)
         }
     }

--- a/lib/stdlib.rgr
+++ b/lib/stdlib.rgr
@@ -241,10 +241,51 @@ operators {
                 (forkctx _ ) (def 2) "if let " (typeof 1) "::" (typeof 2) "(" (e 2) ") = " (e 1) ".clone() { /* union case */" nl I
                         (block 3)
                         nl i "}"
-            ) 
-            
+            )
+
         }
-    }    
+    }
+    ; `is v Shape.Case` — the kind test of `case` with the binding and the
+    ; block taken away. `case v x:Shape.Case { … }` answers "is it this case?"
+    ; and then hands the arm a narrowed `x`; an arm that only wants the answer
+    ; pays for a binding it never reads. On Rust that binding costs a
+    ; `.clone()` of the scrutinee (a refcount pair for every reference case),
+    ; on Go a declared-and-discarded local, on ES6/Python a dead assignment.
+    ; This is an expression, so it composes: `return (is self EvalValue.Number)`
+    ; replaces the whole `case self n:… { return true } return false` shape.
+    ; Every template below is the same discriminant test the `case` operator
+    ; above already lowers to on that target — nothing new is invented, and no
+    ; target evaluates (e 1) more than once.
+    is _:boolean ( arg@(union):T item@(noeval):T ) {
+        templates {
+            ranger ( "(is " (e 1) " " (typeof 2) ")" )
+            ; S5 FlatTaggedObject: the stable kind tag, no `var x = …` after it
+            es6    ( "(" (e 1) " != null && " (e 1) ".__rg_kind === \"" (typeof 2) "\")" )
+            ; single underscore — __rg_kind would be Python-mangled on the instance
+            python ( "(" (e 1) " is not None and getattr(" (e 1) ", \"_rg_kind\", None) == \"" (typeof 2) "\")" )
+            ; S5 tagged struct: the tag compare alone, no variant pointer bound
+            go     ( "(" (e 1) ".tag == " (typeof 1) "_tag_" (rawtype 2) ")" )
+            ; matches! reads the discriminant in place — no clone of the
+            ; scrutinee, which is the whole point of this operator on Rust
+            rust   ( "matches!(" (e 1) ", " (typeof 1) "::" (typeof 2) "(..))" )
+            ; holds_alternative is already the bare index compare; the `case`
+            ; template only added mpark::get on top of it
+            cpp    ( "mpark::holds_alternative<" (typeof 2) ">(" (e 1) ")"
+                (plugin 'makefile' ((dep 'variant.hpp' 'https://github.com/mpark/variant/releases/download/v1.2.2/variant.hpp')))
+            )
+            csharp ( "(" (e 1) " is " (typeof 2) ")" )
+            kotlin ( "(" (e 1) " is " (typeof 2) ")" )
+            dart   ( "(" (e 1) " is " (typeof 2) ")" )
+            java7  ( "(" (e 1) " instanceof " (typeof 2) ")" )
+            php    ( "(is_object(" (e 1) ") && get_class(" (e 1) ") == \"" (typeof 2) "\")" )
+            scala  ( "(" (e 1) ".isInstanceOf[" (typeof 2) "])" )
+            ; Swift's enum test is `if case`, a statement — an immediately
+            ; applied closure is the only way to spell it as an expression.
+            ; (e 1) is still named once, so it is still evaluated once.
+            swift3 ( "({ () -> Bool in if case ." (rawtype 2) " = " (e 1) " { return true }; return false })()" )
+            swift6 ( "({ () -> Bool in if case ." (rawtype 2) " = " (e 1) " { return true }; return false })()" )
+        }
+    }
     ; Reference identity: are these two names the same object? `==` means
     ; something different on every target — structural on Kotlin, a trait bound
     ; on Rust, pointer on C++ — so identity gets its own operator rather than a

--- a/tests/fixtures/is_operator.rgr
+++ b/tests/fixtures/is_operator.rgr
@@ -1,0 +1,114 @@
+; `is v _:Shape.Case` / `is v _:Shape.Group` — the kind test of `case` without
+; the binding or the block (SHAPES_IS_OPERATOR.md).
+;
+; Every question is answered TWICE: once through `case`, once through `is`.
+; A target where the two lowerings disagree prints a mismatched pair, so this
+; fixture proves agreement rather than merely proving the program compiled.
+;
+; The group rows matter most: a group is not a discriminant any target can
+; test, so `is` on a group expands into a disjunction over the group's member
+; cases. Rust and Go would not compile a group tag at all, and ES6/Python would
+; compare against a tag no case ever carries.
+
+shape Val {
+    group Prim @(value)
+    group Ref @(reference) {
+        def id:int 0
+    }
+
+    case Nul does Prim
+    case Num does Prim {
+        def n:double 0.0
+    }
+    case Txt does Ref {
+        def s:string ""
+    }
+    case Lst does Ref {
+        def k:int 0
+    }
+}
+
+class IsProbe {
+    sfn caseNul:boolean (v:Val) {
+        case v x:Val.Nul {
+            return true
+        }
+        return false
+    }
+    sfn isNul:boolean (v:Val) {
+        return (is v _:Val.Nul)
+    }
+    sfn caseNum:boolean (v:Val) {
+        case v x:Val.Num {
+            return true
+        }
+        return false
+    }
+    sfn isNum:boolean (v:Val) {
+        return (is v _:Val.Num)
+    }
+    sfn caseTxt:boolean (v:Val) {
+        case v x:Val.Txt {
+            return true
+        }
+        return false
+    }
+    sfn isTxt:boolean (v:Val) {
+        return (is v _:Val.Txt)
+    }
+    ; group tests — expand to a disjunction over the group's cases
+    sfn isPrim:boolean (v:Val) {
+        return (is v _:Val.Prim)
+    }
+    sfn isRef:boolean (v:Val) {
+        return (is v _:Val.Ref)
+    }
+    ; `is` composed: disjunction, negation, and as an `if` condition with the
+    ; payload read by a following `case`
+    sfn isNumOrTxt:boolean (v:Val) {
+        return ((is v _:Val.Num) || (is v _:Val.Txt))
+    }
+    sfn isNotNum:boolean (v:Val) {
+        return (false == (is v _:Val.Num))
+    }
+    sfn describe:string (v:Val) {
+        if (is v _:Val.Nul) {
+            return "nul"
+        }
+        if (is v _:Val.Num) {
+            case v x:Val.Num {
+                return ("num" + (to_string (floor x.n)))
+            }
+        }
+        if (is v _:Val.Txt) {
+            case v x:Val.Txt {
+                return ("txt" + x.s)
+            }
+        }
+        return "lst"
+    }
+    sfn b:string (x:boolean) {
+        return (? x "T" "F")
+    }
+    sfn row:string (v:Val) {
+        def line:string ""
+        line = line + (IsProbe.b((IsProbe.caseNul(v)))) + (IsProbe.b((IsProbe.caseNum(v)))) + (IsProbe.b((IsProbe.caseTxt(v))))
+        line = line + "/" + (IsProbe.b((IsProbe.isNul(v)))) + (IsProbe.b((IsProbe.isNum(v)))) + (IsProbe.b((IsProbe.isTxt(v))))
+        line = line + "/" + (IsProbe.b((IsProbe.isPrim(v)))) + (IsProbe.b((IsProbe.isRef(v))))
+        line = line + "/" + (IsProbe.b((IsProbe.isNumOrTxt(v)))) + (IsProbe.b((IsProbe.isNotNum(v))))
+        line = line + "/" + (IsProbe.describe(v))
+        return line
+    }
+    sfn m@(main):void () {
+        def a:Val (new Val.Nul())
+        def c:Val (new Val.Num(42.0))
+        def d:Val (new Val.Txt(0 "hi"))
+        def e:Val (new Val.Lst(0 3))
+        def out:string ""
+        out = out + (IsProbe.row(a)) + " "
+        out = out + (IsProbe.row(c)) + " "
+        out = out + (IsProbe.row(d)) + " "
+        out = out + (IsProbe.row(e))
+        print out
+    }
+}

--- a/tests/is-operator.test.ts
+++ b/tests/is-operator.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  expectOutput,
+  expectGoOutput,
+  expectKotlinOutput,
+  expectPythonOutput,
+  expectRustOutput,
+  getGeneratedCppCode,
+  getGeneratedKotlinCode,
+  getGeneratedRustCode,
+  getGeneratedSwiftCode,
+  isGoAvailable,
+  isKotlinAvailable,
+  isPythonAvailable,
+  isRustAvailable,
+} from "./helpers/compiler";
+
+const FIXTURE = "tests/fixtures/is_operator.rgr";
+
+/**
+ * `is v _:Shape.Case` — the kind test of `case` with the binding and the block
+ * removed (SHAPES_IS_OPERATOR.md).
+ *
+ * The fixture answers every question twice, once through `case` and once
+ * through `is`, so a disagreement between the two lowerings shows up as a
+ * mismatched pair in the output rather than as a silent wrong answer. Each row
+ * is `case/is/group/composed/describe`.
+ *
+ * Targets whose toolchain is not installed are covered by asserting the
+ * emitted expression instead: that is the only guard Swift has, since its
+ * toolchain cannot be fetched in CI sandboxes.
+ */
+describe("the `is` kind test", () => {
+  // nul          num          txt           lst
+  const EXPECTED =
+    "TFF/TFF/TF/FT/nul FTF/FTF/TF/TF/num42 FFT/FFT/FT/TT/txthi FFF/FFF/FT/FT/lst";
+
+  describe("runs identically across targets", () => {
+    it("ES6", () => {
+      expect(expectOutput(FIXTURE, EXPECTED).output).toContain(EXPECTED);
+    });
+
+    it.skipIf(!isPythonAvailable())("Python", () => {
+      expect(expectPythonOutput(FIXTURE, EXPECTED).output).toContain(EXPECTED);
+    });
+
+    it.skipIf(!isGoAvailable())("Go", () => {
+      expect(expectGoOutput(FIXTURE, EXPECTED).output).toContain(EXPECTED);
+    });
+
+    it.skipIf(!isRustAvailable())("Rust", () => {
+      expect(expectRustOutput(FIXTURE, EXPECTED).output).toContain(EXPECTED);
+    });
+
+    it.skipIf(!isKotlinAvailable())("Kotlin", () => {
+      expect(expectKotlinOutput(FIXTURE, EXPECTED).output).toContain(EXPECTED);
+    });
+  });
+
+  /**
+   * Each target must emit the discriminant test it already uses for `case`,
+   * and nothing more — no binding, no clone, no block.
+   */
+  describe("lowers to the target's own discriminant test", () => {
+    it("Rust: matches! — no clone of the scrutinee", () => {
+      const gen = getGeneratedRustCode(FIXTURE);
+      expect(gen.success).toBe(true);
+      expect(gen.code).toContain("matches!(v, union_Val::Val_Num(..))");
+      // the `case` form clones; the `is` form must not
+      expect(gen.code).toMatch(/fn isNum\([^)]*\)[^{]*\{\s*matches!\(/);
+    });
+
+    it("C++: holds_alternative, without the mpark::get the case form adds", () => {
+      const gen = getGeneratedCppCode(FIXTURE);
+      expect(gen.success).toBe(true);
+      expect(gen.code).toContain("mpark::holds_alternative<Val_Num>(v)");
+    });
+
+    it("Kotlin: an `is` check against the case class", () => {
+      const gen = getGeneratedKotlinCode(FIXTURE);
+      expect(gen.success).toBe(true);
+      expect(gen.code).toContain("(v is Val_Num)");
+    });
+
+    it("Swift: `if case` has no expression form, so an applied closure", () => {
+      const gen = getGeneratedSwiftCode(FIXTURE);
+      expect(gen.success).toBe(true);
+      expect(gen.code).toContain("if case .Val_Num = v { return true }; return false");
+      // the value operand is named once, so it is evaluated once
+      const test = gen.code.match(
+        /\{ \(\) -> Bool in if case \.Val_Num = (\w+) \{ return true \}; return false \}\)\(\)/
+      );
+      expect(test).not.toBeNull();
+    });
+  });
+
+  /**
+   * A group is not a discriminant any target can compare: the generated union
+   * carries one tag per CASE. Rust and Go would not compile a group tag at all
+   * (`union_Val::union_Val_Prim` names no variant), and the tag-string targets
+   * would compare against a tag no case ever carries and answer false forever.
+   * So a group test expands into a disjunction over the group's member cases.
+   */
+  describe("a group expands into its member cases", () => {
+    it("Rust: one matches! per case of the group, or-ed", () => {
+      const gen = getGeneratedRustCode(FIXTURE);
+      expect(gen.success).toBe(true);
+      expect(gen.code).toContain(
+        "(matches!(v, union_Val::Val_Nul(..))) || (matches!(v, union_Val::Val_Num(..)))"
+      );
+      // the group must never reach a writer as a tag of its own
+      expect(gen.code).not.toContain("union_Val::union_Val_Prim");
+    });
+
+    it("Kotlin: one `is` per case of the group, or-ed", () => {
+      const gen = getGeneratedKotlinCode(FIXTURE);
+      expect(gen.success).toBe(true);
+      expect(gen.code).toContain("((v is Val_Nul)) || ((v is Val_Num))");
+    });
+
+    it("Swift: one `if case` per case of the group, or-ed", () => {
+      const gen = getGeneratedSwiftCode(FIXTURE);
+      expect(gen.success).toBe(true);
+      expect(gen.code).toContain("if case .Val_Nul = v");
+      expect(gen.code).toContain("if case .Val_Num = v");
+      // Swift lowers a group to its OWN enum, so a group tag here would be a
+      // comparison against a different type entirely
+      expect(gen.code).not.toContain("if case .union_Val_Prim");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR introduces the `is` operator for testing shape case membership without the overhead of binding and block opening that `case` requires. The operator answers "does this value hold that case?" as a boolean expression that composes into conditionals and other expressions.

## Key Changes

- **New `is` operator in stdlib** (`compiler/stdlib.rgr` and `lib/stdlib.rgr`): Implements shape case testing across all target languages (Rust, C++, Go, ES6, Python, Kotlin, Dart, Swift, Java, PHP, Scala, C#). Each target emits its native discriminant test without the binding overhead of `case`.

- **Documentation**: 
  - Added `SHAPES_IS_OPERATOR.md` explaining the operator's purpose, spelling, and per-target code generation
  - Added `docs/site/src/content/docs/language/shapes.md` documenting shape declarations and narrowing operators
  - Updated `docs/site/src/content/docs/targets/overview.md` with shape state information per target

- **Test coverage**: Added `tests/is-operator.test.ts` and `tests/fixtures/is_operator.rgr` with comprehensive cross-target verification, including group membership testing (disjunctions over multiple cases)

- **Real-world usage**: Refactored `EvalValue.rgr` methods (`isNull`, `isNumber`, `isString`, etc.) to use `is` instead of `case`, eliminating unnecessary bindings and blocks

- **Compiler infrastructure**:
  - Added `-inline-statics` compiler flag support in `ng_RangerFlowParser.rgr` for trivial static forwarder inlining (implemented but not enabled by default)
  - Added `PLAN_INLINE_STATICS.md` documenting the inlining optimization (verified correct but minimal performance gain)
  - Updated `VirtualCompiler.rgr` to register the new flag

- **Code generation fixes**: Minor improvements to `bin/output.js` and `ng_CodeNodeCompilerExtensions.rgr` for qualified reference handling and PHP static reference detection

## Implementation Details

The `is` operator:
- Takes a value and a `@(noeval)` shape case parameter (conventionally named `_` to indicate no binding)
- Returns a boolean without opening a new context or binding a variable
- Eliminates per-target costs: Rust avoids `.clone()`, Go avoids unused variable declarations, other targets avoid dead assignments
- Supports group membership testing by expanding into disjunctions over group member cases
- Each target's template is the discriminant test already used by `case`, just without the binding wrapper

The operator is particularly valuable for Rust where `case` clones the scrutinee for every arm, even those that only test the type.

https://claude.ai/code/session_018UhAu39zhvtwywsKKDnHud