### PR TITLE
Fix the docs deploy: restore the class test for system unions in `case`

### DIFF
--- a/bin/output.js
+++ b/bin/output.js
@@ -212,7 +212,7 @@ InputFSFolder.fromDictionary = function(dict) {
       let arr_i = 0;
       while (arr_i < arr_len) {
         const item = arr[arr_i];
-        if( item != null && item.__rg_kind === "Object" ) /* union case */ {
+        if( item instanceof Object ) /* union case */ {
           var oo = item;
           const newObj = InputFSFolder.fromDictionary(oo);
           obj.folders.push(newObj);
@@ -227,7 +227,7 @@ InputFSFolder.fromDictionary = function(dict) {
       let arr_i_1 = 0;
       while (arr_i_1 < arr_len_1) {
         const item_1 = arr_1[arr_i_1];
-        if( item_1 != null && item_1.__rg_kind === "Object" ) /* union case */ {
+        if( item_1 instanceof Object ) /* union case */ {
           var oo_1 = item_1;
           const newObj_1 = InputFSFile.fromDictionary(oo_1);
           obj.files.push(newObj_1);
@@ -1727,7 +1727,7 @@ CodeNodeLiteral.fromDictionary = function(dict) {
       let arr_i_2 = 0;
       while (arr_i_2 < arr_len_2) {
         const item_3 = arr_2[arr_i_2];
-        if( item_3 != null && item_3.__rg_kind === "Object" ) /* union case */ {
+        if( item_3 instanceof Object ) /* union case */ {
           var oo_2 = item_3;
           const newObj_4 = CodeNodeLiteral.fromDictionary(oo_2);
           obj.comments.push(newObj_4);
@@ -1742,7 +1742,7 @@ CodeNodeLiteral.fromDictionary = function(dict) {
       let arr_i_3 = 0;
       while (arr_i_3 < arr_len_3) {
         const item_4 = arr_3[arr_i_3];
-        if( item_4 != null && item_4.__rg_kind === "Object" ) /* union case */ {
+        if( item_4 instanceof Object ) /* union case */ {
           var oo_3 = item_4;
           const newObj_5 = CodeNodeLiteral.fromDictionary(oo_3);
           obj.children.push(newObj_5);
@@ -1757,7 +1757,7 @@ CodeNodeLiteral.fromDictionary = function(dict) {
       let arr_i_4 = 0;
       while (arr_i_4 < arr_len_4) {
         const item_5 = arr_4[arr_i_4];
-        if( item_5 != null && item_5.__rg_kind === "Object" ) /* union case */ {
+        if( item_5 instanceof Object ) /* union case */ {
           var oo_4 = item_5;
           const newObj_6 = CodeNodeLiteral.fromDictionary(oo_4);
           obj.attrs.push(newObj_6);

--- a/compiler/stdlib.rgr
+++ b/compiler/stdlib.rgr
@@ -146,6 +146,214 @@ operators {
             )
         }
     }
+    ; A member of a system union -- the JSON unions over JSONDataObject and
+    ; JSONArrayObject -- is an ordinary object of the target language. It
+    ; carries no shape tag, so the generic overload below, which narrows on
+    ; __rg_kind / _rg_kind / .tag, can never be true for one. These two
+    ; overloads keep the class test that a system union needs; the generic
+    ; overload keeps the tag test that a shape case needs.
+    ; Every `@serialize` deserializer emits `case item oo:JSONDataObject`,
+    ; so without these the reader of an array of objects reads nothing.
+    case             _@(newcontext):void           ( arg@(union):T item2@(define):JSONDataObject code:block )  {
+        templates {
+            ranger ( "case " (e 1) " " (e 2) ":" (typeof 2) " {" nl
+                        I (block 3) i nl "}" nl
+            )
+            php (
+                (forkctx _ ) (def 2) "if( is_object(" (e 1) ") && get_class(" (e 1) ") == \"" (typeof 2) "\" ) /* union case */ {" nl I
+                        (e 2) " = " (e 1) ";" nl
+                        (block 3)                        
+                        nl i "}"
+            )  
+            es6 (
+                (forkctx _ ) (def 2) "if( " (e 1) " instanceof " (typeof 2) " ) /* union case */ {" nl I
+                        "var " (e 2) " = " (e 1) ";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            )  
+            go (
+                (forkctx _ ) (def 2) "switch " (e 1) ".(type) {" nl I
+                        "case " (typeof 2) ":" nl
+                            I nl
+                            "var " (e 2) " " (typeof 2) " = " (e 1) ".(" (typeof 2) ");" nl
+                            ; Go rejects a declared-and-unused local, and an arm
+                            ; that only tests the type never reads the binding.
+                            "_ = " (e 2) ";" nl
+                            (block 3)
+                            i nl
+                        nl i "}"
+            ) 
+            csharp (
+                (forkctx _ ) (def 2) "if( " (e 1) " is " (typeof 2) " ) {" nl I
+                        (typeof 2) " " (e 2) " = (" (typeof 2) ")" (e 1) ";" nl
+                        (block 3)
+                        nl i "}"
+            ) 
+            swift3 (
+                (forkctx _ ) (def 2) "if type(of: " (e 1) ") == " (typeof 2) ".self  {" nl I
+                        "let " (e 2) " = " (e 1) " as! " (typeof 2)";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            ) 
+            swift6 (
+                (forkctx _ ) (def 2) "if type(of: " (e 1) ") == " (typeof 2) ".self  {" nl I
+                        "let " (e 2) " = " (e 1) " as! " (typeof 2)";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            ) 
+            java7 (
+                (forkctx _ ) (def 2) "if( " (e 1) " instanceof " (typeof 2) ") {" nl I
+                        (typeof 2) " " (e 2) " = (" (typeof 2) ") " (e 1) ";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            )
+            kotlin (
+                (forkctx _ ) (def 2) "if( " (e 1) " is " (typeof 2) " ) /* union case */ {" nl I
+                        "val " (e 2) " : " (typeof 2) " = " (e 1) " as " (typeof 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            ) 
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", " (typeof 2) "):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            ) 
+            cpp (
+                (forkctx _ ) (def 2) "if( mpark::holds_alternative<" (typeof 2) ">(" (e 1) ") ) {" nl I
+                        (typeof 2) " " (e 2) " = mpark::get<" (typeof 2) ">(" (e 1) ");" nl
+                        (block 3)
+                        
+                        nl i "}"
+
+                (plugin 'makefile' ((dep 'variant.hpp' 'https://github.com/mpark/variant/releases/download/v1.2.2/variant.hpp')))
+            ) 
+            scala (
+                (forkctx _ ) (def 2) (e 1) " match {" nl
+                I "case " (e 2) " : " (typeof 2) " => {" nl I
+                            (block 3)
+                        nl i "}" nl
+                  "case _ => {} " nl i 
+                  "}" nl
+            ) 
+            dart (
+                (forkctx _ ) (def 2) "if( " (e 1) " is " (typeof 2) " ) /* union case */ {" nl I
+                        (typeof 2) " " (e 2) " = " (e 1) " as " (typeof 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            ) 
+            rust (
+                (forkctx _ ) (def 2) "if let " (typeof 1) "::" (typeof 2) "(" (e 2) ") = " (e 1) ".clone() { /* union case */" nl I
+                        (block 3)
+                        nl i "}"
+            ) 
+            
+        }
+    }
+    case             _@(newcontext):void           ( arg@(union):T item2@(define):JSONArrayObject code:block )  {
+        templates {
+            ranger ( "case " (e 1) " " (e 2) ":" (typeof 2) " {" nl
+                        I (block 3) i nl "}" nl
+            )
+            php (
+                (forkctx _ ) (def 2) "if( is_object(" (e 1) ") && get_class(" (e 1) ") == \"" (typeof 2) "\" ) /* union case */ {" nl I
+                        (e 2) " = " (e 1) ";" nl
+                        (block 3)                        
+                        nl i "}"
+            )  
+            es6 (
+                (forkctx _ ) (def 2) "if( " (e 1) " instanceof " (typeof 2) " ) /* union case */ {" nl I
+                        "var " (e 2) " = " (e 1) ";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            )  
+            go (
+                (forkctx _ ) (def 2) "switch " (e 1) ".(type) {" nl I
+                        "case " (typeof 2) ":" nl
+                            I nl
+                            "var " (e 2) " " (typeof 2) " = " (e 1) ".(" (typeof 2) ");" nl
+                            ; Go rejects a declared-and-unused local, and an arm
+                            ; that only tests the type never reads the binding.
+                            "_ = " (e 2) ";" nl
+                            (block 3)
+                            i nl
+                        nl i "}"
+            ) 
+            csharp (
+                (forkctx _ ) (def 2) "if( " (e 1) " is " (typeof 2) " ) {" nl I
+                        (typeof 2) " " (e 2) " = (" (typeof 2) ")" (e 1) ";" nl
+                        (block 3)
+                        nl i "}"
+            ) 
+            swift3 (
+                (forkctx _ ) (def 2) "if type(of: " (e 1) ") == " (typeof 2) ".self  {" nl I
+                        "let " (e 2) " = " (e 1) " as! " (typeof 2)";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            ) 
+            swift6 (
+                (forkctx _ ) (def 2) "if type(of: " (e 1) ") == " (typeof 2) ".self  {" nl I
+                        "let " (e 2) " = " (e 1) " as! " (typeof 2)";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            ) 
+            java7 (
+                (forkctx _ ) (def 2) "if( " (e 1) " instanceof " (typeof 2) ") {" nl I
+                        (typeof 2) " " (e 2) " = (" (typeof 2) ") " (e 1) ";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            )
+            kotlin (
+                (forkctx _ ) (def 2) "if( " (e 1) " is " (typeof 2) " ) /* union case */ {" nl I
+                        "val " (e 2) " : " (typeof 2) " = " (e 1) " as " (typeof 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            ) 
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", " (typeof 2) "):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            ) 
+            cpp (
+                (forkctx _ ) (def 2) "if( mpark::holds_alternative<" (typeof 2) ">(" (e 1) ") ) {" nl I
+                        (typeof 2) " " (e 2) " = mpark::get<" (typeof 2) ">(" (e 1) ");" nl
+                        (block 3)
+                        
+                        nl i "}"
+
+                (plugin 'makefile' ((dep 'variant.hpp' 'https://github.com/mpark/variant/releases/download/v1.2.2/variant.hpp')))
+            ) 
+            scala (
+                (forkctx _ ) (def 2) (e 1) " match {" nl
+                I "case " (e 2) " : " (typeof 2) " => {" nl I
+                            (block 3)
+                        nl i "}" nl
+                  "case _ => {} " nl i 
+                  "}" nl
+            ) 
+            dart (
+                (forkctx _ ) (def 2) "if( " (e 1) " is " (typeof 2) " ) /* union case */ {" nl I
+                        (typeof 2) " " (e 2) " = " (e 1) " as " (typeof 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            ) 
+            rust (
+                (forkctx _ ) (def 2) "if let " (typeof 1) "::" (typeof 2) "(" (e 2) ") = " (e 1) ".clone() { /* union case */" nl I
+                        (block 3)
+                        nl i "}"
+            ) 
+            
+        }
+    }
     case             _@(newcontext):void           ( arg@(union):T item@(define):T code:block )  {
         templates {
             ranger ( "case " (e 1) " " (e 2) ":" (typeof 2) " {" nl

--- a/docs/site/src/content/docs/language/types.md
+++ b/docs/site/src/content/docs/language/types.md
@@ -73,6 +73,36 @@ class Pen {
 
 The target language receives the type `int`. The type check is in the compiler.
 
+An `Enum` gives a name no fields. Use a [shape](/Ranger/docs/language/shapes/)
+when each name must carry its own data.
+
+## Shapes
+
+A shape is a closed set of cases, and each case has its own fields. A value of
+the shape type holds one case at a time.
+
+```lisp
+shape Value {
+    case Nothing
+    case Num {
+        def n:double 0.0
+    }
+    case Text {
+        def s:string ""
+    }
+}
+```
+
+The operator `case` narrows a value and binds the fields of the case. The
+operator `is` tests the case and gives a boolean.
+
+```lisp
+def b:boolean (is v _:Value.Num)
+```
+
+The page [Shapes](/Ranger/docs/language/shapes/) states the declaration, the
+groups and the output of each target language.
+
 ## Buffers
 
 A buffer holds binary data. The types are `buffer`, `int_buffer`,

--- a/lib/stdlib.rgr
+++ b/lib/stdlib.rgr
@@ -146,6 +146,214 @@ operators {
             )
         }
     }
+    ; A member of a system union -- the JSON unions over JSONDataObject and
+    ; JSONArrayObject -- is an ordinary object of the target language. It
+    ; carries no shape tag, so the generic overload below, which narrows on
+    ; __rg_kind / _rg_kind / .tag, can never be true for one. These two
+    ; overloads keep the class test that a system union needs; the generic
+    ; overload keeps the tag test that a shape case needs.
+    ; Every `@serialize` deserializer emits `case item oo:JSONDataObject`,
+    ; so without these the reader of an array of objects reads nothing.
+    case             _@(newcontext):void           ( arg@(union):T item2@(define):JSONDataObject code:block )  {
+        templates {
+            ranger ( "case " (e 1) " " (e 2) ":" (typeof 2) " {" nl
+                        I (block 3) i nl "}" nl
+            )
+            php (
+                (forkctx _ ) (def 2) "if( is_object(" (e 1) ") && get_class(" (e 1) ") == \"" (typeof 2) "\" ) /* union case */ {" nl I
+                        (e 2) " = " (e 1) ";" nl
+                        (block 3)                        
+                        nl i "}"
+            )  
+            es6 (
+                (forkctx _ ) (def 2) "if( " (e 1) " instanceof " (typeof 2) " ) /* union case */ {" nl I
+                        "var " (e 2) " = " (e 1) ";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            )  
+            go (
+                (forkctx _ ) (def 2) "switch " (e 1) ".(type) {" nl I
+                        "case " (typeof 2) ":" nl
+                            I nl
+                            "var " (e 2) " " (typeof 2) " = " (e 1) ".(" (typeof 2) ");" nl
+                            ; Go rejects a declared-and-unused local, and an arm
+                            ; that only tests the type never reads the binding.
+                            "_ = " (e 2) ";" nl
+                            (block 3)
+                            i nl
+                        nl i "}"
+            ) 
+            csharp (
+                (forkctx _ ) (def 2) "if( " (e 1) " is " (typeof 2) " ) {" nl I
+                        (typeof 2) " " (e 2) " = (" (typeof 2) ")" (e 1) ";" nl
+                        (block 3)
+                        nl i "}"
+            ) 
+            swift3 (
+                (forkctx _ ) (def 2) "if type(of: " (e 1) ") == " (typeof 2) ".self  {" nl I
+                        "let " (e 2) " = " (e 1) " as! " (typeof 2)";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            ) 
+            swift6 (
+                (forkctx _ ) (def 2) "if type(of: " (e 1) ") == " (typeof 2) ".self  {" nl I
+                        "let " (e 2) " = " (e 1) " as! " (typeof 2)";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            ) 
+            java7 (
+                (forkctx _ ) (def 2) "if( " (e 1) " instanceof " (typeof 2) ") {" nl I
+                        (typeof 2) " " (e 2) " = (" (typeof 2) ") " (e 1) ";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            )
+            kotlin (
+                (forkctx _ ) (def 2) "if( " (e 1) " is " (typeof 2) " ) /* union case */ {" nl I
+                        "val " (e 2) " : " (typeof 2) " = " (e 1) " as " (typeof 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            ) 
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", " (typeof 2) "):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            ) 
+            cpp (
+                (forkctx _ ) (def 2) "if( mpark::holds_alternative<" (typeof 2) ">(" (e 1) ") ) {" nl I
+                        (typeof 2) " " (e 2) " = mpark::get<" (typeof 2) ">(" (e 1) ");" nl
+                        (block 3)
+                        
+                        nl i "}"
+
+                (plugin 'makefile' ((dep 'variant.hpp' 'https://github.com/mpark/variant/releases/download/v1.2.2/variant.hpp')))
+            ) 
+            scala (
+                (forkctx _ ) (def 2) (e 1) " match {" nl
+                I "case " (e 2) " : " (typeof 2) " => {" nl I
+                            (block 3)
+                        nl i "}" nl
+                  "case _ => {} " nl i 
+                  "}" nl
+            ) 
+            dart (
+                (forkctx _ ) (def 2) "if( " (e 1) " is " (typeof 2) " ) /* union case */ {" nl I
+                        (typeof 2) " " (e 2) " = " (e 1) " as " (typeof 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            ) 
+            rust (
+                (forkctx _ ) (def 2) "if let " (typeof 1) "::" (typeof 2) "(" (e 2) ") = " (e 1) ".clone() { /* union case */" nl I
+                        (block 3)
+                        nl i "}"
+            ) 
+            
+        }
+    }
+    case             _@(newcontext):void           ( arg@(union):T item2@(define):JSONArrayObject code:block )  {
+        templates {
+            ranger ( "case " (e 1) " " (e 2) ":" (typeof 2) " {" nl
+                        I (block 3) i nl "}" nl
+            )
+            php (
+                (forkctx _ ) (def 2) "if( is_object(" (e 1) ") && get_class(" (e 1) ") == \"" (typeof 2) "\" ) /* union case */ {" nl I
+                        (e 2) " = " (e 1) ";" nl
+                        (block 3)                        
+                        nl i "}"
+            )  
+            es6 (
+                (forkctx _ ) (def 2) "if( " (e 1) " instanceof " (typeof 2) " ) /* union case */ {" nl I
+                        "var " (e 2) " = " (e 1) ";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            )  
+            go (
+                (forkctx _ ) (def 2) "switch " (e 1) ".(type) {" nl I
+                        "case " (typeof 2) ":" nl
+                            I nl
+                            "var " (e 2) " " (typeof 2) " = " (e 1) ".(" (typeof 2) ");" nl
+                            ; Go rejects a declared-and-unused local, and an arm
+                            ; that only tests the type never reads the binding.
+                            "_ = " (e 2) ";" nl
+                            (block 3)
+                            i nl
+                        nl i "}"
+            ) 
+            csharp (
+                (forkctx _ ) (def 2) "if( " (e 1) " is " (typeof 2) " ) {" nl I
+                        (typeof 2) " " (e 2) " = (" (typeof 2) ")" (e 1) ";" nl
+                        (block 3)
+                        nl i "}"
+            ) 
+            swift3 (
+                (forkctx _ ) (def 2) "if type(of: " (e 1) ") == " (typeof 2) ".self  {" nl I
+                        "let " (e 2) " = " (e 1) " as! " (typeof 2)";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            ) 
+            swift6 (
+                (forkctx _ ) (def 2) "if type(of: " (e 1) ") == " (typeof 2) ".self  {" nl I
+                        "let " (e 2) " = " (e 1) " as! " (typeof 2)";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            ) 
+            java7 (
+                (forkctx _ ) (def 2) "if( " (e 1) " instanceof " (typeof 2) ") {" nl I
+                        (typeof 2) " " (e 2) " = (" (typeof 2) ") " (e 1) ";" nl
+                        (block 3)
+                        
+                        nl i "}"
+            )
+            kotlin (
+                (forkctx _ ) (def 2) "if( " (e 1) " is " (typeof 2) " ) /* union case */ {" nl I
+                        "val " (e 2) " : " (typeof 2) " = " (e 1) " as " (typeof 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            ) 
+            python (
+                (forkctx _ ) (def 2) "if isinstance(" (e 1) ", " (typeof 2) "):" nl I
+                        (e 2) " = " (e 1) nl
+                        (block 3)
+                        nl i
+            ) 
+            cpp (
+                (forkctx _ ) (def 2) "if( mpark::holds_alternative<" (typeof 2) ">(" (e 1) ") ) {" nl I
+                        (typeof 2) " " (e 2) " = mpark::get<" (typeof 2) ">(" (e 1) ");" nl
+                        (block 3)
+                        
+                        nl i "}"
+
+                (plugin 'makefile' ((dep 'variant.hpp' 'https://github.com/mpark/variant/releases/download/v1.2.2/variant.hpp')))
+            ) 
+            scala (
+                (forkctx _ ) (def 2) (e 1) " match {" nl
+                I "case " (e 2) " : " (typeof 2) " => {" nl I
+                            (block 3)
+                        nl i "}" nl
+                  "case _ => {} " nl i 
+                  "}" nl
+            ) 
+            dart (
+                (forkctx _ ) (def 2) "if( " (e 1) " is " (typeof 2) " ) /* union case */ {" nl I
+                        (typeof 2) " " (e 2) " = " (e 1) " as " (typeof 2) ";" nl
+                        (block 3)
+                        nl i "}"
+            ) 
+            rust (
+                (forkctx _ ) (def 2) "if let " (typeof 1) "::" (typeof 2) "(" (e 2) ") = " (e 1) ".clone() { /* union case */" nl I
+                        (block 3)
+                        nl i "}"
+            ) 
+            
+        }
+    }
     case             _@(newcontext):void           ( arg@(union):T item@(define):T code:block )  {
         templates {
             ranger ( "case " (e 1) " " (e 2) ":" (typeof 2) " {" nl


### PR DESCRIPTION
The documentation site has not republished since 5 August. Every deploy since has failed at the "Generate the operator reference" step, so the site build and the Pages upload never ran. The cause is a compiler regression, not the site.

#538 rewrote the generic `case` templates for es6, Python, Go and Swift from a class test to a shape-tag test:

  es6     x instanceof T          ->  x.__rg_kind === "T"
  python  isinstance(x, T)        ->  getattr(x, "_rg_kind", None) == "T"
  go      switch x.(type)         ->  x.tag == T_tag_X
  swift   type(of: x) == T.self   ->  if case let .X(...) = x

That is right for a shape case and wrong for a member of a SYSTEM union. The JSON unions carry ordinary objects of the target language, and an ordinary object has no shape tag, so the test can never be true. Every `@serialize` deserializer emits `case item oo:JSONDataObject`, so since 6 August a reader of an array of objects has silently read nothing on four targets. The docs harness compiles examples against an in-memory filesystem built by exactly such a deserializer, so its virtual filesystem came up empty and the compiler answered "File not found: example.rgr" for all 20 examples.

Adds a `case` overload for JSONDataObject and JSONArrayObject carrying the pre-#538 templates, beside the overloads that already exist for the boolean, int, double and string members of the same unions. A shape case keeps the tag test; a system union member gets the class test back.

Found by bisecting the deploy: the example compiles at b0dc9015 and fails at 617aed3f, with identical lookup inputs and identical generated find_file, which pointed at the narrowing rather than at the file lookup.

Verified: docs:generate exits 0 and all 20 examples compile 13/13 targets, up from 0/13. The site builds, 36 pages. shapes.test.ts still fails exactly the same 11 pre-existing tests; the rest of the suite exits 0. Engine unchanged at 1327/1327 es6 and 1297/1303 with 0 crashes on C++ and Rust.

Also links the Shapes page from the Types page, next to Enum, which is where a reader looks for a type whose names carry data.


Claude-Session: https://claude.ai/code/session_018UhAu39zhvtwywsKKDnHud