### PR TITLE
Update Shapes docs and reject unsafe parent→child group widening

### DIFF
--- a/bin/output.js
+++ b/bin/output.js
@@ -16338,9 +16338,6 @@ RangerProcessProcSend.collectProcessClasses = function(ctx) {
                 await this.rewriteToGroupWiden(n2, n1.eval_type_name, n2.eval_type_name, ctx, wr);
                 return true;
               }
-              if ( c1.isSameOrParentClass(n2.eval_type_name, ctx) ) {
-                return true;
-              }
               ctx.addError(n1, (("Union types must be the same =>  " + n1.eval_type_name) + " <> ") + n2.eval_type_name);
               return false;
             }

--- a/compiler/ng_RangerFlowParser.rgr
+++ b/compiler/ng_RangerFlowParser.rgr
@@ -7995,14 +7995,13 @@ class RangerFlowParser {
               if (n1.eval_type_name == n2.eval_type_name) {
                 return true
               }
-              ; C6: source is a subgroup of the expected group — widen via the
-              ; generated `widen_to_<Parent>` helper so native enum targets keep
-              ; a typed conversion without a wrapper object.
+              ; C6: actual (n2/c2) is a subgroup of expected (n1/c1) — widen via
+              ; the generated `widen_to_<Parent>` helper so native enum targets
+              ; keep a typed conversion without a wrapper object.
+              ; Direction matters: Numeric → Printable is allowed; Printable →
+              ; Numeric is not (a Printable may hold a non-Numeric case).
               if ( c2.isSameOrParentClass (n1.eval_type_name ctx)) {
                 this.rewriteToGroupWiden(n2 n1.eval_type_name n2.eval_type_name ctx wr)
-                return true
-              }
-              if ( c1.isSameOrParentClass (n2.eval_type_name ctx)) {
                 return true
               }
               ctx.addError( n1 ('Union types must be the same =>  ' + n1.eval_type_name + " <> " + n2.eval_type_name))

--- a/docs/site/src/content/docs/language/shapes.md
+++ b/docs/site/src/content/docs/language/shapes.md
@@ -1,31 +1,113 @@
 ---
 title: Shapes
-description: A shape is a closed set of cases with a payload. The page states the declaration, the narrowing operators and the output of each target language.
+description: Closed variant families with groups, match exhaustiveness, required operations, and per-target representation.
 ---
 
-A shape is a closed set of cases. Each case has a name and its own fields. A
-value of the shape type holds one case at a time. The compiler knows every
-case, so it can report a case that a `match` statement does not cover.
+A shape is a closed family of cases. Each case has a name and its own fields. A
+value of the shape type holds one case at a time. Groups name restricted views
+of that family; they can carry shared fields and required operations, and they
+are usable as types. The compiler knows every case, so `match` can require that
+every reachable case is handled.
+
+The useful reading order is:
+
+**Shape → Groups → Cases → `match` → Methods / capabilities → Value or reference → Representation**
 
 ```lisp
 shape Value {
+    group Printable {
+        fn render:string ()
+    }
+
+    group Numeric does Printable {
+        fn asDouble:double ()
+    }
+
+    case Num does Numeric {
+        def value:double 0.0
+
+        fn render:string () {
+            return (to_string value)
+        }
+
+        fn asDouble:double () {
+            return value
+        }
+    }
+
+    case Text does Printable {
+        def value:string ""
+
+        fn render:string () {
+            return value
+        }
+    }
+
     case Nothing
-    case Num {
-        def n:double 0.0
-    }
-    case Text {
-        def s:string ""
-    }
 }
 ```
 
-The declaration writes one class for each case and one union over the classes.
-No target language knows the word `shape`. A target carries a shape as well as
-it carries a union.
+A shape has one target-independent semantic model. The compiler may lower it
+through case records and a closed union, but each backend is free to use a more
+native representation. No target language needs the word `shape` in its source.
 
-## The construction of a value
+## Groups
 
-The constructor of a case takes the fields of the case in order.
+A group is a **nominal restricted view** of a closed shape family. It can carry
+shared fields and behavioral requirements, and it can itself be used as a type.
+A case joins a group with `does`. Nested groups widen membership:
+
+```text
+Value.Num <: Value.Numeric <: Value.Printable <: Value
+```
+
+The first useful group example is a group-typed parameter. Member cases are
+accepted without wrapping:
+
+```lisp
+shape Ev {
+    group Callable {
+        fn invoke:string (arg:string)
+    }
+
+    case Fn does Callable {
+        def name:string ""
+        fn invoke:string (arg:string) {
+            return ((name + ":") + arg)
+        }
+    }
+
+    case Builtin does Callable {
+        def opcode:string ""
+        fn invoke:string (arg:string) {
+            return ((opcode + "(") + arg) + ")"
+        }
+    }
+}
+
+fn callIt:string (c:Ev.Callable arg:string) {
+    return (Ev.Callable.invoke(c arg))
+}
+```
+
+Widening follows the subset of cases. A child group may be passed where a parent
+group is expected (`Numeric` → `Printable`). The reverse is an error: a
+`Printable` may hold a `Text`, so it cannot be passed as `Numeric` without
+narrowing.
+
+```lisp
+fn needsNumeric:void (v:Value.Numeric) {
+}
+
+fn hasPrintable:void (v:Value.Printable) {
+    ; needsNumeric(v)   ; compile error — Printable is not Numeric
+}
+```
+
+## Cases and construction
+
+The constructor of a case takes the fields of the case in order, including
+fields inherited from its groups.
 
 ```lisp
 def a:Value (new Value.Nothing())
@@ -33,51 +115,107 @@ def b:Value (new Value.Num(42.0))
 def c:Value (new Value.Text("hello"))
 ```
 
-## The narrowing of a value
+A case type such as `Value.Num` is also a type. Exact-case methods are available
+only when the value is known to be that case.
 
-The operator `case` tests the value and binds the narrowed value to a name. The
-block reads the fields of the case.
+## `match`
+
+`match` is the checked way to cover a closed family. The compiler requires every
+reachable case exactly once. A missing case, a duplicate case, or a catch-all
+wildcard is a compile error.
 
 ```lisp
-case v x:Value.Num {
-    print (to_string x.n)
+fn describe:string (v:Value) {
+    match v {
+        Nothing {
+            return "nothing"
+        }
+        Num n {
+            return (to_string n.value)
+        }
+        Text t {
+            return t.value
+        }
+    }
 }
 ```
 
-## The kind test
-
-The operator `is` answers the question "does the value hold this case?". It
-gives a boolean, and it binds nothing.
+The more important form is a match over a **group** type. Exhaustiveness is
+relative to the declared type, not to the whole shape:
 
 ```lisp
-fn isNumber:boolean (v:Value) {
-    return (is v _:Value.Num)
+fn describePrintable:string (v:Value.Printable) {
+    match v {
+        Num n {
+            return (to_string n.value)
+        }
+        Text t {
+            return t.value
+        }
+    }
 }
 ```
 
-The name `_` is the binding that the operator does not take. The compiler reads
-the case from the type after the colon, so the case needs a name in front of
-it. The operator defines no variable, and the same form can appear two times in
-one block.
+That match is complete because `v` is `Value.Printable`. It does not need to
+cover `Nothing`. An arm may also name a group, or join several cases with `|`.
 
-`is` is an expression. It goes into a `return`, into an `if` condition, and
-into a boolean operator.
+## Required operations
+
+A bodyless method on a group is a **required operation**. Every member case must
+provide a compatible implementation. These are not ordinary abstract methods or
+virtual dispatch: calls are statically qualified and lower to generated ops
+classes with exhaustive dispatch.
 
 ```lisp
-if (is v _:Value.Nothing) {
-    return "nothing"
+group Callable {
+    fn invoke:string (arg:string)
 }
-return ((is v _:Value.Num) || (is v _:Value.Text))
+
+fn callIt:string (c:Ev.Callable arg:string) {
+    return (Ev.Callable.invoke(c arg))
+}
 ```
 
-Use `case` when the block reads the payload of the case. Use `is` when the
-program needs the answer only. The binding of `case` has a cost: on the Rust
-target it writes a clone of the value.
+A missing implementation or an incompatible signature is a compiler error. A
+group may also supply a default body; a case that replaces it must mark the
+replacement with `@(override)`.
 
-## Groups
+Case-only methods stay on the case. Call them after narrowing, or through the
+exact case type — for example `Value.Num.doubled(n)` after a `Num n` arm, not
+on a `Value.Printable` value.
 
-A group is a name for a set of cases. A case joins a group with `does`. A group
-declares fields that each case of the group receives.
+## Group fields
+
+A field declared on a group is projected through the group type without
+narrowing. For a reference group the field is readable and writable; the
+compiler lowers the access to generated `get_` / `set_` helpers.
+
+```lisp
+shape Value {
+    group Ref {
+        def identityId:int 0
+    }
+    case Items does Ref {
+        def items:[int]
+    }
+}
+
+fn readId:int (r:Value.Ref) {
+    return r.identityId
+}
+```
+
+## Value and reference semantics
+
+`@(value)` and `@(reference)` declare observable copy, equality and identity
+rules. They are not layout hints.
+
+| | `@(value)` | `@(reference)` |
+| --- | --- | --- |
+| Copy | copies the payload | shares the payload |
+| `==` | compares content | compares identity |
+| Identity | none | stable for the value's lifetime |
+| Mutable fields | not allowed | allowed |
 
 ```lisp
 shape Value {
@@ -96,16 +234,58 @@ shape Value {
 }
 ```
 
-The operator `is` accepts a group. The compiler writes one test for each case
-of the group and joins the tests with `||`.
+A value case is immutable: assigning to one of its fields is a compile error.
+Build a new value instead. A reference case keeps identity across copies and
+across subgroup → parent widening.
+
+When a case is in no annotated group, the compiler defaults to `@(value)` for
+scalar-only payloads and `@(reference)` otherwise, and it may warn so the
+program states the choice explicitly.
+
+## Narrowing with `case` and `is`
+
+The operator `case` tests the value and binds the narrowed value to a name. Use
+it when the block reads the payload of one case.
 
 ```lisp
-def b:boolean (is v _:Value.Prim)
+case v x:Value.Num {
+    print (to_string x.n)
+}
 ```
 
-## The output of each target language
+The operator `is` answers whether the value holds a case or a group. It gives a
+boolean and binds nothing. The name `_` is the unused binding; the compiler
+reads the case from the type after the colon.
 
-The operator `is` writes the test that the target language already uses for
+```lisp
+fn isNumber:boolean (v:Value) {
+    return (is v _:Value.Num)
+}
+
+def b:boolean (is v _:Value.Printable)
+```
+
+`is` is an expression. It goes into a `return`, into an `if` condition, and into
+a boolean operator. Prefer `match` when the program must cover the family;
+prefer `case` when one arm reads a payload; prefer `is` when only the boolean
+matters. The binding of `case` has a cost: on the Rust target it writes a clone
+of the value.
+
+## Representation per target
+
+Semantics stay the same across targets. The physical form does not:
+
+| Target | Typical representation |
+| --- | --- |
+| TypeScript | Typed union with a discriminant (`__rg_kind`) |
+| ES6 / Python | Tagged object with a stable kind field |
+| Rust / Swift | Native enum |
+| Go | Tagged struct |
+| Kotlin / C# / Dart | Interface (or sealed interface) implemented by each case |
+| C++ | Variant; scalar value cases stored by value |
+| Java / PHP / Scala | Portable class-per-case union where a native form is not selected |
+
+The operator `is` writes the discriminant test that the target already uses for
 `case`. It adds no new form.
 
 | Target | The output of `is v _:Value.Num` |
@@ -125,15 +305,13 @@ Swift has no expression form of `if case`. The compiler writes a closure and
 calls it. The value operand has one name in the output, so the program reads it
 one time.
 
-## The state of each target language
+## Tests and target status
 
-The test `tests/is-operator.test.ts` runs one program on JavaScript, Python,
-Go, Rust and Kotlin. It compares the answer of `case` against the answer of
-`is` for each case and for each group. The same program also runs on C++, Java
-and PHP.
+The fixtures under `tests/fixtures/shape_*.rgr` and `tests/shapes.test.ts` cover
+construction, `match` exhaustiveness, group and case methods, required
+operations, field projection, subgroup widening, and value/reference rules. The
+test `tests/is-operator.test.ts` compares `case` against `is` on the toolchains
+present in CI.
 
-The Swift toolchain is not available in the test container. The test reads the
-output of the Swift writer instead of a run of the program.
-
-The page [Target languages](/Ranger/docs/targets/overview/) states the limits
-of a shape on each target language.
+The page [Target languages](/Ranger/docs/targets/overview/) states the limits of
+a shape on each target language.

--- a/docs/site/src/content/docs/language/types.md
+++ b/docs/site/src/content/docs/language/types.md
@@ -78,30 +78,31 @@ when each name must carry its own data.
 
 ## Shapes
 
-A shape is a closed set of cases, and each case has its own fields. A value of
-the shape type holds one case at a time.
+A shape is a closed family of cases. Groups name restricted views of that
+family; `match` checks that every reachable case is handled.
 
 ```lisp
 shape Value {
-    case Nothing
-    case Num {
-        def n:double 0.0
+    group Printable {
+        fn render:string ()
     }
-    case Text {
+    case Num does Printable {
+        def n:double 0.0
+        fn render:string () {
+            return (to_string n)
+        }
+    }
+    case Text does Printable {
         def s:string ""
+        fn render:string () {
+            return s
+        }
     }
 }
 ```
 
-The operator `case` narrows a value and binds the fields of the case. The
-operator `is` tests the case and gives a boolean.
-
-```lisp
-def b:boolean (is v _:Value.Num)
-```
-
-The page [Shapes](/Ranger/docs/language/shapes/) states the declaration, the
-groups and the output of each target language.
+The page [Shapes](/Ranger/docs/language/shapes/) covers groups, `match`,
+required operations, value/reference semantics and per-target representation.
 
 ## Buffers
 

--- a/docs/site/src/content/docs/targets/overview.md
+++ b/docs/site/src/content/docs/targets/overview.md
@@ -59,11 +59,13 @@ for that target.
 
 ## The state of a shape on each target language
 
-A [shape](/Ranger/docs/language/shapes/) is a closed set of cases. The
-declaration writes one class for each case and one union over the classes. The
-table states the result of one program that tests each case and each group. The
-program compares the answer of the operator `case` against the answer of the
-operator `is`.
+A [shape](/Ranger/docs/language/shapes/) is a closed family of cases with one
+target-independent semantic model. Backends may use a native form — a typed
+union with a discriminant, a native enum, a tagged struct, an interface, or a
+variant with scalar cases stored by value — rather than only a portable
+class-per-case union. The table states the result of one program that tests
+each case and each group. The program compares the answer of the operator
+`case` against the answer of the operator `is`.
 
 | Target | The program runs | The known limit |
 | --- | --- | --- |
@@ -72,7 +74,7 @@ operator `is`.
 | Go | yes | none |
 | Kotlin | yes | none |
 | Java | yes | none |
-| C++ | yes | The variant holds a scalar case behind a pointer. The test asks for the case by value. |
+| C++ | yes | Scalar value cases ride inside the variant by value. |
 | Rust | yes | A case value is not wrapped into the union. See the note below. |
 | PHP | yes | none for a shape |
 | Swift | not tested | The toolchain is not available in the test container. The test reads the output of the writer. |

--- a/tests/fixtures/shape_group_parent_to_child.rgr
+++ b/tests/fixtures/shape_group_parent_to_child.rgr
@@ -1,0 +1,46 @@
+; A parent-group value must not be accepted where a child group is required
+; (PLAN_SHAPES.md §7 / C6). Printable may hold Text, so it is not Numeric.
+shape Value {
+    group Printable {
+        fn render:string ()
+    }
+
+    group Numeric does Printable {
+        fn asDouble:double ()
+    }
+
+    case Num does Numeric {
+        def value:double 0.0
+
+        fn render:string () {
+            return (to_string value)
+        }
+
+        fn asDouble:double () {
+            return value
+        }
+    }
+
+    case Text does Printable {
+        def value:string ""
+
+        fn render:string () {
+            return value
+        }
+    }
+}
+
+class Main {
+    fn needsNumeric:void (v:Value.Numeric) {
+        print (to_string (Value.Numeric.asDouble(v)))
+    }
+
+    fn hasPrintable:void (v:Value.Printable) {
+        this.needsNumeric(v)
+    }
+
+    sfn main:void () {
+        def m:Main (new Main())
+        m.hasPrintable((new Value.Text("hi")))
+    }
+}

--- a/tests/shapes.test.ts
+++ b/tests/shapes.test.ts
@@ -648,6 +648,13 @@ describe("shapes (closed variant families)", () => {
       );
     });
 
+    it("rejects a parent group passed where a child group is required", () => {
+      expectCompileError(
+        `${FIXTURES_DIR}/shape_group_parent_to_child.rgr`,
+        "invalid argument type"
+      );
+    });
+
     it("rejects a case-only method called with a group-typed value", () => {
       expectCompileError(
         `${FIXTURES_DIR}/shape_case_method_on_group.rgr`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Validates and applies the Shapes documentation feedback against `PLAN_SHAPES.md`, fixtures, and the compiler.

### Documentation

Rewrites the public Shapes page around:

**Shape → Groups → Cases → `match` → Methods/capabilities → value/reference → representation**

Adds coverage that was already implemented (C1–C6 / S2–S5) but missing from the docs:

- Groups as nominal typed views, nested groups, and subgroup widening
- `match` with family and group-scoped exhaustiveness
- Required operations (bodyless group methods)
- Group field projection
- `@(value)` / `@(reference)` semantics
- Target-independent semantics with native per-backend representation

Also updates the short Shapes blurb in Types and the representation wording on Target languages.

### Compiler fix (feedback confirmed)

The feedback about directional subgroup checking was **correct**.

In `areEqualTypes`, the union/union path allowed:

1. `actual ⊆ expected` → widen (correct: `Numeric` → `Printable`)
2. `expected ⊆ actual` → accept with no rewrite (**incorrect**: `Printable` → `Numeric`)

`tests/fixtures/shape_group_parent_to_child.rgr` compiled successfully before the fix. The second check is removed; parent → child now fails as expected.

### Not done in this PR

- Separating type-relation checking from AST rewrite (`rewriteToGroupWiden` during overload probing) — real concern, larger cleanup
- Making `ShapeViewDesc` the authoritative subtyping source — also noted as follow-up

### Feedback corrections

- `fn describe:v:string` in the feedback example is a typo; docs use `fn describe:string`
- Representation claims match S5 (TS discriminant, Rust/Swift enum, Go tagged struct, Kotlin/C# interfaces, C++ by-value scalar variants)

### Test plan

- [x] `rejects a parent group passed where a child group is required` (new)
- [x] Other non-Rust group/case method tests in `tests/shapes.test.ts`
- [ ] Full `tests/shapes.test.ts` (some Rust group-method runs already fail on current `master` in this environment; not introduced here)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bd01276-f02f-4de2-ad30-4e6f7fb1519f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bd01276-f02f-4de2-ad30-4e6f7fb1519f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

